### PR TITLE
docs(blog): blockchain architecture blog program — inventory + 34 drafted posts

### DIFF
--- a/docs/blog/blog-topics-inventory.md
+++ b/docs/blog/blog-topics-inventory.md
@@ -1,0 +1,562 @@
+# FairWins Blog Topic Inventory — Blockchain System Architecture
+
+*An editorial backlog of engineering deep-dives drawn from the FairWins /
+Prediction DAO codebase, aimed at the crypto and digital-asset developer
+ecosystem.*
+
+This document inventories the discrete systems in the platform that are
+strong candidates for architecture blog posts. Each entry lists a brief
+description, the intended audience, category tags, whether it belongs to a
+broader series or stands alone, and a quality evaluation.
+
+The one published post to date —
+[*Private Prediction Markets: Confidential Terms with Trustless
+Settlement*](private-prediction-markets-envelope-encryption.md) — is folded
+into the **Privacy Architecture** series below as the anchor piece.
+
+---
+
+## How to read the quality evaluation
+
+Each topic carries a score from **1–5** built from four factors:
+
+- **Novelty** — how uncommon or hard-won the approach is.
+- **Audience pull** — how much the crypto/dev ecosystem actively searches for it.
+- **Differentiation** — whether we can say something most writeups don't.
+- **Proof** — whether shipped, tested code backs the claims (not vaporware).
+
+- ⭐⭐⭐⭐⭐ **Flagship** — lead with these; broad reach and a genuinely
+  differentiated take.
+- ⭐⭐⭐⭐ **Strong** — reliably good technical content with clear demand.
+- ⭐⭐⭐ **Solid** — worth writing, narrower audience or more familiar ground.
+- ⭐⭐ **Niche** — valuable to a specific segment; lower reach.
+
+---
+
+## Summary matrix
+
+| # | Topic | Series | Score | Primary audience |
+|---|-------|--------|-------|------------------|
+| 1 | Role-based access control & the operations control plane | Identity & Access | ⭐⭐⭐⭐ | Protocol / backend eng |
+| 2 | Soulbound memberships + transferable vouchers | Identity & Access | ⭐⭐⭐⭐ | Token designers, product |
+| 3 | Sanctions & compliance gating as a contract primitive | Identity & Access | ⭐⭐⭐ | Compliance eng, founders |
+| 4 | Passkey smart accounts (ERC-4337 + WebAuthn) | Accounts & Keys | ⭐⭐⭐⭐⭐ | Wallet / AA developers |
+| 5 | Account recovery & unified connect | Accounts & Keys | ⭐⭐⭐⭐ | Wallet / UX eng |
+| 6 | Sponsored gas with a self-hosted verifying paymaster (ERC-7677) | Accounts & Keys | ⭐⭐⭐⭐⭐ | AA / infra developers |
+| 7 | Safe multisig custody integration | Custody & Multisig | ⭐⭐⭐ | Treasury / DAO eng |
+| 8 | On-chain multisig policy engine (transaction guards) | Custody & Multisig | ⭐⭐⭐⭐ | Security / DAO eng |
+| 9 | Intent-based gasless payments (EIP-712 + EIP-3009) | Gasless Rails | ⭐⭐⭐⭐ | dApp / relayer devs |
+| 10 | Relayer gateway architecture (policy + engine split) | Gasless Rails | ⭐⭐⭐⭐ | Infra / backend eng |
+| 11 | UUPS upgrades & storage-layout safety | Contract Architecture | ⭐⭐⭐⭐ | Solidity engineers |
+| 12 | The two-facet proxy: beating the 24 KB limit | Contract Architecture | ⭐⭐⭐⭐⭐ | Solidity engineers |
+| 13 | Deterministic / singleton deployment across chains | Contract Architecture | ⭐⭐⭐ | Protocol / DevOps eng |
+| 14 | The wager lifecycle contract | Prediction Markets | ⭐⭐⭐⭐ | Smart-contract devs |
+| 15 | Oracle adapter abstraction (Polymarket / Chainlink / UMA) | Prediction Markets | ⭐⭐⭐⭐⭐ | Oracle / integration eng |
+| 16 | Draw resolution & open-challenge wagers | Prediction Markets | ⭐⭐⭐ | Smart-contract devs |
+| 17 | Wager pools: ERC-1167 clones & address-keyed payouts | Prediction Markets | ⭐⭐⭐⭐ | Smart-contract devs |
+| 18 | Envelope encryption for private markets *(published)* | Privacy Architecture | ⭐⭐⭐⭐⭐ | Applied crypto, fintech |
+| 19 | Multi-recipient encryption | Privacy Architecture | ⭐⭐⭐ | Applied crypto eng |
+| 20 | Client-side encrypted data sync | Privacy Architecture | ⭐⭐⭐ | Privacy / app eng |
+| 21 | The nullifier system | Privacy Architecture | ⭐⭐⭐⭐ | ZK / privacy eng |
+| 22 | The FeeRouter: one source of truth for platform fees | Finance Surfaces | ⭐⭐⭐⭐ | Protocol / product eng |
+| 23 | Earn: wrapping ERC-4626 lending vaults with fee disclosure | Finance Surfaces | ⭐⭐⭐ | DeFi integrators |
+| 24 | Predict: Polymarket trading via builder codes | Finance Surfaces | ⭐⭐⭐⭐ | DeFi / trading devs |
+| 25 | Bitcoin: adding a non-EVM chain to an EVM app | Finance Surfaces | ⭐⭐⭐⭐⭐ | Multi-chain / wallet eng |
+| 26 | ClearPath: a multi-network external DAO registry | Multi-chain Infra | ⭐⭐⭐ | DAO / infra eng |
+| 27 | Indexing without a subgraph (graceful degradation) | Multi-chain Infra | ⭐⭐⭐⭐ | Data / infra eng |
+| 28 | The unified activity ledger | Multi-chain Infra | ⭐⭐⭐ | Full-stack / data eng |
+| 29 | AI-driven smart-contract security review in CI | Security & DevOps | ⭐⭐⭐⭐⭐ | Security eng, AI-curious |
+| 30 | Coverage & audit gates that fail loudly | Security & DevOps | ⭐⭐⭐ | Eng leads, security |
+| 31 | Symbolic execution & fuzzing a wager protocol | Security & DevOps | ⭐⭐⭐⭐ | Security researchers |
+| 32 | Spec-driven development with Spec Kit | Security & DevOps | ⭐⭐⭐ | Eng leaders, agent devs |
+| 33 | CallsignRegistry: an in-house ENS-style naming system | Standalone | ⭐⭐⭐ | Naming / identity eng |
+| 34 | TokenFactory: templated token minting | Standalone | ⭐⭐ | Token / product eng |
+
+---
+
+## Series 1 — Identity & Access
+
+The role model, membership economics, and compliance gates. Great for
+founders and protocol engineers wrestling with "who can do what, and how do
+we sell access without a database."
+
+### 1. Role-based access control & the operations control plane
+- **Description:** One user-purchasable role and six operator roles, every
+  privileged action gated by exactly one role via OpenZeppelin AccessControl,
+  surfaced through a grouped `/admin` console where each view appears only if
+  the connected wallet holds the required role. Covers the discipline of
+  "one action, one role," the operations control plane grouping (Control Room,
+  Incident Response, Compliance, Membership & Revenue, Protocol Config,
+  Identity, Access Control, Infrastructure), and how role checks flow from
+  contract to UI.
+- **Audience:** Protocol/backend engineers, technical founders.
+- **Tags:** `access-control`, `rbac`, `solidity`, `openzeppelin`, `admin-ux`.
+- **Series:** Identity & Access (part 1).
+- **Quality:** ⭐⭐⭐⭐ — Access control is universally relevant; the
+  role-to-console mapping is a concrete, reusable pattern most teams reinvent.
+
+### 2. Soulbound memberships + transferable vouchers
+- **Description:** Membership is a **soulbound** (non-transferable),
+  time-bound tier sold in USDC by `MembershipManager` with per-tier throughput
+  limits. Vouchers (`MembershipVoucher`, ERC-721) decouple *purchase* from
+  *ownership*: a voucher confers nothing while held, so it can be gifted or
+  resold, and redeeming it burns the NFT and writes the soulbound membership
+  to the redeemer. A clean case study in when to make a token
+  transferable vs. not, and how to build a gift/resale market on top of a
+  non-transferable primitive.
+- **Audience:** Token designers, product engineers, growth.
+- **Tags:** `soulbound`, `erc721`, `tokenomics`, `memberships`, `access-control`.
+- **Series:** Identity & Access (part 2).
+- **Quality:** ⭐⭐⭐⭐ — The soulbound-plus-voucher split is a genuinely
+  interesting design tension with clear product motivation.
+
+### 3. Sanctions & compliance gating as a contract primitive
+- **Description:** `SanctionsGuard` (`ISanctionsGuard`) is a shared screening
+  primitive reused across wagers, pools, and membership redemption. Explores
+  compliance as a composable on-chain check rather than an off-chain
+  afterthought, and how the same guard threads through independent subsystems.
+- **Audience:** Compliance engineers, regulated-product founders.
+- **Tags:** `compliance`, `sanctions`, `access-control`, `solidity`.
+- **Series:** Identity & Access (part 3).
+- **Quality:** ⭐⭐⭐ — Important and underdiscussed, but a narrower audience
+  than the first two entries.
+
+---
+
+## Series 2 — Accounts & Keys
+
+Passwordless accounts, recovery, and sponsored gas. This is the highest-demand
+cluster right now — account abstraction and passkeys are hot search terms.
+
+### 4. Passkey smart accounts (ERC-4337 + WebAuthn)
+- **Description:** Account-native passkey wallets built on a
+  `CoinbaseSmartWallet` / `MultiOwnable` foundation with WebAuthn (`webauthn-sol`,
+  `FreshCryptoLib` P-256), ERC-1271 signatures, and ERC-4337 UserOps. Master
+  seed derivation client-side, no seed phrase for the user. Covers the account
+  contract, factory/first-use deploy, and the WebAuthn-to-secp256r1 verification
+  path.
+- **Audience:** Wallet developers, account-abstraction engineers.
+- **Tags:** `account-abstraction`, `erc4337`, `passkeys`, `webauthn`, `p256`, `erc1271`.
+- **Series:** Accounts & Keys (part 1).
+- **Quality:** ⭐⭐⭐⭐⭐ — Passkeys + AA is one of the most-searched wallet
+  topics; we have real, shipped contracts and libraries to show.
+
+### 5. Account recovery & unified connect
+- **Description:** The unified connect/recovery flow (spec 045) that merges
+  wallet connection and account recovery into one surface, plus controller
+  changes for passkey accounts. Tackles the hardest UX problem in
+  self-custody: what happens when the device is lost, without reintroducing a
+  seed phrase.
+- **Audience:** Wallet/UX engineers, product designers.
+- **Tags:** `account-recovery`, `passkeys`, `self-custody`, `ux`, `account-abstraction`.
+- **Series:** Accounts & Keys (part 2).
+- **Quality:** ⭐⭐⭐⭐ — Recovery is the make-or-break of passkey adoption;
+  high interest, real design decisions to share.
+
+### 6. Sponsored gas with a self-hosted verifying paymaster (ERC-7677)
+- **Description:** A self-hosted **verifying paymaster** (EntryPoint v0.6,
+  `FairWinsVerifyingPaymaster`) that reimburses the alto bundler from a
+  FairWins-funded deposit, authorized per-op by a KMS-signed **ERC-7677**
+  endpoint on the relay gateway (`POST /v1/paymaster`, reusing screening,
+  quotas, and killswitch). Includes the never-stranded fallback to
+  self-funded UserOps and honest fee disclosure (sponsored vs. user-pays).
+- **Audience:** Account-abstraction and infrastructure developers.
+- **Tags:** `paymaster`, `erc7677`, `erc4337`, `gasless`, `bundler`, `kms`.
+- **Series:** Accounts & Keys (part 3).
+- **Quality:** ⭐⭐⭐⭐⭐ — Running your own paymaster + bundler (not a vendor
+  SDK) is exactly the kind of hard-won infra writeup the AA community devours.
+
+---
+
+## Series 3 — Custody & Multisig
+
+For treasury, DAO, and security-minded readers: how organizational funds are
+held and constrained.
+
+### 7. Safe multisig custody integration
+- **Description:** Safe-based custody (spec 043) with a `SafeProposalHub` and
+  guard scaffolding for treasury and operator funds. How an app integrates
+  Safe as the custody layer for privileged/treasury operations rather than
+  rolling its own multisig.
+- **Audience:** Treasury engineers, DAO tooling builders.
+- **Tags:** `safe`, `multisig`, `custody`, `treasury`.
+- **Series:** Custody & Multisig (part 1).
+- **Quality:** ⭐⭐⭐ — Solid and practical; Safe integration is well-trodden,
+  so differentiation comes from the guard/policy angle in part 2.
+
+### 8. On-chain multisig policy engine (transaction guards)
+- **Description:** `SafePolicyGuard` / `SafeGuard` — a policy engine (spec 049)
+  that enforces rules on multisig transactions *at execution time* via Safe's
+  guard interface. Encodes spending policies, allow/deny rules, and
+  constraints directly on-chain, so the multisig can't execute a transaction
+  that violates policy even with enough signatures.
+- **Audience:** Security engineers, DAO/treasury tooling builders.
+- **Tags:** `safe`, `multisig`, `policy-engine`, `transaction-guard`, `security`.
+- **Series:** Custody & Multisig (part 2).
+- **Quality:** ⭐⭐⭐⭐ — Programmable, enforced-on-chain multisig policy is a
+  meatier, more differentiated topic than plain Safe integration.
+
+---
+
+## Series 4 — Gasless Rails
+
+Two rails, one story: how the platform lets users transact without holding gas.
+
+### 9. Intent-based gasless payments (EIP-712 + EIP-3009)
+- **Description:** Relayed intents (specs 035/036): every actor action has an
+  EIP-712 `…WithSig` twin, and value moves via EIP-3009
+  (`…WithAuthorization`). Covers the discipline of keeping intent structs
+  **byte-identical across three places** (contract typehashes, frontend, and
+  gateway), and the always-available self-submit fallback.
+- **Audience:** dApp developers, meta-transaction/relayer engineers.
+- **Tags:** `eip712`, `eip3009`, `meta-transactions`, `gasless`, `intents`.
+- **Series:** Gasless Rails (part 1).
+- **Quality:** ⭐⭐⭐⭐ — The three-way struct-sync discipline is a real,
+  battle-tested lesson that most tutorials skip.
+
+### 10. Relayer gateway architecture (policy + engine split)
+- **Description:** The relayer infrastructure (spec 036): a **policy gateway**
+  (`relay-gateway`) that handles screening, quotas, and killswitch, in front of
+  an **execution engine** (`oz-relayer`) and the alto bundler. Why the split
+  matters, how the same gateway serves both relayed intents and the ERC-7677
+  paymaster endpoint, and how it stays optional (self-submit never stranded).
+- **Audience:** Infrastructure and backend engineers.
+- **Tags:** `relayer`, `infrastructure`, `gasless`, `cloud-run`, `api-gateway`.
+- **Series:** Gasless Rails (part 2).
+- **Quality:** ⭐⭐⭐⭐ — The policy/engine separation and shared-gateway reuse
+  is a strong systems-design narrative.
+
+---
+
+## Series 5 — Contract Architecture
+
+Solidity craft: upgrades, size limits, and deterministic deployment. Pure
+engineer bait.
+
+### 11. UUPS upgrades & storage-layout safety
+- **Description:** Multiple UUPS proxies at stable addresses (`WagerRegistry`,
+  `MembershipManager`, `WagerPoolFactory`, `FeeRouter`, `CallsignRegistry`) all
+  built on a shared `UUPSManaged` base: one-time `initialize` instead of a
+  constructor, append-only storage with a trailing `__gap`, and a CI-gated
+  `check:storage-layout`. How to ship logic changes in place without corrupting
+  state.
+- **Audience:** Solidity engineers.
+- **Tags:** `uups`, `proxy`, `upgradeable`, `storage-layout`, `solidity`.
+- **Series:** Contract Architecture (part 1).
+- **Quality:** ⭐⭐⭐⭐ — Upgrade safety is a perennial pain point; the CI gate
+  and shared base make for a concrete, copyable pattern.
+
+### 12. The two-facet proxy: beating the 24 KB contract-size limit
+- **Description:** The wager registry is **two facets behind one proxy**:
+  `WagerRegistry` delegatecalls unknown selectors to `WagerRegistryIntents`
+  (the `…WithSig` twins plus relocated batch/auto-resolve functions) because the
+  main implementation sits against the EIP-170 24 KB code limit. Both inherit a
+  single `WagerRegistryCore` storage definition, validated as a pair by
+  `check:storage-layout`. A real-world answer to "my contract won't fit."
+- **Audience:** Solidity engineers hitting the size ceiling.
+- **Tags:** `eip170`, `proxy`, `delegatecall`, `facets`, `solidity`, `diamond-adjacent`.
+- **Series:** Contract Architecture (part 2).
+- **Quality:** ⭐⭐⭐⭐⭐ — The 24 KB limit is a wall every ambitious protocol
+  hits; a shipped, non-Diamond solution with shared storage is highly
+  clickable and rarely written up well.
+
+### 13. Deterministic / singleton deployment across chains
+- **Description:** Singleton deployment patterns (see
+  `docs/developer-guide/singleton-deployment-patterns.md`) and
+  `getContractAddressForChain` as the single resolver, giving stable addresses
+  across Mordor, Polygon, and Ethereum. How deterministic deployment keeps
+  frontend, subgraph, and gateway pointed at the right contract on every chain.
+- **Audience:** Protocol engineers, DevOps.
+- **Tags:** `create2`, `deterministic-deployment`, `multi-chain`, `devops`.
+- **Series:** Contract Architecture (part 3).
+- **Quality:** ⭐⭐⭐ — Useful and practical, somewhat more familiar territory.
+
+---
+
+## Series 6 — Prediction Markets
+
+The core product surface. These pair well with the published privacy post.
+
+### 14. The wager lifecycle contract
+- **Description:** `WagerRegistry` v2 as a state machine:
+  `WagerCreated` → `WagerAccepted` → `PayoutClaimed` / `WagerRefunded` /
+  `WagerCancelled` / `WagerDrawn`, with two absolute deadlines
+  (`acceptDeadline`, `resolveDeadline`), checks-effects-interactions
+  throughout, and USDC/WMATIC escrow. A clean anatomy of a peer-to-peer escrow
+  contract.
+- **Audience:** Smart-contract developers.
+- **Tags:** `escrow`, `state-machine`, `solidity`, `prediction-markets`, `p2p`.
+- **Series:** Prediction Markets (part 1).
+- **Quality:** ⭐⭐⭐⭐ — The lifecycle framing is approachable and broadly
+  instructive for anyone building escrow.
+
+### 15. Oracle adapter abstraction (Polymarket / Chainlink / UMA)
+- **Description:** A single `IOracleAdapter` interface with concrete adapters
+  for Polymarket, Chainlink Data Feeds, Chainlink Functions, and UMA's
+  Optimistic Oracle V3. How one resolution interface absorbs three very
+  different oracle models (push feeds, request/callback, optimistic dispute),
+  and the trade-offs each brings.
+- **Audience:** Oracle integrators, smart-contract engineers.
+- **Tags:** `oracles`, `chainlink`, `uma`, `polymarket`, `adapter-pattern`.
+- **Series:** Prediction Markets (part 2).
+- **Quality:** ⭐⭐⭐⭐⭐ — A side-by-side of three major oracle designs behind
+  one interface is genuinely valuable and rarely covered in one place.
+
+### 16. Draw resolution & open-challenge wagers
+- **Description:** Draw handling (spec 004) for wagers that resolve to neither
+  side, and open-challenge wagers (spec 024/041) — code-gated wagers with no
+  named opponent that anyone can take. Covers the edge cases that make a
+  betting protocol robust.
+- **Audience:** Smart-contract developers.
+- **Tags:** `prediction-markets`, `escrow`, `edge-cases`, `solidity`.
+- **Series:** Prediction Markets (part 3).
+- **Quality:** ⭐⭐⭐ — A good depth piece for the series; narrower on its own.
+
+### 17. Wager pools: ERC-1167 clones & address-keyed payouts
+- **Description:** Group wager pools (spec 034) as a deliberately parallel
+  system: a `WagerPoolFactory` (UUPS) that clones **immutable** `WagerPool`
+  instances via ERC-1167 minimal proxies, with no anonymity layer — membership,
+  voting, and claims are by public wallet address, resolved by a
+  creator-proposed payout matrix keyed by winner address that members approve
+  to a threshold. A study in choosing a different architecture for a sibling
+  feature.
+- **Audience:** Smart-contract developers.
+- **Tags:** `erc1167`, `minimal-proxy`, `clones`, `factory`, `governance`.
+- **Series:** Prediction Markets (part 4).
+- **Quality:** ⭐⭐⭐⭐ — The "when clones beat a registry" contrast and
+  address-keyed payout matrix make for a substantive piece.
+
+---
+
+## Series 7 — Privacy Architecture
+
+The published post anchors this series; the rest deepen the privacy story.
+
+### 18. Envelope encryption for private prediction markets *(published)*
+- **Description:** Confidential wager terms with trustless settlement via
+  envelope encryption — the existing flagship post. Already live at
+  [`private-prediction-markets-envelope-encryption.md`](private-prediction-markets-envelope-encryption.md).
+- **Audience:** Applied cryptographers, fintech engineers.
+- **Tags:** `encryption`, `envelope-encryption`, `privacy`, `prediction-markets`.
+- **Series:** Privacy Architecture (part 1, published).
+- **Quality:** ⭐⭐⭐⭐⭐ — Strong narrative-driven anchor; already the model
+  for tone and depth.
+
+### 19. Multi-recipient encryption
+- **Description:** Multi-recipient encryption (spec 005): encrypting a single
+  payload so that several parties can each decrypt it, without re-encrypting
+  per recipient at rest. The key-wrapping mechanics behind sharing an encrypted
+  wager with more than one viewer.
+- **Audience:** Applied cryptography engineers.
+- **Tags:** `encryption`, `key-wrapping`, `privacy`, `cryptography`.
+- **Series:** Privacy Architecture (part 2).
+- **Quality:** ⭐⭐⭐ — Good technical follow-up; depends on part 1 for context.
+
+### 20. Client-side encrypted data sync
+- **Description:** Encrypted data sync (spec 032): synchronizing user data
+  across devices while keeping plaintext on the client only. How the server
+  stores ciphertext it can't read and how keys travel with the user.
+- **Audience:** Privacy-focused app engineers.
+- **Tags:** `e2ee`, `data-sync`, `privacy`, `client-side-encryption`.
+- **Series:** Privacy Architecture (part 3).
+- **Quality:** ⭐⭐⭐ — Practical E2EE sync content; moderate reach.
+
+### 21. The nullifier system
+- **Description:** The nullifier system (`docs/NULLIFIER_SYSTEM.md`,
+  `docs/developer-guide/nullifier-system.md`): preventing double-spend/replay
+  of privacy-preserving actions using nullifiers, a core primitive from the ZK
+  world applied here. How nullifiers are derived, stored, and checked.
+- **Audience:** ZK and privacy engineers.
+- **Tags:** `nullifiers`, `zk`, `privacy`, `replay-protection`.
+- **Series:** Privacy Architecture (part 4).
+- **Quality:** ⭐⭐⭐⭐ — Nullifiers are catnip for the ZK-curious and
+  underexplained outside pure-ZK contexts.
+
+---
+
+## Series 8 — Finance Surfaces
+
+The "money moves" features — Earn, Predict, fees, and Bitcoin. Appeals to
+DeFi builders and product teams.
+
+### 22. The FeeRouter: one source of truth for platform fees
+- **Description:** `FeeRouter` (spec 060, UUPS) as the *single* fee-config
+  store: every configurable fee is a `bytes32 serviceId` with a per-service
+  hard cap, never a hardcoded bps value in client or gateway code. Atomic
+  wrapped charging (`depositToVaultWithFee`), honest pre-signature disclosure
+  with a `maxFeeBps` ceiling members can't be charged above, and
+  byte-identical zero-fee behavior. A model for centralizing fee logic without
+  centralizing trust.
+- **Audience:** Protocol and product engineers.
+- **Tags:** `fees`, `fee-router`, `solidity`, `uups`, `product`.
+- **Series:** Finance Surfaces (part 1).
+- **Quality:** ⭐⭐⭐⭐ — "One source of truth for fees, capped and disclosed"
+  is a clean, opinionated design story many teams get wrong.
+
+### 23. Earn: wrapping ERC-4626 lending vaults with fee disclosure
+- **Description:** Earn/lending rewards (spec 050) that route deposits into
+  ERC-4626 vaults, charging a fee atomically through the FeeRouter and
+  disclosing the live rate before signature. How to wrap an external yield
+  source without custody surprises.
+- **Audience:** DeFi integrators.
+- **Tags:** `erc4626`, `defi`, `lending`, `yield`, `fees`.
+- **Series:** Finance Surfaces (part 2).
+- **Quality:** ⭐⭐⭐ — Useful integration pattern; ERC-4626 is familiar ground.
+
+### 24. Predict: Polymarket trading via builder codes
+- **Description:** Predict (spec 057): Polymarket CLOB trading with **no
+  contract changes and no custody** — the member's wallet is the only order
+  signer — monetized through Polymarket's builder-code program (a `bytes32`
+  code attached to every order for a builder fee). Why the additive builder fee
+  must be disclosed as its own honest line, and why it's Polygon-only.
+- **Audience:** DeFi/trading integrators.
+- **Tags:** `polymarket`, `clob`, `trading`, `builder-codes`, `non-custodial`.
+- **Series:** Finance Surfaces (part 3).
+- **Quality:** ⭐⭐⭐⭐ — Non-custodial CLOB integration + builder-code
+  monetization is a timely, concrete revenue-model writeup.
+
+### 25. Bitcoin: adding a non-EVM chain to an EVM-native app
+- **Description:** Bitcoin support (spec 061), the first **non-EVM** network:
+  string network ids kept strictly parallel to the numeric EVM chain map,
+  client-side BIP84/BIP86 key derivation from the passkey master seed, rotating
+  receive addresses with gap-limit-20 discovery, fail-safe stamp handling, and
+  a hard fee-signing ceiling. How to bolt a fundamentally different chain onto
+  an EVM codebase without corrupting its abstractions.
+- **Audience:** Multi-chain and wallet engineers.
+- **Tags:** `bitcoin`, `non-evm`, `bip84`, `bip86`, `hd-wallets`, `multi-chain`.
+- **Series:** Finance Surfaces (part 4).
+- **Quality:** ⭐⭐⭐⭐⭐ — "We added Bitcoin to our Ethereum app and here's every
+  boundary we had to guard" is a rare, highly shareable engineering story.
+
+---
+
+## Series 9 — Multi-chain Infrastructure
+
+Cross-cutting infra: DAO registries, indexing, and the activity ledger.
+
+### 26. ClearPath: a multi-network external DAO registry
+- **Description:** ClearPath (specs 030/042) and `ExternalDAORegistry`: a
+  standard for referencing and integrating external DAOs across multiple
+  networks. The data model and resolution flow for treating other DAOs as
+  first-class, multi-network citizens.
+- **Audience:** DAO tooling and infrastructure engineers.
+- **Tags:** `dao`, `registry`, `multi-chain`, `interoperability`.
+- **Series:** Multi-chain Infra (part 1).
+- **Quality:** ⭐⭐⭐ — Interesting for the DAO-tooling niche; narrower reach.
+
+### 27. Indexing without a subgraph (graceful degradation)
+- **Description:** Networks-without-subgraph support
+  (`docs/developer-guide/networks-without-subgraph.md`): how the app keeps
+  working when The Graph isn't available on a chain, falling back to direct RPC
+  reads and event scanning. Designing features that degrade honestly instead of
+  breaking on unsupported networks.
+- **Audience:** Data and infrastructure engineers.
+- **Tags:** `the-graph`, `subgraph`, `indexing`, `rpc`, `graceful-degradation`.
+- **Series:** Multi-chain Infra (part 2).
+- **Quality:** ⭐⭐⭐⭐ — "What to do when there's no subgraph" is a real
+  operational problem with little published guidance.
+
+### 28. The unified activity ledger
+- **Description:** The unified activity ledger (spec 051): a single normalized
+  feed that merges wagers, pools, transfers, and other events into one
+  chronological view across subgraph and RPC sources. How to reconcile
+  heterogeneous on-chain activity into one coherent timeline.
+- **Audience:** Full-stack and data engineers.
+- **Tags:** `activity-feed`, `indexing`, `data-modeling`, `full-stack`.
+- **Series:** Multi-chain Infra (part 3).
+- **Quality:** ⭐⭐⭐ — Solid full-stack content; a familiar problem shape.
+
+---
+
+## Series 10 — Security & DevOps
+
+How the protocol is verified and shipped. Strong for security researchers and
+engineering leaders — and the AI-security angle is a standout.
+
+### 29. AI-driven smart-contract security review in CI
+- **Description:** The Ethereum security agent (`.github/agents/`,
+  `docs/developer-guide/ethereum-security-agent*.md`): an AI security reviewer
+  wired into CI that reviews contract changes against a curated checklist.
+  How an LLM-based reviewer complements — not replaces — Slither, symbolic
+  execution, and human review, and how it's configured to be useful rather than
+  noisy.
+- **Audience:** Security engineers, AI-in-DevOps-curious teams.
+- **Tags:** `ai-security`, `ci`, `smart-contract-security`, `llm`, `devops`.
+- **Series:** Security & DevOps (part 1).
+- **Quality:** ⭐⭐⭐⭐⭐ — AI + smart-contract security is a magnet topic right
+  now, and a shipped CI agent (not a demo) is strongly differentiated.
+
+### 30. Coverage & audit gates that fail loudly
+- **Description:** Audit-coverage gating (spec 046) and the "CI fails loudly —
+  no `continue-on-error`" doctrine: coverage thresholds, storage-layout checks,
+  Slither/Medusa, and how the gates are wired so a regression can't merge.
+- **Audience:** Engineering leads, security-minded teams.
+- **Tags:** `ci`, `test-coverage`, `audit`, `quality-gates`, `slither`.
+- **Series:** Security & DevOps (part 2).
+- **Quality:** ⭐⭐⭐ — Good engineering-culture piece; less flashy than part 1.
+
+### 31. Symbolic execution & fuzzing a wager protocol
+- **Description:** The static-analysis, symbolic-execution, and fuzz-testing
+  stack (`docs/security/`): Slither for static analysis, Manticore for symbolic
+  execution (see `docs/MANTICORE_FIX.md`), and Medusa/fuzzing for property
+  testing — applied to escrow and payout logic. What each tool actually caught.
+- **Audience:** Security researchers, advanced Solidity engineers.
+- **Tags:** `symbolic-execution`, `fuzzing`, `manticore`, `slither`, `formal-methods`.
+- **Series:** Security & DevOps (part 3).
+- **Quality:** ⭐⭐⭐⭐ — A concrete tour of heavyweight verification tools with
+  real findings is high-value for the security crowd.
+
+### 32. Spec-driven development with Spec Kit
+- **Description:** How the repo uses GitHub's Spec Kit
+  (`/speckit-*` workflow: constitution → specify → clarify → plan → tasks →
+  analyze → implement) to ship 60+ features repeatably, with a binding
+  constitution every plan must pass. A process story about building complex
+  crypto systems with (and alongside) coding agents.
+- **Audience:** Engineering leaders, agent/tooling developers.
+- **Tags:** `spec-driven-development`, `spec-kit`, `process`, `ai-agents`.
+- **Series:** Security & DevOps (part 4).
+- **Quality:** ⭐⭐⭐ — Process content with real breadth to point at; appeals
+  to the growing "build with agents" audience.
+
+---
+
+## Standalone topics
+
+Discrete systems that don't need a series to stand on.
+
+### 33. CallsignRegistry: an in-house ENS-style naming system
+- **Description:** `CallsignRegistry` (spec 054, UUPS): an **optional**,
+  Gold-tier-gated `%callsign` naming registry with ENS-style commit→reveal
+  registration, standalone (not routed through the wager path), holding no
+  funds, resolving identity for display with the priority **address book >
+  callsign > ENS > generated**. A study in building your own naming layer and
+  keeping it strictly optional on the value path.
+- **Audience:** Naming/identity engineers, product teams.
+- **Tags:** `naming`, `ens`, `commit-reveal`, `identity`, `uups`.
+- **Series:** Standalone.
+- **Quality:** ⭐⭐⭐ — "Why and how we built our own ENS-lite" is a fun,
+  self-contained build story.
+
+### 34. TokenFactory: templated token minting
+- **Description:** `TokenFactory` (spec 028) with token templates: minting new
+  tokens from vetted templates rather than arbitrary bytecode. The template
+  model and what it constrains.
+- **Audience:** Token/product engineers.
+- **Tags:** `token-factory`, `erc20`, `templates`, `minting`.
+- **Series:** Standalone.
+- **Quality:** ⭐⭐ — Useful but the most familiar/commoditized topic in the set.
+
+---
+
+## Suggested publishing order
+
+1. **Passkey smart accounts** (#4) — highest search demand, strong hook.
+2. **The two-facet proxy** (#12) — pure engineer bait, very shareable.
+3. **Oracle adapter abstraction** (#15) — three oracles, one interface.
+4. **Sponsored gas / verifying paymaster** (#6) — completes the AA story.
+5. **AI-driven security review in CI** (#29) — rides the AI-security wave.
+6. **Bitcoin on an EVM app** (#25) — distinctive multi-chain narrative.
+
+From there, fill in each series around these anchors. The published envelope
+encryption post already demonstrates the house style: a concrete human
+scenario, then the architecture revealed stage by stage.

--- a/docs/blog/blog-topics-inventory.md
+++ b/docs/blog/blog-topics-inventory.md
@@ -362,15 +362,23 @@ The published post anchors this series; the rest deepen the privacy story.
 - **Quality:** ⭐⭐⭐ — Practical E2EE sync content; moderate reach.
 
 ### 21. The nullifier system
-- **Description:** The nullifier system (`docs/NULLIFIER_SYSTEM.md`,
-  `docs/developer-guide/nullifier-system.md`): preventing double-spend/replay
-  of privacy-preserving actions using nullifiers, a core primitive from the ZK
-  world applied here. How nullifiers are derived, stored, and checked.
+- **Description:** A design-history explainer, corrected during drafting to
+  match the repo. FairWins' "nullifier system" (`docs/NULLIFIER_SYSTEM.md`,
+  `docs/developer-guide/nullifier-system.md`) is **not** a ZK anti-replay
+  nullifier — it is an **archived moderation/blocklist primitive** built on an
+  RSA accumulator with deterministic hash-to-prime
+  (`contracts-archive/security/NullifierRegistry.sol`), with no live
+  deployment. The post explains what a ZK nullifier is (Semaphore/Tornado
+  background), what FairWins actually built and why it shares the
+  set-membership shape, and why it was shelved in favor of the live
+  `SanctionsGuard` + `MembershipManager` compliance path.
 - **Audience:** ZK and privacy engineers.
-- **Tags:** `nullifiers`, `zk`, `privacy`, `replay-protection`.
+- **Tags:** `nullifiers`, `rsa-accumulator`, `privacy`, `design-history`,
+  `moderation`.
 - **Series:** Privacy Architecture (part 4).
-- **Quality:** ⭐⭐⭐⭐ — Nullifiers are catnip for the ZK-curious and
-  underexplained outside pure-ZK contexts.
+- **Quality:** ⭐⭐⭐⭐ — Nullifiers are catnip for the ZK-curious; the honest
+  "what we built, why we shelved it" arc is more interesting than the blurb's
+  original framing.
 
 ---
 

--- a/docs/blog/posts/01-rbac-operations-control-plane/blog.md
+++ b/docs/blog/posts/01-rbac-operations-control-plane/blog.md
@@ -1,0 +1,158 @@
+# One Action, One Role: RBAC and the Operations Control Plane
+
+*How FairWins maps every privileged action to exactly one on-chain role — and makes the admin console prove it*
+
+| | |
+|---|---|
+| **Series** | Identity & Access (part 1) |
+| **Part** | 1 of 34 |
+| **Audience** | Protocol/backend engineers, technical founders |
+| **Tags** | `access-control`, `rbac`, `solidity`, `openzeppelin`, `admin-ux` |
+| **Reading time** | ~8 minutes |
+
+## The compliance officer who couldn't reach her own tool
+
+Picture a compliance officer at a wagering platform. Her job is narrow and serious: when an address needs to be blocked from the protocol, she adds it to an on-chain deny-list, with a reason recorded on-chain. The smart contract is ready for her — `SanctionsGuard.setDenied` is gated on a dedicated `SANCTIONS_ADMIN_ROLE`, and her multisig holds that role. Nothing else. She cannot pause the protocol, cannot touch the treasury, cannot freeze a wager account.
+
+Then she opens the admin panel and the deny-list tab isn't there.
+
+This was a real gap in FairWins' control-surface audit (G5 in `docs/system-overview/control-surface-audit.md`): the contract defined `SANCTIONS_ADMIN_ROLE`, but the frontend's role model didn't know it existed, so the deny-list view was gated on `DEFAULT_ADMIN_ROLE` instead. The on-chain access control was correct — and operationally useless. To do her job, the compliance officer would have needed full protocol admin, which is exactly the privilege escalation the role was designed to prevent. The alternative was worse: quietly granting her `DEFAULT_ADMIN_ROLE` "just so the tab shows up."
+
+The lesson generalizes. Role-based access control isn't only a Solidity problem. A role that exists on-chain but not in the operator's UI creates pressure to over-grant, and over-granting is how least privilege dies in practice. This post walks through both halves of FairWins' answer: the on-chain role discipline ("one action, one role") and the `/admin` operations control plane that mirrors it, view by view.
+
+## The role inventory: one paid role, six operator roles
+
+FairWins is a peer-to-peer wager platform — smart contracts escrow stakes and resolve wagers from external oracles. Its access model, documented in `docs/system-overview/roles-and-tiers.md`, is deliberately small: **one user-purchasable role and six core operator roles**, all enforced with [OpenZeppelin AccessControl](https://docs.openzeppelin.com/contracts/5.x/access-control).
+
+The paid role is `WAGER_PARTICIPANT_ROLE`, defined in `contracts/wagers/WagerRegistryCore.sol`. It's required to create or accept wagers and is sold in USDC by `MembershipManager` as a soulbound, time-bound tier (Bronze through Platinum). That's a topic for part 2 of this series. This post is about the other six — the operator roles:
+
+| Role | Defined in | Authority |
+|---|---|---|
+| `DEFAULT_ADMIN_ROLE` | OZ AccessControl (`0x00`) | Protocol wiring, tier config, treasury withdrawal, role administration |
+| `GUARDIAN_ROLE` | `contracts/wagers/WagerRegistryCore.sol` | `pause()` / `unpause()` the registry |
+| `ACCOUNT_MODERATOR_ROLE` | `contracts/wagers/WagerRegistryCore.sol` | `freezeAccount` / `unfreezeAccount` |
+| `ROLE_MANAGER_ROLE` | `contracts/access/MembershipManager.sol` | Grant/revoke memberships out-of-band |
+| `SANCTIONS_ADMIN_ROLE` | `contracts/access/SanctionsGuard.sol` | Discretionary deny-list (`setDenied`) |
+| `UPGRADER_ROLE` | `contracts/upgradeable/UUPSManaged.sol` | Replace UUPS proxy implementations |
+
+Every role is a plain `bytes32` keccak hash — no registry contract, no role NFTs, no bespoke permission language:
+
+```solidity
+// contracts/wagers/WagerRegistryCore.sol
+bytes32 public constant WAGER_PARTICIPANT_ROLE = keccak256("WAGER_PARTICIPANT_ROLE");
+bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
+bytes32 public constant ACCOUNT_MODERATOR_ROLE = keccak256("ACCOUNT_MODERATOR_ROLE");
+```
+
+Beyond the core six, individual registries define narrow roles for their own surface: `TOKEN_ISSUER_ROLE` on `contracts/tokens/TokenFactory.sol`, `FEE_ADMIN_ROLE` on `contracts/fees/FeeRouter.sol`, and `REGISTRY_CURATOR_ROLE` / `MODERATOR_ROLE` / `VERIFIER_ROLE` on `contracts/naming/CallsignRegistry.sol`. Same pattern, scoped to one contract each.
+
+## One action, one role
+
+The discipline that holds the model together: **every privileged function is gated by exactly one role**. Not "admin or guardian," not a points system — one `onlyRole` modifier per entrypoint. The emergency controls in `contracts/wagers/WagerRegistry.sol` are the cleanest illustration:
+
+```solidity
+function pause() external onlyRole(GUARDIAN_ROLE) { _pause(); }
+function unpause() external onlyRole(GUARDIAN_ROLE) { _unpause(); }
+
+function freezeAccount(address user, string calldata reason)
+    external
+    onlyRole(ACCOUNT_MODERATOR_ROLE)
+```
+
+Configuration setters (`setOracleAdapter`, `setSanctionsGuard`, `setTokenAllowed`, `setMembershipManager`) all take `onlyRole(DEFAULT_ADMIN_ROLE)`. The one interesting exception proves the rule: `setIntentExtension` — which swaps the registry's second facet, and is therefore upgrade-equivalent — is gated on `UPGRADER_ROLE`, not admin, because it changes what code runs behind the proxy.
+
+Upgrades themselves live in a shared base every upgradeable contract inherits:
+
+```solidity
+// contracts/upgradeable/UUPSManaged.sol
+bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+function __UUPSManaged_init(address admin) internal onlyInitializing {
+    __UUPSUpgradeable_init();
+    __AccessControl_init();
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    _grantRole(UPGRADER_ROLE, admin);
+}
+
+function _authorizeUpgrade(address newImplementation)
+    internal override onlyRole(UPGRADER_ROLE) {}
+```
+
+`UPGRADER_ROLE` is separated from `DEFAULT_ADMIN_ROLE` on purpose: it can later be reassigned to a timelock or multisig with no code change, and because `_authorizeUpgrade` is defined once in the base and never removed by an upgrade, the ability to perform *future* upgrades is always preserved.
+
+### The negative space matters as much
+
+`docs/system-overview/roles-and-tiers.md` maintains a table of what each role **cannot** do, and it's worth internalizing why that table exists. A guardian can stop the whole protocol but cannot seize an account. An account moderator can freeze an account but cannot pause the protocol or move treasury funds. A role manager can hand out memberships but cannot revoke admin roles. The compliance officer can block an address but holds no other privilege. The upgrader can ship new logic but cannot grant itself anything. Even `DEFAULT_ADMIN_ROLE` has hard limits: it cannot create wagers on behalf of users, cannot resolve wagers, and cannot move escrowed stakes — there is simply no function for it. When you design a role, write the "cannot" list first; it tells you whether the role is actually narrow or just labeled that way.
+
+## The control plane: role checks flow from contract to UI
+
+The operator side lives at `/admin` (`frontend/src/components/AdminPanel.jsx`), consolidated after the control-surface audit into a grouped **operations control plane**: Control Room, Incident Response, Compliance, Membership & Revenue, Protocol Config, Identity, Access Control, Infrastructure.
+
+The core UI rule mirrors the contract rule: **each view is gated by the on-chain role its actions require, and a group renders only if the operator holds at least one usable view inside it.** The frontend computes role hashes exactly the way the contracts do —
+
+```js
+// frontend/src/components/AdminPanel.jsx
+const ROLE_HASHES = {
+  GUARDIAN: ethers.keccak256(ethers.toUtf8Bytes('GUARDIAN_ROLE')),
+  SANCTIONS_ADMIN: ethers.keccak256(ethers.toUtf8Bytes('SANCTIONS_ADMIN_ROLE')),
+  DEFAULT_ADMIN: ethers.ZeroHash,
+  // ...
+}
+```
+
+— and checks them via `hasRole(bytes32, address)` against the live contracts. The grouping/gating model itself is a pure function in `frontend/src/components/admin/adminNav.js`, so it's unit-testable without rendering anything:
+
+```js
+{
+  label: 'Incident Response',
+  items: [
+    isGuardian && item('emergency', 'Emergency'),
+    isAccountModerator && item('moderation', 'Account Moderation'),
+  ].filter(Boolean),
+},
+{
+  label: 'Compliance',
+  items: [
+    (isSanctionsAdmin || isAdmin) && item('deny-list', 'Deny-list'),
+  ].filter(Boolean),
+},
+```
+
+A guardian signing in sees Control Room, Incident Response, and Infrastructure — nothing else. The compliance officer from the opening now sees Control Room and Compliance. The panel isn't enforcing security (the contracts do that); it's making the on-chain permission set legible, so nobody needs to over-grant a role just to make a screen appear.
+
+One subtlety the panel gets right: roles live on different contracts, so grants must be routed to the contract that *defines* the role, not blanket-sent to one registry:
+
+```js
+// frontend/src/components/AdminPanel.jsx
+const roleHomeContract = (role) => {
+  if (role === 'ROLE_MANAGER') return membershipManagerAddr
+  if (role === 'SANCTIONS_ADMIN') return sanctionsGuardAddr
+  if (role === 'TOKEN_ISSUER') return tokenFactoryAddr
+  return wagerRegistryAddr
+}
+```
+
+The Control Room's Overview tile answers the operator's first question on any bad day: is the protocol live, is the gateway live, is anything paused or killswitched, and *who am I signed in as, with which powers*.
+
+## Design decisions
+
+**Why plain OpenZeppelin AccessControl and nothing fancier?** `bytes32` role hashes checked with `onlyRole` are boring, audited, and universally understood by tooling and reviewers. The one-role-per-action discipline gives you most of what elaborate permission systems promise, without a new trust surface. The cost is granularity: `withdrawFees` today requires full `DEFAULT_ADMIN_ROLE`, and splitting out a dedicated `TREASURER_ROLE` would need a contract upgrade — a documented future candidate, not a config change.
+
+**Why does the UI gate on roles at all if contracts enforce them?** Because the failure mode of a role-blind UI isn't a security hole — it's privilege creep. The G5 gap showed that when the frontend doesn't model a role, operators get granted a bigger one. Modeling every role in the panel is what keeps the on-chain least-privilege design honest in day-to-day operations.
+
+**What's deliberately *not* in the control plane.** Two categories are excluded by policy, not oversight. Anything requiring the air-gapped floppy keystore — UUPS upgrades, `UPGRADER_ROLE` actions — stays on scripted, offline paths (`docs/runbooks/contract-upgrades.md`). And the relay gateway's killswitch and quotas are env/signal-driven with **no remote admin API on purpose**: an authenticated web killswitch would be a new attack surface, and the gateway's worst case is designed to be "refuses to relay," never "steals funds." The panel shows their state read-only and links the runbook.
+
+**Not everything needs a role.** Maintenance sweeps (`batchExpireOpen`, `autoResolveFromPolymarket`, `autoResolveFromOracle`) are permissionless on-chain — anyone can run them, so the Maintenance view is open to any operator. And some contracts (`WagerPool` clones, `MembershipVoucher`, `KeyRegistry`) have **no admin surface by design**: no role can drain or redirect funds because no function exists to do it. The strongest access control is the entrypoint you never wrote.
+
+## Sources
+
+- `docs/system-overview/roles-and-tiers.md` — role inventory, tier table, "cannot do" matrix
+- `docs/system-overview/control-surface-audit.md` — full control-surface inventory, gap analysis (G1–G10), control-plane grouping
+- `contracts/wagers/WagerRegistryCore.sol`, `contracts/wagers/WagerRegistry.sol` — role constants, `pause`/`freezeAccount` gating
+- `contracts/access/MembershipManager.sol` — `ROLE_MANAGER_ROLE`, admin setters, `initialize`
+- `contracts/access/SanctionsGuard.sol` — `SANCTIONS_ADMIN_ROLE`, `setDenied`
+- `contracts/upgradeable/UUPSManaged.sol` — `UPGRADER_ROLE`, `_authorizeUpgrade`
+- `contracts/fees/FeeRouter.sol`, `contracts/tokens/TokenFactory.sol`, `contracts/naming/CallsignRegistry.sol` — registry-scoped roles
+- `frontend/src/components/AdminPanel.jsx`, `frontend/src/components/admin/adminNav.js` — role hashes, view gating, role→contract grant routing
+- OpenZeppelin AccessControl documentation — https://docs.openzeppelin.com/contracts/5.x/access-control
+- OpenZeppelin UUPS / proxy documentation — https://docs.openzeppelin.com/contracts/5.x/api/proxy

--- a/docs/blog/posts/01-rbac-operations-control-plane/social.md
+++ b/docs/blog/posts/01-rbac-operations-control-plane/social.md
@@ -1,0 +1,30 @@
+# Social & Image — One Action, One Role: RBAC and the Operations Control Plane
+
+## X (Twitter)
+
+Your on-chain RBAC is only as good as your admin UI. We found a role (`SANCTIONS_ADMIN_ROLE`) that existed in Solidity but not in the frontend — so the operator's tab was gated on full admin. How FairWins fixed it: one action, one role, contract to console. 🔗 <link> #solidity #web3 #rbac
+
+## LinkedIn
+
+Least privilege dies quietly: not when a contract is exploited, but when an operator gets granted a bigger role "just so the tab shows up."
+
+During FairWins' control-surface audit we found exactly that. Our compliance deny-list was gated on-chain by a dedicated `SANCTIONS_ADMIN_ROLE` — correct, narrow, auditable. But the frontend's role model didn't know the role existed, so the deny-list view required full `DEFAULT_ADMIN_ROLE`. The compliance officer couldn't reach her own tool without protocol-wide admin.
+
+The new post covers how we rebuilt both halves:
+
+- The role inventory: one user-purchasable role and six operator roles, all plain OpenZeppelin AccessControl `bytes32` hashes — no bespoke permission system
+- The "one action, one role" discipline, including the negative-space table of what each role explicitly cannot do
+- The `/admin` operations control plane: each view gated by the exact on-chain role its actions require, with a unit-testable pure-function nav model and per-contract grant routing
+- What deliberately stays off the panel: air-gapped upgrade keys, and a relay gateway with no remote admin API by design
+
+If you run privileged operations against smart contracts, the reusable idea is simple: model every on-chain role in your operator UI, or watch over-granting erode your least-privilege design.
+
+Read it here: <link>
+
+How does your team keep operator UIs in sync with on-chain roles?
+
+#smartcontracts #solidity #accesscontrol #web3 #platformengineering
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an isometric style: a central translucent control room floating above a stylized blockchain grid, composed of eight distinct glowing panels arranged around a command console, each panel connected by a single luminous line to its own uniquely shaped key hovering below — visualizing "one action, one role." Each key fits exactly one lock on one panel; one warm amber key-and-panel pair stands out among cool-toned counterparts to suggest a compliance officer reaching her dedicated tool. Deep navy and teal base palette with a single warm amber accent, soft volumetric lighting from the upper left, subtle circuit-line texture in the background, generous negative space, precise geometric shapes with slight depth and soft shadows, fintech-engineering brand mood, no text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/02-soulbound-memberships-vouchers/blog.md
+++ b/docs/blog/posts/02-soulbound-memberships-vouchers/blog.md
@@ -1,0 +1,116 @@
+# Soulbound Memberships, Transferable Vouchers: Splitting a Token in Two
+
+*Why FairWins made membership non-transferable, then built a gift-and-resale market on top of it anyway*
+
+| | |
+|---|---|
+| **Series** | Identity & Access, part 2 |
+| **Audience** | Token designers, product engineers, growth |
+| **Tags** | `soulbound`, `erc721`, `tokenomics`, `memberships`, `access-control` |
+| **Reading time** | ~8 minutes |
+
+> **Responsible use.** FairWins wagers are based on publicly available information and legitimate forecasting. Memberships gate access to that activity; they are not a mechanism for circumventing any law. All participants remain fully subject to applicable laws and compliance requirements, and every membership grant — however acquired — passes sanctions screening.
+
+## The gift you can't give
+
+A FairWins membership is deliberately boring. You pay USDC — $2 for Bronze, $8 Silver, $25 Gold, $100 Platinum — and for 30 days your wallet can create and accept wagers, up to a per-tier throughput limit. The membership is **soulbound**: it lives at your address, it cannot be transferred, and there is no market for it. That's a feature. Access records that can move are access records that can be stolen, rented to sanctioned parties, or flash-loaned through a compliance check.
+
+Then a product request landed: *let me buy a membership for a friend.* And its sibling: *let me resell the one I bought and don't want.* Both are completely reasonable — gift cards and secondary markets are table stakes for any paid product — and both are, on their face, impossible. A soulbound record keyed to an address has nothing to hand over. Making it transferable would torch the properties the platform depends on: sanctions screening happens when membership is granted, usage limits are tracked per address, and `WagerRegistry` trusts that the address holding a membership is the address that was screened.
+
+The wrong fix is a "transfer with re-screening" function on the membership itself — a mutable access record with a moving owner, special-cased through every downstream read. The fix FairWins shipped in spec 026 is cleaner: don't make the membership transferable. Make the *right to claim one* transferable, and keep the two ideas in separate contracts with separate lifecycles.
+
+## Two rails, one membership
+
+The first thing to notice is what "soulbound" means here. A FairWins membership is not an NFT with transfers disabled — it is not a token at all. It's a plain storage record inside `MembershipManager` (a UUPS proxy, spec 027), keyed by `(address, role)`:
+
+```solidity
+// contracts/interfaces/IMembershipManager.sol
+struct Membership {
+    Tier    tier;        // None, Bronze, Silver, Gold, Platinum
+    uint64  expiresAt;
+    uint32  monthCount;  // rolling 30-day wager-creation counter
+    uint32  activeCount; // concurrent open wagers
+    uint64  monthAnchor;
+}
+```
+
+There is no `transfer` to disable because there is nothing to transfer — non-transferability falls out of the data model rather than being enforced against it. (This is worth contrasting with the soulbound-token discourse around [EIP-5192](https://eips.ethereum.org/EIPS/eip-5192), which standardizes *locked* ERC-721s. EIP-5192 solves the problem of making a token non-transferable while keeping it wallet-visible. FairWins didn't need the token part at all: memberships are read by contracts, not displayed in wallets, so a mapping is simpler, cheaper, and has no transfer surface to audit.)
+
+Direct purchase (`purchaseTier` / `purchaseTierWithTerms`) writes that record: sanctions screen the buyer, pull the tier's USDC price, set `tier` and `expiresAt`, reset the counters. Thirty days later it lapses.
+
+Spec 026 adds a **second acquisition rail** that converges on the exact same record. `contracts/access/MembershipVoucher.sol` is a real, freely transferable ERC-721 — "FairWins Membership Voucher", symbol `FWMV` — minted for the tier's configured USDC price. The critical property is what a voucher *doesn't* do:
+
+- It confers **no membership** while held. `hasActiveRole` on the holder stays false; no clock starts, no limits accrue.
+- It never expires. A voucher is a bearer claim you can hold for a year and still redeem into a full 30-day membership.
+- It snapshots its `(role, tier, durationDays)` at mint. If the admin later reprices or deactivates the tier, the voucher still grants exactly what it was minted for.
+
+Because the voucher is inert, it is safe to trade. Gifting is a `transferFrom`. Reselling is any standard NFT marketplace — the contract advertises a best-effort [EIP-2981](https://eips.ethereum.org/EIPS/eip-2981) royalty to the treasury (2.5% default, hard-capped at 5% by `MAX_ROYALTY_BPS`; `setRoyaltyBps` reverts above it). Nothing about a transfer touches compliance, because nothing about a transfer grants access.
+
+## Redemption: where the rails converge
+
+The voucher becomes a membership through `redeemVoucher(uint256 voucherId, bytes32 acceptedTermsHash)` on `MembershipManager`. This is the single control point where everything a direct purchaser faces is imposed on the redeemer:
+
+```solidity
+// contracts/access/MembershipManager.sol — _redeemVoucher (abridged)
+if (IMembershipVoucher(v).ownerOf(voucherId) != actor) revert NotVoucherOwner();
+IMembershipVoucher.VoucherInfo memory info = IMembershipVoucher(v).voucherInfo(voucherId);
+
+Membership storage m = _memberships[actor][info.role];
+if (m.tier != Tier.None && m.expiresAt > block.timestamp) revert AlreadyActive();
+
+_screen(actor); // sanctions screen — fail-closed, before effects
+
+m.tier = info.tier;                    // grant the snapshotted (role, tier)
+m.expiresAt = uint64(block.timestamp) + uint64(info.durationDays) * 1 days;
+m.monthCount = 0;
+m.monthAnchor = uint64(block.timestamp);
+_recordTerms(actor, info.role, acceptedTermsHash);
+
+IMembershipVoucher(v).burn(voucherId); // interaction LAST — reverts roll everything back
+```
+
+The ordering is strict checks-effects-interactions, and it carries the product's failure semantics: if the redeemer is sanctioned, or already has an active membership for the role, the whole call reverts and the voucher is **untouched** — still owned, still tradable. A legitimate buyer is never punished because a previous holder couldn't redeem. The burn is the only external call, performed last, against a contract the manager itself was wired to via `setVoucher`.
+
+Note who gets screened: **only the redeemer, only at redemption.** Minters and secondary buyers are deliberately unscreened. That's an explicitly accepted tradeoff, recorded in the spec: a sanctioned party could profit from reselling a voucher without ever redeeming it. What they can never do is convert one into platform access, because the screen sits exactly where standing is granted — the same non-bypassable choke point the direct rail uses. Compliance lives at the point of *use*, not the point of *trade*.
+
+After redemption, the two rails are indistinguishable. `WagerRegistry` reads the same `Membership` struct either way and has no idea how it was acquired — spec 026's FR-008 makes that a hard requirement, verified by running the full membership and wager suites against both rails.
+
+## The economics are deliberately flat
+
+A voucher costs exactly the tier's configured price — the same `TierConfig.priceUSDC` the direct rail charges — so neither rail is cheaper and there's no mint-vs-purchase arbitrage. Proceeds go to the treasury **at mint** (the voucher does `token.safeTransferFrom(msg.sender, treasury_, cfg.priceUSDC)` before `_safeMint`), which works because granting a membership at redemption costs the platform nothing on-chain; no escrow or solvency reserve is needed for outstanding vouchers. There is no primary refund: minter's remorse is resolved by reselling or redeeming. And the on-chain `tokenURI` — self-contained JSON plus SVG, no IPFS dependency — literally says "Utility access token, not an investment" in the token description.
+
+Batch buying and direct gifting arrive via a third contract, `contracts/access/VoucherBatchMinter.sol`, because the voucher is immutable and only ever mints one token to `msg.sender`. The helper's `mintBatch(role, tier, quantity, recipient)` pulls exactly `quantity × price` in one approval, loops the mints (capped at `MAX_QUANTITY = 50`), and forwards every token to the recipient in the same transaction. It is stateless and custody-free — no funds or NFTs at rest, allowance reset to zero after the loop via `forceApprove`, no admin, no withdrawal path, no upgradeability. If it isn't deployed on a network, single self-mint still works and the UI degrades honestly.
+
+## Privacy: pseudonymity, stated plainly
+
+The voucher rail has a quiet second use. Because redemption only checks that the redeemer *owns* the voucher — never that they minted it — a holder can transfer a voucher to a fresh wallet and redeem there. The resulting membership record stores no back-reference to the mint or trade history, so wagering activity isn't on-chain-linked to the wallet that bought the voucher. The relayed twin `redeemVoucherWithSig` (spec 035's EIP-712 intent rail) goes further: since redemption moves no money, a relayer can submit it, so even the gas payer needn't be the trading wallet.
+
+The spec is emphatic about not overselling this. Mints, transfers, and burns are public ERC-721 events; anyone can watch a voucher move. What fresh-wallet redemption provides is **pseudonymity, not cryptographic unlinkability**, and FR-020 requires the UI to say exactly that. Zero-knowledge redemption was considered and explicitly scoped out.
+
+## Design decisions
+
+**Mutable logic upgradeable, bearer asset immutable.** `MembershipManager` is a UUPS proxy — spec 026's redemption capability shipped as the first in-place, append-only upgrade of the spec 027 proxy (the `voucher` address slot consumed one `__gap` slot; `check:storage-layout` gates it in CI). The voucher is the opposite: intentionally *not* upgradeable, because a tradable bearer asset's rules must not change after purchase, and an immutable contract minimizes the attack surface on a USDC-taking token. Screening, Terms, and grant logic — the parts that must evolve — live behind the proxy; the thing people pay for is frozen.
+
+**The membership is a mapping, not a locked NFT.** No transfer function to disable, no operator approvals to reason about, no EIP-5192 lock semantics to implement. The cost is wallet invisibility, which doesn't matter for a record only contracts read.
+
+**Least privilege at the seam.** The manager never gets broad minting rights over vouchers, and the voucher never writes memberships. The voucher's `burn` accepts exactly two callers — the owner (or approved operator) and the `membershipManager` address — so redemption authority is scoped to the one action redemption needs (FR-025).
+
+**Royalty as a hint, not a cage.** Enforced royalties would mean allowlisted operators or a platform marketplace, killing open composability and trade privacy. A flat 2.5% EIP-2981 hint with a contract-enforced 5% ceiling keeps the utility framing defensible and accepts that some marketplaces will ignore it — the platform earns reliably on the primary mint.
+
+**Screening only where standing is granted.** One choke point, identical for both rails, fail-closed, with the documented residual that unredeemed vouchers trade unscreened.
+
+The general pattern travels well: when you need a token to be both non-transferable (for compliance and integrity) and transferable (for gifting and resale), you don't need one token that does both badly. You need two artifacts — an inert, tradable *claim* and a soulbound *grant* — joined by a single, guarded redemption that burns one and writes the other.
+
+## Sources
+
+- `specs/026-membership-vouchers/spec.md` — voucher rail requirements, clarifications, accepted tradeoffs
+- `specs/027-upgradeable-membership/` — UUPS migration of the membership authority
+- `contracts/access/MembershipManager.sol` — `_purchaseTier`, `_redeemVoucher`, `redeemVoucherWithSig`, storage layout and `__gap`
+- `contracts/access/MembershipVoucher.sol` — mint, snapshot, burn authorization, EIP-2981, on-chain `tokenURI`
+- `contracts/access/VoucherBatchMinter.sol` — custody-free batch/gift helper
+- `contracts/interfaces/IMembershipManager.sol` — `Membership`, `TierConfig`, `Tier`
+- `docs/system-overview/roles-and-tiers.md` — tier table ($2/$8/$25/$100, 30-day terms) and role model
+- [ERC-721: Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721)
+- [EIP-2981: NFT Royalty Standard](https://eips.ethereum.org/EIPS/eip-2981)
+- [EIP-5192: Minimal Soulbound NFTs](https://eips.ethereum.org/EIPS/eip-5192)
+- [OpenZeppelin Contracts — ERC721, ERC2981, AccessControl](https://docs.openzeppelin.com/contracts)

--- a/docs/blog/posts/02-soulbound-memberships-vouchers/social.md
+++ b/docs/blog/posts/02-soulbound-memberships-vouchers/social.md
@@ -1,0 +1,26 @@
+# Social & Image — Soulbound Memberships, Transferable Vouchers: Splitting a Token in Two
+
+## X (Twitter)
+
+How do you gift a non-transferable membership? Split the token in two: an inert ERC-721 voucher that trades freely + a soulbound access record it burns into. Sanctions screening happens once — at redemption, where standing is granted. 🎟️ 🔗 <link> #Solidity #tokendesign #web3
+
+## LinkedIn
+
+"Make the membership transferable" is the obvious answer to gifting and resale — and the wrong one when your access records feed compliance checks and per-address usage limits.
+
+FairWins memberships are soulbound by construction: not a locked NFT, just a storage record keyed to an address, with nothing to transfer. So how do you build a gift-and-resale market on top of that? By making the *right to claim* a membership transferable instead. The new post walks through the split:
+
+- A membership voucher as a plain ERC-721 bearer claim: minted at the tier's USDC price, confers zero access while held, never expires, snapshots its (role, tier) at mint so later config changes can't touch it
+- Redemption as the single control point: strict checks-effects-interactions, sanctions screening fail-closed on the redeemer only, voucher burned last so a failed redemption leaves it intact and re-tradable
+- Why the tradable asset is immutable while the redemption logic lives behind a UUPS proxy — and why the mapping beat an EIP-5192 locked token
+- Honest privacy: fresh-wallet redemption gives pseudonymity, not unlinkability, and the UI is required to say so
+
+If you're designing a token that "should" be both transferable and soulbound, the answer may be two artifacts joined by a burn.
+
+Read it here: <link>
+
+Where do you put the compliance choke point in a two-token design — mint, transfer, or redemption? #Solidity #tokenomics #smartcontracts #NFT #accesscontrol
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern editorial illustration, isometric style, of a two-part token metaphor: on the left, a glowing paper gift ticket (voucher) being passed between two abstract geometric hands across an open marketplace of floating pedestals; on the right, the ticket dissolving into particles as it feeds into a solid, anchored badge fused into a stone pillar — the badge visibly locked in place with a subtle chain-link base, conveying "soulbound." A thin luminous path connects the two halves through a stylized archway gate (the redemption checkpoint) with a small shield emblem. Deep navy and teal base palette with a single warm amber accent on the ticket and the path of light; soft ambient lighting with gentle rim highlights on the isometric surfaces, faint grid texture in the background for a fintech-engineering feel. Balanced composition with clear left-to-right narrative flow and generous negative space at the top. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/03-sanctions-compliance-gating/blog.md
+++ b/docs/blog/posts/03-sanctions-compliance-gating/blog.md
@@ -1,0 +1,130 @@
+# Sanctions Screening as a Contract Primitive: One Guard, Every Value Path
+
+*Why FairWins moved compliance from a frontend check into a shared, fail-closed on-chain guard — and how the same 100 lines of Solidity thread through wagers, pools, memberships, and token issuance*
+
+---
+
+> **Important Note**: This article describes prediction markets based on publicly available information and legitimate forecasting. Nothing here is a mechanism for trading on material non-public information or circumventing securities regulations. All participants remain fully subject to applicable laws, compliance requirements, and fiduciary obligations.
+
+---
+
+| | |
+|---|---|
+| **Series** | Identity & Access, part 3 |
+| **Audience** | Compliance engineers, regulated-product founders, Solidity engineers |
+| **Tags** | `compliance`, `sanctions`, `access-control`, `solidity`, `fail-closed` |
+| **Reading time** | ~9 minutes |
+
+## The check that wasn't there
+
+Picture the code review. Your team ships wallet screening for a peer-to-peer wager platform: when a user connects, the frontend reads the Chainalysis sanctions oracle over RPC, and if the address is listed, the UI refuses to proceed. The compliance box is ticked. The demo looks great.
+
+A week later someone on the security review asks the obvious question: *what happens if a sanctioned address never opens your frontend?* The contracts are publicly callable on Polygon. Anyone with a script and an ABI can call `createWager` directly. Your screening layer — the one your Terms of Service describe as a control — is a suggestion.
+
+This is the trap that catches most "compliance-aware" dApps. OFAC sanctions exposure is strict liability: it does not matter that you *intended* to block the address, or that your UI *would have* blocked it. If your smart contract accepted escrow from a listed address, the transaction happened. A screen that lives only in the client is not a control; it's theater with good intentions.
+
+FairWins' answer, built in spec `007-compliance-gating`, is to treat sanctions screening the way you'd treat reentrancy protection: as a contract primitive. One small, shared contract — `SanctionsGuard` — is consulted by every value-bearing entry point across the platform. The frontend still pre-checks (fast UX, no wasted gas), but the layer that actually enforces is the one nobody can route around.
+
+## The guard itself
+
+`contracts/access/SanctionsGuard.sol` is deliberately small: about 100 lines, no proxy, no funds, no upgradeability. It composes two lists behind a single verdict:
+
+1. **The Chainalysis on-chain Sanctions Oracle** — a public contract Chainalysis maintains that answers `isSanctioned(address)` against the OFAC SDN set (deployed on Polygon mainnet at `0x40C57923924B5c5c5455c48D93317139ADDaC8fb`).
+2. **An operator-maintained discretionary deny-list** — a plain `mapping(address => bool)` for addresses associated with illicit finance beyond SDN membership, mutated only by `SANCTIONS_ADMIN_ROLE`.
+
+The interface (`contracts/interfaces/ISanctionsGuard.sol`) exposes exactly what consumers need:
+
+```solidity
+interface ISanctionsGuard {
+    function isAllowed(address account) external view returns (bool);
+    function checkBlocked(address account) external view; // reverts SanctionedAddress(account)
+    function isDenied(address account) external view returns (bool);
+    function sanctionsOracle() external view returns (address);
+
+    function setDenied(address account, bool denied, string calldata reason) external;
+    function setSanctionsOracle(address oracle) external;
+
+    event DenyListUpdated(address indexed account, bool denied, address indexed actor, string reason);
+    event SanctionsOracleUpdated(address indexed oracle);
+
+    error SanctionedAddress(address account);
+}
+```
+
+Two views matter. `isAllowed` returns a boolean for callers that want to branch (the frontend's advisory read uses this). `checkBlocked` reverts with `SanctionedAddress(account)` — the form contracts consume, because in Solidity a revert in the Checks phase is the cheapest, safest way to make a whole transaction never happen.
+
+Note what the admin surface records. `setDenied` takes a human-readable `reason` and emits `DenyListUpdated` with the account, the direction of the change, the acting admin, and the reason — so the deny-list's entire history is an on-chain audit trail: who blocked whom, when, and why. There is no off-chain compliance database to subpoena or lose; the event log *is* the record. The admin keys behind both roles follow the platform's air-gapped floppy-keystore flow, so list mutations require a deliberate offline signing ceremony.
+
+## Fail-closed, for real
+
+The interesting engineering is in how the guard talks to the oracle. The naive version — `oracle.isSanctioned(account)` inside a `try/catch` — has a sharp edge: if the configured oracle address has no code (a bad deploy config, a selfdestructed target, the wrong chain), a high-level Solidity call doesn't behave the way you'd hope, and return-data decoding failures aren't reliably swallowed by `catch`. The guard instead does the query by hand:
+
+```solidity
+function _queryOracle(address account) internal view returns (bool sanctioned, bool ok) {
+    address oracle = address(_oracle);
+    if (oracle == address(0)) return (false, true); // deny-list-only
+    (bool success, bytes memory data) = oracle.staticcall(
+        abi.encodeWithSelector(IChainalysisSanctionsOracle.isSanctioned.selector, account)
+    );
+    if (!success || data.length < 32) return (false, false); // fail-closed
+    return (abi.decode(data, (bool)), true);
+}
+```
+
+A low-level `staticcall` gives the guard full control over every failure mode: revert, out-of-gas bubble-up, empty return data from a codeless address, malformed return data. Anything short of a well-formed 32-byte answer means the configured oracle "gave no usable answer," and `isAllowed` returns false for *every* account. Spec 007's FR-019 states the invariant plainly: if the screening source is unavailable, refuse the screened action rather than allow it unscreened.
+
+There is one deliberate exception, and it's a configuration, not a failure. An oracle set to `address(0)` means *deny-list-only enforcement* — the posture for networks where Chainalysis simply doesn't deploy (Polygon Amoy gets a `MockSanctionsOracle` in tests; production injects the real mainnet address at deploy time, never hardcoded, per FR-022/FR-055). The distinction is precise: a **configured but broken** oracle blocks everyone; an **unset** oracle blocks only the deny-list. Confusing those two states is how fail-closed systems quietly become fail-open.
+
+## One guard, four subsystems
+
+What makes this a *primitive* rather than a feature is reuse. A grep for `ISanctionsGuard` across `contracts/` finds the same pattern in four independent subsystems:
+
+**Wagers** (`contracts/wagers/WagerRegistryCore.sol`): every escrow entry point starts its Checks phase with a three-line helper —
+
+```solidity
+function _screen(address account) internal view {
+    ISanctionsGuard guard = sanctionsGuard;
+    if (address(guard) != address(0)) guard.checkBlocked(account);
+}
+```
+
+`createWager` screens the creator as its first check. The accept path screens *both* sides — the taker **and** the original creator — because acceptance is the moment the second stake enters escrow, and the creator may have been listed since they posted the wager. This implements spec 007's FR-021: re-screen at wager entry, every time.
+
+**Memberships** (`contracts/access/MembershipManager.sol`): `purchaseTier`, `upgradeTier`, `extendMembership`, and voucher redemption (`redeemVoucher`, spec 026) all call `_screen(actor)` before any USDC moves. Even the admin-only `grantMembership` screens the grantee — the guard is non-bypassable *including by operators*, so a role-holder can't hand standing to a listed address by accident.
+
+**Wager pools** (`contracts/pools/WagerPoolFactory.sol`): pools screen creators and joiners through the same guard, with one extra invariant worth stealing: a `screeningRequired` flag set at initialization. On production networks the factory *refuses to run unconfigured* — `screen()` reverts `ScreeningNotConfigured` if the flag is set but the guard address is zero. The "unset means disabled" convenience that's fine for local development becomes an impossible state in production.
+
+**Token issuance** (`contracts/tokens/TokenFactory.sol`, spec 028) screens issuers and injects the guard into the tokens it clones, and the callsign registry (`contracts/naming/CallsignRegistry.sol`, spec 054) checks `isAllowed` before letting anyone register a name.
+
+Each consumer holds its own settable reference (`setSanctionsGuard`, admin-gated), so the guard can be rewired without upgrading any consumer — and a single `setDenied` call propagates instantly to every subsystem. One list, one admin surface, one event stream, four enforcement points.
+
+## What is deliberately *not* screened
+
+The consumption table in `specs/007-compliance-gating/contracts/ISanctionsGuard.md` has a line that's easy to read past: exit and refund paths — `claimRefund`, `claimPayout`, `batchExpireOpen`, `declareDraw` — are **not** screened.
+
+This is the design decision most teams get wrong in the other direction. If a party is added to the deny-list *after* their stake enters escrow, screening the exit path would permanently trap their funds in your contract. That converts a screening control into an asset freeze — a materially different (and much heavier) legal act than refusing new business, and one that turns your escrow contract into a custodian of blocked property. FairWins draws the line where the spec draws it: a listed address can take no *new* action that moves value in, but can always recover what is already theirs. The guard gates entry, never exit.
+
+## Trade-offs
+
+**Gas on every entry.** Each screened action pays for a cross-contract `staticcall`, and (when the oracle is set) a second one into Chainalysis. That's real overhead on the hot path. The team judged it acceptable because the alternative — screening only at membership time — leaves the FR-021 gap: an address listed mid-membership could keep wagering until renewal.
+
+**Trusting an external oracle.** The Chainalysis oracle is a centralized, permissioned data source; FairWins takes its answers as ground truth. The mitigations are structural rather than trust-minimized: the oracle is read-only from the guard's perspective, it can be swapped by `DEFAULT_ADMIN_ROLE` if compromised or deprecated, and the discretionary deny-list works even with the oracle unset. This is an honest trade — no decentralized OFAC feed exists, and pretending otherwise doesn't help anyone.
+
+**Fail-closed can mean downtime.** If Chainalysis' contract ever reverted for everyone, every screened FairWins entry point would halt until an admin re-pointed or unset the oracle. That's the cost of FR-019, accepted with eyes open: brief unavailability is recoverable; a strict-liability violation is not.
+
+**Defense in depth, not defense in one place.** The on-chain guard is one layer of spec 007's stack: a Cloudflare edge geo-gate (HTTP 451 with an origin-lock header so the gate can't be bypassed by hitting the origin), an advisory app-layer oracle read for fast UX, versioned hash-addressed legal documents, and on-chain consent records. The guard is the layer that holds when every other layer is skipped — because on a public chain, one of them always can be.
+
+## Sources
+
+- `specs/007-compliance-gating/spec.md` — compliance & legal gating layer (FR-016–FR-022, FR-054–FR-055)
+- `specs/007-compliance-gating/contracts/ISanctionsGuard.md` — behavior contract and consumption table
+- `contracts/access/SanctionsGuard.sol` — guard implementation (fail-closed staticcall, deny-list, roles)
+- `contracts/interfaces/ISanctionsGuard.sol`, `contracts/interfaces/IChainalysisSanctionsOracle.sol`
+- `contracts/wagers/WagerRegistryCore.sol`, `contracts/wagers/WagerRegistry.sol` — `_screen` in create/accept paths
+- `contracts/access/MembershipManager.sol` — screening on purchase/upgrade/extend/grant/voucher redemption
+- `contracts/pools/WagerPoolFactory.sol` — `screeningRequired` invariant, `ScreeningNotConfigured`
+- `contracts/tokens/TokenFactory.sol`, `contracts/naming/CallsignRegistry.sol` — additional consumers
+- Chainalysis on-chain sanctions oracle: https://go.chainalysis.com/chainalysis-oracle-docs.html
+- OFAC SDN list: https://ofac.treasury.gov/sanctions-list-service
+- OpenZeppelin AccessControl: https://docs.openzeppelin.com/contracts/5.x/access-control
+- RFC 7725 (HTTP 451 Unavailable For Legal Reasons): https://www.rfc-editor.org/rfc/rfc7725

--- a/docs/blog/posts/03-sanctions-compliance-gating/social.md
+++ b/docs/blog/posts/03-sanctions-compliance-gating/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Sanctions Screening as a Contract Primitive: One Guard, Every Value Path
+
+## X (Twitter)
+
+Frontend sanctions screening on a public chain is theater — anyone can call your contracts directly. We made screening a contract primitive: one fail-closed SanctionsGuard consulted by wagers, pools, memberships & token issuance. Entry is gated; exit never is. 🔗 <link> #Solidity #web3 #compliance
+
+## LinkedIn
+
+If your smart contracts are publicly callable, a sanctions check that lives only in your frontend is not a control — it's a suggestion. OFAC exposure is strict liability: it doesn't matter that your UI *would have* blocked the address if the contract accepted its escrow anyway.
+
+In part 3 of our Identity & Access series, we walk through how FairWins turned sanctions screening into a shared on-chain primitive instead of an off-chain afterthought:
+
+- A ~100-line SanctionsGuard combining the Chainalysis on-chain oracle with an operator deny-list whose full history (actor, reason, timestamp) lives in event logs
+- Fail-closed by construction: a low-level staticcall treats a broken, codeless, or malformed oracle as "block everyone" — while an intentionally unset oracle degrades to deny-list-only
+- One guard threading through four independent subsystems — wagers, pools, memberships, token issuance — with re-screening at every value entry point
+- The line most teams draw wrong: refund and payout paths are deliberately unscreened, so a newly listed address can always recover its own escrowed funds. Screening gates entry, never exit
+
+We also cover the honest trade-offs: gas on the hot path, trusting a centralized oracle, and accepting downtime as the price of fail-closed.
+
+Read the full post: <link>
+
+Where do you draw the line between screening new business and freezing existing funds? 
+
+#SmartContracts #Compliance #Solidity #web3 #Sanctions
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an isometric style: a single translucent guardhouse checkpoint standing at the convergence of four glowing circuit-board pathways, each path flowing inward from a different abstract structure (a pair of balanced scales, a ring of connected nodes, a stack of membership cards, a minted coin press), with small geometric traveler tokens passing through the checkpoint's gate while one token is halted by a raised barrier; outbound lanes on the far side flow freely with no gate. Deep navy and teal base palette with a single warm amber accent on the checkpoint beacon and the halted token, soft diffuse rim lighting with subtle depth shadows, fine line detail, generous negative space, fintech-engineering editorial mood. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/04-passkey-smart-accounts/blog.md
+++ b/docs/blog/posts/04-passkey-smart-accounts/blog.md
@@ -1,0 +1,119 @@
+# Passkey Smart Accounts: Putting WebAuthn Signatures on an ERC-4337 Wallet
+
+*How FairWins turned Face ID into a self-custodial Ethereum account — no seed phrase, no browser extension, and a P-256 verifier that runs on-chain*
+
+| | |
+|---|---|
+| **Series** | Accounts & Keys (part 1) |
+| **Audience** | Wallet developers, account-abstraction engineers |
+| **Tags** | `account-abstraction`, `erc4337`, `passkeys`, `webauthn`, `p256`, `erc1271` |
+| **Reading time** | ~9 minutes |
+
+## The curve nobody asked for
+
+Picture the onboarding funnel for a peer-to-peer wager platform. A friend sends you a wager link. You have never installed MetaMask, you have never written twelve words on paper, and you are not going to start tonight. What you do have is a phone with a fingerprint sensor and a secure enclave that has been signing things for you — payments, logins — for years.
+
+That enclave speaks WebAuthn. When you register a passkey, the authenticator mints a keypair and will sign challenges after a biometric check, without the private key ever leaving the hardware. This is exactly the custody model crypto wallets have been chasing: keys that cannot be exported, phished, or pasted into a fake support chat.
+
+There is one problem, and it is a stubborn one: the curve. Secure enclaves and platform authenticators sign on **secp256r1** (P-256, the NIST curve). Ethereum externally-owned accounts recover signatures on **secp256k1**. There is no way to make a passkey pretend to be an EOA — `ecrecover` will never accept a P-256 signature. If you want passkeys to control funds, the account itself has to become a smart contract that knows how to verify P-256, and something other than the user has to be able to feed it transactions, because a passkey cannot pay gas from an address that does not exist yet.
+
+That is the shape of FairWins spec 041: an **ERC-4337 smart account** owned by a WebAuthn credential, with on-chain P-256 verification, deterministic counterfactual addresses, and first-use deployment. This post walks the contract stack in `contracts/account/` — what we vendored, what we wired around it, and where the sharp edges were.
+
+## An account is a set of owners, not a key
+
+The account contract is a vendored **Coinbase Smart Wallet v1.1.0** — `contracts/account/CoinbaseSmartWallet.sol` plus its pinned dependency closure (`webauthn-sol`, `FreshCryptoLib`, Solady, `account-abstraction`). The vendoring rule, documented in `contracts/account/README.md`, is strict: no logic modifications, path-only import rewrites. We wanted an audited, widely deployed account implementation, not a fork we would have to re-audit forever.
+
+The foundation is `contracts/account/MultiOwnable.sol`, and its central trick is that an owner is just `bytes`:
+
+- a 32-byte ABI-encoded Ethereum address (a linked EOA), or
+- a 64-byte P-256 public key — the `(x, y)` coordinates of a passkey.
+
+Both kinds sit in the same index-addressed mapping and are interchangeable controllers. Adding or removing one (`addOwnerPublicKey(bytes32 x, bytes32 y)`, `addOwnerAddress(address)`, `removeOwnerAtIndex`) is an owner-authorized self-call, and `removeOwnerAtIndex` reverts with `LastOwner()` rather than let an account brick itself by removing its final controller.
+
+Signature validation dispatches on the owner's byte length. Every signature arrives wrapped with the index of the owner that produced it:
+
+```solidity
+struct SignatureWrapper {
+    /// @dev The index of the owner that signed, see `MultiOwnable.ownerAtIndex`
+    uint256 ownerIndex;
+    /// @dev If `MultiOwnable.ownerAtIndex` is an Ethereum address, this should be `abi.encodePacked(r, s, v)`
+    ///      If `MultiOwnable.ownerAtIndex` is a public key, this should be `abi.encode(WebAuthnAuth)`.
+    bytes signatureData;
+}
+```
+
+In `CoinbaseSmartWallet._isValidSignature`, 32-byte owners go through Solady's `SignatureCheckerLib` (ECDSA or nested ERC-1271); 64-byte owners take the WebAuthn path:
+
+```solidity
+if (ownerBytes.length == 64) {
+    (uint256 x, uint256 y) = abi.decode(ownerBytes, (uint256, uint256));
+
+    WebAuthn.WebAuthnAuth memory auth = abi.decode(sigWrapper.signatureData, (WebAuthn.WebAuthnAuth));
+
+    return WebAuthn.verify({challenge: abi.encode(hash), requireUV: false, webAuthnAuth: auth, x: x, y: y});
+}
+```
+
+This one function backs both ERC-4337 `validateUserOp` and ERC-1271 `isValidSignature` — one verification path for transactions and off-chain signatures alike.
+
+## Verifying WebAuthn where gas is real
+
+A WebAuthn assertion is not a bare signature over a hash. The authenticator signs `sha256(authenticatorData || sha256(clientDataJSON))`, where `clientDataJSON` embeds the challenge (base64url-encoded) and a ceremony type. `contracts/account/lib/webauthn-sol/WebAuthn.sol` re-runs the relevant verification steps from the W3C spec on-chain: it checks the client data `type` is `"webauthn.get"`, that the encoded challenge in the JSON matches the expected hash, that the User Present flag is set in `authenticatorData`, and it rejects high-`s` P-256 signatures to close the malleability hole. The library's NatSpec is refreshingly explicit about what it deliberately does *not* verify — origin, `rpIdHash`, signature counters — trusting platform authenticators and app-site association to enforce those, which is the honest trade for keeping verification affordable.
+
+Then comes the actual curve math. P-256 verification in pure EVM is expensive, so the library tries the **RIP-7212 precompile** at address `0x100` first — about 3,450 gas on Polygon and Amoy, where FairWins runs passkeys today. On chains without the precompile, the `staticcall` returns empty and the code falls back to `FCL_ecdsa.ecdsa_verify` from FreshCryptoLib, a Solidity implementation costing a couple hundred thousand gas. The same bytecode serves both worlds — which is precisely why the deferred ETC/Mordor increment needs no contract changes, only a self-hosted bundler.
+
+## An address before an account
+
+The user's account address must exist before any contract does — it is where a friend sends their stake. `contracts/account/CoinbaseSmartWalletFactory.sol` makes the address a pure function of the initial owners:
+
+```solidity
+function createAccount(bytes[] calldata owners, uint256 nonce)
+    external payable virtual returns (CoinbaseSmartWallet account)
+{
+    if (owners.length == 0) revert OwnerRequired();
+
+    (bool alreadyDeployed, address accountAddress) =
+        LibClone.createDeterministicERC1967(msg.value, implementation, _getSalt(owners, nonce));
+    ...
+}
+```
+
+The salt is `keccak256(abi.encode(owners, nonce))`, and the account is a deterministic ERC-1967 proxy over the shared implementation. `getAddress(owners, nonce)` predicts the address without deploying anything. FairWins deploys the factory itself through a canonical CREATE2 deployer with a pinned salt (`scripts/deploy/deploy-account-stack.js`), so the factory — and therefore every account address — is identical on every supported network. Recorded deployment keys: `entryPoint`, `accountFactory`, `accountImpl`.
+
+Deployment happens lazily. The first time the user acts, the frontend (`frontend/src/lib/passkey/sendBatch.js`) attaches ERC-4337 `initCode` that calls `createAccount`; the EntryPoint deploys the account and executes the operation in the same transaction. One war story worth passing on, preserved as a comment in `frontend/src/lib/passkey/smartAccount.js`: viem's smart-account helper defaults to the *canonical Coinbase factory address*, which derives a **different** counterfactual address than the FairWins-deployed factory. Left unpinned, every UserOp was built for an empty account and reverted with "exceeds balance". The fix is to pin the sender to the address returned by the FairWins factory's `getAddress` and generate `initCode` against that same factory. If you integrate any vendored factory with a generic AA SDK, audit its address-derivation defaults first.
+
+## ERC-1271, with a seatbelt
+
+Wagering on FairWins mostly rides gasless EIP-712 intents (specs 035/036), and USDC moves via EIP-3009 authorizations — both off-chain signatures. A contract account signs those through **ERC-1271**: verifiers call `isValidSignature(hash, signature)` and expect the `0x1626ba7e` magic value.
+
+The vendored `contracts/account/ERC1271.sol` adds one crucial layer: an anti-cross-account-replay wrapper. Because the same passkey can own several accounts, a naive implementation would let a signature approved for account A validate on account B. So the contract never verifies the raw hash — it verifies `replaySafeHash(hash)`, an EIP-712 hash of `CoinbaseSmartWalletMessage(bytes32 hash)` under a domain separator bound to `block.chainid` and `address(this)`. A signature is valid for exactly one account on exactly one chain. On the platform side, spec 041 extended `contracts/upgradeable/SignerIntentBase.sol` with an ECDSA-then-ERC-1271 check so intent verification accepts contract signers, with a matching fail-closed `eth_call` fallback in `services/relay-gateway/src/intent/verify.js`. One honest scope note: the EIP-3009 payment leg is still ECDSA-only in the intent twins, so passkey stake-moving actions ride `executeBatch` UserOps until the ERC-7598 bytes-signature leg is plumbed through — `test/fork/usdc-erc1271-authorization.test.js` already proves native USDC accepts the contract-account authorization.
+
+`executeBatch(Call[] calldata calls)` matters for UX too: approve-and-act becomes one biometric ceremony instead of two.
+
+## No seed phrase does not mean no keys
+
+Passkeys sign; they do not encrypt. FairWins' private-market features need deterministic encryption keys, so `frontend/src/lib/passkey/prfKeys.js` uses the WebAuthn **PRF extension**: a fixed, versioned evaluation point (`fairwins.prf.salt.v1`) is fed through the authenticator's PRF, the output through HKDF-SHA256 (`info="fairwins-kek-v1"`) into a key-encryption key, which wraps a random 32-byte master seed with AES-GCM. Every controller on the account unwraps the *same* master seed, so encryption keys survive device changes. Authenticators without PRF degrade explicitly — the UI reports encryption unavailable rather than deriving silently wrong keys.
+
+## Design decisions
+
+- **Vendor, don't fork.** Coinbase Smart Wallet v1.1.0 is battle-tested and audited; the repo's rule of zero logic modifications means upstream audits remain meaningful. The one deviation is documented in `MultiOwnable.sol` itself: an ERC-7201 NatSpec annotation removed because tooling choked on it — a comment, not bytecode.
+- **User-sovereign upgrades.** The account is UUPS-upgradeable, but `_authorizeUpgrade` is `onlyOwner`. FairWins holds no authority over deployed instances — deliberately outside the platform's `UUPSManaged` regime, and the reason this is genuinely self-custodial rather than "self-custodial."
+- **`requireUV: false`.** The account checks User Present, not User Verified, at the contract layer, matching upstream. Platform authenticators enforce biometrics at the ceremony; hard-requiring UV on-chain would strand security keys that report UP only.
+- **Precompile-first, fallback-always.** RIP-7212 where available, FreshCryptoLib elsewhere. Costlier on precompile-less chains, but one bytecode everywhere beats per-chain builds.
+- **Gas honesty.** Spec 041 shipped with users paying their own UserOp gas (FR-015); spec 050 later superseded that with a self-hosted verifying paymaster — but the confirm UI only ever claims "sponsored" when a sponsorship was actually obtained, and the self-funded fallback keeps users never stranded.
+
+The result: an account a user opens with a thumbprint, funds at an address that exists before the contract does, and controls through keys that no server — including ours — ever holds.
+
+## Sources
+
+- `specs/041-passkey-wallet-login/` — feature spec and plan
+- `docs/developer-guide/passkey-accounts.md` — architecture guide
+- `contracts/account/CoinbaseSmartWallet.sol`, `contracts/account/MultiOwnable.sol`, `contracts/account/CoinbaseSmartWalletFactory.sol`, `contracts/account/ERC1271.sol`
+- `contracts/account/lib/webauthn-sol/WebAuthn.sol`, `contracts/account/lib/FreshCryptoLib/`
+- `frontend/src/lib/passkey/smartAccount.js`, `frontend/src/lib/passkey/prfKeys.js`
+- ERC-4337: <https://eips.ethereum.org/EIPS/eip-4337>
+- ERC-1271: <https://eips.ethereum.org/EIPS/eip-1271>
+- EIP-712: <https://eips.ethereum.org/EIPS/eip-712>
+- RIP-7212 (secp256r1 precompile): <https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md>
+- WebAuthn Level 2 (W3C): <https://www.w3.org/TR/webauthn-2/>
+- Coinbase Smart Wallet: <https://github.com/coinbase/smart-wallet>

--- a/docs/blog/posts/04-passkey-smart-accounts/social.md
+++ b/docs/blog/posts/04-passkey-smart-accounts/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Passkey Smart Accounts: Putting WebAuthn Signatures on an ERC-4337 Wallet
+
+## X (Twitter)
+
+Your phone's secure enclave signs P-256. Ethereum recovers secp256k1. No amount of UX polish fixes a curve mismatch — so we made the account a contract. ERC-4337 + WebAuthn, RIP-7212 precompile at ~3,450 gas, no seed phrase. 🔗 <link> #AccountAbstraction #passkeys #ERC4337
+
+## LinkedIn
+
+Most crypto onboarding still starts with "write down these twelve words." The hardware to do better has been in everyone's pocket for years — but secure enclaves sign on secp256r1 (P-256), and Ethereum EOAs only understand secp256k1. You cannot bridge that gap at the key level; you have to bridge it at the account level.
+
+Our new engineering post walks through how FairWins ships self-custodial passkey wallets on ERC-4337 smart accounts, built on the vendored Coinbase Smart Wallet stack:
+
+- How `MultiOwnable` treats a 64-byte P-256 public key and a 20-byte EOA as interchangeable account controllers
+- Verifying full WebAuthn assertions on-chain: clientDataJSON checks, malleability guards, and the RIP-7212 precompile with a FreshCryptoLib fallback
+- Deterministic counterfactual addresses and first-use deployment via ERC-4337 initCode — including a real bug from an SDK's hardwired factory address
+- ERC-1271 replay-safe hashing, so one passkey owning multiple accounts can never have a signature replayed across them
+
+Honest trade-offs included: what the on-chain verifier deliberately skips, and why account upgrades belong to users, not the platform.
+
+Read the full post: <link>
+
+If you are building on account abstraction — where did passkey integration bite you first: the curve, the factory, or the gas?
+
+#AccountAbstraction #ERC4337 #WebAuthn #passkeys #web3
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration, isometric style, for an engineering blog banner about passkey-controlled smart contract wallets. Central metaphor: a large translucent isometric vault-like cube (the smart account) standing on a circuit-board plane, its door opened not by a metal key but by a glowing fingerprint hovering in front of a smartphone; from the fingerprint, a luminous curved line (suggesting an elliptic curve) arcs into the vault and threads through a series of small geometric verification gates — hexagons and check-marked nodes — before reaching a stack of coin-like tokens inside. Secondary detail: faint mathematical curve traces and hashed-block patterns etched into the background plane. Composition: vault slightly right of center, phone and fingerprint lower left, generous negative space top left for headline overlay. Color mood: deep navy and teal base palette with a single warm amber accent reserved for the fingerprint and the signature path. Lighting: soft ambient glow with crisp rim light on the isometric edges, subtle depth haze in the background. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/05-account-recovery-unified-connect/blog.md
+++ b/docs/blog/posts/05-account-recovery-unified-connect/blog.md
@@ -1,0 +1,120 @@
+# Losing Every Passkey Shouldn't Mean Losing the Account
+
+*How FairWins merged wallet connection and account recovery into one surface — and made passkey accounts recoverable without reintroducing a seed phrase*
+
+| | |
+|---|---|
+| **Series** | Accounts & Keys (part 2) |
+| **Part** | 5 of 34 |
+| **Audience** | Wallet/UX engineers, account-abstraction developers, product designers |
+| **Tags** | `account-recovery`, `passkeys`, `self-custody`, `ux`, `account-abstraction` |
+| **Reading time** | ~9 minutes |
+
+## The phone in the river
+
+A member signs up for FairWins with a passkey. No seed phrase, no extension — Face ID creates a P-256 credential, and an ERC-4337 smart account derives from it. It's the onboarding passkeys promised: nothing to write down, nothing to lose.
+
+Then the phone goes in the river. Or the browser profile gets wiped, or the laptop dies. Platform sync (iCloud Keychain, Google Password Manager) catches most of these cases — but not all. A passkey created in an unsynced browser profile is simply gone. With a seed-phrase wallet, the answer was brutal but well understood: type the twelve words back in. Passkeys deliberately removed those twelve words. So what's the recovery story?
+
+At the same time, our pre-consolidation frontend had a quieter problem that made any recovery story moot: *connecting* was already broken in three different ways. Three surfaces offered connection — the header button, the wallet page, and the dashboard welcome screen — each with different options and ordering (one couldn't reach passkey at all), and parallel attempts could race a background session restore into a stuck state. Worse, two shipped defects blocked passkey users outright: on Chrome and Brave, signing back in could leave a session that crashed every transaction with `Cannot read properties of undefined (reading 'id')`, and Brave silently signed users into their *first* passkey no matter which account they picked.
+
+Spec 045 (`specs/045-unified-connect-recovery/`) treats these as one problem: connection, controller management, and recovery are the same lifecycle, and they should live behind one surface. This post walks through how it works — and why the contract layer needed zero changes.
+
+## The account layer already had the answer
+
+FairWins passkey accounts (spec 041) are vendored Coinbase Smart Wallet contracts. Their auth core, `contracts/account/MultiOwnable.sol`, stores owners as raw bytes in ERC-7201 namespaced storage: a 32-byte ABI-encoded Ethereum address *or* a 64-byte P-256 public key. A passkey and a MetaMask address are interchangeable controllers of the same account:
+
+```solidity
+/// @notice Adds a new Ethereum-address owner.
+function addOwnerAddress(address owner) external virtual onlyOwner {
+    _addOwnerAtIndex(abi.encode(owner), _getMultiOwnableStorage().nextOwnerIndex++);
+}
+
+/// @notice Adds a new public-key owner.
+function addOwnerPublicKey(bytes32 x, bytes32 y) external virtual onlyOwner {
+    _addOwnerAtIndex(abi.encode(x, y), _getMultiOwnableStorage().nextOwnerIndex++);
+}
+```
+
+Every owner is a full 1-of-N peer: any single controller can add or remove the others. Two invariants matter for recovery. First, `removeOwnerAtIndex` reverts with `LastOwner()` when only one owner remains, so an account can never be stranded controllerless. Second, `_checkOwner` accepts any registered owner (or the account itself), so an EOA owner can call `addOwnerPublicKey` with an *ordinary transaction* — no bundler, no UserOp, no relayer.
+
+That's the entire recovery primitive. If a second controller exists when disaster strikes, recovery is one contract call. The 045 plan (`specs/045-unified-connect-recovery/plan.md`) says it plainly: **no contract changes** — the work is making people actually *have* that second controller, and making the client honest enough to use it.
+
+## One connect surface, serialized
+
+The first deliverable is `frontend/src/components/wallet/ConnectModal.jsx`: the single connect surface. Every entry point — header button, wallet page, dashboard welcome — opens the same dialog via `WalletContext.openConnectModal()`; no other component renders connector choices (FR-001). Options are ordered Passkey → WalletConnect → browser extension wallets, with the first two featured — all three fully supported. Availability is probed and shown honestly ("not detected", "not supported") before the user commits, rather than failing on tap (FR-003).
+
+`WalletContext` serializes attempts: at most one connect flow in flight, and a background session restore can never override a user-initiated connection (FR-004). A first-time passkey explainer renders inside the modal exactly once per browser, tracked by a `fairwins.passkey.explainer.v1` localStorage marker — and if storage is blocked, the explainer may repeat but never blocks connecting.
+
+## The two bugs that made passkeys unusable
+
+The unified surface only matters if the passkey path underneath it is sound. Two root-cause fixes shipped with it.
+
+**The incomplete credential record.** The connector's sign-*in* branch never recorded the asserted credential the way sign-*up* did. The local credential book (`fairwins.passkey.credentials.v1`) is what the transaction path feeds into viem's WebAuthn account; an incomplete record meant `buildAccount` dereferenced `undefined` deep inside the signer — the infamous `reading 'id'` crash. The fix is layered: the connector (`frontend/src/connectors/passkey.js`) now remembers and, when possible, repairs the record on every sign-in (FR-005), and `frontend/src/lib/passkey/smartAccount.js` refuses incomplete records *before* any ceremony with a typed `CredentialRecordIncomplete` error that the UI turns into "sign in again with your passkey" (FR-006). Validate at the boundary; never let storage shape leak into a WebAuthn stack trace.
+
+**The unpinned ceremony.** A bare WebAuthn `get()` lets the platform pick any discoverable credential — and Brave/Chromium silently assert the *first* one, locking multi-account users out of everything but account one. `getAssertion` in `frontend/src/lib/passkey/credentials.js` now pins every session-bound ceremony to the session's `credentialId` (FR-008), and when the browser knows several passkeys, the app presents its own account picker before the ceremony rather than trusting the platform chooser (FR-007). A deliberate `discoverable: true` escape hatch still issues a bare request for passkeys the browser has never recorded — the platform's own chooser makes that pick, so the app never guesses.
+
+A subtler third fix follows directly from recovery: once accounts can gain controllers, signatures can no longer assume owner slot zero. `resolveOwnerIndex` reads the on-chain owner list and matches the credential's owner bytes to its real index (FR-009):
+
+```js
+export async function resolveOwnerIndex({ chainId, accountAddress, credential, deps = {} }) {
+  // ...
+  const ownerBytes = publicKeyToOwnerBytes(credential.publicKey).toLowerCase()
+  const match = result.controllers.find((c) => c.ownerBytes?.toLowerCase() === ownerBytes)
+  if (!match) throw new CredentialNotControllerError()
+  return Number(match.index)
+}
+```
+
+Counterfactual accounts fall back to index 0; a deployed account that no longer lists the credential throws, because signing would be guessing.
+
+## Linking before disaster
+
+Recovery requires a second controller linked *while you still have passkey access*. `frontend/src/components/account/ControllersPanel.jsx` lists every controller from the on-chain owner set (with local-only labels), and supports adding a second passkey, linking an external wallet, and removing controllers — each mutation an owner-authorized self-call through `sendCalls`, one ceremony each.
+
+Two policies gate linking. The UI states explicitly that a linked wallet gains *full control* of the account — 1-of-N means full peer, and pretending otherwise would be dishonest. And every candidate address is sanctions-screened before the on-chain call, fail-closed: flagged *or unscreenable* means refused (FR-011). Accounts with a single controller get a persistent device-loss warning pointing at the fix (FR-013).
+
+## Recovery without FairWins
+
+`frontend/src/components/account/RecoverAccountPanel.jsx` is the wallet-only path (FR-014). The user connects the linked wallet — no passkey anywhere — and walks a guided flow:
+
+1. **Which account?** No reverse owner→accounts index exists on-chain, so the app asks for the account address, hinted by addresses the browser has previously associated with passkeys. (The alternative — an indexer dependency on the recovery path — would violate the point of the exercise.)
+2. **Verify ownership.** The panel first checks `getCode` on the target — a counterfactual or wrong-network address used to surface as a cryptic `BAD_DATA` decode error; now it's a plain-language explanation. Then it calls `isOwnerAddress(wallet)` and refuses to continue unless the wallet is a controller.
+3. **Create and authorize.** A fresh passkey ceremony on the new device, then one ordinary ethers v6 transaction: `addOwnerPublicKey(x, y)` straight from the EOA signer. Only after the receipt confirms does the app record the credential locally — so the very next passkey sign-in can transact.
+
+Because the account is a standard, publicly documented contract, the same recovery works with generic tools if FairWins the service disappears. The runbook (`docs/runbooks/passkey-account-recovery.md`) shows it with Foundry's `cast`:
+
+```bash
+cast call $ACCOUNT "isOwnerAddress(address)(bool)" $WALLET --rpc-url $RPC
+cast send $ACCOUNT "addOwnerAddress(address)" $NEW_WALLET --rpc-url $RPC --private-key ...
+```
+
+For a pure-CLI recovery the runbook recommends `addOwnerAddress` with a fresh wallet (a P-256 key is awkward to produce outside the app), then linking a new passkey from the app later.
+
+## Design decisions
+
+**No guardians, no social recovery.** Recovery is strictly "any pre-linked controller can act." An account whose only passkey lived on a lost, unsynced device is unrecoverable *by design* — no one, including FairWins, can help. That's a hard trade, made deliberately: guardian schemes reintroduce trusted parties and timelock complexity, and platform passkey sync already covers the common device-loss case. The mitigation is UX pressure to link a second controller early, not a custodial backstop.
+
+**1-of-N, not thresholds.** Every controller is a full peer. Simpler to reason about, and it's what makes wallet-only recovery a single transaction — but it means linking a wallet is a full grant of custody, which the UI must (and does) say out loud. Members who want threshold custody have the separate Safe multisig feature (spec 043); it's explicitly out of scope here.
+
+**Recovery restores control, not secrets.** The owner list gates funds, but encrypted-feature keys derive from a master seed wrapped per-controller (`lib/passkey/prfKeys.js`). A recovered controller that never held the seed can't decrypt old data until keys are re-wrapped from a controller that has it — the runbook calls this out. On-chain, encrypted-backup *pointers* live in `contracts/privacy/BackupPointerRegistry.sol` (spec 002), but that's a separate lifecycle: spec 045 recovery never touches it.
+
+**Frontend-only fix for a frontend-caused outage.** Both shipped defects were client bugs against a correct contract. Fixing them at the storage-record and ceremony-request layers — with typed errors instead of crashes — kept the blast radius in `frontend/src` and let the audited vendored contracts stay untouched.
+
+The result: connection has one front door, every passkey ceremony is pinned to a credential the user actually chose, and losing every passkey is an inconvenience instead of an ending — provided you linked something first. The app's whole job is making sure you did.
+
+## Sources
+
+- `specs/045-unified-connect-recovery/spec.md`, `plan.md` — requirements (FR-001–FR-016) and implementation plan
+- `specs/041-passkey-wallet-login/` — the underlying passkey account feature
+- `docs/developer-guide/passkey-accounts.md` — contract stack and frontend architecture
+- `docs/runbooks/passkey-account-recovery.md` — in-app and generic-tools recovery paths
+- `contracts/account/MultiOwnable.sol` — owner list, `addOwnerPublicKey`, `LastOwner()` invariant
+- `frontend/src/components/wallet/ConnectModal.jsx`, `frontend/src/connectors/passkey.js` — unified surface and sign-in record repair
+- `frontend/src/lib/passkey/credentials.js`, `frontend/src/lib/passkey/smartAccount.js` — ceremony pinning, `resolveOwnerIndex`, credential validation
+- `frontend/src/components/account/ControllersPanel.jsx`, `RecoverAccountPanel.jsx` — controller management and wallet-only recovery
+- ERC-4337 (Account Abstraction): https://eips.ethereum.org/EIPS/eip-4337
+- ERC-7201 (Namespaced Storage Layout): https://eips.ethereum.org/EIPS/eip-7201
+- ERC-1271 (Contract Signature Validation): https://eips.ethereum.org/EIPS/eip-1271
+- WebAuthn Level 2: https://www.w3.org/TR/webauthn-2/
+- Coinbase Smart Wallet: https://github.com/coinbase/smart-wallet

--- a/docs/blog/posts/05-account-recovery-unified-connect/social.md
+++ b/docs/blog/posts/05-account-recovery-unified-connect/social.md
@@ -1,0 +1,34 @@
+# Social & Image — Losing Every Passkey Shouldn't Mean Losing the Account
+
+## X (Twitter)
+
+Passkeys killed the seed phrase. So what happens when the phone dies?
+
+Our answer: any linked wallet is a full 1-of-N owner — recovery is one plain `addOwnerPublicKey(x, y)` tx to the smart account. No bundler, no relayer, no us.
+
+🔗 <link>
+
+#passkeys #AccountAbstraction #selfcustody
+
+## LinkedIn
+
+Recovery is the make-or-break problem for passkey wallets. Seed phrases were brutal, but everyone knew the recovery story. Passkeys deleted the twelve words — and if your credential lived in an unsynced browser profile, platform sync won't save you.
+
+Our latest engineering post covers how FairWins made passkey smart accounts recoverable without reintroducing a seed phrase — and why the contracts needed zero changes:
+
+- One connect surface for passkey, WalletConnect, and browser wallets, with serialized attempts so parallel connects and background session restores can never race into a stuck state
+- Root-causing two shipped defects: the Chrome/Brave "reading 'id'" crash (an incomplete local credential record) and Brave silently asserting the first passkey (an unpinned WebAuthn ceremony — fixed with allowCredentials pinning plus an in-app account picker)
+- Linking an external wallet as a full 1-of-N controller on the vendored Coinbase Smart Wallet MultiOwnable owner list, sanctions-screened fail-closed, with honest "this wallet gains full control" consent
+- Wallet-only recovery: verify isOwnerAddress on-chain, create a fresh passkey, authorize it with one ordinary transaction — reproducible with Foundry's cast even if our service disappears
+
+The hard trade: no guardians, no custodial backstop. An account that never linked a second controller is unrecoverable by design.
+
+Read the full post: <link>
+
+How is your team handling passkey recovery — pre-linked controllers, guardians, or something else?
+
+#AccountAbstraction #passkeys #selfcustody #web3 #walletengineering
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration, abstract-geometric style, for an engineering blog banner about account recovery for passkey wallets. Central metaphor: a large translucent vault-like hexagonal chamber (the smart account) with several distinct keys docked into slots around its rim — one glowing fingerprint-shaped key visibly shattered or fading away, while a second, intact key (an angular hardware-wallet-like shape) turns in its slot and re-lights the chamber, projecting a fresh new fingerprint key into an empty slot. Thin circuit-like connection lines converge from three doorways on the left into a single doorway feeding the chamber, suggesting many entry points unified into one. Composition: chamber slightly right of center, doorways left, generous negative space, strong diagonal flow from left doorways to the re-lit key. Deep navy and teal base palette with a single warm amber accent reserved for the intact key and the newly projected key. Soft ambient lighting with subtle rim glow on geometric edges, faint grid texture in the background, precise vector-like linework, fintech-engineering mood, minimal and confident. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/06-sponsored-gas-verifying-paymaster/blog.md
+++ b/docs/blog/posts/06-sponsored-gas-verifying-paymaster/blog.md
@@ -1,0 +1,97 @@
+# Sponsored Gas Without a Vendor: A Self-Hosted ERC-7677 Verifying Paymaster
+
+*How FairWins made "no network fee" true — with a 173-line contract, a KMS key, and the relay gateway it already ran*
+
+- **Series:** Accounts & Keys, part 3
+- **Part:** 6 of 34
+- **Audience:** Account-abstraction and infrastructure developers
+- **Tags:** `paymaster`, `erc7677`, `erc4337`, `gasless`, `bundler`, `kms`
+- **Reading time:** ~9 minutes
+
+---
+
+## The lie in the confirm screen
+
+A member creates a FairWins passkey account, receives 40 USDC from a friend, and tries to send 10 of it onward. The confirm screen says "Gasless · sponsored — no network fee." They tap confirm with their fingerprint. The transfer fails.
+
+Under the hood, the EntryPoint rejected the UserOperation with `AA21 — Smart Account does not have sufficient funds`. The account held USDC and zero POL. With no paymaster configured, every ERC-4337 UserOperation must prefund its own gas from the account's native balance — and a stablecoin-only account has none. Worse, on the account's very first action the prefund also covers on-chain deployment, so during a gas spike even an account holding *some* native token could fail.
+
+The product had promised sponsorship before the infrastructure existed. That violated one of FairWins' standing principles — the UI must never claim a state that isn't true — and there were two ways to fix it: change the copy, or make the claim true. Spec 050 chose the second, with a constraint the product owner set explicitly: no third-party paymaster service. No Pimlico, no Circle. FairWins already ran its own ERC-4337 bundler (pimlico's alto, self-hosted on Cloud Run) and its own relay gateway for gasless intents. Sponsorship had to be built from those parts.
+
+This post walks through what that took: a deliberately minimal verifying paymaster contract on EntryPoint v0.6, an ERC-7677 endpoint bolted onto the existing policy gateway, a KMS-held signing key, and — because the platform's never-stranded rule is non-negotiable — a fallback that keeps every user able to act even when sponsorship is down.
+
+## What a verifying paymaster actually is
+
+ERC-4337 lets a UserOperation name a paymaster: a contract that tells the EntryPoint "I'll pay for this one." The EntryPoint deducts the actual gas cost from the paymaster's deposit and reimburses the bundler's beneficiary. The whole design question is *how the paymaster decides which ops to pay for*.
+
+A *verifying* paymaster answers with a signature. An off-chain service inspects each operation, and if it approves, signs a digest binding that exact op. The contract's only job is to recover the signer:
+
+```solidity
+function validatePaymasterUserOp(UserOperation calldata userOp, bytes32, uint256)
+    external view override onlyEntryPoint
+    returns (bytes memory context, uint256 validationData)
+{
+    (uint48 validUntil, uint48 validAfter, bytes calldata signature) =
+        _parsePaymasterAndData(userOp.paymasterAndData);
+
+    bytes32 digest = MessageHashUtils.toEthSignedMessageHash(
+        getHash(userOp, validUntil, validAfter));
+    (address recovered, ECDSA.RecoverError err,) = ECDSA.tryRecover(digest, signature);
+    bool sigFailed = err != ECDSA.RecoverError.NoError || recovered != verifyingSigner;
+
+    // context "" => EntryPoint skips postOp (pure sponsoring, no settlement).
+    return ("", _packValidationData(sigFailed, validUntil, validAfter));
+}
+```
+
+That is the heart of `contracts/account/FairWinsVerifyingPaymaster.sol` — 173 lines including the interface it vendors. The digest from `getHash` commits to the op's sender, nonce, `initCode`, `callData`, all five gas fields, the chain id, the paymaster's own address, and a validity window. An approval therefore cannot be replayed on a different op, a different chain, a different paymaster, or after its TTL. Notably absent: any `senderNonce` mapping. Replay of the *same* op is already impossible — the account's own EntryPoint nonce makes each UserOperation single-use — so the paymaster's validation touches no storage at all. Zero-storage, external-call-free validation is the safest posture under ERC-7562's validation rules, which means the contract stays portable to any public bundler later, even though FairWins' own bundler doesn't enforce them.
+
+The approval travels in `paymasterAndData` with the v0.6 layout: `[paymaster (20)] [validUntil (6)] [validAfter (6)] [signature (65)]` — 97 bytes.
+
+The economics are equally simple. The contract holds a deposit at the EntryPoint (`deposit()` is permissionless; `withdrawTo` is owner-only), and that deposit *is* the sponsorship pool and the hard loss cap. Polygon mainnet runs at `0xe14554D14eB5DeC47f7824ebeeDa6C9f3A50d105` against the canonical v0.6 EntryPoint (`0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789`), recorded in `deployments/`. When the EntryPoint executes a sponsored op, it draws the gas cost from that deposit and reimburses the alto bundler's executor — FairWins pays FairWins's bundler back, per-op, with on-chain accounting.
+
+## The decision half: ERC-7677 on the existing gateway
+
+The signature has to come from somewhere, and *where* is the real policy decision. ERC-7677 standardizes how a wallet client asks a paymaster service for sponsorship: two JSON-RPC methods, `pm_getPaymasterStubData` (a dummy-signature stub so gas estimation sizes `verificationGasLimit` correctly) and `pm_getPaymasterData` (the real, signed approval). Because the frontend already builds UserOps with viem, adopting the standard meant the client work was nearly free — `createPaymasterClient` pointed at the endpoint, unmodified.
+
+Rather than stand up a paymaster microservice, spec 050 added `POST /v1/paymaster` to the relay gateway that already fronts FairWins' relayed-intent rail (spec 036). That gateway already had the three controls sponsorship needs, and the paymaster route composes the *same modules* rather than reimplementing them (`services/relay-gateway/src/paymaster/policy.js`):
+
+1. **Killswitch** — one env flag halts all sponsorship within a single request cycle; clients fall back to self-submit.
+2. **Sanctions screening** — keyed off the smart-account address, fail-closed, same screen the intent path uses.
+3. **Quotas** — per-account (6 ops/min, 25/day) and global (500/day) rate limits.
+
+Two ceilings are new, because sponsorship spends real money per op: a gas-units sanity cap (3M gas; a deploy-plus-transfer runs under ~2M) and a worst-case cost cap (`totalGas × maxFeePerGas ≤ 2 POL`), so a single deliberately expensive op can't burn a large slice of the deposit. Every refusal happens *before* signing — a refused request costs the operator nothing. Only a granted op reaches step nine of the pipeline: the actual signature.
+
+That signature comes from Google Cloud KMS. The gateway holds no key material; `services/relay-gateway/src/paymaster/sign.js` derives the signer's Ethereum address from the KMS public key at boot, then signs each approval digest via `asymmetricSign`, normalizing the DER output to a low-S 65-byte `{r,s,v}` signature. The contract's `verifyingSigner` is set to that derived address, and the gateway **refuses to boot** if its KMS key doesn't match the on-chain signer — a config drift that would silently break every sponsorship instead fails loudly at deploy time.
+
+One discipline deserves its own paragraph: the digest is computed in two codebases. `FairWinsVerifyingPaymaster.getHash` (Solidity) and `getHash` in `services/relay-gateway/src/paymaster/build.js` (JS) must stay byte-identical — thirteen ABI-encoded fields in exact order — or every sponsored op fails with an opaque `AA34`. A cross-check test deploys the real contract and asserts the two implementations agree, the same struct-sync discipline FairWins already applies to its EIP-712 intent types.
+
+## Never stranded, never dishonest
+
+Sponsorship is best-effort infrastructure, and the platform rule is that optional infrastructure never strands a user. The frontend treats *any* failure to obtain sponsorship — endpoint down, killswitch, quota, sanctions refusal, network error — identically: rebuild the bundler client without a paymaster and retry once, self-funded (`frontend/src/lib/passkey/sendBatch.js`). There's a subtle trap here the code comments call out: an op that reverts in bundler *simulation* (say, a transfer exceeding the account's balance) must be surfaced, not retried — a self-funded retry would revert identically and mask the real error behind a confusing `AA21`. So the fallback classifier lets only genuine sponsorship/transport failures through.
+
+The disclosure follows the same honesty rule that produced this feature in the first place. The account builder returns a `sponsored` boolean — true only when a paymaster is actually wired for this attempt — and the confirm UI renders from it: "Gasless — no network fee" when true, "You pay the POL network fee" when false, including the exact shortfall if the account lacks the native token to self-fund. On networks with no deployed paymaster, the config simply omits the sponsor URL and the path behaves exactly as before, honest copy included. Spec 050's success criteria demand the disclosure match the outcome in 100% of cases; the mechanism makes that structural rather than aspirational.
+
+## Design decisions
+
+**Stay on EntryPoint v0.6.** EntryPoint v0.7 is newer, but the deployed account factory, the Coinbase smart-account implementation, and alto are all v0.6 — and migrating changes every deterministic account *address*, orphaning deployed accounts and any funds sent to their counterfactual addresses. Not worth it for a paymaster. The v0.6 verifying pattern is the most well-trodden path in AA.
+
+**Verifying, not ERC-20.** A fee-in-USDC paymaster was considered and rejected: it needs a price oracle, token-pull-and-refund accounting, and an approval in the first op — more contract surface, more failure modes, for an outcome where the user still pays. Sponsoring is the smallest pattern and the only one that makes "no network fee" literally true.
+
+**Self-hosted, eyes open.** Rejecting vendor paymasters costs real work — KMS plumbing, quota design, runway monitoring — and buys independence: no vendor coupling of bundler to paymaster, no per-op markup, and policy (sanctions, quotas, killswitch) enforced in FairWins' own gateway rather than a third party's dashboard.
+
+**Bounded compromise blast radius.** A stolen `verifyingSigner` key can approve sponsorships — spending the deposit on other people's gas — but *cannot withdraw funds*; withdrawal is owner-only, and the owner key lives on FairWins' air-gapped floppy keystore. Worst-case loss is the deposit, throttled by quotas, cut off by the killswitch, and recovered by rotating the signer via `setVerifyingSigner` (`docs/runbooks/paymaster-operations.md`). Never overfunding the deposit — topping up on a 48-hour runway alert instead — keeps that worst case small by policy, not hope.
+
+**Identity-open eligibility.** Sponsorship isn't gated on membership tier. Any passkey account that passes screening and is within quota qualifies; spend is bounded by the ceilings, the pool, and the killswitch rather than by narrowing who benefits.
+
+## Sources
+
+- `specs/050-sponsored-paymaster/spec.md`, `research.md`, `contracts/gateway-paymaster-api.md`
+- `contracts/account/FairWinsVerifyingPaymaster.sol`
+- `services/relay-gateway/src/paymaster/build.js`, `sign.js`, `policy.js`
+- `services/alto-bundler/README.md`
+- `frontend/src/lib/passkey/smartAccount.js`, `frontend/src/lib/passkey/sendBatch.js`
+- `docs/runbooks/paymaster-operations.md`
+- ERC-4337: Account Abstraction Using Alt Mempool — https://eips.ethereum.org/EIPS/eip-4337
+- ERC-7677: Paymaster Web Service Capability — https://eips.ethereum.org/EIPS/eip-7677
+- ERC-7562: Account Abstraction Validation Scope Rules — https://eips.ethereum.org/EIPS/eip-7562

--- a/docs/blog/posts/06-sponsored-gas-verifying-paymaster/social.md
+++ b/docs/blog/posts/06-sponsored-gas-verifying-paymaster/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Sponsored Gas Without a Vendor: A Self-Hosted ERC-7677 Verifying Paymaster
+
+## X (Twitter)
+
+We rejected every vendor paymaster and built our own: a 173-line ERC-4337 v0.6 verifying paymaster with zero-storage validation, an ERC-7677 endpoint on our existing relay gateway, and a KMS-held signer. Worst-case loss = the deposit. Here's the full writeup 🔗 <link>
+
+#ERC4337 #AccountAbstraction #paymaster
+
+## LinkedIn
+
+Our passkey smart accounts had a broken promise: the confirm screen said "sponsored — no network fee," but with no paymaster configured, every UserOperation from a USDC-only account failed with AA21. We had two options — change the copy, or make it true. We made it true, without a third-party paymaster service.
+
+The new post walks through how FairWins ships sponsored gas on infrastructure it already runs:
+
+- A minimal EntryPoint v0.6 verifying paymaster whose validation is signature-only and zero-storage — ERC-7562-safe, portable to any bundler, with the EntryPoint deposit as a hard loss cap.
+- An ERC-7677 endpoint (pm_getPaymasterStubData / pm_getPaymasterData) added to the existing relay gateway, reusing its sanctions screening, per-account and global quotas, and killswitch — plus per-op gas and cost ceilings so one expensive op can't drain the pool.
+- A Cloud KMS signing key whose derived address must match the on-chain verifyingSigner, enforced by a fail-loud boot check; a compromised signer can grief the deposit but can never withdraw it.
+- A never-stranded fallback: any sponsorship failure degrades to self-funded submission with honest fee disclosure — the UI never claims "free" unless it is.
+
+Full architecture and trade-offs (why v0.6, why verifying over ERC-20, why self-hosted): <link>
+
+If you run account abstraction in production — would you self-host the paymaster, or is a vendor the right call at your scale?
+
+#AccountAbstraction #ERC4337 #ERC7677 #web3infrastructure #Ethereum
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an isometric style for a fintech-engineering blog banner: a compact, self-contained glass-and-metal toll gate standing on an abstract circuit-board causeway, where a stream of small glowing transaction cubes passes through free of charge while a single mechanical arm below the gate stamps each cube with a tiny luminous seal of approval; behind the gate, a transparent reservoir tank holds a finite pool of warm amber liquid (the gas deposit) with a visible level gauge, slowly metering drops to a relay tower in the background; composition uses strong diagonal flow from lower-left to upper-right with generous negative space at the top for headline overlay; deep navy and teal base palette with a single warm amber accent on the seal stamps and reservoir, soft rim lighting and subtle volumetric glow, precise geometric linework, minimal texture, no text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/07-safe-multisig-custody/blog.md
+++ b/docs/blog/posts/07-safe-multisig-custody/blog.md
@@ -1,0 +1,128 @@
+# Integrating Safe as a Custody Layer — Without Running Safe's Backend
+
+*How FairWins wires Safe v1.4.1 multisig vaults into a serverless app: on-chain approvals, an events-only proposal hub, and one "operate as" seam*
+
+---
+
+| | |
+|---|---|
+| **Series** | Custody & Multisig (part 1 of 2) |
+| **Part** | 7 of 34 |
+| **Audience** | Treasury engineers, DAO tooling builders |
+| **Tags** | `safe`, `multisig`, `custody`, `treasury` |
+| **Reading time** | ~9 minutes |
+
+> **Note**: FairWins wagers are peer-to-peer forecasts on publicly available information. Nothing here changes that: vault-originated wagers pass the same sanctions and membership checks as personal-wallet actions, and all participants remain subject to applicable law.
+
+---
+
+## Three Signers, One Vault, Zero Servers
+
+The Ethereum Classic Cooperative holds its funds the way most serious on-chain organizations do: in a Safe multisig, where no single keyholder can move money. When we set out to support that pattern inside FairWins — so a group could hold a shared treasury and place wagers or send payments *as the group*, under an M-of-N approval threshold — the multisig itself was the easy part. Safe's contracts are battle-tested, audited for years, and already deployed on our target chains. Rolling our own multisig would have been the single worst security decision available to us.
+
+The hard part was everything around the contracts. The Safe ecosystem's coordination story assumes a hosted backend: the Safe Transaction Service stores proposed transactions and collected signatures off-chain, a client gateway serves them to the wallet UI, and a config service describes each chain. The ETC Cooperative's own fork of the Safe wallet, `etclabscore/web-core`, self-hosts that entire stack pointed at Ethereum Classic.
+
+FairWins has a constitutional rule that forbids exactly this: **no app backend**. The app must keep working — and members must never be stranded — if every piece of FairWins-operated infrastructure disappears. A custody feature whose approvals live in a database we run would violate that on day one.
+
+So the integration question became: how do co-owners of a Safe discover a pending transaction, verify it, approve it, and execute it, using nothing but the chain? Spec 043 is the answer, and it required writing surprisingly little Solidity — one 66-line contract with no state, no funds, and no authority.
+
+## Why Safe, and Which Safe
+
+"Vault" in FairWins means a stock **Safe v1.4.1** proxy — not a fork, not a wrapper. Vaults created in FairWins are interoperable with the rest of the Safe ecosystem, and existing Safes (like the Cooperative's) can be loaded by address.
+
+Version choice mattered more than expected. Safe v1.4.1 was deployed everywhere through the per-chain Safe Singleton Factory, so its canonical addresses are **byte-identical across Ethereum Classic (61), Mordor (63), and Polygon (137)**: one `SafeProxyFactory` at `0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67`, one `SafeL2` singleton at `0x29fcB43b46531BcA003ddC8FCB67FFE91900C762`, one `MultiSendCallOnly`, one fallback handler — the same six addresses on every target chain. (v1.3.0 is also live on ETC, but its ETC/Mordor deployment uses the `eip155` address set while Polygon uses `canonical` — a per-chain config matrix we didn't want.) We verified presence with live `eth_getCode` calls, not just the `safe-deployments` JSON; the addresses live in `frontend/src/config/safeContracts.js`, and `getSafeContracts(chainId)` returning `undefined` is how the UI honestly says "unavailable on this network."
+
+New vaults use the `SafeL2` singleton (it emits richer events for indexing) and deploy via `SafeProxyFactory.createProxyWithNonce(singleton, initializer, saltNonce)` — CREATE2, so the UI shows the vault's address before it exists.
+
+Notably, there is no runtime Safe SDK in the app. `@safe-global/protocol-kit` assumes the Transaction Service we refuse to run; the ABIs we actually need are tiny and stable, so they're hand-maintained in `frontend/src/abis/` and driven through ethers v6 like every other contract in the codebase.
+
+## Approvals Without Signatures: the On-Chain-Only Flow
+
+Safe supports two ways to authorize a transaction: off-chain ECDSA signatures collected somewhere, or **on-chain hash approvals**. We use only the second. The flow, implemented in `frontend/src/lib/custody/vaultTransaction.js`:
+
+1. **Build** the `SafeTx` at the vault's current `nonce()`.
+2. **Hash** it — an EIP-712 hash over the `SafeTx` type with domain `{chainId, verifyingContract: safe}`, proven byte-for-byte equal to the Safe's own `getTransactionHash` in our tests.
+3. **Approve**: each owner sends an on-chain `Safe.approveHash(safeTxHash)` transaction. The chain itself becomes the signature store.
+4. **Execute**: once approvals meet the threshold, any owner calls `execTransaction` with a *pre-validated* signature bundle — no ECDSA anywhere:
+
+```js
+export function buildPrevalidatedSignatures(approverAddresses) {
+  // For each approving owner, 65 bytes: r = owner left-padded to 32 bytes,
+  // s = 32 zero bytes, v = 0x01 — concatenated in ASCENDING owner order
+  // (Safe's checkNSignatures loop requires currentOwner > lastOwner).
+  ...
+}
+```
+
+For `v == 1`, the Safe accepts a signature block iff `approvedHashes[owner][hash] != 0` (or the owner is `msg.sender`). Duplicate approvals can't double-count — the ascending-owner-order requirement makes a repeated block invalid on-chain, and the encoder rejects duplicates client-side first.
+
+This flow is inherently never-stranded: the vault's state *is* the coordination state. If FairWins vanishes, any generic Safe tooling can read the same `approvedHashes` and finish the job.
+
+## The Missing Piece: Preimage Discovery
+
+On-chain approvals create one real gap. `ApproveHash` events reveal only a 32-byte hash. A co-owner asked to approve `0x3f9a…` has no idea what it does — the full parameters (`to, value, data, operation, nonce`) don't appear on-chain until execution, which is too late to review.
+
+The Safe Transaction Service exists largely to fill this gap. Our replacement is `contracts/custody/SafeProposalHub.sol` — an immutable, events-only broadcaster:
+
+```solidity
+function propose(
+    address safe,
+    address to,
+    uint256 value,
+    bytes calldata data,
+    uint8 operation,
+    uint256 nonce,
+    bytes32 safeTxHash
+) external {
+    if (operation > 1) revert InvalidOperation();
+    if (data.length > MAX_DATA_LENGTH) revert DataTooLong();
+    emit Proposed(safe, msg.sender, safeTxHash, to, value, data, operation, nonce);
+}
+```
+
+That is essentially the whole contract. No state, no funds, no roles, no external calls; it cannot approve or execute anything. The proposer emits the transaction's full preimage; co-owner clients index `Proposed` for their vaults, **recompute the Safe transaction hash from the emitted parameters, and reject anything that doesn't equal the claimed `safeTxHash`** before ever calling `approveHash`. Integrity is free: a tampered or spoofed preimage produces a different hash and dies in the co-owner's own client. The worst a malicious `propose` can do is waste the proposer's gas. There's also an advisory `cancel` event — advisory because the Safe nonce, not the hub, is the real arbiter of which transaction is live.
+
+And because even this tiny contract is optional infrastructure, there's a fallback: the proposer can export the `SafeTx` as a signed EIP-712 typed payload and share it as a link or QR code. The co-owner imports it, verifies the same hash, and approves — working even on a chain where the hub was never deployed. The hub is recorded per network in `deployments/` (Polygon: `0x94b5b38C247CE51F7C42C83B63115998b7e970E7`), deliberately built without OpenZeppelin imports so it compiles for pre-Cancun targets like ETC and Mordor.
+
+## "Operate As" — One Seam, Every Money-Moving Surface
+
+A custody tab that only sends transfers is a standalone Safe client, not an integration. The point of spec 043 is that a member can *become* the vault: create a wager staked from the vault, or pay someone from it, with the action gated on co-owner approval.
+
+The frontend previously had no act-as concept — identity was always the connected wallet address. Rather than teach every flow about contract accounts, all money-moving surfaces route their final intent through one seam, `frontend/src/lib/custody/submitAsActiveAccount.js`:
+
+- **Personal mode**: send through the connected signer, exactly as before.
+- **Vault mode**: build the `SafeTx` (batching `approve` + action through `MultiSendCallOnly` when an ERC-20 allowance is needed), broadcast it via the hub, record the proposer's own `approveHash` — and return a **pending proposal**, never an executed action.
+
+`MultiSendCallOnly` rather than `MultiSend` is a deliberate restriction: the batch's inner transactions can only `CALL`, never nested-delegatecall — a smaller attack surface for the routine approve-then-act pattern. A persistent banner shows which identity is active, and a pending vault action appears *only* in the vault's queue — it never shows up as a phantom entry in My Wagers or transfer history until the chain confirms it, because implying state the chain hasn't confirmed is exactly the dishonesty the design forbids.
+
+One honest wrinkle surfaced during research. Inbound movements — receiving funds, triggering a refund owed to the vault — need no threshold, since `claimRefund` in the wager registry is caller-agnostic and routes funds to recorded parties. But `claimPayout` requires `msg.sender == winner`, and its gasless twin recovers an EOA signature via `ecrecover` with no EIP-1271 support. So a vault that *wins* a wager must claim through a threshold-approved `execTransaction`. We documented that as the FR-022c exception rather than pretending a single owner could pull the payout; fixing it properly means adding EIP-1271 verification to the registry's intent facet, which is future work, not v1.
+
+## The Guard Socket
+
+Everything above makes the vault usable; it doesn't yet make it *governable* beyond M-of-N. Safe's answer to programmable policy is the transaction guard: a contract the Safe consults via `checkTransaction(...)` before executing anything and `checkAfterExecution(...)` after. The custody family ships the scaffolding for this — `contracts/custody/ISafeGuard.sol`, a dependency-free replica of Safe v1.4.1's guard interface whose selectors (and thus its ERC-165 interface id, which `setGuard` checks) are byte-identical to the canonical one, and `contracts/custody/PolicyGuardSetup.sol`, a stateless helper delegatecalled from `Safe.setup` so a new vault is policy-governed from its very first transaction, with the initial policy committed into the vault's CREATE2 address.
+
+What those policies look like — spending rules enforced at execution time, so a quorum of compromised signers still can't violate them — is spec 049, and it's the subject of part 2.
+
+## Design Decisions
+
+- **Adopt Safe v1.4.1, don't fork it.** Years of audits and ecosystem interoperability for free; the version chosen specifically because its canonical addresses match across all three target chains.
+- **No hosted coordination.** On-chain `approveHash` + pre-validated signatures replace the Safe Transaction Service entirely. Cost: every approval is a gas-paying transaction. Benefit: the chain is the single source of truth, and the never-stranded rule holds.
+- **Events-only discovery with client-side verification.** `SafeProposalHub` carries data, never trust; the signed-payload fallback means zero required infrastructure.
+- **One `submitAsActiveAccount` seam** instead of per-surface vault logic — seven heterogeneous flows reroute through one audited chokepoint.
+- **Honest state over convenience.** Pending vault actions live only in the vault queue; the vault-won-payout exception is documented instead of papered over.
+- **References-only backup.** The encrypted app backup (spec 032) stores vault addresses and labels — never key material; the vault itself lives on-chain and reloads by address.
+
+## Sources
+
+- `specs/043-safe-multisig-custody/` — spec.md, research.md (decisions 1–8), plan.md
+- `docs/developer-guide/safe-custody.md` — developer guide
+- `docs/developer-guide/treasury-security.md` — multisig-owned `TreasuryVault` pattern
+- `contracts/custody/SafeProposalHub.sol`, `contracts/custody/ISafeGuard.sol`, `contracts/custody/PolicyGuardSetup.sol`
+- `frontend/src/lib/custody/vaultTransaction.js`, `frontend/src/lib/custody/submitAsActiveAccount.js`, `frontend/src/config/safeContracts.js`
+- `deployments/polygon-chain137-v2.json` — `safeProposalHub` address
+- Safe contracts & docs — https://safe.global / https://github.com/safe-global/safe-smart-account
+- Safe deployments registry — https://github.com/safe-global/safe-deployments
+- EIP-712 (typed structured data hashing) — https://eips.ethereum.org/EIPS/eip-712
+- EIP-1271 (contract signature validation) — https://eips.ethereum.org/EIPS/eip-1271
+- ERC-165 (interface detection) — https://eips.ethereum.org/EIPS/eip-165
+- ETC Cooperative Safe wallet fork — https://github.com/etclabscore/web-core

--- a/docs/blog/posts/07-safe-multisig-custody/social.md
+++ b/docs/blog/posts/07-safe-multisig-custody/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Integrating Safe as a Custody Layer, Without Running Safe's Backend
+
+## X (Twitter)
+
+We integrated Safe multisig custody with zero backend: on-chain approveHash + pre-validated sigs (v=1, r=owner) replace the Transaction Service, and a 66-line events-only contract handles proposal discovery. Clients verify every preimage by recomputing the hash. 🔗 <link> #Safe #multisig #web3
+
+## LinkedIn
+
+Most Safe integrations quietly depend on a hosted backend — the Safe Transaction Service stores proposals and signatures off-chain, and if it disappears, coordination stops. FairWins has a hard rule against app backends, so we integrated Safe v1.4.1 as our custody layer using only the chain itself.
+
+The new post walks through the architecture:
+
+- The on-chain-only approval flow: each owner calls approveHash, then anyone executes with pre-validated signature bundles (v=1, r=owner address) — no off-chain ECDSA collection anywhere.
+- SafeProposalHub, a stateless, events-only contract for co-owner discovery. Clients recompute the EIP-712 Safe transaction hash from emitted parameters and reject mismatches, so the hub carries data but never trust — plus a signed-payload QR fallback so the feature works with zero infrastructure.
+- One "operate as the vault" seam routing every money-moving surface (wagers, payments, swaps) into the vault's threshold-gated queue.
+- Why Safe v1.4.1 specifically: canonical addresses are identical across Ethereum Classic, Mordor, and Polygon.
+
+We also cover the honest edge cases — like why a vault-won wager payout still needs threshold approval when refunds don't.
+
+Read the full post: <link>
+
+If you've integrated Safe without the Transaction Service, what did you use for proposal discovery?
+
+#Safe #multisig #custody #DAOtooling #smartcontracts
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern editorial illustration, isometric style: a translucent geometric vault shaped like a faceted glass cube floating at center, sealed by three interlocking mechanical keys converging from different angles, each key held by an abstract faceless figure standing on separate floating platforms connected only by thin glowing chain-links of blockchain blocks — no wires to any central server; a small radiant beacon beside the vault emits concentric broadcast rings carrying tiny document glyphs toward the figures, symbolizing an events-only proposal broadcaster. Deep navy and teal base palette with a single warm amber accent on the beacon's rings and the keyways, soft diffused rim lighting, subtle grid horizon fading into darkness, generous negative space, precise vector-like edges, fintech-engineering brand mood, no text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/08-multisig-policy-engine/blog.md
+++ b/docs/blog/posts/08-multisig-policy-engine/blog.md
@@ -1,0 +1,130 @@
+# Enough Signatures Is Not Enough: An On-Chain Policy Engine for Safe Multisigs
+
+*How a singleton transaction guard turns threshold approval into threshold approval plus policy — with no admin key and no way to brick a vault*
+
+| | |
+|---|---|
+| **Series** | Custody & Multisig (part 2) |
+| **Part** | 8 of 34 |
+| **Audience** | Security engineers, DAO/treasury tooling builders |
+| **Tags** | `safe`, `multisig`, `policy-engine`, `transaction-guard`, `security` |
+| **Reading time** | ~9 minutes |
+
+## The transaction that had every signature it needed
+
+A three-owner treasury Safe runs a 2-of-3 threshold. One Tuesday, a proposal appears in the queue: send 180,000 USDC to an address nobody recognizes. Owner one approves it from a phone between meetings — the amount looks like the quarterly market-maker payment, and the proposal description says as much. Owner two approves an hour later for the same reason. The threshold is met. The transaction executes. The address belonged to whoever phished owner one's session and queued the proposal.
+
+Nothing in the multisig failed. That is the uncomfortable part. A threshold multisig has exactly one control — *k* of *n* owners agree — and once that bar is cleared, the Safe will send any amount, to any destination, at any time. Every mitigation teams usually reach for is procedural: "we review destinations carefully," "we never approve on mobile," "large transfers get a call first." Procedures are policy that lives in people's heads, and people approve things between meetings.
+
+FairWins' custody feature (spec 043, covered in part 1 of this series) gives members shared Safe vaults with a propose/approve queue. Spec 049 adds the missing layer: a **policy engine** that constrains what an *approved* vault transaction may do — after the owners' threshold is met, before execution. The phished proposal above dies at execution against a per-transaction limit or a recipient allowlist, no matter how many signatures it collected.
+
+The interesting engineering question is where such rules can live so that they are actually binding. Client-side checks are advisory — anyone can call the Safe directly. A backend policy service is a trusted party. The answer Safe's architecture offers is the **transaction guard**, and spec 049 builds the whole engine as one.
+
+## Where a guard sits in Safe's execution path
+
+Safe v1.4.1 lets a Safe register a guard contract that gets a veto over every `execTransaction`. Just before executing an approved transaction, the Safe calls the guard's `checkTransaction` with the full transaction context; if the guard reverts, the transaction never executes. After execution it calls `checkAfterExecution`.
+
+FairWins keeps a dependency-free local replica of the interface in `contracts/custody/ISafeGuard.sol`, byte-identical to the canonical one (Safe's `Enum.Operation` is `uint8` in the ABI, so the selectors — and the ERC-165 interface id that `setGuard` checks as `GS300` — match exactly):
+
+```solidity
+interface ISafeGuard {
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes calldata signatures,
+        address msgSender
+    ) external;
+
+    function checkAfterExecution(bytes32 txHash, bool success) external;
+}
+```
+
+The implementation, `contracts/custody/SafePolicyGuard.sol`, is a **singleton per chain**: one immutable contract holds every opted-in vault's rule configuration and live accounting, keyed by the Safe's address. Because the Safe itself is `msg.sender` when it calls the guard, the guard always knows which vault's policy to evaluate — no registration handshake needed.
+
+Two properties define the trust model. First, the guard is **restriction-only**: it can block a transaction but can never initiate, approve, or execute one, and it holds no funds (non-payable everywhere). Second, **the vault is the only authority over its own policy**: every call to `configureRules` requires `msg.sender == safe`, which is only reachable as a Safe self-transaction — meaning a policy change rides the same threshold-approved proposal queue as moving money. There is no owner, no admin role, and the contract is deliberately not upgradeable, because an upgrade key over the guard would be a backdoor over every vault's enforcement.
+
+## The rules
+
+Version 1 ships the classic treasury controls, each independently optional per vault:
+
+- **Per-transaction limit** — per asset (`address(0)` for the native coin, or an ERC-20 address); no single outgoing transaction may exceed it.
+- **24-hour-window limit** — per asset; the window opens at the first counted spend and resets 24 hours later.
+- **Recipient allowlist** — outgoing value may only go to approved addresses.
+- **Cooldown** — a minimum delay between fund-moving transactions.
+
+A transaction is *counted* — subject to limits and cooldown — when it carries native `value > 0` or calls one of three ERC-20 selectors the guard decodes: `transfer`, `transferFrom`, and `approve`. Counting `approve` is not an accident: an approval is a spending grant, and skipping it would leave an approve-then-pull bypass where the vault approves a spender within no limit and the spender drains the allowance later.
+
+The allowlist has a subtlety worth copying. For decoded token actions it gates the *beneficiary* — the `transfer`/`transferFrom` recipient or the `approve` spender — not the token contract being called. For everything else it gates the call target, so calldata the guard cannot decode still cannot reach an un-allowlisted contract. Native value riding a call additionally gates the target.
+
+Calldata decoding in `_classify` slices exactly the canonical argument words (`data[4:68]` for `transfer`/`approve`, `data[4:100]` for `transferFrom`). Solidity functions ignore extra trailing calldata for static arguments, so the guard classifies a padded call exactly as the token itself would execute it — padding can neither dodge classification nor spuriously revert it.
+
+## Hard denials: the bypasses you must close first
+
+Limits are worthless if the transaction can step outside the accounting. While any rule is active, the guard hard-rejects two shapes:
+
+- **`operation == DELEGATECALL`.** Delegatecalled code runs in the Safe's own storage context — it can move funds without tripping any decode path and can literally rewrite the guard slot. The consequence is that MultiSend batching is unavailable on policy vaults; since spec 043's flows are single-call, nothing regresses.
+- **`gasPrice != 0`.** Safe's gas-refund mechanism pays `refundReceiver` out of the Safe. That is an uncounted outflow, so refund transactions are refused outright.
+
+Both denials are typed errors (`DelegatecallBlocked`, `GasRefundBlocked`), like every other rejection — clients decode one canonical error format instead of parsing revert strings.
+
+## Lockout-proofing: a policy you can always loosen
+
+The classic failure mode of on-chain policy is self-imprisonment: owners set a cooldown of a year, or enable an allowlist with only a now-defunct address, and the vault is bricked. Spec 049's answer (FR-008) is a pair of exemptions at the top of the shared evaluation function:
+
+```solidity
+// Lockout-proof exemptions (FR-008): vault self-management and policy
+// configuration bypass all fund rules; both still require the vault's
+// own approval threshold.
+if (to == safe) return ("", false);
+if (to == address(this)) {
+    if (value != 0) return (abi.encodeWithSelector(ValueToGuardBlocked.selector), false);
+    return ("", false);
+}
+```
+
+Transactions targeting the Safe itself (owner, threshold, and guard management) or the guard (policy configuration, with `value == 0` enforced so the exemption cannot smuggle funds) bypass all fund rules — while still requiring the vault's threshold. A too-strict policy can therefore always be loosened by the same collective consent that created it; no vault can be locked out by its own rules. This is proven against a real Safe v1.4.1 deployment in `test/integration/policy-guard-safe.test.js`, not just against a mock.
+
+## One evaluation path, shared by enforcement and preview
+
+Owners should learn a transaction violates policy *before* they spend signatures on it. The guard exposes `previewTransaction`, a read-only twin of `checkTransaction` that runs the exact same internal `_checkPolicy` function and returns the would-be revert data. The frontend (`frontend/src/lib/custody/policy.js`) pre-flights every proposal through it, so what the UI displays can never drift from what the chain enforces — there is one rule evaluator, used verbatim by both paths.
+
+Enforcement itself follows checks-effects with no interactions at all: `_checkPolicy` is read-only, then `_commitAccounting` writes window and cooldown state. The guard makes zero external calls, so there is no reentrancy surface to reason about.
+
+## Policy from block one
+
+A vault attached to a guard after creation has a gap: transactions before attachment are unpoliced. `contracts/custody/PolicyGuardSetup.sol` closes it. It is a stateless helper delegatecalled from `Safe.setup(to, data, ...)` during vault creation: running in the new proxy's context, it writes the guard address directly into Safe's guard storage slot (`keccak256("guard_manager.guard.address")`), re-performs the ERC-165 `GS300` acceptance check that writing the slot directly would otherwise skip, emits a byte-identical `ChangedGuard` event for explorer parity, and then `call`s the guard's `configureRules` calldata — at which point `msg.sender` seen by the guard *is* the new Safe, so the creation path needs no special authority carve-out. Any revert bubbles up and aborts the whole vault creation: a half-configured vault can never deploy. And because the full initializer is hashed into the CREATE2 salt, the vault's predicted address commits to its initial policy.
+
+For existing vaults, attachment is ordered so there is no half-set gap: queue `configureRules` first (inert without the guard), then `setGuard` (activates).
+
+## Design decisions and accepted limits
+
+**Immutable singleton, no proxy.** Elsewhere FairWins is aggressively UUPS (`WagerRegistry`, `MembershipManager`), but the guard has no upgrade path on purpose: whoever can swap the implementation can disable every vault's enforcement. Upgrades ship as a *new* guard deployment that each vault adopts via its own threshold-approved `setGuard` — consent per vault, not fiat from a deploy key. Both contracts deploy deterministically via CREATE2 and are recorded in `deployments/` under `safePolicyGuard` / `policyGuardSetup`, rolling out Mordor (63) then Polygon (137).
+
+**Fixed-reset window, not rolling.** A true rolling 24-hour window requires unbounded per-transaction history on-chain. The fixed-reset window admits up to 2× the limit across a span that straddles a reset — a bounded, disclosed weakening (research.md R3), surfaced in the UI rather than hidden.
+
+**Unvalued calldata passes limits.** The guard values native transfers and three ERC-20 selectors; a DEX swap or arbitrary contract call passes spending limits unvalued. It still faces the allowlist on the call target, so a vault that needs full lockdown enables the allowlist and gets it.
+
+**Conservative accounting.** Window and cooldown state commit in `checkTransaction`, before execution. If the Safe's inner call fails without reverting the outer transaction, the spend still counts. Overcounting can only restrict, never permit — the safe direction to be wrong in.
+
+The through-line: every rule that exists is enforced exactly, every gap that exists is named, bounded, and disclosed, and no key anywhere can waive either.
+
+## Sources
+
+- `specs/049-multisig-policy-engine/` — spec, plan, research, data model
+- `docs/developer-guide/multisig-policy-engine.md`
+- `contracts/custody/SafePolicyGuard.sol`
+- `contracts/custody/ISafeGuard.sol`
+- `contracts/custody/PolicyGuardSetup.sol`
+- `test/integration/policy-guard-safe.test.js`, `test/custody/SafePolicyGuard.test.js`
+- `frontend/src/lib/custody/policy.js`
+- Safe transaction guards (Safe v1.4.1 `GuardManager`): https://docs.safe.global/advanced/smart-account-guards and https://github.com/safe-global/safe-smart-account
+- ERC-165 (interface detection, the `GS300` check): https://eips.ethereum.org/EIPS/eip-165
+- ERC-20 (`transfer`/`transferFrom`/`approve` semantics): https://eips.ethereum.org/EIPS/eip-20
+- EIP-1014 (CREATE2, deterministic deployment): https://eips.ethereum.org/EIPS/eip-1014

--- a/docs/blog/posts/08-multisig-policy-engine/social.md
+++ b/docs/blog/posts/08-multisig-policy-engine/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Enough Signatures Is Not Enough: An On-Chain Policy Engine for Safe Multisigs
+
+## X (Twitter)
+
+Your multisig has one control: k-of-n signatures. Phish two owners and the treasury is gone. We built a Safe transaction guard enforcing spending limits, allowlists + cooldowns at execution — no admin key, no way to brick a vault. 🔗 <link> #Safe #multisig #web3security
+
+## LinkedIn
+
+A threshold multisig has exactly one control: k of n owners agree. Once that bar is cleared, the Safe will send any amount, to any destination. Every other safeguard most teams rely on is procedural — and procedures fail quietly when someone approves a plausible-looking proposal between meetings.
+
+Our latest engineering post walks through FairWins' on-chain multisig policy engine: a singleton Safe v1.4.1 transaction guard that enforces rules on approved transactions at execution time. It covers:
+
+- How Safe's guard interface (checkTransaction / checkAfterExecution) gives a contract veto power over every execution, and why the engine is one immutable singleton per chain with no admin role and no upgrade key
+- The v1 rule set — per-transaction limits, 24-hour window limits, recipient allowlists, cooldowns — and why counting ERC-20 approve() closes the approve-then-pull bypass
+- Lockout-proofing: vault self-management and policy configuration bypass fund rules (but still require the threshold), so a too-strict policy can always be loosened and no vault can brick itself
+- Honest trade-offs: fixed-reset windows vs. rolling, unvalued calldata, conservative pre-execution accounting, and why delegatecall and gas refunds are hard-denied
+
+If you run a DAO treasury or build custody tooling, the design decisions here — especially what we chose *not* to make upgradeable — may be useful.
+
+🔗 <link>
+
+Where do you draw the line between on-chain enforcement and operational procedure for treasury controls?
+
+#Safe #multisig #DAOtreasury #smartcontracts #web3security
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an isometric style: a large translucent vault chamber rendered as a geometric glass cube containing stacked coin columns, with three abstract key shapes converging on its door — but between the keys and the vault stands a slim luminous gate frame, a lattice of horizontal bars and checkpoints suggesting rules being evaluated, one bar glowing as it blocks a single outgoing coin stream while another stream passes cleanly through. Composition: vault cube slightly right of center, gate frame in the foreground left, thin circuit-like paths connecting them across a minimal grid floor. Color mood: deep navy and dark teal base surfaces with cool cyan edge light, and a single warm amber accent reserved for the blocked stream and the active gate bar, consistent with a fintech-engineering brand. Soft directional lighting from the upper left, subtle depth-of-field haze in the background, matte textures with faint isometric grid lines. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/09-intent-based-gasless-payments/blog.md
+++ b/docs/blog/posts/09-intent-based-gasless-payments/blog.md
@@ -1,0 +1,128 @@
+# One Signature, Zero Gas: Intent-Based Payments with EIP-712 and EIP-3009
+
+*How FairWins turned every user action into a signed intent — and the byte-identical struct discipline that keeps three codebases honest*
+
+---
+
+| | |
+|---|---|
+| **Series** | Gasless Rails (part 1 of 2) |
+| **Part** | 9 of 34 |
+| **Audience** | dApp developers, meta-transaction and relayer engineers |
+| **Tags** | `eip712`, `eip3009`, `meta-transactions`, `gasless`, `intents` |
+| **Reading time** | ~8 minutes |
+
+---
+
+## The Stranded User
+
+A user wins a wager on FairWins. Fifty USDC sits in escrow with their address recorded as the winner. All they have to do is call `claimPayout`. One problem: their wallet holds exactly zero POL. They funded it with USDC from an exchange, they've never touched Polygon's native token, and they have no intention of learning what a gas station is. Their money is on-chain, provably theirs, and unreachable.
+
+The pre-intent flow was worse than one stranded action — it was two transactions per money-in action. Creating a wager meant an ERC-20 `approve()` followed by the create call. Accepting one meant the same dance. Every step required native gas, and the spec for this feature (`specs/035-intent-based-payments/spec.md`) named the failure mode plainly: a user who holds only the platform stablecoin is stranded — they cannot act at all.
+
+The worst version of this is asymmetric: a user who scraped together gas to *stake* but can't afford gas to *claim*. Money in, no money out. Any gasless design that fixes deposits but not withdrawals has built a lobster trap.
+
+Spec 035's answer is to make the entire platform operate on **signed intents**. The user signs a structured message off-chain — free — describing exactly what they want. Anyone can carry that message on-chain, but the on-chain effect is always attributed to the *signer*, never the submitter. One signature replaces approve-plus-act, and a relayer's gas wallet pays the transaction fee.
+
+## Anatomy of an Intent
+
+An intent is an [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed struct. Every action on the platform has one — `CreateWagerIntent`, `AcceptWagerIntent`, `ClaimPayoutIntent`, `DeclareDrawIntent`, `PurchaseTierIntent`, and so on. Each struct binds three things:
+
+1. **The acting address** — a named field (`creator`, `taker`, `claimant`, `member`) that must equal the recovered signer.
+2. **Every action parameter** — stake amounts, deadlines, the wager ID, the metadata hash. Nothing is left for the submitter to fill in.
+3. **A replay guard and validity window** — a random 32-byte `nonce`, plus `validAfter` / `validBefore` timestamps.
+
+Here is the accept-wager struct as the contract declares it in `contracts/wagers/WagerRegistryIntents.sol`:
+
+```solidity
+bytes32 private constant ACCEPT_WAGER_INTENT_TYPEHASH = keccak256(
+    "AcceptWagerIntent(uint256 wagerId,address taker,bytes32 paymentNonce,"
+    "bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+);
+```
+
+Signatures are verified under a **per-contract domain**: `("FairWins WagerRegistry", "1", chainId, proxyAddress)` for wager actions, `("FairWins MembershipManager", "1", ...)` for membership actions. Chain ID and verifying contract in the domain mean a signature is valid on exactly one contract on exactly one network — a nonce consumed on one contract can never be replayed on another.
+
+The verification machinery lives in one shared mixin, `contracts/upgradeable/SignerIntentBase.sol`. Its `_verifyIntent` checks the validity window, recovers the signer (ECDSA first, then an [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) `isValidSignature` staticcall so contract accounts — including FairWins' passkey smart wallets — can sign intents too), and burns the nonce before the action body runs any external interaction. A failed intent never consumes its nonce; a succeeded one can never run twice.
+
+One detail worth stealing: the nonce map lives in [ERC-7201](https://eips.ethereum.org/EIPS/eip-7201)-namespaced storage rather than sequential slots. That made `SignerIntentBase` safe to add to two *already-live* UUPS proxies (`WagerRegistry` and `MembershipManager`) without shifting a single existing storage slot or spending `__gap` reserve.
+
+## The Payment Leg: EIP-3009
+
+Signature-based actions are the easy half. The hard half is money-in actions — the intent says "stake 50 USDC," but the contract still has to actually pull 50 USDC without a prior `approve()`.
+
+This is what [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) exists for. Circle's USDC implements `receiveWithAuthorization`: the token holder signs an authorization — under the *stablecoin's own* EIP-712 domain, not FairWins' — naming a payee, an amount, a validity window, and a random nonce. The payee contract presents that signature to the token and the transfer executes. No allowance ever exists.
+
+So a money-in intent carries two signatures: the FairWins intent and the USDC authorization. Which raises the attack that defines this design: **what stops a relayer from mixing and matching?** Take Alice's payment authorization, pair it with a different action; take her accept-intent for wager 41, staple on an authorization meant for something else.
+
+The answer is that the two legs are cryptographically stapled. Every money-in intent struct carries a `paymentNonce` field — you can see it in the typehash above — and the contract asserts that the relayer-supplied authorization is exactly the one the signer committed to:
+
+```solidity
+function _pullWithAuthorization(
+    address token, address from, uint256 expectedValue,
+    bytes32 expectedPaymentNonce, ERC3009Auth memory auth
+) internal {
+    if (auth.value != expectedValue || auth.nonce != expectedPaymentNonce)
+        revert PaymentAuthMismatch();
+    IERC3009(token).receiveWithAuthorization(
+        from, address(this), auth.value,
+        auth.validAfter, auth.validBefore, auth.nonce,
+        auth.v, auth.r, auth.s
+    );
+}
+```
+
+The token itself enforces the third edge: `receiveWithAuthorization` requires the payee to be the calling contract, so the money can only land in the registry. The net result, stated in `docs/developer-guide/gasless-intents.md`: a relayer can *censor* an intent, but it can never substitute, redirect, or resize a payment. That is the correct trust boundary for optional infrastructure.
+
+## The Twin Invariant
+
+Every gasless entrypoint is a *twin* of an existing self-submit function — `acceptWager` gains `acceptWagerWithAuthorization`, `claimPayout` gains `claimPayoutWithSig` — and both twins run **identical checks and effects against the acting identity**: sanctions screening, membership gating, ownership, account freeze. For self-submit that identity is `msg.sender`; for the intent path it is the recovered signer. The submitter's own entitlements are never consulted. Both facets of the wager registry inherit the same `WagerRegistryCore` action bodies, so the twins cannot drift apart behaviorally: the twin is a thin verification wrapper around the exact same internal function the direct call uses.
+
+(The registry hosts these twins on a second implementation facet reached by delegatecall, because the main implementation sits 116 bytes shy of the EVM's 24 KB code limit — a story that deserves, and gets, its own post.)
+
+## The Three-Way Struct Sync
+
+Here is the lesson most meta-transaction tutorials skip. The EIP-712 struct definitions exist in **three places**:
+
+- the Solidity typehash strings in `contracts/wagers/WagerRegistryIntents.sol` (and `MembershipManager.sol`),
+- the frontend signing definitions in `frontend/src/lib/relay/intentTypes.js`,
+- the gateway verification definitions in `services/relay-gateway/src/intent/intentTypes.js`.
+
+These must stay **byte-identical**. Not semantically equivalent — byte-identical. EIP-712 hashes the full type string, so `uint256 wagerId` versus `uint wagerId`, a reordered field, or a renamed one produces a different typehash, a different digest, and a signature that recovers to a random address. The failure is silent at build time and absolute at runtime: `InvalidIntentSignature`, every time, for every user.
+
+The discipline FairWins landed on: the deployed contract typehashes are *authoritative*; each JS file declares in its header comment which spec document it mirrors and where deviations from the spec doc were resolved in the contract's favor (the schemas doc elided fields with `…`; the deployed `AcceptWagerIntent` really does carry `paymentNonce`, so both JS files do too). The gateway file goes further and makes itself the single source its own verification, encoding, and tests all derive from — a schema change inside that service is a one-file edit. When later features added intent structs (wager pools, the callsign registry), each new struct shipped simultaneously in all three places with cross-references in comments. It is unglamorous, and it is the difference between a working gasless rail and a support queue.
+
+## Never Stranded
+
+The final rule is architectural humility: the relayer is optional infrastructure, and the design must survive its absence. Every gasless flow keeps a **self-submit fallback** — the original pay-your-own-gas path is never removed, and the frontend hook `frontend/src/lib/relay/useIntentAction.js` enforces it at wiring time: the hook *throws during development* if a call site fails to supply a `selfSubmit` function, so no screen can ship a gasless-only dead end. Relayer unset, unhealthy, rate-limiting, timing out — the hook transparently falls back, and the on-chain result is identical.
+
+The fallback also covers chains where the payment leg simply doesn't exist. Mordor's USC stablecoin lacks EIP-3009; the frontend's `stablecoinDomain()` check throws `PaymentUnsupportedOnChain` *before* the wallet prompt ever opens, and the flow self-submits. And status is honest end to end: the UI never shows `confirmed` before a mined transaction exists — signed, pending, confirmed, expired, and failed are distinct, truthful states.
+
+## Design Decisions
+
+**Random nonces, not sequential.** Nonces are client-generated random 32-byte values, usable out of order — EIP-3009's own scheme, adopted for intents too. Sequential nonces serialize a user's actions and let one stuck intent block everything behind it; random nonces let a user sign three intents and have them land in any order. Cancellation is targeted: `invalidateNonce(nonce)` kills one specific unsubmitted intent, and `invalidateNonceWithSig` makes even *cancellation* gasless.
+
+**Sign everything, trust nothing.** Every parameter the action consumes is inside the signed struct. The alternative — signing a hash of parameters delivered out-of-band — is fewer bytes but gives wallets nothing legible to display. EIP-712 typed data means the wallet shows the user the actual stake, deadline, and counterparty they are authorizing.
+
+**Fee netting is bounded and segregated.** An optional second EIP-3009 authorization lets the platform recover gas costs in USDC, but it is capped on-chain (`FeeExceedsCap`), settles atomically with the action, and pays a segregated `gasFeeRecipient` — never the relayer's hot key. A compromised relayer gains no fee-redirection power.
+
+**Censorship is the accepted residual risk.** A relayer can decline to submit. It cannot forge, alter, or replay. Because self-submit always exists, censorship degrades to inconvenience — the user pays their own gas and proceeds. That trade — accept censorship, eliminate custody — is the entire design in one sentence.
+
+---
+
+> **Note**: FairWins wagers are peer-to-peer agreements based on publicly available information and legitimate forecasting. Gasless submission changes who pays the transaction fee, not who is accountable: every intent is attributed to its signer, who remains fully subject to applicable law and the platform's compliance screening.
+
+## Sources
+
+- `specs/035-intent-based-payments/spec.md` — feature spec, user stories, never-stranded rule
+- `specs/035-intent-based-payments/contracts/intent-eip712-schemas.md` — intent struct schemas
+- `docs/developer-guide/gasless-intents.md` — architecture overview, twin invariant, rollout
+- `contracts/upgradeable/SignerIntentBase.sol` — shared verification mixin, nonce map, fee netting
+- `contracts/wagers/WagerRegistryIntents.sol` — the `…WithSig` / `…WithAuthorization` twins
+- `frontend/src/lib/relay/intentTypes.js` — frontend struct definitions and domain builders
+- `frontend/src/lib/relay/useIntentAction.js` — never-stranded enforcement point
+- `services/relay-gateway/src/intent/intentTypes.js` — gateway struct definitions
+- [EIP-712: Typed structured data hashing and signing](https://eips.ethereum.org/EIPS/eip-712)
+- [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009)
+- [ERC-1271: Standard Signature Validation Method for Contracts](https://eips.ethereum.org/EIPS/eip-1271)
+- [ERC-7201: Namespaced Storage Layout](https://eips.ethereum.org/EIPS/eip-7201)

--- a/docs/blog/posts/09-intent-based-gasless-payments/social.md
+++ b/docs/blog/posts/09-intent-based-gasless-payments/social.md
@@ -1,0 +1,32 @@
+# Social & Image — One Signature, Zero Gas: Intent-Based Payments with EIP-712 and EIP-3009
+
+## X (Twitter)
+
+Your user won 50 USDC on-chain. Their wallet has zero POL. Their money is provably theirs — and unreachable.
+
+We made every action a signed EIP-712 intent, stapled to an EIP-3009 payment leg via a shared paymentNonce. Relayers can censor, never redirect.
+
+🔗 <link>
+
+#EIP712 #gasless #web3dev
+
+## LinkedIn
+
+The most common way users abandon a dApp is not a bug — it is a wallet holding stablecoin but zero native gas token. They cannot approve, cannot act, and in the worst case cannot even claim funds they already won.
+
+Our new engineering post walks through how FairWins rebuilt every user action as an intent-based gasless flow, and the operational discipline that keeps it correct:
+
+- Every action gets a `…WithSig` twin: an EIP-712 struct binding the actor, every parameter, a random 32-byte nonce, and a validity window — verified on-chain with identical sanctions, membership, and ownership checks as the direct-call path.
+- Money-in actions staple an EIP-3009 `receiveWithAuthorization` to the intent via a shared `paymentNonce`, so a relayer can censor a payment but can never substitute, redirect, or resize one.
+- The struct definitions live in three codebases — Solidity typehashes, the frontend signer, and the relay gateway — and must stay byte-identical. One reordered field means every signature recovers to a random address.
+- The never-stranded rule: self-submit is mandatory at every call site, enforced by the frontend hook itself, so the relayer remains optional infrastructure rather than a single point of failure.
+
+Full write-up: <link>
+
+How does your team keep EIP-712 structs in sync across contract, client, and backend — codegen, tests, or discipline?
+
+#EIP712 #EIP3009 #MetaTransactions #Solidity #Web3Engineering
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an isometric style: a single elegant fountain pen signing a large translucent document sheet, and from the signature line a glowing continuous ribbon flows rightward through three identical crystalline gates (representing three synchronized systems) before terminating at a stylized blockchain of linked hexagonal blocks; a small paper airplane (the relayer) carries the ribbon across a gap, while a faint parallel dotted path underneath shows an alternative direct route to the same blocks, suggesting a fallback. Composition is a left-to-right horizontal flow with generous negative space, subtle grid lines in the background evoking structured typed data. Color mood: deep navy and teal base tones with a single warm amber accent tracing the signature ribbon; soft diffuse lighting with gentle rim highlights on the crystalline gates. Fintech-engineering brand feel, precise and minimal, no text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/10-relayer-gateway-architecture/blog.md
+++ b/docs/blog/posts/10-relayer-gateway-architecture/blog.md
@@ -1,0 +1,125 @@
+# Censor, Never Steal: Splitting a Relayer into a Policy Gateway and an Execution Engine
+
+*How FairWins runs a hot gas key in production by making sure the service that decides is never the service that signs*
+
+| | |
+|---|---|
+| **Series** | Gasless Rails (part 2 of 2) |
+| **Part** | 10 of 34 |
+| **Audience** | Infrastructure and backend engineers |
+| **Tags** | `relayer`, `infrastructure`, `gasless`, `cloud-run`, `api-gateway` |
+| **Reading time** | ~9 minutes |
+
+---
+
+## The button that spends someone else's money
+
+In [part 1 of this series](../09-intent-based-gasless-payments/blog.md) we covered the protocol side of gasless intents: every actor action on the FairWins wager registry has an EIP-712 `…WithSig` twin, so a user with zero gas can sign a claim or an acceptance off-chain and let someone else pay to submit it. That post ended where this one begins — with an uncomfortable word: *someone*.
+
+Someone has to run a server. That server has to hold a funded key, accept signed blobs from the open internet, and turn them into transactions it pays for. Every failure mode you can imagine is on the menu: the key gets stolen; a bot drains the gas wallet with ten thousand valid-but-worthless intents; a sanctioned wallet routes an action through your infrastructure; a single deliberately expensive transaction burns a week of gas budget; or the whole thing goes down at 2 a.m. and users with signed intents are stranded mid-wager.
+
+FairWins had an extra constraint. The platform's standing directive is *no backend* — contracts, a static SPA, and a subgraph. The relayer is the deliberate, documented exception to that rule (spec 036 FR-001/FR-004), and being the exception raised the bar: if a server must exist, its blast radius has to be provably small.
+
+The answer that shipped is a split. One service decides *whether a transaction should exist*. A different service decides *how it gets mined*. Neither can do the other's job, and the design goal is a one-liner from the architecture doc: the hosted stack can only ever **censor, never steal**.
+
+## The split: policy in front, mechanics behind
+
+The deployed footprint is a single Cloud Run service running three sidecar containers that talk over localhost:
+
+- **`relay-gateway`** (`services/relay-gateway/`) — the policy front-end, written in-house. It terminates client traffic, recovers the signer from the EIP-712/EIP-3009 signature, and runs the full validation pipeline: kill switch → parse → chain active → payment-class support → target/action allow-list → signer recovery → param/window binding → dedup on the intent's `uniquenessMarker` → fail-closed sanctions re-screen → per-signer and global quotas → bounded-queue back-pressure → per-chain gas spend cap → fee check → encode the exact `…WithSig`/`…WithAuthorization` calldata.
+- **`oz-relayer`** (`services/oz-relayer/`) — the execution engine, an unmodified [OpenZeppelin Relayer](https://docs.openzeppelin.com/relayer) built from source at a pinned tag. It owns everything the gateway deliberately doesn't: per-chain nonce lanes, gas pricing and bumping (legacy type-0 transactions on Ethereum Classic networks, EIP-1559 on Polygon), inclusion tracking, RPC failover, and the gas key itself — held in Cloud KMS on an HSM, never exportable.
+- **Redis** — ephemeral queue state for the engine. Deliberately disposable: nonce and queue state reconstructs from chain, so losing it on restart is benign.
+
+The seam between the two is intentionally narrow. The gateway's engine client (`services/relay-gateway/src/engine/client.js`) says it plainly:
+
+```js
+/**
+ * The engine sees ONLY a built transaction ({to, value, data, speed}) — never a
+ * FairWins intent or the recovered signer; all policy stays in the gateway.
+ * ...
+ * Written as a thin adapter interface so the engine is swappable (rrelayer/MIT
+ * fallback exposes an equivalent submit + webhook surface) without touching policy.
+ */
+async submitTransaction({ relayerId, to, data, speed = 'fast' }) { ... }
+```
+
+That narrowness buys three things. First, the engine is **swappable** — it's an off-the-shelf OSS component behind a four-field interface, so if the project ever needs to change engines, no policy code moves. Second, the engine is **auditable by configuration**: its behavior is a declarative `config.json` (`services/oz-relayer/config/config.json`) with per-chain `gas_price_cap`, `min_balance`, and — crucially — `whitelist_receivers` pinning the gas key so it can only ever pay for calls into the FairWins proxy contracts. Third, the policy is **testable without a chain**: the gateway's pipeline is dependency-injected modules under `src/policy/`, exercised by vitest with every chain and engine access mocked.
+
+Status flows back the other way, and it is deliberately honest (FR-006): the engine calls a webhook on the gateway with an HMAC-SHA256 signature over the raw body, verified timing-safe, and only after that webhook reports the transaction mined does `GET /v1/intents/:id` ever say `confirmed`. The gateway never guesses.
+
+## Fail closed where money moves
+
+The most instructive policy module is the sanctions re-screen (`services/relay-gateway/src/policy/sanctions.js`). The on-chain contracts already screen every actor through `ISanctionsGuard` — so why screen again in the gateway? Because the relayer pays gas *before* the contract gets a chance to revert, and "we paid to submit a sanctioned wallet's transaction" is a sentence nobody wants to write. The gateway therefore re-screens the *recovered* signer — not any client-asserted address — against the same on-chain guard, and the failure semantics are strict:
+
+```js
+} catch {
+  // Fail closed: an unreachable/erroring guard is NEVER treated as allowed (SC-005).
+  throw new GatewayError(503, 'screening_unavailable',
+    'sanctions screening could not be performed; try again or self-submit')
+}
+if (!allowed) {
+  throw new GatewayError(403, 'sanctioned_signer', 'signer failed sanctions screening')
+}
+```
+
+Guard says no → `403`. Guard unreachable → `503`, never "assume fine and submit". The on-chain screen remains authoritative; this layer just guarantees the relayer's money never moves for a wallet the chain would reject.
+
+The rest of the pipeline follows the same instinct. Only allow-listed `(targetContract, action)` pairs are ever encoded, and the target addresses are read from the version-pinned `deployments/*-chain<ID>-v2.json` records at startup — a mismatch fails boot (FR-025). Quotas are enforced per signer and globally, an estimated-gas spend cap bounds each chain per window, and a bounded queue turns overload into `429 backpressure` instead of an unbounded memory balloon.
+
+## What a total compromise buys an attacker
+
+The split makes the trust budget legible enough to fit in a table:
+
+| Component | Holds | Can do | Cannot do |
+|---|---|---|---|
+| `relay-gateway` | two shared secrets (origin lock, webhook) | refuse/accept intents, screen, rate-limit | sign, move funds, forge a signer (it is *recovered*) |
+| `oz-relayer` engine | a KMS key *handle* | sign gas transactions to allow-listed receivers | exceed the gas price cap, pay non-whitelisted addresses, spend user funds |
+| Cloud KMS (HSM) | the secp256k1 gas key | produce signatures | export the private key |
+| Gas wallet | a small gas balance | pay gas | anything else — no contract authority |
+
+Compromise the entire hosted stack and you get: the gas balance, plus the ability to refuse service. No user funds are reachable — stakes sit in escrow contracts that verify every signature themselves. No admin authority is reachable — contract admin keys live on the air-gapped floppy keystore, an entirely separate custody tier. The on-chain entrypoints re-verify and re-screen everything regardless of what the gateway claims. That is what "censor, never steal" means as an engineering property rather than a slogan.
+
+## One policy chassis, two gasless rails
+
+FairWins runs two gasless rails, and here is where the split pays for itself twice. The first rail is the relayed intents above. The second (spec 050) is sponsored ERC-4337 UserOperations for passkey smart accounts: a self-hosted verifying paymaster contract (`contracts/account/FairWinsVerifyingPaymaster.sol`) reimburses a bundler — pimlico's **alto**, running as its own hardened service in `services/alto-bundler/` — from a FairWins-funded EntryPoint deposit.
+
+A sponsored UserOp needs a per-operation authorization signature, served over [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677). Rather than standing up a second policy service, the same gateway grew a `POST /v1/paymaster` route — and it *composes the same policy modules the intent path uses*. From `services/relay-gateway/src/paymaster/policy.js`:
+
+> The killswitch, sanctions screen, and per-account/global quotas are the SAME modules the intent path uses (composed in the route); this module adds the two per-op ceilings that bound a single sponsored op's cost so one deliberately-expensive UserOp can't burn a large slice of the deposit.
+
+So the paymaster path is: shared killswitch → shared sanctions screen → shared quota factory (keyed by smart account) → two new per-op ceilings (`gas_ceiling_exceeded`, `cost_ceiling_exceeded`) → KMS-signed approval with a short validity window. One perimeter, one audit stream, one kill switch — two economically distinct rails. Even the health endpoint unifies them: `/healthz` reports both the gas wallet's runway in hours and the paymaster's EntryPoint deposit runway, so operators watch one number pair for both rails.
+
+The same chassis has since absorbed the platform's other gateway needs — the OpenSea collectibles proxy (specs 055/056) and the Polymarket trading proxy (spec 057) ride the same origin lock, killswitch, and quota machinery. The policy gateway turned out to be the platform's one reusable backend.
+
+## Optional by construction: the never-stranded rule
+
+Everything above would still be a liability if users *needed* it. They don't. Spec 036's FR-002 — the never-stranded rule — requires that every covered action completes via self-submit with an identical on-chain result when the relayer is stopped, killed, or censoring.
+
+The client enforces this mechanically. Before requesting a signature, the SPA's intent client probes the gateway's status endpoint with a bounded ~2-second timeout. Probe fails, kill switch active, chain reported down, or any relay error mid-flow → the SPA silently routes the same action through the user's own wallet as a normal user-paid transaction. Same calldata target, same on-chain result; the only difference is who paid.
+
+The paymaster rail has the same property in ERC-7677 terms: any error from `POST /v1/paymaster` — unsupported chain, unconfigured signer, ceiling exceeded — and the SPA rebuilds the UserOp without a paymaster and self-funds it, with the confirm UI honestly disclosing that the user pays.
+
+Optionality also shapes operations (`docs/runbooks/relayer-operations.md`). The kill switch (FR-015) is boot-configurable and toggleable at runtime via `SIGUSR2`; flipping it turns `POST /v1/intents` into `503 killswitch_active` while status polling stays up and in-flight engine transactions still track to inclusion — no accepted intent is dropped, and every new one degrades to self-submit. Because the worst case is "users pay their own gas," the kill switch is cheap to pull, which means operators will actually pull it.
+
+## Design decisions
+
+**Build the policy, buy the engine.** Nonce management, gas bumping, and RPC failover are solved problems with sharp edges; the OpenZeppelin Relayer does them well, and FairWins runs it unmodified from a pinned tag (AGPL-safe — configured, never forked). The policy layer, by contrast, encodes FairWins-specific judgments — which contracts, which actions, whose signatures, what limits — that no off-the-shelf relayer could know. The split puts custom code exactly where the custom decisions are.
+
+**Single instance first, honestly.** Phase 1 pins Cloud Run to one instance; dedup, quotas, and spend counters are in-process. That is admitted plainly in the README rather than hidden: restart loss is benign because the on-chain `uniquenessMarker` is single-use — a replayed intent can never double-spend — and a momentarily reset rate limit is a loosening, not a breach. The policy modules are factories with narrow interfaces precisely so Phase 2 can swap in shared Redis without touching the pipeline.
+
+**Fail closed on money, fail soft on availability.** Sanctions screening and target pinning fail closed — the gateway would rather refuse than guess. Availability fails soft — every refusal degrades to self-submit. The asymmetry is the point: the only thing this infrastructure is allowed to break is its own usefulness.
+
+**Document the wart.** The engine's Cloud KMS signer (v1.4.0) cannot use keyless workload identity and needs an exported service-account key — held in Secret Manager, scoped to `signerVerifier` only, flagged in the architecture doc as a tracked follow-up rather than quietly accepted. Known limitations written down are limitations that get fixed.
+
+## Sources
+
+- `specs/036-relayer-infrastructure/` — spec, plan, data model, API contracts
+- `docs/architecture/relayer-infrastructure.md` — system context, topology, trust boundaries
+- `docs/runbooks/relayer-operations.md` — kill switch, key rotation, funding
+- `docs/developer-guide/gasless-intents.md` — protocol semantics (part 1 of this series)
+- `services/relay-gateway/` — policy gateway (`src/policy/`, `src/engine/client.js`, `src/paymaster/`, `src/server.js`, `README.md`)
+- `services/oz-relayer/config/config.json` — engine policies (gas caps, receiver whitelist)
+- `services/alto-bundler/README.md` — bundler hardening for the sponsored-UserOp rail
+- `specs/050-sponsored-paymaster/` + `docs/runbooks/paymaster-operations.md` — ERC-7677 sponsorship
+- [EIP-712](https://eips.ethereum.org/EIPS/eip-712), [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009), [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337), [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677)
+- [OpenZeppelin Relayer documentation](https://docs.openzeppelin.com/relayer)

--- a/docs/blog/posts/10-relayer-gateway-architecture/social.md
+++ b/docs/blog/posts/10-relayer-gateway-architecture/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Censor, Never Steal: Splitting a Relayer into a Policy Gateway and an Execution Engine
+
+## X (Twitter)
+
+How do you run a hot gas key in production? Make sure the service that decides is never the service that signs. Our relayer splits policy (screening, quotas, killswitch) from execution (nonces, gas, KMS key) — worst case: censor, never steal. 🔗 <link> #web3 #infrastructure #gasless
+
+## LinkedIn
+
+Gasless transactions sound great until you're the one operating the relayer: a funded key on a server, accepting signed blobs from the open internet, paying gas for strangers.
+
+Part 2 of our Gasless Rails series covers how FairWins made that server safe to run — by splitting it in two. A policy gateway decides whether a transaction should exist; a separate execution engine decides how it gets mined. Neither can do the other's job.
+
+The post walks through:
+
+- The policy/engine seam: the gateway recovers signers, screens them fail-closed against an on-chain sanctions guard, enforces quotas and spend caps — then hands the engine only `{to, data, speed}`, never the intent
+- Why the trust budget fits in a table: a full compromise of the hosted stack yields the gas balance plus the ability to refuse service — no user funds, no admin authority
+- How the same policy chassis serves two rails: relayed EIP-712 intents and an ERC-7677 verifying-paymaster endpoint for ERC-4337 UserOps, sharing one killswitch, one quota system, one audit stream
+- The never-stranded rule: every flow degrades to self-submit with an identical on-chain result, so the kill switch is cheap enough to actually pull
+
+Read it here: <link>
+
+If you operate relayers or paymasters: where do you draw the line between policy and execution — and what does a total compromise of your stack actually buy an attacker?
+
+#web3 #ethereum #infrastructure #accountabstraction #relayer
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in isometric style showing two distinct connected machines as a metaphor for policy/engine separation: on the left, an elegant gatehouse or checkpoint structure with a series of translucent filter gates (some open, some closed) through which small glowing envelope shapes queue and pass; on the right, a compact industrial engine block with visible gears and a single key locked inside a small transparent vault, sending signed envelopes up along a rail toward an abstract blockchain lattice in the background. A thin dashed alternate pathway arcs around both machines, showing one envelope bypassing them entirely — the fallback route. Composition: the two machines occupy the lower two-thirds, connected by a single narrow bridge conduit, with generous negative space above. Color mood: deep navy and teal base palette with one warm amber accent reserved for the glowing envelopes and the vaulted key, consistent with a fintech-engineering brand. Soft directional lighting from the upper left with subtle long shadows, crisp vector-like edges, minimal texture. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/11-uups-upgrades-storage-safety/blog.md
+++ b/docs/blog/posts/11-uups-upgrades-storage-safety/blog.md
@@ -1,0 +1,128 @@
+# UUPS Upgrades Without the Footguns: One Base Contract, One CI Gate
+
+*How FairWins ships new escrow logic to a live, funds-bearing address — and why a storage-layout check runs before every merge*
+
+| | |
+|---|---|
+| **Series** | Contract Architecture (part 1) |
+| **Part** | 11 of 34 |
+| **Audience** | Solidity engineers |
+| **Tags** | `uups`, `proxy`, `upgradeable`, `storage-layout`, `solidity` |
+| **Reading time** | ~9 minutes |
+
+## The redeploy that strands everyone
+
+Picture the escrow contract at the center of a peer-to-peer wager platform. It holds real stakes — USDC locked between counterparties — indexed by a subgraph, addressed by a frontend, referenced by every open wager. Now the roadmap calls for open-challenge wagers: a new creation path, new state, new events, on the same contract.
+
+Before spec 025, FairWins had exactly one way to ship that: deploy a new contract at a new address. And a new contract starts with empty storage. Every wager, every balance, every mapping on the old address is left behind. Existing wagers become **stranded** — still holding funds, but on a contract the app no longer points at. Users get migrated or settled out-of-band on every release. The frontend and subgraph get repointed. Nobody enjoys any of it.
+
+The fix is old news in principle — put a proxy in front of the logic — but the failure modes of upgradeable contracts are notorious enough that "just use UUPS" is not a plan. An uninitialized implementation can be hijacked. A constructor that silently never runs behind a proxy can start your wager IDs at zero. One reordered state variable can scramble the storage of a contract that custodies user money, and Solidity will not warn you.
+
+So FairWins built the upgrade machinery once, made it boring, and made the dangerous part mechanically impossible to merge. Seven contracts now sit behind UUPS proxies at stable addresses — `WagerRegistry`, `MembershipManager`, `TokenFactory`, `ExternalDAORegistry`, `WagerPoolFactory`, `CallsignRegistry`, `FeeRouter` — all inheriting a single ~40-line base, all validated by the same CI gate.
+
+## The shape: ERC-1967 proxy, UUPS logic
+
+Each upgradeable contract is an [ERC-1967](https://eips.ethereum.org/EIPS/eip-1967) proxy in front of a swappable implementation, using the UUPS pattern ([EIP-1822](https://eips.ethereum.org/EIPS/eip-1822)): the upgrade function lives in the *implementation*, not the proxy, keeping the proxy minimal and the upgrade authorization logic upgradeable itself. The proxy address is the stable one — the address users, the frontend, and the subgraph consume. The implementation changes on every upgrade.
+
+`deployments/<network>-chain<id>-v2.json` records **both**: the proxy under e.g. `wagerRegistry` and the current implementation under `wagerRegistryImpl`. That dual record is not bookkeeping trivia — the storage-layout gate diffs new code against the *recorded deployed implementation*, so the file is what makes the safety check network-aware.
+
+## One base to inherit, not copy
+
+The reusable piece is `contracts/upgradeable/UUPSManaged.sol`. It contains no business logic — just the upgrade and access machinery every adopter needs, wired so the classic UUPS mistakes can't be made twice:
+
+```solidity
+abstract contract UUPSManaged is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function __UUPSManaged_init(address admin) internal onlyInitializing {
+        __UUPSUpgradeable_init();
+        __AccessControl_init();
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(UPGRADER_ROLE, admin);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    uint256[50] private __gap;
+}
+```
+
+Three deliberate choices are packed in here.
+
+**The implementation can never be initialized.** The constructor calls `_disableInitializers()`, so a bare implementation contract — the thing sitting at `wagerRegistryImpl`, reachable by anyone — can never be initialized and hijacked. Only the proxy, delegatecalling into this logic, can be initialized, and only once. This closes the textbook UUPS attack where someone initializes the raw implementation, grants themselves the upgrade role on it, and `selfdestruct`s or redirects it.
+
+**Upgrades are least-privilege and non-brickable.** `UPGRADER_ROLE` is separate from `DEFAULT_ADMIN_ROLE`, so upgrade authority can later move to a timelock or multisig with no code change. And `_authorizeUpgrade` lives in the base every implementation inherits — it is never removed by an upgrade, so the ability to perform *future* upgrades is always preserved. On live networks the role is held by an air-gapped floppy-keystore admin; the runbook is blunt about the flip side: lose that key and the contract keeps working but can never be upgraded again.
+
+**The base reserves its own gap.** `uint256[50] private __gap` at the base level means FairWins can add base state later without shifting every child's layout. (The OpenZeppelin `*Upgradeable` parents contribute no sequential slots — they use [ERC-7201](https://eips.ethereum.org/EIPS/eip-7201) namespaced storage.)
+
+## `initialize` replaces the constructor — and one bug everyone hits
+
+Behind a proxy, a constructor runs in the implementation's context and never touches proxy storage. So adopters replace it with a one-time `initialize` guarded by OpenZeppelin's `initializer` modifier. `WagerRegistry`'s version (in `contracts/wagers/WagerRegistry.sol`) calls `__UUPSManaged_init(admin)` first, then does exactly what the old constructor did — with one line that earns its comment:
+
+```solidity
+_nextWagerId = 1; // MOVED from the inline initializer (must run behind the proxy)
+```
+
+This is the single most common conversion bug, called out in `docs/developer-guide/upgradeable-contracts.md`: an **inline state initializer** like `uint256 _nextWagerId = 1;` runs in constructor context and is silently ignored behind a proxy. Miss it and your wager IDs start at 0 — a bug no compiler flags. The rule: declare bare, assign inside `initialize`.
+
+Later upgrades that need to seed new state get a `reinitializer(N)`. When feature 024 (open challenges) landed as an in-place upgrade, the already-initialized proxy needed its EIP-712 domain set — so `initializeOpenChallenges() external reinitializer(2)` calls `__EIP712_init(...)`, invoked via `upgradeToAndCall` during the upgrade. Fresh deploys set the domain in `initialize` and can never call the reinitializer (version 2 > version 1). State that defaults to zero needs no reinitializer at all.
+
+## Append-only storage, and a gap that shrinks on schedule
+
+Proxy storage safety reduces to one rule: **never insert, reorder, remove, or retype existing state variables — only append.** Each contract ends its state with a trailing reserve, and appended state consumes it. `contracts/wagers/WagerRegistryCore.sol` — the single storage-layout definition shared by both registry facets — shows the rule living through two real upgrades:
+
+```solidity
+/// @dev Trailing storage reserve for append-only upgrades. Reduced 50 → 48 when the two
+///      open-challenge mappings were appended (feature 024), then 48 → 45 for spec 035
+///      (`feeNettingEnabled`+`gasFeeRecipient` pack into one slot, `maxGasFee`, `intentExtension`).
+///      Never insert or reorder existing state above this gap.
+uint256[45] private __gap;
+```
+
+Feature 024 appended two mappings (gap 50 → 48). Spec 035 appended a packed `bool`+`address` slot, a `uint256`, and an `address` (48 → 45). The gap shrinks by exactly the slots appended, so total layout size — and everything above the gap — never moves.
+
+## The CI gate: making the unsafe upgrade unmergeable
+
+Convention alone doesn't survive contact with a Tuesday afternoon. So the rule is enforced by `npm run check:storage-layout` (`scripts/deploy/check-storage-layout.js`), gating in CI via `.github/workflows/test.yml`. Built on OpenZeppelin's `hardhat-upgrades` validators, it runs two checks per contract in `UPGRADEABLE_CONTRACTS`:
+
+- **With a recorded deployment** (an `<key>Impl` address in `deployments/`): `upgrades.validateUpgrade(deployedImpl, Factory, { kind: "uups" })` — the new implementation must be storage-layout *compatible* with what is actually on-chain. A reordered, removed, or retyped slot fails the build before the upgrade can exist.
+- **Without one**: `upgrades.validateImplementation(...)` — the unsafe-pattern checks (missing `_disableInitializers`, stray `selfdestruct`/`delegatecall`, non-namespaced base storage).
+
+Adding a contract to the gate is one line — `{ name: "FeeRouter", deploymentsKey: "feeRouter" }` — which is how five later adopters inherited spec 025's safety net for free. The script exits non-zero on any failure; per project constitution, CI fails loudly.
+
+And the check is defense-in-depth, not the last line: the deploy tooling in `scripts/deploy/lib/upgradeable.js` runs the same validation again at execution time. `upgradeProxy({ name, proxyAddress })` calls OZ's `validateUpgrade` *before anything is sent on-chain*, deploys the new implementation, calls `upgradeToAndCall` signed by the `UPGRADER_ROLE` admin, and reports both addresses so `deployments/` records the new `…Impl`. An incompatible upgrade throws locally instead of corrupting funds remotely. `deployProxy` is only for first-time cutover — the runbook warns that re-running the deploy script mints a *new* proxy; to change logic on a live deployment you run an upgrade, never a redeploy.
+
+The pattern has been exercised for real: feature 024 shipped as an in-place upgrade of the `wagerRegistry` proxy, and spec 026's voucher redemption as the first in-place upgrade of the `membershipManager` proxy — same address, all state preserved, ABI grows.
+
+## Design decisions
+
+**UUPS over Transparent proxy.** The upgrade function in the implementation keeps the proxy minimal and lets the authorization policy itself evolve. The cost — an implementation that forgets `_authorizeUpgrade` bricks upgrades — is neutralized by putting the gate in the inherited base, where no upgrade can drop it.
+
+**A shared base instead of per-contract wiring.** Copy-pasted proxy plumbing drifts; drifted plumbing is where initializer lockouts get forgotten. `UUPSManaged` centralizes `_disableInitializers`, the role grants, and the upgrade gate, so an adopter's diff is just: inherit, convert constructor to `initialize`, add a `__gap`, register with the tooling.
+
+**Coexistence over migration at cutover.** The legacy non-upgradeable registry couldn't be retro-wrapped, and on-chain state migration of live escrow was judged unsafe for v1. Spec 025 chose coexistence: legacy wagers stay settle-only on the old address while all new wagers land on the proxy, and the app surfaces both honestly until the legacy side drains.
+
+**No downgrades — roll forward.** There is no automatic rollback. A bad upgrade is corrected by upgrading again to a fixed implementation; the non-brickable gate guarantees that path always exists, and prior implementation addresses live in the deployments file's git history if re-pointing to a known-good build is the fastest fix.
+
+**Honest limits.** Upgradeability is a trust statement, not a free lunch: whoever holds `UPGRADER_ROLE` can replace the code that custodies user stakes. FairWins mitigates with least-privilege role separation, an air-gapped signing key, and a documented path to a timelock/multisig — but "upgradeable" and "immutable" are opposite promises, and the platform makes that choice per contract deliberately (the `MembershipVoucher` bearer NFT, for instance, is intentionally *not* upgradeable).
+
+## Sources
+
+- `specs/025-upgradeable-registry/spec.md` — motivation, coexistence cutover, upgrade-safety clarifications
+- `specs/027-upgradeable-membership/` — second adopter (MembershipManager)
+- `contracts/upgradeable/UUPSManaged.sol` — shared base (role gate, initializer lockout, base `__gap`)
+- `contracts/wagers/WagerRegistry.sol` / `contracts/wagers/WagerRegistryCore.sol` — `initialize`, `reinitializer(2)`, append-only storage history
+- `scripts/deploy/check-storage-layout.js` + `.github/workflows/test.yml` — the CI gate
+- `scripts/deploy/lib/upgradeable.js` — `deployProxy` / `upgradeProxy` / `getImplementation`
+- `docs/developer-guide/upgradeable-contracts.md` — adopter guide, inline-initializer bug
+- `docs/runbooks/contract-upgrades.md` — pre-flight, in-place upgrade, rollback, failure modes
+- `deployments/mordor-chain63-v2.json` — proxy + implementation records
+- EIP-1822 (UUPS): https://eips.ethereum.org/EIPS/eip-1822
+- ERC-1967 (proxy storage slots): https://eips.ethereum.org/EIPS/eip-1967
+- ERC-7201 (namespaced storage): https://eips.ethereum.org/EIPS/eip-7201
+- OpenZeppelin UUPS & Upgrades Plugins docs: https://docs.openzeppelin.com/contracts/5.x/api/proxy#UUPSUpgradeable, https://docs.openzeppelin.com/upgrades-plugins/

--- a/docs/blog/posts/11-uups-upgrades-storage-safety/social.md
+++ b/docs/blog/posts/11-uups-upgrades-storage-safety/social.md
@@ -1,0 +1,28 @@
+# Social & Image — UUPS Upgrades Without the Footguns: One Base Contract, One CI Gate
+
+## X (Twitter)
+
+Shipping new logic to a live escrow contract without stranding a wager: 7 UUPS proxies, one ~40-line shared base, and a CI gate that diffs storage layouts against the deployed impl before merge. The `__gap` shrank 50→48→45 — on purpose. 🔗 <link> #Solidity #UUPS #web3
+
+## LinkedIn
+
+Every Solidity team eventually faces the same problem: the contract holding user funds needs new logic, but a fresh deployment starts with empty storage — stranding every balance and mapping at the old address.
+
+Our latest engineering post walks through how FairWins made in-place upgrades boring (in the best way) across seven UUPS proxies, from the wager escrow to the fee router:
+
+- A single shared base, `UUPSManaged`, that locks out implementation hijacking (`_disableInitializers`), separates `UPGRADER_ROLE` from admin, and keeps the upgrade path non-brickable by construction
+- Constructor-to-`initialize` conversion, including the silent bug everyone hits: inline state initializers that never run behind a proxy
+- Append-only storage with a trailing `__gap` that shrinks by exactly the slots each upgrade appends — with the real history from two shipped upgrades
+- A CI-gated storage-layout check that validates new code against the *recorded deployed implementation*, so a state-corrupting upgrade fails the build instead of corrupting funds
+
+We also cover the honest trade-off: upgradeability is a trust statement, and some contracts (like bearer-asset NFTs) deliberately stay immutable.
+
+Read the full post: <link>
+
+How does your team gate storage-layout compatibility — CI, deploy-time validation, or both?
+
+#Solidity #SmartContracts #UUPS #DevOps #Ethereum
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an isometric style: a stable architectural pedestal (representing a proxy contract at a fixed address) on which a glowing modular engine block is being swapped out by a robotic crane arm, while a translucent column of neatly stacked data slots beneath the pedestal remains perfectly undisturbed — the bottom slots solid and locked, a few reserve slots at the top shown as empty outlined placeholders. To one side, a small checkpoint gate with a green scanning beam inspects the incoming engine block before it can dock, suggesting automated validation. Composition: wide 16:9 scene with the pedestal slightly left of center, generous negative space on the right, subtle grid floor fading into the background. Color mood: deep navy and teal base palette with a single warm amber accent on the engine block being installed and the scanner beam highlight. Lighting: soft directional studio light with gentle rim glow on the isometric edges, faint cool ambient haze. Precision-engineered fintech aesthetic, minimal detail noise, no text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/12-two-facet-proxy-24kb/blog.md
+++ b/docs/blog/posts/12-two-facet-proxy-24kb/blog.md
@@ -1,0 +1,146 @@
+# The Two-Facet Proxy: Beating the 24 KB Contract-Size Limit
+
+*How FairWins added sixteen gasless entrypoints to a contract with 116 bytes of headroom — without adopting a Diamond*
+
+| | |
+|---|---|
+| **Series** | Contract Architecture (part 2) |
+| **Part** | 2 of 3 |
+| **Audience** | Solidity engineers hitting the EIP-170 size ceiling |
+| **Tags** | `eip170`, `proxy`, `delegatecall`, `facets`, `solidity`, `diamond-adjacent` |
+| **Reading time** | ~9 minutes |
+
+---
+
+## 116 bytes of headroom
+
+Every ambitious protocol eventually meets the same compiler output:
+
+```
+Warning: Contract code size is 24460 bytes and exceeds 24576 bytes (a limit
+introduced in Spurious Dragon). This contract may not be deployable on Mainnet.
+```
+
+Except in our case it wasn't a warning yet. When FairWins started spec 035 — platform-wide gasless intents — the `WagerRegistry` implementation compiled to **24,460 of 24,576 bytes**. That's 116 bytes of headroom. The feature called for roughly sixteen new signer-attributed entrypoints: a `…WithSig` or `…WithAuthorization` twin for every core action (create, accept, claim, refund, draw, decline, declare-winner, and the open-challenge variants), each carrying EIP-712 verification, replay-nonce bookkeeping, and for the money-in paths an atomic EIP-3009 stake pull plus optional fee netting.
+
+Sixteen entrypoints do not fit in 116 bytes. They don't fit in 2 KB. And the usual escape hatches all had problems. Cranking optimizer runs down shrinks bytecode but taxes every user's gas forever. External libraries move code out, but retrofitting `DELEGATECALL`-linked libraries across a live, audited escrow contract is invasive surgery. Deploying the intent surface as a *separate contract* at a *separate address* breaks the thing that matters most: the registry is a UUPS proxy at a **stable address** — one ABI, one event stream for the subgraph, one EIP-712 domain that thousands of already-signed intents verify against.
+
+The limit itself is [EIP-170](https://eips.ethereum.org/EIPS/eip-170): since the Spurious Dragon hardfork, deployed runtime code is capped at `0x6000` (24,576) bytes, so that a `CALL` can never force a node to load unboundedly large code from disk. It is not going away, and Polygon — FairWins' flagship network — enforces it like mainnet does.
+
+What shipped instead is a pattern we'd describe as *diamond-adjacent*: **one proxy, two implementations, one storage definition**.
+
+## One proxy, two facets
+
+The registry today is three contracts in `contracts/wagers/`:
+
+| Contract | Role |
+|---|---|
+| `WagerRegistryCore.sol` | Abstract base: **the** storage layout plus every internal action body. Both facets inherit it. |
+| `WagerRegistry.sol` | The main facet — the actual UUPS implementation. Every pre-existing external function, plus a `fallback()`. |
+| `WagerRegistryIntents.sol` | The extension facet — the `…WithSig`/`…WithAuthorization` twins, fee-netting admin/getters, and relocated cold paths. |
+
+The proxy (a standard ERC-1967/UUPS proxy from spec 025) points at `WagerRegistry`. A call to a known selector — `createWager`, `acceptWager`, `claimPayout` — dispatches normally inside the main facet, exactly as before the split. A call to a selector the main facet *doesn't* define lands in its fallback, which forwards the raw calldata to the second implementation:
+
+```solidity
+/// @custom:oz-upgrades-unsafe-allow delegatecall
+fallback() external {
+    address ext = intentExtension;
+    if (ext == address(0)) revert UnknownFunction();
+    assembly {
+        calldatacopy(0, 0, calldatasize())
+        let ok := delegatecall(gas(), ext, 0, calldatasize(), 0, 0)
+        returndatacopy(0, 0, returndatasize())
+        switch ok
+        case 0 { revert(0, returndatasize()) }
+        default { return(0, returndatasize()) }
+    }
+}
+```
+
+Because this is a `delegatecall` from code *already executing in the proxy's context*, the extension facet runs against the proxy's storage, emits events attributed to the proxy's address, and — critically for signed intents — sees `address(this)` as the proxy. The EIP-712 domain (`"FairWins WagerRegistry"`, version `"1"`, chainId, verifying contract) is therefore identical whether a function lives in facet one or facet two. Callers see a single contract.
+
+Which functions went where was a deliberate sort. The intent twins obviously live in `WagerRegistryIntents`. But the split also bought headroom by relocating **cold paths** out of the main facet: `batchExpireOpen`, `autoResolveFromPolymarket`, and `autoResolveFromOracle` are keeper-style functions with no latency-sensitive callers, so they moved behind the fallback with byte-identical behavior. Even three view getters (`feeNettingEnabled`, `gasFeeRecipient`, `maxGasFee`) sit in the extension purely for main-facet code-size headroom. Hot user paths stay in the main facet and pay zero extra dispatch cost; only relayed intents and keeper calls pay the one extra `DELEGATECALL` hop.
+
+## The storage discipline that makes it safe
+
+Two implementations executing against one storage layout is exactly the failure mode that bricks proxies. The defense is structural, not procedural: **the layout is defined once**, in `WagerRegistryCore`, and both facets inherit it. From the base contract's own header:
+
+> BOTH facets execute against the SAME proxy storage, so both MUST inherit this exact contract — the storage layout is defined once, here, and can never drift between facets.
+
+`WagerRegistryCore` also holds every internal action body (`_createWager`, `_acceptWager`, `_claimPayout`, …), each taking the acting identity as an explicit parameter instead of reading `msg.sender`. The self-submit externals in the main facet pass `msg.sender`; the intent twins pass the recovered signer. One body, two attributions — the "twin invariant" — so checks and effects can't drift between the gasless and self-submit paths any more than storage can.
+
+The usual UUPS rules still apply on top: storage is append-only above a trailing `uint256[45] private __gap` (it shrank 48 → 45 when spec 035 appended the packed fee-netting scalars and the `intentExtension` slot). The intent replay-nonce map deliberately lives elsewhere — in `contracts/upgradeable/SignerIntentBase.sol`, which uses **ERC-7201 namespaced storage** at a fixed keccak-derived slot, costing zero gap slots and making the mixin safe to add to an already-live proxy.
+
+Discipline you can't verify is hope. So `npm run check:storage-layout` — the CI-gating script from part 1 of this series — grew a facet-pair mode in `scripts/deploy/check-storage-layout.js`:
+
+```javascript
+// Facet pairs sharing ONE proxy's storage (spec 035): the extension facet is
+// delegatecalled from the main facet's fallback, so its storage layout MUST be
+// compatible with the main implementation's.
+const FACET_PAIRS = [
+  { main: "WagerRegistry", facet: "WagerRegistryIntents" },
+];
+```
+
+It runs OpenZeppelin's `upgrades.validateUpgrade(MainFactory, FacetFactory, { kind: "uups" })` — treating the facet as if it were an upgrade of the main implementation, so any sequential-slot drift fails CI before it can ship. The check is intentionally one-directional: the extension additionally carries `SignerIntentBase`'s ERC-7201 namespace, which the main facet legitimately does not declare, and a namespaced slot can never collide with sequential or gap slots.
+
+Two smaller honesty notes baked into the code. The extension facet is annotated `@custom:oz-upgrades-unsafe-allow missing-initializer` — by design it is *never* initialized; the proxy is initialized exactly once through the main facet, and `UUPSManaged`'s constructor disables initializers on the bare implementations. And the fallback's `delegatecall` carries `@custom:oz-upgrades-unsafe-allow delegatecall`, an explicit acknowledgment rather than a suppression of a surprise.
+
+## Governance: routing is upgrading
+
+Pointing the fallback at new code is equivalent in authority to replacing the implementation — the extension runs with full access to the proxy's storage. So the wiring function is gated accordingly:
+
+```solidity
+function setIntentExtension(address extension) external onlyRole(UPGRADER_ROLE) {
+    intentExtension = extension;
+    emit IntentExtensionUpdated(extension);
+}
+```
+
+`UPGRADER_ROLE` — the same role that authorizes UUPS upgrades, held by the air-gapped floppy-keystore admin — controls the extension pointer. Setting it to zero disables the entire intent surface (the fallback reverts with `UnknownFunction`), which doubles as a kill switch: because every gasless flow keeps a self-submit twin, turning the facet off degrades the product to "users pay their own gas," never to "users are stranded."
+
+## Developer experience: one ABI at one address
+
+Tooling sees one contract. The test helper `test/helpers/proxy.js` exports `deployWagerRegistry`, which deploys the main implementation behind an `ERC1967Proxy`, deploys `WagerRegistryIntents`, wires `setIntentExtension` as the admin, and returns an ethers `Contract` bound to the proxy address with a **merged ABI** — `mergeAbis(Impl.interface, IntentsImpl.interface)`, deduplicating fragments and dropping constructors and fallbacks. Tests and integrators call `registry.acceptWagerWithAuthorization(...)` and `registry.acceptWager(...)` on the same object without knowing a facet boundary exists. The subgraph needs no changes at all: every event still originates from the proxy address.
+
+## Why not a full Diamond?
+
+[EIP-2535](https://eips.ethereum.org/EIPS/eip-2535) (Diamonds) is the canonical answer to "my contract won't fit," and it deserves an honest comparison rather than a strawman.
+
+A Diamond gives you a generic selector-to-facet mapping, `diamondCut` for per-selector upgrades, loupe functions for on-chain introspection, and effectively unlimited facets. If we expected the registry to keep growing indefinitely across many independently-upgraded modules, that machinery would earn its cost.
+
+We chose against it for four concrete reasons:
+
+1. **We already had a proxy standard.** The registry was a shipped UUPS proxy at a stable address (spec 025), with deploy tooling, an upgrade runbook, and CI validation built around `hardhat-upgrades`. Migrating to a Diamond proxy would have meant replacing working, audited infrastructure to solve a code-size problem — maximum blast radius for the actual requirement.
+2. **Tooling and verification.** OpenZeppelin's upgrade-safety validators understand UUPS; they don't validate diamonds. Our facet-pair check reuses `validateUpgrade` unchanged. Block-explorer verification and ABI handling for diamonds remain rougher than "one implementation plus one extension."
+3. **Hot paths stay on normal dispatch.** A Diamond routes *every* call through the fallback and a selector-mapping `SLOAD`. In the two-facet design, `createWager` and `claimPayout` dispatch directly in the main facet exactly as before; only the relayed and keeper paths pay the extra hop.
+4. **Audit surface.** A Diamond's cut logic, selector registry, and loupe are their own attack surface with their own history of subtle bugs. Our routing layer is twelve lines of assembly plus one role-gated setter.
+
+The trade-offs cut the other way too, and it's worth being plain about them. The two-facet pattern has **no on-chain introspection** — nothing enumerates which selectors the extension serves; the merged ABI is an off-chain convention. Selector precedence is implicit: if both facets defined the same function, the main facet would silently win, because the fallback only fires for selectors the main facet lacks (the shared `WagerRegistryCore` base and interface definitions make an accidental collision a compile-time conflict in practice, but the proxy itself doesn't check). Facet upgrades are all-or-nothing per facet, not per selector. And the pattern scales awkwardly past two or three facets — a chain of fallbacks is a worse Diamond, not a better one. If the extension facet itself ever approaches 24 KB, the right move is probably a real Diamond, and we'd rather make that call then than pre-pay for it now.
+
+For one contract, one overflow, and a hard requirement to preserve a live address, ABI, event stream, and EIP-712 domain: two facets, one storage core, and a CI gate was the smallest design that is actually safe.
+
+*FairWins wagers settle from public-information outcomes via external oracles; participants remain subject to applicable law and compliance obligations in their jurisdictions.*
+
+## Design decisions
+
+- **Split by temperature, not just by feature.** The extension facet took the new intent twins *and* relocated cold paths (`batchExpireOpen`, `autoResolveFrom*`) and even three view getters, maximizing main-facet headroom while keeping user-facing hot paths on direct dispatch.
+- **One storage definition, enforced twice.** Both facets inherit `WagerRegistryCore` (structural guarantee); `check:storage-layout` validates the pair with `validateUpgrade` in CI (mechanical guarantee). Neither alone is sufficient — inheritance can't catch a facet compiled from a stale branch; a script can't stop someone declaring state in a facet unless the convention exists.
+- **New cross-cutting state goes in ERC-7201 namespaces.** `SignerIntentBase`'s nonce map costs zero gap slots and is safe to add to live proxies — the same trick `EIP712Upgradeable` uses.
+- **Routing authority equals upgrade authority.** `setIntentExtension` is `UPGRADER_ROLE`-gated because a delegatecall target with full storage access *is* an implementation, whatever you call it.
+- **Zero-address as kill switch, backed by the never-stranded rule.** Disabling the facet degrades gracefully because every gasless entrypoint has a self-submit twin.
+
+## Sources
+
+- `contracts/wagers/WagerRegistry.sol` — main facet, fallback delegatecall, `setIntentExtension`
+- `contracts/wagers/WagerRegistryIntents.sol` — extension facet: intent twins, relocated cold paths, fee-netting admin
+- `contracts/wagers/WagerRegistryCore.sol` — shared storage layout + actor-threaded internal action bodies, `__gap` history
+- `contracts/upgradeable/SignerIntentBase.sol` — ERC-7201 namespaced replay-nonce mixin
+- `scripts/deploy/check-storage-layout.js` — `FACET_PAIRS` validation (`npm run check:storage-layout`)
+- `test/helpers/proxy.js` — `deployWagerRegistry` + `mergeAbis` merged-ABI helper
+- `docs/developer-guide/gasless-intents.md` — facet-split architecture table, pre-split size (24,460 / 24,576 bytes)
+- `specs/035-intent-based-payments/` — spec, plan, research for the gasless-intent feature
+- [EIP-170: Contract code size limit](https://eips.ethereum.org/EIPS/eip-170)
+- [EIP-2535: Diamonds, Multi-Facet Proxy](https://eips.ethereum.org/EIPS/eip-2535)
+- [ERC-7201: Namespaced Storage Layout](https://eips.ethereum.org/EIPS/eip-7201)
+- [OpenZeppelin Upgrades plugin](https://docs.openzeppelin.com/upgrades-plugins/) — `validateUpgrade` used for facet-pair checking

--- a/docs/blog/posts/12-two-facet-proxy-24kb/social.md
+++ b/docs/blog/posts/12-two-facet-proxy-24kb/social.md
@@ -1,0 +1,34 @@
+# Social & Image — The Two-Facet Proxy: Beating the 24 KB Contract-Size Limit
+
+## X (Twitter)
+
+Our contract compiled to 24,460 of 24,576 bytes — 116 bytes of headroom — and the next feature needed 16 new entrypoints.
+
+We didn't reach for a Diamond. One proxy, two implementations, one shared storage base, and a CI gate that validates the pair.
+
+🔗 <link>
+
+#Solidity #EVM #SmartContracts
+
+## LinkedIn
+
+Every serious Solidity team eventually hits EIP-170: deployed bytecode is capped at 24,576 bytes, and no optimizer setting saves you once a live, audited contract needs a large new feature. Our wager registry sat at 24,460 bytes when a gasless-transactions spec called for roughly sixteen new EIP-712 entrypoints.
+
+The obvious answer is an EIP-2535 Diamond. We shipped something smaller instead — and the new post walks through exactly how and why:
+
+- One UUPS proxy, two implementation facets: unknown selectors delegatecall from the main contract's fallback to an extension facet, so callers still see one address, one ABI, one event stream, and one EIP-712 domain.
+- A single abstract base contract defines the storage layout and all internal action bodies; both facets inherit it, so layouts structurally cannot drift.
+- A CI gate runs OpenZeppelin's validateUpgrade on the facet pair, treating the extension as an upgrade of the main implementation — drift fails the build.
+- An honest comparison with Diamonds: what we gave up (introspection, per-selector upgrades) and what we kept (direct dispatch on hot paths, existing tooling, a twelve-line routing layer).
+
+If your contract is creeping toward the ceiling, this is a shipped, testable pattern you can borrow before committing to a full facet framework.
+
+🔗 <link>
+
+Where do you draw the line between "split the contract" and "adopt a Diamond"?
+
+#Solidity #EVM #SmartContracts #Web3 #ProtocolEngineering
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an isometric style: a single tall vault-like structure (representing one contract address) whose interior is revealed in cutaway to contain two interlocking crystalline blocks — one large primary block and one slimmer companion block — both plugged into the same glowing foundation slab etched with a fine grid (the shared storage layout). A thin beam of light routes from the vault's front door around the primary block into the companion block, suggesting calls being forwarded internally. Around the vault, a faint measuring gauge or ruler motif nearly filled to its top edge hints at a hard size limit almost reached. Deep navy and teal base palette with a single warm amber accent on the routing beam and the foundation grid lines; soft ambient lighting with gentle rim highlights on the crystalline edges; generous negative space, precise geometry, fintech-engineering mood. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/13-deterministic-singleton-deployment/blog.md
+++ b/docs/blog/posts/13-deterministic-singleton-deployment/blog.md
@@ -1,0 +1,140 @@
+# One Salt, Three Chains: What Deterministic Deployment Actually Buys You
+
+*How FairWins uses the Safe Singleton Factory for stable addresses across Mordor, Polygon, and Amoy — and why a per-chain resolver is still non-negotiable*
+
+| | |
+|---|---|
+| **Series** | Contract Architecture, part 3 |
+| **Audience** | Protocol engineers, DevOps |
+| **Tags** | `create2`, `deterministic-deployment`, `multi-chain`, `devops` |
+| **Reading time** | ~9 minutes |
+
+---
+
+## The Bug That Ships Silently
+
+Picture the failure mode every multi-chain team eventually hits. You redeploy a contract to a testnet — maybe a compiler bump, maybe a constructor tweak. The deploy script prints a fresh address. Someone updates the frontend config. Nobody updates the subgraph manifest. The relay gateway keeps the old address in an environment variable that was set three months ago in a dashboard nobody remembers.
+
+Nothing crashes. The frontend talks to the new contract, the indexer indexes the old one, and the gateway relays transactions into a contract that no longer matches the ABI it was policy-checked against. Users see wagers that "exist" but never index, or gasless transactions that revert with no obvious cause. The bug isn't in any one system — it's in the *drift between them*.
+
+FairWins runs its escrow, membership, and oracle stack on three live EVM networks — Mordor (Ethereum Classic's testnet, chain 63), Polygon Amoy (80002), and Polygon mainnet (137) — with three independent consumers of every contract address: a React frontend, a Graph subgraph, and a relay gateway that sponsors gasless transactions. That's nine opportunities per contract for address drift.
+
+The defense has two layers, and it's worth being precise about what each one does. Deterministic deployment makes addresses *reproducible* — the same deploy script produces the same address, every run, and often the same address on every chain. A single-source-of-truth resolver makes addresses *consistent* — every consumer reads from one record per chain, mechanically. The first layer is the popular one. The second is the one that actually prevents the bug.
+
+## Layer 1: CREATE2 via the Safe Singleton Factory
+
+Ordinary contract creation (`CREATE`) derives the new address from the deployer's address and nonce. Nonces are history: run the same script twice, or on a chain where the deployer has sent one extra transaction, and you get a different address. [EIP-1014](https://eips.ethereum.org/EIPS/eip-1014) added `CREATE2`, which removes history from the equation:
+
+```
+address = keccak256(0xff ++ deployer ++ salt ++ keccak256(init_code))[12:]
+```
+
+Deployer, salt, init code. Nothing else. If those three inputs are identical on two chains, the address is identical on two chains.
+
+The catch is the `deployer` term. If each chain's deployment EOA calls `CREATE2` through its own throwaway factory, the factory addresses differ and determinism collapses. The standard fix is a *shared* factory that already exists at the same address everywhere. FairWins uses the [Safe Singleton Factory](https://github.com/safe-global/safe-singleton-factory), pinned in `scripts/deploy/lib/constants.js`:
+
+```javascript
+/**
+ * Safe Singleton Factory address - same on all EVM networks
+ * Used for deterministic CREATE2 deployments
+ */
+const SINGLETON_FACTORY_ADDRESS = "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7";
+```
+
+The factory itself was placed at that address on each network via a presigned deployment transaction (the same family of techniques as [EIP-2470](https://eips.ethereum.org/EIPS/eip-2470)'s keyless deployment). Calling it is trivially simple: send a transaction whose data is `salt ++ init_code`, and it executes `CREATE2` on your behalf. Because the factory is the `deployer` term in the address formula, every chain computes the same result.
+
+The workhorse is `deployDeterministic` in `scripts/deploy/lib/helpers.js`. Before spending any gas, it computes where the contract *will* land and checks whether it's already there:
+
+```javascript
+// Compute deterministic address
+const initCodeHash = ethers.keccak256(deploymentData);
+const deterministicAddress = ethers.getCreate2Address(
+  SINGLETON_FACTORY_ADDRESS,
+  salt,
+  initCodeHash
+);
+
+// Check if contract is already deployed
+const existingCode = await ethers.provider.getCode(deterministicAddress);
+if (existingCode !== "0x") {
+  return {
+    address: deterministicAddress,
+    contract: ContractFactory.attach(deterministicAddress),
+    alreadyDeployed: true
+  };
+}
+```
+
+That `getCode` check is the quiet superpower: **idempotency**. Re-running `scripts/deploy/deploy.js` against a network where everything is already deployed is a no-op that attaches to existing contracts instead of minting duplicates. A partially failed deploy can simply be re-run; whatever landed stays put, whatever didn't gets deployed. The helper also enforces the [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860) 49,152-byte initcode limit and warns past the [EIP-170](https://eips.ethereum.org/EIPS/eip-170) 24,576-byte runtime limit before it wastes a transaction finding out on-chain.
+
+Salts are human-readable, versioned strings, hashed via `generateSalt` (`ethers.id`, i.e. `keccak256` of the UTF-8 string). The active deployment uses the prefix recorded in every `deployments/*-v2.json` file:
+
+```
+salt = keccak256("FairWins-P2P-v2.0-KeyRegistry")
+```
+
+Bump the version prefix and you get a clean, parallel address space for a v3 — old deployments stay untouched and reachable.
+
+One more ergonomic detail: local Hardhat networks obviously don't ship with the factory pre-installed. `ensureSingletonFactory` detects a local chain, funds the factory's one-shot signer address, and replays the presigned deployment transaction from the `@safe-global/safe-singleton-factory` package — so `localhost` and CI exercise the *same* deployment path as production instead of a mock shortcut.
+
+## Where Determinism Actually Holds — and Where It Honestly Doesn't
+
+Here's the part most write-ups skip. "Same address on every chain" has three preconditions — same factory, same salt, same init code — and *init code includes the ABI-encoded constructor arguments*. Look at the recorded deployments and the pattern is textbook:
+
+- **`KeyRegistry`** takes no constructor arguments. It sits at `0xcEFdeBba8E040c035c690ca9057cF22E73247c24` on Mordor, Amoy, *and* Polygon. Full determinism.
+- **`SanctionsGuard`** takes an admin and an oracle address. Mordor and Amoy both point at a mock sanctions oracle, so they share `0xdF41355dD5E47FCA4eE2F2205af4C70Dab8C13B3`. Polygon points at the real Chainalysis sanctions oracle (`0x40C579…C8fb`) — different constructor arg, different init code, different address. Working exactly as designed.
+- **UUPS proxies** — `wagerRegistry`, `membershipManager`, `wagerPoolFactory` — are *not* CREATE2-deployed at all. A comment in `scripts/deploy/deploy.js` says it plainly: *"unlike the prior CREATE2 deploy this is NOT idempotent — re-running mints a new proxy."* Their address stability comes from a different mechanism entirely: the proxy is deployed once per chain and then never redeployed. Logic changes ship as in-place upgrades through `scripts/deploy/lib/upgradeable.js`, gated by `npm run check:storage-layout` in CI. Stable address, swappable implementation — determinism by *policy*, not by opcode.
+
+This is the honest taxonomy: CREATE2 gives cross-chain address equality only to immutable, argument-free singletons. Everything else gets *per-chain* address stability — which turns out to be what the consumers actually need.
+
+## Layer 2: One Record Per Chain, One Resolver Everywhere
+
+Because addresses can legitimately differ per chain, no consumer is allowed to assume they don't. Every deploy run writes its results to `deployments/<network>-chain<id>-v2.json` — network, deployer, per-contract addresses, constructor args, salt prefix, deploy blocks. The repo treats these files as the source of truth for on-chain addresses, and three consumers hang off them:
+
+**The frontend** never hand-edits addresses. `npm run sync:frontend-contracts` (see `scripts/utils/sync-frontend-contracts.js`) reads the deployment record and rewrites the per-network address maps in `frontend/src/config/contracts.js`, scoped to the right network block. It also re-emits plain-JSON ABIs from the hand-maintained JS ABI modules so downstream consumers read generated artifacts, not hand-copied ones. At runtime, exactly one function resolves addresses:
+
+```javascript
+export function getContractAddressForChain(contractName, chainId) {
+  if (chainId == null) return getContractAddress(contractName)
+  const chainContracts = NETWORK_CONTRACTS[chainId]
+  return chainContracts ? chainContracts[contractName] : undefined
+}
+```
+
+Chain-aware, and honest about absence: Mordor has no Polymarket, Chainlink, or UMA, so those adapter keys simply don't exist in its map and the resolver returns `undefined` — the UI degrades the capability rather than pointing at a wrong address. The landing page's "deployed on" list is even derived from the same maps (`getDeployedNetworks` filters for networks carrying a live `wagerRegistry`), so shipping a new chain updates the marketing surface with zero UI edits.
+
+**The subgraph** keys its manifests off `subgraph/networks.json`, which carries the same per-network addresses and start blocks as the deployment records.
+
+**The relay gateway** is the strictest consumer. `services/relay-gateway/src/config/index.js` reads the `deployments/*-chain<ID>-v2.json` files directly at boot, and refuses to start if any enabled chain is missing a record with `wagerRegistry`, `membershipManager`, and `sanctionsGuard` addresses. The comment in the file states the policy: *fail loudly — never run against a stale/unknown target*. A gateway that sponsors gas for user transactions must never relay into a contract it can't identify; a crash at boot is infinitely cheaper than a policy check against the wrong bytecode.
+
+Same information, three consumption styles — regenerated config for the frontend, manifest data for the indexer, boot-time validation for the gateway — but a single upstream artifact per chain.
+
+## Design Decisions
+
+**Safe Singleton Factory over a bespoke deployer.** Rolling a custom CREATE2 factory means custody of a deployer key per chain and a new audit surface. The Safe factory already exists at one address across the EVM networks FairWins targets (including Mordor — a useful test, since niche chains are where presigned-deployment schemes usually break), and it's the same infrastructure Safe itself relies on.
+
+**Idempotent scripts over deployment ceremony.** The `getCode`-then-attach pattern means "deploy" and "verify the deployment exists" are the same command. There is no separate resume path to maintain, and CI can run the real deploy script against a fresh Hardhat chain on every push.
+
+**Recorded addresses over computed addresses.** A tempting shortcut is to have consumers *compute* CREATE2 addresses instead of reading a record. FairWins deliberately doesn't: proxies aren't CREATE2, constructor args vary by chain, and a computed address tells you where a contract *would* be, not that the right bytecode is actually there. The `deployments/` records capture what was verifiably deployed; the resolver distributes that fact.
+
+**Per-chain resolution as a hard rule.** Even for `KeyRegistry` — genuinely identical on all three chains today — code goes through `getContractAddressForChain`. Hardcoding "it's the same everywhere" bakes today's coincidence into tomorrow's outage the first time a chain needs a divergent deploy.
+
+The trade-offs are real: the singleton factory is a dependency you don't control (if a future chain lacks it, someone must fund and replay the presigned deployment first); byte-identical init code requires compiler and metadata discipline; and CREATE2 determinism simply doesn't extend to upgradeable proxies, which carry their own upgrade-governance burden instead. Deterministic deployment is a tool, not a doctrine — the resolver is the doctrine.
+
+## Sources
+
+- `scripts/deploy/lib/helpers.js` — `deployDeterministic`, `generateSalt`, `ensureSingletonFactory`
+- `scripts/deploy/lib/constants.js` — `SINGLETON_FACTORY_ADDRESS`, per-network token/oracle addresses
+- `scripts/deploy/deploy.js` — v2 deployment orchestration, salt prefix `FairWins-P2P-v2.0-`, proxy non-idempotency notes
+- `scripts/deploy/lib/upgradeable.js` + `scripts/deploy/check-storage-layout.js` — in-place UUPS upgrades
+- `scripts/utils/sync-frontend-contracts.js` — deployment-record → frontend config/ABI sync
+- `deployments/mordor-chain63-v2.json`, `deployments/amoy-chain80002-v2.json`, `deployments/polygon-chain137-v2.json` — recorded addresses compared above
+- `frontend/src/config/contracts.js` — `getContractAddressForChain`, `getDeployedNetworks`, per-network maps
+- `services/relay-gateway/src/config/index.js` — boot-time deployment-record validation
+- `subgraph/networks.json` — per-network subgraph addresses
+- `docs/developer-guide/singleton-deployment-patterns.md` — pattern research and alternatives survey
+- [EIP-1014: Skinny CREATE2](https://eips.ethereum.org/EIPS/eip-1014)
+- [EIP-2470: Singleton Factory](https://eips.ethereum.org/EIPS/eip-2470)
+- [EIP-170: Contract code size limit](https://eips.ethereum.org/EIPS/eip-170), [EIP-3860: Limit and meter initcode](https://eips.ethereum.org/EIPS/eip-3860)
+- [Safe Singleton Factory](https://github.com/safe-global/safe-singleton-factory)
+- [OpenZeppelin proxy documentation](https://docs.openzeppelin.com/contracts/5.x/api/proxy) (UUPS / ERC-1967)

--- a/docs/blog/posts/13-deterministic-singleton-deployment/social.md
+++ b/docs/blog/posts/13-deterministic-singleton-deployment/social.md
@@ -1,0 +1,26 @@
+# Social & Image — One Salt, Three Chains: What Deterministic Deployment Actually Buys You
+
+## X (Twitter)
+
+CREATE2 gives you the same address on every chain — until a constructor arg differs. How FairWins deploys via the Safe Singleton Factory, why the deploy script is idempotent, and why a per-chain resolver still does the real work. 🔗 <link> #Solidity #DevOps
+
+## LinkedIn
+
+The worst multi-chain bug ships silently: a redeploy mints a fresh address, the frontend gets updated, the subgraph doesn't, and the relay gateway keeps an address from a three-month-old env var. Nothing crashes — the systems just quietly drift apart.
+
+Our latest FairWins engineering post walks through the two-layer defense we run across Mordor, Amoy, and Polygon:
+
+- CREATE2 via the Safe Singleton Factory: same salt + same init code = same address, with human-readable versioned salts and idempotent deploy scripts (re-running is a safe no-op)
+- Where determinism honestly breaks: per-chain constructor args change the init code, and UUPS proxies aren't CREATE2 at all — their stability comes from in-place upgrades, not opcodes
+- One recorded deployment file per chain as the single source of truth, consumed three ways: regenerated frontend config, subgraph manifests, and a relay gateway that refuses to boot against an unknown target
+- Why "resolve per chain, every time" is the rule even for contracts that happen to share an address today
+
+Read the full post: <link>
+
+How does your team keep contract addresses in sync across frontends, indexers, and off-chain services — computed, recorded, or something else?
+
+#Solidity #DevOps #SmartContracts #Ethereum #web3
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern isometric editorial illustration of deterministic multi-chain deployment: three identical translucent glass platforms floating in a row, each platform representing a blockchain network, with a single glowing geometric key descending from above and stamping an identical crystalline cube structure onto all three platforms simultaneously via thin beams of light — the same shape landing in the same position on each platform. Fine circuit-like traces connect the platforms to a small central ledger tablet below, suggesting one shared record feeding every surface. Deep navy background with teal accents on the glass platforms and traces, and a single warm amber glow on the descending key and its light beams as the only warm accent. Soft ambient lighting with gentle rim light on the platform edges, subtle depth-of-field haze, precise fintech-engineering aesthetic, uncluttered composition with generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/14-wager-lifecycle-contract/blog.md
+++ b/docs/blog/posts/14-wager-lifecycle-contract/blog.md
@@ -1,0 +1,130 @@
+# The Wager Lifecycle Contract: Anatomy of a Peer-to-Peer Escrow State Machine
+
+*How FairWins' `WagerRegistry` turns a handshake bet into seven explicit states, two hard deadlines, and a payout nobody can strand*
+
+---
+
+| | |
+|---|---|
+| **Series** | Prediction Markets — Part 1 |
+| **Audience** | Smart-contract developers |
+| **Tags** | `escrow`, `state-machine`, `solidity`, `prediction-markets`, `p2p` |
+| **Reading time** | ~9 minutes |
+
+> **Responsible-use note.** FairWins wagers are peer-to-peer forecasts on publicly available information. Nothing here is a mechanism for trading on material non-public information or circumventing regulation; all participants remain fully subject to applicable law and compliance obligations in their jurisdiction.
+
+---
+
+## The bet that never pays out
+
+Two engineers bet 200 USDC on whether a protocol upgrade ships before the end of the quarter. Both are good for it. Neither wants to hand the money to the other in advance, neither wants a third party holding it, and both have seen how this ends without structure: the outcome lands, the loser goes quiet, and the "bet" becomes an awkward memory.
+
+The failure modes of an informal wager are surprisingly enumerable. The counterparty never actually commits their stake. The event resolves but nobody has authority to say who won. The event *doesn't* resolve — the upgrade is cancelled — and there's no agreed path to unwind. Or the money is committed somewhere and a bug, a dispute, or a disappearing party leaves it stuck forever.
+
+An escrow contract worth deploying has to close every one of those holes explicitly. That is what FairWins' `WagerRegistry` (`contracts/wagers/WagerRegistry.sol`) does: it is less a "betting contract" than a state machine over other people's money, where every state has a defined set of exits and no state is a dead end. This post walks its anatomy — the states, the deadlines, the resolution paths, and the checks-effects-interactions discipline that holds it together.
+
+## Seven states, no dead ends
+
+Every wager is a `Wager` struct in proxy storage, and its position in the lifecycle is a single enum (`contracts/interfaces/IWagerRegistryTypes.sol`):
+
+```solidity
+enum Status { None, Open, Active, Resolved, Cancelled, Refunded, Draw }
+
+enum ResolutionType {
+    Either, Creator, Opponent, ThirdParty,
+    Polymarket, ChainlinkDataFeed, ChainlinkFunctions, UMA
+}
+```
+
+The happy path is short. `createWager` escrows the creator's stake and writes the wager as `Open`, emitting `WagerCreated`. The named opponent calls `acceptWager`, their stake is pulled in, the status flips to `Active`, and `WagerAccepted` fires. Once the outcome is known, the wager becomes `Resolved` with a recorded `winner`, and the winner calls `claimPayout` to receive both stakes in one transfer (`PayoutClaimed`).
+
+The interesting design is in the unhappy paths, because each live state has an exit that requires no cooperation from the other side:
+
+- **`Open`, opponent never shows.** The creator can `cancelOpen` (emits `WagerCancelled`), the opponent can `declineWager` — both refund the creator immediately — or anyone can call `claimRefund` after the accept deadline passes, emitting `WagerRefunded`.
+- **`Active`, outcome never lands.** After the resolve deadline, `claimRefund` returns each side's own stake and marks the wager `Refunded`.
+- **`Active`, the event genuinely ties.** Both participants consent to a draw (or the arbitrator declares one), each stake goes home, and `WagerDrawn` fires.
+
+One subtlety for anyone reading the source: the pre-acceptance exits (`cancelOpen`, `declineWager`) don't set `Status.Cancelled` — they refund the creator and `delete` the wager record entirely, reclaiming storage. The enum value exists for ABI stability, but a cancelled offer simply ceases to be. Post-acceptance exits, by contrast, keep the record and mark it `Refunded` or `Draw`, because two parties' history now hangs off it.
+
+## Two absolute deadlines
+
+Every wager carries two Unix timestamps set at creation: `acceptDeadline` and `resolveDeadline`. They are absolute, not durations, and the contract validates their shape in one shared check (`contracts/wagers/WagerRegistryCore.sol`):
+
+```solidity
+uint64 public constant MAX_ACCEPT_WINDOW = 30 days;
+uint64 public constant MAX_RESOLVE_WINDOW = 180 days;
+
+function _checkDeadlines(uint64 acceptDeadline, uint64 resolveDeadline) internal view {
+    if (acceptDeadline <= block.timestamp) revert BadDeadlines();
+    if (resolveDeadline <= acceptDeadline) revert BadDeadlines();
+    if (acceptDeadline > block.timestamp + MAX_ACCEPT_WINDOW) revert BadDeadlines();
+    if (resolveDeadline > block.timestamp + MAX_RESOLVE_WINDOW) revert BadDeadlines();
+}
+```
+
+The ordering constraint (`accept < resolve`) means the machine can never enter `Active` with its resolution window already closed. The caps mean no wager can hold funds hostage indefinitely: an offer goes stale within 30 days, and even a fully active wager has a guaranteed exit within 180. Deadlines are the liveness half of the design — the state machine guarantees *which* transitions are legal, and the deadlines guarantee that *some* transition is always eventually available to a single, unilateral caller.
+
+Notice also who may trigger the timeout path. `claimRefund` deliberately pays the original participants regardless of who calls it, so a neutral third party — or an automated keeper via `batchExpireOpen` — can sweep expired wagers without being able to redirect a cent.
+
+## Eight ways to decide a winner
+
+`ResolutionType` is fixed per wager at creation and determines exactly one authority that can settle it. The first four are human paths, checked in `_declareWinner`:
+
+- **`Either`** — either participant may declare. This is mutual-trust settlement, and the contract restricts it to equal-stakes wagers (`EitherRequiresEqualStakes`): on an asymmetric wager, the side risking less could self-declare and seize the larger stake, so leveraged offers must name a single settler, an arbitrator, or an oracle.
+- **`Creator` / `Opponent`** — exactly one named party declares.
+- **`ThirdParty`** — an arbitrator, named at creation and required to be neither participant, declares alone.
+
+The remaining four are oracle paths — `Polymarket`, `ChainlinkDataFeed`, `ChainlinkFunctions`, `UMA` — where `declareWinner` reverts outright and anyone may instead call the auto-resolve entrypoints, which read the linked condition through an `IOracleAdapter` (`contracts/oracles/IOracleAdapter.sol`) and map the boolean outcome to a winner via the `creatorIsYes` flag recorded at creation. Creation-time validation (`_checkOracleLinkage`) refuses an oracle wager whose condition is missing, whose adapter is unwired, or whose condition has *already resolved* — a stale-condition bet is a bet on a known answer.
+
+Draws follow the same authority split. For the participant types, `declareDraw` accumulates consent in a two-bit mask — the first call emits `DrawProposed`, the second settles — and either side can `revokeDraw` before the other agrees, so a one-sided proposal never locks anything. An arbitrator settles a draw solo. Oracle types can't be drawn manually at all; a draw there arises only from the oracle reporting a tie.
+
+## Checks-effects-interactions, everywhere it counts
+
+The registry escrows allowlisted ERC-20 stakes — USDC and WMATIC in practice, with amounts as `uint128` and the allowlist admin-controlled via `setTokenAllowed`. Every function that moves tokens follows the same shape, and the payout path is the cleanest illustration:
+
+```solidity
+function _claimPayout(address actor, uint256 wagerId) internal {
+    Wager storage w = _wagers[wagerId];
+    if (w.status != Status.Resolved) revert NotResolved();
+    if (actor != w.winner) revert NotWinner();
+    if (w.paid) revert AlreadyPaid();
+
+    w.paid = true;
+    // Compute as uint256 to avoid uint128 overflow on sum
+    uint256 payout = uint256(w.creatorStake) + uint256(w.opponentStake);
+    IERC20(w.token).safeTransfer(w.winner, payout);
+
+    emit PayoutClaimed(wagerId, w.winner, payout);
+}
+```
+
+Checks first (right state, right caller, not yet paid), then the effect (`w.paid = true`), then the interaction (the transfer). Even with OpenZeppelin's `ReentrancyGuard` wrapping every external entrypoint, the ordering stands on its own: a reentrant or misbehaving token sees the wager already marked paid. The same pattern repeats in `_settleDraw` and `_claimRefund`, where status flips and consent state is cleared before any `safeTransfer` runs.
+
+The checks phase is also where the compliance and membership layers live, uniformly across create and accept: a sanctions screen (`ISanctionsGuard.checkBlocked`) on the acting parties, then a membership gate (`IMembershipManager.checkCanCreate`) — all evaluated before a single token moves.
+
+## Design decisions
+
+**Exits stay open when the machine is paused.** A `GUARDIAN_ROLE` pause halts *new* activity — `createWager` and `acceptWager` carry `whenNotPaused` — but `declareWinner`, `declareDraw`, `claimPayout`, and `claimRefund` deliberately do not. An emergency stop must never become a mechanism for stranding escrowed funds; only per-account freezes (an explicitly moderated state) block an individual's exits.
+
+**Absolute timestamps over durations.** Storing `acceptDeadline`/`resolveDeadline` as absolute `uint64` values makes every timeout check a single comparison against `block.timestamp`, makes deadlines legible off-chain without reconstruction, and lets the frontend, subgraph, and keepers all agree on expiry without knowing creation time.
+
+**One authority per wager, chosen up front.** There is no fallback chain from oracle to arbitrator to participant. A wager's resolution path is a creation-time commitment both sides accepted; ambiguity about who settles is precisely the failure mode of the handshake bet, so the contract refuses to reintroduce it.
+
+**Events as the integration surface.** `WagerCreated`, `WagerAccepted`, `WagerResolved`, `PayoutClaimed`, `WagerRefunded`, `WagerCancelled`, and `WagerDrawn` mirror every transition, and an append-only per-user index (`getUserWagers`) gives O(user) lookups without log scans. The subgraph and frontend never need to reconstruct state transitions from storage diffs.
+
+**A state machine at a stable address.** Since spec 025 (`specs/025-upgradeable-registry/`), the registry is a UUPS proxy: wager state lives at a permanent address while logic ships as in-place upgrades, gated by a storage-layout compatibility check so an upgrade can extend the machine but never scramble the wagers already inside it. The behavior in this post — every state, every exit — survives an upgrade because the upgrade process is not allowed to touch the storage that encodes it.
+
+The result is an escrow contract you can audit as a graph: seven states, a bounded clock on every edge that holds money, and no node without an exit. That shape — not any single clever line — is what makes it safe to lock 400 USDC between two people who trust the outcome more than they trust each other.
+
+## Sources
+
+- `contracts/wagers/WagerRegistry.sol` — external entrypoints, admin surface, pause/freeze semantics
+- `contracts/wagers/WagerRegistryCore.sol` — shared state, `_checkDeadlines`, `_createWager`, `_declareWinner`, `_declareDraw`, `_claimPayout`, `_claimRefund`
+- `contracts/interfaces/IWagerRegistryTypes.sol` — `Status` / `ResolutionType` enums, `Wager` struct, event definitions
+- `contracts/oracles/IOracleAdapter.sol` — oracle resolution interface
+- `docs/developer-guide/smart-contracts.md` — state-machine diagram, resolution-type table, deployed addresses
+- `specs/025-upgradeable-registry/spec.md` — UUPS migration rationale and storage-layout guarantees
+- `test/WagerRegistry.test.js`, `test/WagerRegistry.draw.test.js` — lifecycle, deadline, refund, and draw-consent behavior
+- OpenZeppelin Contracts: ReentrancyGuard, SafeERC20, AccessControl, UUPS — https://docs.openzeppelin.com/contracts
+- EIP-712 (typed structured data signing, used by the open-challenge accept path) — https://eips.ethereum.org/EIPS/eip-712
+- ERC-1822 / UUPS proxiable standard — https://eips.ethereum.org/EIPS/eip-1822

--- a/docs/blog/posts/14-wager-lifecycle-contract/social.md
+++ b/docs/blog/posts/14-wager-lifecycle-contract/social.md
@@ -1,0 +1,28 @@
+# Social & Image — The Wager Lifecycle Contract
+
+## X (Twitter)
+
+A P2P escrow contract is really a state machine over other people's money. FairWins' WagerRegistry: 7 states, 2 hard deadlines (30d accept / 180d resolve), 8 resolution authorities — and no state without a unilateral exit. Anatomy inside. 🔗 <link> #Solidity #SmartContracts #web3
+
+## LinkedIn
+
+Informal bets fail in predictable ways: the counterparty never commits their stake, nobody has authority to declare the winner, the event never resolves, or the money gets stuck. Building an on-chain escrow that closes every one of those holes is a design exercise in state machines, not just token transfers.
+
+Part 1 of our Prediction Markets series dissects FairWins' `WagerRegistry` — the peer-to-peer wager escrow contract — as a lifecycle:
+
+- Seven explicit states (Open → Active → Resolved/Refunded/Draw) where every state that holds funds has an exit requiring no cooperation from the other party
+- Two absolute deadlines per wager (acceptDeadline, resolveDeadline) with hard caps of 30 and 180 days, so escrow can never be stranded indefinitely
+- Eight resolution types — participant-declared, arbitrator, and oracle-driven (Polymarket, Chainlink, UMA) — each fixing exactly one settlement authority at creation
+- Checks-effects-interactions discipline on every token movement, and why exit paths deliberately stay open even when the contract is paused
+
+If you're building anything that escrows funds between untrusting parties, the lifecycle framing here generalizes well beyond wagers.
+
+Read the full post: <link>
+
+What's your approach to guaranteeing liveness in escrow contracts — timeouts, keepers, or something else?
+
+#Solidity #SmartContracts #Ethereum #DeFi #Engineering
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an isometric abstract-geometric style: a stylized circular flow of seven connected glass-like nodes arranged as a state diagram, with glowing directional arrows tracing paths between them — one bright path flowing forward through three nodes to a vault-like cube releasing two coin streams, and secondary escape paths looping back from every node toward a safe-return gate. Two small hourglass forms sit on the connecting edges, suggesting deadlines. Deep navy and teal base palette with a single warm amber accent lighting the winning path and the hourglasses; soft rim lighting, subtle depth-of-field, generous negative space, fintech-engineering mood, precise and technical rather than playful. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/15-oracle-adapter-abstraction/blog.md
+++ b/docs/blog/posts/15-oracle-adapter-abstraction/blog.md
@@ -1,0 +1,150 @@
+# Three Kinds of Truth, One Interface: The Oracle Adapter Layer
+
+*How a single `IOracleAdapter` contract interface absorbs push feeds, request/callback oracles, optimistic dispute, and Polymarket's resolved markets — without the escrow contract knowing the difference*
+
+| | |
+|---|---|
+| **Series** | Prediction Markets (part 2) |
+| **Part** | 15 of 34 |
+| **Audience** | Oracle integrators, smart-contract engineers |
+| **Tags** | `oracles`, `chainlink`, `uma`, `polymarket`, `adapter-pattern` |
+| **Reading time** | ~9 minutes |
+
+---
+
+> **Important Note**: This article describes prediction markets based on publicly available information and legitimate forecasting. Oracle-settled wagers are not a mechanism for trading on material non-public information or circumventing securities regulations. All participants remain fully subject to applicable laws and compliance requirements.
+
+---
+
+## Three wagers, three truths
+
+Consider three wagers a member might create on FairWins:
+
+1. *"ETH closes above $4,000 on September 30."* The truth is a number that a Chainlink price feed already publishes on-chain, continuously, whether anyone asks or not.
+2. *"The city's open-data API reports more than 40mm of rainfall for October."* The truth lives behind an HTTPS endpoint. Nothing on-chain knows it until someone goes and fetches it.
+3. *"The Meridian–Vantage merger closes before Q3."* The truth is a human judgment about a messy real-world event. No feed publishes it; no API is authoritative. Someone has to assert it, and someone else has to be able to dispute them.
+
+Each of these needs a fundamentally different oracle. The first is a **push feed**: data arrives on-chain on the oracle's schedule and you read the latest value. The second is **request/callback**: you send a request, a decentralized network executes it off-chain, and the answer comes back in an asynchronous callback. The third is **optimistic dispute**: anyone may assert the answer with a bond; the assertion stands unless challenged within a liveness window, and challenges escalate to a voting-based resolution.
+
+FairWins' escrow contract — the `WagerRegistry` covered in part 1 — should not care about any of this. It holds two stakes and needs exactly one bit: did YES win? The engineering problem is designing the seam so that four very different resolution machines (the three above, plus reading Polymarket's already-resolved markets) all collapse to that one bit, with the same failure semantics, behind the same interface.
+
+## The interface: one bit, one sentinel
+
+The seam is `contracts/oracles/IOracleAdapter.sol`. Every adapter — Polymarket, Chainlink Data Feeds, Chainlink Functions, UMA Optimistic Oracle V3 — implements it. The heart of the interface is two functions:
+
+```solidity
+function isConditionResolved(bytes32 conditionId)
+    external view returns (bool resolved);
+
+function getOutcome(bytes32 conditionId) external view returns (
+    bool outcome,      // true if the "YES" or "PASS" side won
+    uint256 confidence, // basis points, 10000 = 100%
+    uint256 resolvedAt  // timestamp; 0 = not resolved
+);
+```
+
+Three conventions do the real work:
+
+**`bytes32 conditionId` is the universal key.** Each adapter defines what a condition id *means* — a Polymarket CTF condition hash, an admin-registered feed-threshold config, a Functions request template, an UMA claim — but to the registry it is an opaque 32-byte handle stored on the wager.
+
+**The outcome is a `bool`, deliberately.** FairWins wagers are binary: creator takes one side, opponent takes the other. Collapsing every oracle's richer output (payout numerator arrays, `int256` feed answers, DON byte responses, assertion verdicts) down to a single bool at the adapter boundary means the registry's settlement code has exactly one shape.
+
+**`resolvedAt == 0` is the unresolved sentinel.** `getOutcome` is a view; it never reverts on "not yet." A zero timestamp tells the caller there is nothing to act on. This one convention carries surprising weight, as we'll see with Polymarket ties.
+
+The interface also carries operational surface: `oracleType()` (a human-readable tag like `"Polymarket"` or `"UMA-OOv3"`), `isAvailable()` (is the underlying oracle actually deployed and responsive on this network?), `isConditionSupported`, and `getConditionMetadata`.
+
+## The consumer: how `WagerRegistry` stays oracle-agnostic
+
+The registry (`contracts/wagers/WagerRegistryCore.sol`) holds a dedicated `IOracleAdapter public polymarketAdapter` slot — kept for ABI compatibility with the original Polymarket-only design — plus a generic registry for everything after it:
+
+```solidity
+mapping(ResolutionType => IOracleAdapter) public oracleAdapters;
+```
+
+`ResolutionType` (in `contracts/interfaces/IWagerRegistryTypes.sol`) enumerates `Polymarket`, `ChainlinkDataFeed`, `ChainlinkFunctions`, and `UMA` alongside the human-arbitrated types. Admins wire adapters with `setPolymarketAdapter` / `setOracleAdapter`; an unset adapter simply disables that resolution type on that network.
+
+The adapter is consulted at exactly two moments in a wager's life:
+
+**At creation**, `_checkOracleLinkage` enforces that an oracle-typed wager carries a non-zero condition id, that the adapter for its type is configured, and — the stale-condition mitigation — that the condition is *not already resolved*. You cannot open a wager on an outcome the oracle has already decided.
+
+**At settlement**, anyone may call `autoResolveFromPolymarket(wagerId)` or the generic `autoResolveFromOracle(wagerId)` (both live in the `WagerRegistryIntents` facet; part 1 covered why the registry is two facets behind one proxy). The path is permissionless by design — settlement is a pure function of public oracle state, so there is no reason to gate who triggers it. The generic path is four lines of essence: look up the adapter for `w.resolutionType`, call `getOutcome`, revert `ConditionNotResolved` if `resolvedAt == 0`, otherwise settle the win.
+
+That's the whole coupling. The registry never imports a Chainlink or UMA interface.
+
+## Adapter one: Polymarket, reading someone else's settled truth
+
+`contracts/oracles/PolymarketOracleAdapter.sol` doesn't run an oracle at all — it reads the output of one. Polymarket markets settle on the Gnosis Conditional Token Framework (CTF), where a condition id is `keccak256(oracle, questionId, outcomeSlotCount)` and resolution is a pair of payout numerators: `[1,0]` means YES, `[0,1]` means NO. The adapter fetches `getPayoutNumerators` from the CTF contract (Polygon only — Polymarket runs nowhere else), caches the result, and maps `payouts[0] > payouts[1]` to `outcome = true`.
+
+The subtle case is a tie. Polymarket markets occasionally resolve 50/50 — an "invalid" or UMA-disputed market. Equal numerators are not a decidable YES/NO, and paying either side would be wrong. The adapter's answer is the sentinel:
+
+```solidity
+// A tie (equal payout numerators — e.g. a 50/50 split or an
+// "invalid"/UMA-disputed Polymarket resolution) is not a decidable
+// YES/NO outcome. Return the unresolved sentinel (resolvedAt=0) so
+// WagerRegistry leaves the wager unsettled and the deadline-based
+// refund path returns both stakes, rather than paying a fixed side.
+if (cached.passNumerator == cached.failNumerator) {
+    return (false, 0, 0);
+}
+```
+
+On the registry side, `autoResolveFromPolymarket` disambiguates: `resolvedAt == 0` *plus* `isConditionResolved() == true` means "resolved tie," and the wager settles as an immediate draw — both stakes back. A genuinely unresolved market reverts and the deadline-based refund path remains the backstop. The failure mode of an undecidable question is a refund, never a coin-flip payout.
+
+**Trade-offs:** you can only wager on questions Polymarket already lists; resolution timing is entirely external; and you inherit Polymarket's own resolution stack (which is itself UMA underneath). In exchange, the adapter is nearly free to operate — no bonds, no subscriptions, no feed curation — which is why it's the model FairWins exposes first.
+
+## Adapter two: Chainlink Data Feeds, a threshold on a push feed
+
+`contracts/oracles/ChainlinkDataFeedOracleAdapter.sol` turns a continuously-updated price feed into a binary outcome. An admin registers a condition as `(feed, threshold, comparison, deadline)` — the comparison being one of `GT/GTE/LT/LTE/EQ` — against an allowlisted `AggregatorV3Interface` feed. After the deadline, *anyone* calls `evaluate(conditionId)`: it reads `latestRoundData()`, requires `updatedAt >= deadline` (rejecting stale data with `StaleFeedData`), compares the answer to the threshold, and caches the boolean forever.
+
+**Trade-offs:** this model only answers questions that reduce to *number vs. threshold at/after time T* — but for those it is the cheapest and lowest-trust of the four, because the data is already on-chain and the evaluation is a pure function anyone can trigger. The honest caveat: `latestRoundData()` is the latest answer *at evaluation time*, not the answer at the deadline instant. The staleness check bounds this (the round must postdate the deadline), and the first caller after the deadline fixes the reading — an incentive to evaluate promptly if the number is drifting your way.
+
+## Adapter three: Chainlink Functions, request/callback for arbitrary APIs
+
+`contracts/oracles/ChainlinkFunctionsOracleAdapter.sol` handles truths that live behind an API. A condition registers an encoded Chainlink Functions request (the JavaScript source is pinned by a `sourceHash`), a subscription id, gas limit, and DON id. `requestResolution(conditionId)` — again permissionless — sends the request to the Decentralized Oracle Network; the answer arrives asynchronously in the inherited `fulfillRequest` callback, which decodes the DON script's single `uint8` return (0 = NO, 1 = YES) and caches it.
+
+Asynchrony forces two guards the synchronous adapters don't need: a `conditionToPendingRequest` mapping rejects a second request while one is in flight, and a DON-reported error emits `RequestFailed` and leaves the condition unresolved — so a flaky API means "try again," never "wrong answer cached forever."
+
+**Trade-offs:** maximum expressiveness — any public API a script can query — paid for in trust and operations. You are trusting the registered script and the API it queries; the source hash makes the script auditable but not less trusted. There's a funded subscription to maintain, and the request/callback round trip means resolution is a two-transaction affair.
+
+## Adapter four: UMA Optimistic Oracle V3, truth by unchallenged assertion
+
+`contracts/oracles/UMAOptimisticOracleV3Adapter.sol` handles the merger question — outcomes that need human judgment. A condition registers a human-readable `claim`, a bond currency and amount, and a liveness window. `assertResolution(conditionId, asserter)` pulls the bond from the caller and posts the claim to UMA's Optimistic Oracle V3 via `assertTruth`. If the liveness window passes undisputed, OOv3 calls back `assertionResolvedCallback(assertionId, assertedTruthfully)` and the adapter caches the verdict. If disputed, the question escalates to UMA's Data Verification Mechanism (a token-holder vote) and resolves through the same callback — the adapter doesn't distinguish a quiet settlement from a fought one.
+
+One implementation detail worth stealing: the adapter reserves `conditionToAssertion[conditionId]` with a sentinel value *before* the external `assertTruth` call, so a reentrant call sees "assertion already pending" and reverts — checks-effects-interactions preserved without a post-call write to that mapping (the real `assertionId → conditionId` link lives in a separate mapping written after the call). The regression suite for this lives in `test/oracles/UMAOptimisticOracleV3Adapter.test.js`.
+
+**Trade-offs:** the only model of the four that can answer *arbitrary* questions — at the cost of capital (someone must post the bond), latency (the liveness window is a floor on resolution time), and an economic-security assumption: an unchallenged false assertion wins, so the bond must make watching worthwhile.
+
+## Shared discipline across all four
+
+The adapters converge on more than the interface. All cache resolutions in an identical `CachedResolution` struct, making `getOutcome` a cheap view after the first resolution. All make the resolution *trigger* permissionless while keeping condition *registration* owner-only — curation is trusted, settlement is not. And all take an explicit `admin` constructor argument rather than `Ownable(msg.sender)`: FairWins deploys adapters deterministically via CREATE2 through the Safe Singleton Factory, and `msg.sender` in that context is the factory, not the operator. `test/oracles/AdapterDeterministicOwnership.test.js` is the regression test for the day that bug shipped.
+
+`isAvailable()` earns its keep off-chain: spec 023 (`specs/023-oracle-graph-gating/`) gates the frontend's oracle-wager entry point per network, so a user on a chain with no adapters never starts a flow that dead-ends. And spec 003 (`specs/003-polymarket-only-oracle-ui/`) is the abstraction's quiet payoff: the frontend currently exposes *only* the Polymarket model, hiding Chainlink and UMA behind a configuration switch — while the contracts keep all four fully supported. Narrowing the product surface required zero contract changes, because the seam was already there.
+
+## Design decisions
+
+- **A `bool` outcome, not a payout vector.** Binary wagers need one bit; forcing every oracle's output through that funnel at the adapter boundary keeps settlement code singular. The cost is that multi-outcome markets need a different design (wager pools solve this differently — spec 034).
+- **Sentinel over revert for "unresolved."** `getOutcome` as a non-reverting view lets the registry, the frontend, and keepers poll cheaply, and lets "resolved tie" and "not resolved" share a wire format while the registry disambiguates with one extra call.
+- **Fail toward refund.** Undecidable Polymarket outcomes settle as draws; failed Functions requests stay unresolved; stale feeds revert. No path guesses a winner.
+- **`confidence` is honest.** Every adapter today returns 10,000 basis points (or 0 with the sentinel). The field exists so a future probabilistic adapter can report less than certainty without an interface break — it is headroom, not a claim.
+- **Adapters are peripherals, not dependencies.** The registry works with zero adapters configured; each adapter degrades to "this resolution type unavailable here," and the UI reflects that per network.
+
+Four resolution machines, three interaction models, one interface — and an escrow contract that never learned the difference.
+
+## Sources
+
+- `contracts/oracles/IOracleAdapter.sol` — the shared interface
+- `contracts/oracles/PolymarketOracleAdapter.sol` — CTF resolved-market reads, tie sentinel
+- `contracts/oracles/ChainlinkDataFeedOracleAdapter.sol` — push-feed threshold evaluation
+- `contracts/oracles/ChainlinkFunctionsOracleAdapter.sol` — request/callback via DON
+- `contracts/oracles/UMAOptimisticOracleV3Adapter.sol` — optimistic assertion + dispute callback
+- `contracts/wagers/WagerRegistryCore.sol`, `contracts/wagers/WagerRegistryIntents.sol` — `_checkOracleLinkage`, `autoResolveFromPolymarket`, `autoResolveFromOracle`
+- `contracts/interfaces/IWagerRegistryTypes.sol` — `ResolutionType` enum
+- `specs/003-polymarket-only-oracle-ui/spec.md` — Polymarket-only frontend exposure
+- `specs/023-oracle-graph-gating/spec.md` — per-network oracle availability gating
+- `test/oracles/` — adapter unit tests incl. `AdapterDeterministicOwnership.test.js`
+- `docs/developer-guide/oracle-open-challenges.md` — oracle-settled open challenges
+- Chainlink Data Feeds: https://docs.chain.link/data-feeds
+- Chainlink Functions: https://docs.chain.link/chainlink-functions
+- UMA Optimistic Oracle V3: https://docs.uma.xyz/developers/optimistic-oracle-v3
+- Polymarket documentation: https://docs.polymarket.com
+- Gnosis Conditional Token Framework: https://docs.gnosis.io/conditionaltokens/

--- a/docs/blog/posts/15-oracle-adapter-abstraction/social.md
+++ b/docs/blog/posts/15-oracle-adapter-abstraction/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Three Kinds of Truth, One Interface: The Oracle Adapter Layer
+
+## X (Twitter)
+
+One escrow contract, four oracles: Polymarket resolved markets, Chainlink push feeds, request/callback Functions, UMA optimistic assertions. All collapse to one bool behind IOracleAdapter — and an undecidable tie becomes a refund, never a coin flip. 🔗 <link> #Solidity #Oracles
+
+## LinkedIn
+
+An escrow contract that settles forecasting wagers needs exactly one bit from the outside world: did YES win? But the truth behind that bit can live in very different places — a price feed that publishes on-chain continuously, an HTTPS API nothing on-chain knows about, or a messy real-world event that needs a human assertion with a dispute window.
+
+Our latest FairWins engineering post covers how one Solidity interface absorbs all of them:
+
+- The `IOracleAdapter` seam: an opaque `bytes32` condition id, a single `bool` outcome, and a `resolvedAt == 0` sentinel for "nothing to act on yet"
+- Four adapters, three interaction models: Polymarket resolved-market reads, Chainlink Data Feed thresholds, Chainlink Functions request/callback, and UMA Optimistic Oracle V3 assertions
+- Failure semantics that never guess: a 50/50 or invalid market settles as a draw with both stakes returned — no path invents a winner
+- Why the escrow registry never imports a Chainlink or UMA interface, and how that let the product narrow to Polymarket-only with zero contract changes
+
+These are skill-based forecasts on publicly available information, and the design goal is honest settlement — including when the honest answer is "nobody won."
+
+Read the full post: <link>
+
+If you've integrated multiple oracle providers behind one interface, what convention did you standardize on for "not resolved yet"?
+
+#Solidity #Oracles #SmartContracts #Chainlink #web3
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean abstract-geometric editorial illustration of oracle abstraction: three distinct luminous data streams flowing from the left — a smooth continuous wave of stacked tick marks, a dotted request-and-return loop arcing out and back, and a slower stream passing through an hourglass-like dispute chamber — all converging into a single elegant prism-shaped adapter node at center, which emits one clean unified beam continuing right into a simple sealed vault form. The three incoming streams are visibly different in texture and rhythm; the outgoing beam is singular and calm. Deep navy background with teal and cyan tones for the streams and vault, and a single warm amber glow concentrated on the central prism node as the only warm accent. Soft studio lighting, faint grid horizon, precise fintech-engineering aesthetic, generous negative space, balanced left-to-right composition. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/16-draw-resolution-open-challenges/blog.md
+++ b/docs/blog/posts/16-draw-resolution-open-challenges/blog.md
@@ -1,0 +1,162 @@
+# When Nobody Wins and Anyone Can Play: Draw Resolution and Open-Challenge Wagers
+
+*The two edge cases that make a peer-to-peer betting protocol feel finished: settling a wager that has no fair winner, and posting a wager that has no opponent yet*
+
+| | |
+|---|---|
+| **Series** | Prediction Markets, part 3 |
+| **Part** | 16 of 34 |
+| **Audience** | Smart-contract developers |
+| **Tags** | `prediction-markets`, `escrow`, `edge-cases`, `solidity` |
+| **Reading time** | ~9 minutes |
+
+---
+
+> **Responsible-use note**: FairWins wagers concern publicly available information and legitimate forecasting between consenting parties. Nothing here is a mechanism for trading on material non-public information or evading applicable law. All participants remain fully subject to the laws, compliance requirements, and professional obligations that apply to them.
+
+---
+
+## Two Wagers That the Happy Path Can't Handle
+
+Dana and Priya have 200 USDC each escrowed on whether a cup final ends in a home win. Mid-week, the match is abandoned — rescheduled outside the window their wager described. Neither of them should win. Under the original `WagerRegistry`, their only exit was to do nothing: wait for the `resolveDeadline` to pass, then call `claimRefund`, which returns both stakes on a timed-out Active wager. It works, but it is slow, and on-chain it is indistinguishable from two people who simply forgot about their bet. An indexer, a history view, or a dispute reviewer cannot tell a deliberate "we agree this is void" from abandonment.
+
+The second gap is at the other end of the lifecycle. Marcus wants to post a wager to his group chat: 50 USDC on a Polymarket market, first taker wins the other side. But `createWager` binds a named `opponent` at creation, and only that exact address can accept. There is no way to say "whoever wants this, take it" — let alone to do so without broadcasting the private terms to every mempool scanner watching for fresh escrow.
+
+These are the edge cases that separate a demo from a protocol. FairWins closed them with two features: **draw resolution** (spec 004) — a deliberate, distinctly-recorded "both stakes back" outcome — and **open-challenge wagers** (specs 024 and 041) — counterparty-less wagers gated by a four-word claim code. Both live in the same contracts: `contracts/wagers/WagerRegistry.sol` and the shared storage/logic base `contracts/wagers/WagerRegistryCore.sol`.
+
+## A Seventh Terminal State
+
+The wager state machine gained one enum member and one event:
+
+```solidity
+enum Status { None, Open, Active, Resolved, Cancelled, Refunded, Draw }
+
+event WagerDrawn(uint256 indexed wagerId, address indexed creator,
+                 address indexed opponent, address by);
+```
+
+(`contracts/interfaces/IWagerRegistryTypes.sol`.) `Draw` is terminal and distinct from `Refunded`, which is the whole point: the subgraph and the app can render "settled as a draw" differently from "timed out." Settlement itself is deliberately boring — it reuses the proven refund shape, checks-effects-interactions throughout:
+
+```solidity
+function _settleDraw(uint256 wagerId, Wager storage w, address by) internal {
+    w.status = Status.Draw;
+    delete _drawConsent[wagerId];
+    membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
+    membershipManager.recordClose(w.opponent, WAGER_PARTICIPANT_ROLE);
+
+    IERC20 token = IERC20(w.token);
+    token.safeTransfer(w.creator, w.creatorStake);
+    token.safeTransfer(w.opponent, w.opponentStake);
+
+    emit WagerDrawn(wagerId, w.creator, w.opponent, by);
+}
+```
+
+Each party gets back exactly their own stake — stakes need not be equal, and no value moves between participants. Status flips and consent state clears before any token transfer, and both parties' concurrency slots on the `MembershipManager` are released.
+
+## Who Gets to Say "Draw"?
+
+The interesting design question was authority. A unilateral draw is an attack: the losing side of an `Either`-resolved wager would declare a draw the moment the outcome went against them. Spec 004 splits authority three ways by resolution type, implemented in `_declareDraw`:
+
+- **Participant-resolved wagers** (`Either`, `Creator`, `Opponent`) require *both* parties. The contract keeps a per-wager consent bitmask — `bit0` for the creator, `bit1` for the opponent — outside the `Wager` struct so `getWager`'s ABI is untouched:
+
+```solidity
+uint8 consent = _drawConsent[wagerId];
+if ((consent & bit) == 0) {
+    consent |= bit;
+    _drawConsent[wagerId] = consent;
+    emit DrawProposed(wagerId, actor);
+}
+if (consent == _CONSENT_BOTH) {
+    _settleDraw(wagerId, w, actor);
+}
+```
+
+  The first `declareDraw` records a proposal; the second party's call completes it. Crucially, a pending proposal never locks the wager — `declareWinner` and the timeout refund remain fully available, and the proposer can back out via `revokeDraw` (emitting `DrawRevoked`). "Declining" a draw needs no action at all: just don't confirm.
+
+- **`ThirdParty` wagers**: the named arbitrator settles a draw alone, consistent with their existing authority to declare a winner.
+
+- **Oracle-resolved wagers** (Polymarket, Chainlink, UMA): no human — participant, arbitrator, or admin — can force a draw. `_declareDraw` reverts with `DrawNotApplicable()`. A draw on these wagers can only come from the oracle itself.
+
+Manual draws are also rejected after the `resolveDeadline` (`ResolveExpired`) — past that point the timeout refund already returns both stakes, so a manual draw would only muddy the record.
+
+## The Oracle Tie
+
+Polymarket markets can resolve indecisively: a 50/50 split, or an "invalid" resolution after a UMA dispute. The `PolymarketOracleAdapter` (`contracts/oracles/PolymarketOracleAdapter.sol`) detects this as equal payout numerators from the Conditional Tokens Framework and returns its unresolved sentinel (`resolvedAt == 0`) rather than inventing a winner. That sentinel is ambiguous, though — it also means "not resolved yet." The resolve path disambiguates in `contracts/wagers/WagerRegistryIntents.sol`:
+
+```solidity
+(bool outcome, , uint256 resolvedAt) = polymarketAdapter.getOutcome(w.polymarketConditionId);
+if (resolvedAt == 0) {
+    if (polymarketAdapter.isConditionResolved(w.polymarketConditionId)) {
+        _settleDraw(wagerId, w, msg.sender);   // resolved tie -> immediate draw
+        return;
+    }
+    revert ConditionNotResolved();             // genuinely unresolved -> unchanged
+}
+_settleOracleWin(wagerId, w, outcome);
+```
+
+A resolved tie settles as a draw the moment anyone calls `autoResolveFromPolymarket` — no waiting out the deadline. A decisive market still produces a winner; an unresolved one still reverts.
+
+## A Wager With No Opponent
+
+Open challenges (spec 024) attack the second gap. `createOpenWager` creates a wager with `w.opponent` left as `address(0)`, escrows the creator's stake as usual, and binds one new thing: a `claimAuthority` address. That address is the on-chain face of a **four-word claim code** — four words from the BIP-39 English wordlist (2048⁴ = 2⁴⁴ combinations), generated client-side and never sent to any server.
+
+The trick is that the code *is* a keypair. `frontend/src/utils/claimCode/deriveFromCode.js` derives, from the normalized four words, a secp256k1 private key (`keccak256("FairWins/claim/v1" || code)`) whose address becomes the on-chain `claimAuthority`, plus an independent domain-separated symmetric key that seals the private terms envelope. One shareable secret does triple duty:
+
+1. **Discovery** — `openWagerIdForClaim(authority)` maps the derived address to the single live wager. Without the code, an open challenge is one indistinguishable entry among many.
+2. **Accept authorization** — the taker proves knowledge of the code by presenting an EIP-712 signature *from the code-derived key*:
+
+```solidity
+bytes32 digest = _hashTypedDataV4(
+    keccak256(abi.encode(OPEN_ACCEPT_TYPEHASH, wagerId, taker)));
+if (digest.recover(signature) != authority) revert BadClaimSignature();
+```
+
+   The typed struct is `OpenAccept(uint256 wagerId, address taker)`. Binding `taker` into the signed digest is the front-running defense: a mempool observer who copies a pending `acceptOpenWager` transaction cannot replay the signature for their own address — re-signing requires the code.
+3. **Readability** — the symmetric key opens the encrypted terms, replacing the usual recipient-key encryption that is impossible when the recipient is unknown at creation.
+
+The first valid acceptance binds the taker as opponent, flips the wager to `Active`, and calls `_clearClaim`, which frees the commitment for reuse — uniqueness is enforced only among *currently open* challenges (`ClaimAuthorityInUse` on collision), so no unbounded state accumulates.
+
+## Guardrails for an Unknown Counterparty
+
+An unknown taker changes the threat model, and `createOpenWager` encodes the responses directly:
+
+- **No self-resolution.** `Creator` and `Opponent` resolution types revert with `OpenResolutionTypeNotAllowed` — a lone unknown party must never be the sole resolver. Open challenges are restricted to oracle types, `Either`, and `ThirdParty`.
+- **Equal stakes only.** One `stake` parameter sets both sides. A publicly shared code with asymmetric odds would invite adverse-selection sniping of the favorable side; symmetric stakes make the race merely about *who* takes the bet, not an economic edge.
+- **Silver-and-above to create, any active tier to take.** Per `docs/system-overview/roles-and-tiers.md`, posting a code-gated wager is a higher-tier privilege (`getActiveTier(...) >= Silver`, else `InsufficientMembershipTier`), while accepting runs the same gauntlet as any named opponent — sanctions screening of both parties, active membership, concurrency limits — with no tier floor and no membership backdoor.
+- **No decline.** `declineWager` on an open challenge reverts with `DeclineNotAllowedForOpenChallenge`; the creator's `cancelOpen` is the sole release for an unaccepted open challenge.
+- **Party separation.** The creator cannot take their own challenge (`SelfWager`), and a taker who is the named arbitrator is refused (`ArbitratorCannotTake`) — a check that must run at accept because the opponent was unknown at creation.
+
+Spec 041 then layered on oracle-settled open challenges: the creator picks a Polymarket market and the *event* defines the timeline — `frontend/src/lib/openChallenge/oracleTimeline.js` derives `acceptDeadline` from the market's end date and `resolveDeadline` from end-plus-settlement-buffer, both capped. Combined with the tie-handling above, the platform's most trustless combination falls out for free: a challenge anyone with the code can take, settled automatically by a public market, and refunding both sides if that market resolves invalid.
+
+## Design Decisions
+
+**Draw is a new outcome, not a new resolution type.** The eight resolution types (who resolves) are untouched; a draw is a ninth thing that can *happen*, gated per-type. That kept the accept, escrow, and payout paths byte-identical for every wager that never draws.
+
+**Mutual consent over unilateral mercy.** Requiring both signatures on participant-resolved draws costs a second transaction, but removes the "losing side declares a draw" grief entirely — and because an unconfirmed proposal never locks anything, the worst a stalling counterparty can do is nothing.
+
+**No admin override for stuck oracles.** A permanently unresolved oracle falls back to the deadline refund, which already returns both stakes. Adding a human draw override for oracle wagers would have created a trusted party where the whole point was not having one.
+
+**A fast KDF, honestly scoped.** The v1 code derivation is two keccak passes — deliberately cheap. With the commitment public on-chain, a determined attacker with dedicated hardware could brute-force 2⁴⁴; spec 024 accepts this residual risk explicitly, scopes the guarantee to casual/indiscriminate guessing, and requires the UI to say so for meaningful stakes. The `v1` domain tags (`FairWins/claim/v1`, `FairWins/terms/v1`) leave room to swap in a memory-hard KDF without breaking existing wagers.
+
+**Code-derived readability, forever.** Even after acceptance, the opponent reads terms via the code — there is no re-keying to their registered encryption key. Losing the code means "terms unavailable," never lost funds or blocked resolution.
+
+Edge cases are where escrow protocols earn trust. A wager that can end with nobody winning, and begin with nobody on the other side, is a wager system that has met its users.
+
+## Sources
+
+- `specs/004-draw-resolution/spec.md` — draw resolution requirements and authority model
+- `specs/024-open-challenge-wagers/spec.md` — claim-code open challenges, entropy floor, tier gating
+- `specs/041-oracle-open-challenges/spec.md` — oracle-settled open challenges, event-derived timelines
+- `contracts/wagers/WagerRegistry.sol` — `createOpenWager`, `acceptOpenWager`, `declareDraw`, `revokeDraw`
+- `contracts/wagers/WagerRegistryCore.sol` — `_declareDraw`, `_settleDraw`, `_acceptOpenWager`, draw-consent bitmask
+- `contracts/wagers/WagerRegistryIntents.sol` — `autoResolveFromPolymarket` tie disambiguation
+- `contracts/oracles/PolymarketOracleAdapter.sol` — equal-payout-numerator tie detection
+- `contracts/interfaces/IWagerRegistryTypes.sol` — `Status` enum, `WagerDrawn` / `DrawProposed` / `DrawRevoked` events
+- `frontend/src/utils/claimCode/deriveFromCode.js`, `frontend/src/utils/claimCode/wordlist.js` — code→keypair derivation, BIP-39 wordlist
+- `frontend/src/lib/openChallenge/oracleTimeline.js` — event-derived deadlines
+- `docs/system-overview/roles-and-tiers.md` — Silver+ creation gate, tier limits
+- EIP-712: Typed structured data hashing and signing — https://eips.ethereum.org/EIPS/eip-712
+- BIP-39: Mnemonic code for generating deterministic keys — https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+- Polymarket / Conditional Tokens documentation — https://docs.polymarket.com

--- a/docs/blog/posts/16-draw-resolution-open-challenges/social.md
+++ b/docs/blog/posts/16-draw-resolution-open-challenges/social.md
@@ -1,0 +1,28 @@
+# Social & Image — When Nobody Wins and Anyone Can Play: Draw Resolution and Open-Challenge Wagers
+
+## X (Twitter)
+
+How does an escrow contract settle a forecast nobody should win? FairWins added a distinct Draw state (mutual consent, per-resolution-type authority) and open challenges gated by a 4-word claim code that is secretly a keypair. 🔗 <link> #Solidity #SmartContracts
+
+## LinkedIn
+
+Two edge cases separate a demo escrow contract from a finished protocol. First: a forecast between two parties is voided by events — the match is abandoned, the question becomes moot. Neither side should win, but "wait for the deadline and refund" is indistinguishable on-chain from two people forgetting about it. Second: someone wants to post a challenge with no named counterparty — first qualified taker joins — without broadcasting the terms to every mempool observer.
+
+Our latest FairWins engineering post walks through how both were closed:
+
+- A distinct `Draw` terminal state that returns each party exactly their own stake, with authority split by resolution type: mutual consent for participant-resolved wagers, arbitrator-only for third-party, and no human override at all for oracle-settled ones
+- Tie handling: an invalid or 50/50 oracle resolution settles as an immediate draw — the protocol refunds rather than inventing a winner
+- Open challenges gated by a four-word claim code that doubles as a keypair: discovery, EIP-712 accept authorization bound to the taker's address (front-running defense), and terms decryption from one shareable secret
+- The guardrails an unknown counterparty demands: no self-resolution, equal stakes only, tier gating, sanctions screening
+
+These are skill-based forecasts on public information between consenting, screened participants — and the design bias throughout is refund over guesswork.
+
+Read the full post: <link>
+
+Where do you draw the line between admin override and pure protocol rules when a contract outcome becomes undecidable?
+
+#Solidity #SmartContracts #Ethereum #ProtocolDesign
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern isometric editorial illustration of balanced settlement and open invitation: at center, a perfectly level glass balance scale holding two identical translucent coin stacks, each connected by a thin light trace flowing back outward to its own side — value returning to where it came from, no winner — beneath a calm geometric arch. To the right, a slightly open door-shaped portal formed of four floating faceted tokens arranged in a vertical line, acting as a key, with a soft path of light leading through it toward the scale. Deep navy background with teal tones on the glass scale, arch, and light traces, and a single warm amber glow on the four-token key and the doorway edge as the only warm accent. Soft diffuse lighting with gentle rim highlights, subtle floating particles, precise fintech-engineering aesthetic, uncluttered composition with generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/17-wager-pools-erc1167/blog.md
+++ b/docs/blog/posts/17-wager-pools-erc1167/blog.md
@@ -1,0 +1,97 @@
+# Wager Pools: ERC-1167 Clones and Address-Keyed Payouts
+
+*Why FairWins gave group wagers their own factory of immutable minimal-proxy clones — and why the winner's address is the claim code*
+
+| | |
+|---|---|
+| **Series** | Prediction Markets (part 4) |
+| **Part** | 17 of 34 |
+| **Audience** | Smart-contract developers |
+| **Tags** | `erc1167`, `minimal-proxy`, `clones`, `factory`, `governance` |
+| **Reading time** | ~8 minutes |
+
+> **Important note**: This article describes wagering based on publicly available information and legitimate forecasting among consenting participants. Wager pools are not a mechanism for trading on material non-public information or circumventing applicable regulation. All participants remain fully subject to applicable laws and compliance requirements — the platform screens every creator and joiner against sanctions and membership gates before funds move.
+
+## Twelve people, one bracket, one escrow
+
+The FairWins `WagerRegistry` is built for a specific shape of agreement: two sides, an oracle or counterparty resolution, one payout. It handles that shape well. But the request that kept coming back from testers was a different shape entirely: *twelve of us ran a season-long fantasy league; first place gets 60%, second gets 30%, third gets 10%. Hold the money so nobody has to chase anyone in March.*
+
+You cannot express that as a 1v1 wager without contortions — sixty-six pairwise wagers, or a designated stakeholder wallet everyone has to trust. What the group actually needs is one escrow that N people pay into, and a resolution mechanism that doesn't depend on any external oracle, because "who won our league" is not a Polymarket condition. The group *is* the oracle.
+
+This is spec 034, and it shipped as **Wager Pools**: a `WagerPoolFactory` that stamps out one isolated `WagerPool` contract per group. It is a deliberately parallel system — a documented exception to the platform rule that all wager escrow routes through `wagerRegistry` — and it made two architectural choices that run opposite to the registry's: the pools are **immutable ERC-1167 clones** rather than logic behind an upgradeable proxy, and resolution is a **creator-proposed payout matrix keyed by public wallet addresses**, approved by the members themselves.
+
+That second choice has a story. The spec directory is still called `specs/034-zk-wager-pools/` because the original design used Semaphore V4: anonymous membership commitments, zero-knowledge approval votes, payouts keyed by claim nullifiers. It worked — real Groth16 proofs verified on-chain in integration tests. Testers killed it anyway. The private "claim code" (a nullifier the winner had to reveal to the creator, not derivable from any public data) was the failure point: it turned "collect your winnings" into a secret-handling exercise. The round-7 addendum in `specs/034-zk-wager-pools/spec.md` records the pivot: Semaphore removed entirely, `ZKWagerPool → WagerPool`, membership, voting, and claims by public wallet address. When your users are a friend group who already know each other, anonymity was cost without benefit — and dropping the BN254 pairing requirement had a side effect: pools became deployable to Ethereum Classic's Mordor testnet, which is the launch target ahead of Polygon.
+
+## One upgradeable factory, N immutable pools
+
+The system has exactly one state-bearing, upgradeable contract: `contracts/pools/WagerPoolFactory.sol`, a UUPS proxy inheriting the platform's shared `contracts/upgradeable/UUPSManaged.sol` base, with append-only storage and a trailing `__gap`. Everything else is a clone:
+
+```solidity
+poolId = ++poolCount;
+pool = Clones.clone(poolImpl);
+
+WagerPool(pool).initialize(
+    p.token, creator, p.buyIn, p.maxMembers,
+    p.thresholdBips, p.acceptDeadline, p.resolveDeadline
+);
+```
+
+`Clones.clone` is OpenZeppelin's implementation of [ERC-1167](https://eips.ethereum.org/EIPS/eip-1167), the minimal proxy standard: a 45-byte contract whose entire runtime code is "delegatecall everything to a hard-coded implementation address." Each pool costs a fraction of a full deployment, gets its own address and its own isolated storage, and shares bytecode with every other pool.
+
+The crucial property is what clones *don't* have: an upgrade path. The implementation address is baked into the clone's bytecode. Once a pool is created, its rules are frozen for its life. The factory admin can call `setTemplate` to point *future* pools at a new `poolImpl`, but no one — not the admin, not an upgrade vote — can change the logic governing money already escrowed. Compare the registry side of the platform, where `WagerRegistry` is a UUPS proxy precisely so a long-lived singleton can evolve in place. A pool is the opposite kind of object: short-lived (bounded by a resolve deadline of at most 180 days), fully parameterized at birth, holding funds for a closed group. For that object, "the rules cannot change under you" is worth more than patchability. The master implementation calls `_disableInitializers()` in its constructor; each clone is initialized exactly once, by the factory, in the same transaction that creates it.
+
+Before cloning anything, `_createPool` screens the creator's real wallet through the same shared singletons the registry uses — `ISanctionsGuard.checkBlocked` and `IMembershipManager.checkCanCreate` under a dedicated `POOL_PARTICIPANT_ROLE` — and validates deadlines with `_checkDeadlines`, which mirrors `WagerRegistry` exactly: `acceptDeadline` in the future and within 30 days, `resolveDeadline` strictly after it and within 180 days. Pools and 1v1 wagers deliberately share the same temporal feel. The pool calls back into the factory (`screen` / `requireMembership`) to apply the same checks to every joiner. On value-bearing networks `screeningRequired` is set, both guards must be configured, and the buy-in token must be on an admin-curated allowlist — `escrowTotal` is derived arithmetically as `memberCount * buyIn`, which only holds for well-behaved tokens, so fee-on-transfer and rebasing tokens are excluded at the door.
+
+## The address is the claim code
+
+Resolution is where the address-based redesign earns its keep. After joining closes — creator's call, auto-close when full, or anyone poking `pokeDeadline` past the accept deadline — the denominator freezes and the creator proposes a full payout matrix:
+
+```solidity
+struct PayoutEntry {
+    address winner;
+    uint256 amount;
+}
+
+function proposeOutcome(PayoutEntry[] calldata entries) external;
+```
+
+`proposeOutcome` validates the matrix on-chain before it can ever be voted on: non-empty, no zero-address winner, and `sum(amounts) == escrowTotal` — the exact escrow, to the wei. The `proposalId` is `keccak256(abi.encode(entries))`, and the `OutcomeProposed` event inlines the entire matrix, so every member reads the precise split from chain data before approving. Nothing about the outcome lives off-chain.
+
+Members approve with a plain transaction. Approvals are counted per `(proposalId, member)` — revising the matrix produces a new id and restarts the tally with no storage reset. The pool resolves when approvals reach a fraction-of-joined threshold:
+
+```solidity
+/// Approvals required = ceil(frozenDenominator * thresholdBips / 10000).
+uint256 req = (num + 9999) / 10000;
+if (req == 0) req = 1;
+if (frozenDenominator >= 2 && req < 2) req = 2;
+```
+
+That last line is a governance floor: in any multi-member pool, at least two approvals are required, so no single member — including the creator, who may also be a joined member — can unilaterally lock a self-dealing payout. The creator *proposes*; only the group *disposes*. And if the group never reaches threshold, the `resolveDeadline` converts the pool to refund-only: every member recovers exactly their buy-in. Funds cannot be stranded by a deadlock.
+
+Claiming is where the "address is the claim code" phrase becomes literal. A winner calls `claim(entries, index, recipient)`; the contract checks that the supplied matrix hashes to `lockedOutcome`, that `entries[index].winner == msg.sender`, and pays `entries[index].amount` to any `recipient` the winner chooses. There is no secret to exchange, nothing to reveal to the creator, nothing to lose. Every party can derive every claim from the public roster. Claims are tracked per **row index** rather than per winner address — `mapping(uint256 => bool) claimedIndex` — a small but deliberate detail: a matrix that lists the same winner in multiple rows (say, first *and* third place) is fully claimable row by row, and never strands escrow. `claim`, `refund`, and `cancel` are the only paths by which value leaves the contract, all behind reentrancy guards and checks-effects-interactions.
+
+## Gasless twins baked into immutable bytecode
+
+Immutability forced one design constraint you don't face with proxies: whatever relayer support a pool will ever have must be in the template on day one. So every actor-attributed action carries an [EIP-712](https://eips.ethereum.org/EIPS/eip-712) `…WithSig` twin — `approveWithSig`, `claimWithSig`, `proposeOutcomeWithSig`, `closeJoiningWithSig`, `cancelWithSig`, `refundWithSig` — via the shared `contracts/upgradeable/SignerIntentBase.sol` mixin, which authorizes the recovered signer instead of `msg.sender` under a per-clone EIP-712 domain (`"FairWins WagerPool"`, version `"1"`) with single-use nonces. The money-in path gets its own relayable form: `joinWithAuthorization` moves USDC via [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) `receiveWithAuthorization`, so a member with zero native gas can still buy in. The strongest case is the winner with an empty gas tank: `claimWithSig` binds the signed intent to `index` and `recipient`, so a relayer can submit the claim but can never redirect the payout.
+
+Clones create one operational wrinkle for relaying: their addresses are dynamic, so a relayer engine cannot pre-whitelist them. The factory answers with pass-through forwarders (`approveWithSigFor`, `claimWithSigFor`, and friends) that let the relayer target only the stable factory address, while an on-chain provenance check — `poolAddressToId[pool] != 0` — guarantees the forwarded call can only reach a pool this factory actually minted. The forwarders add no trust; each clone still verifies the member's signature against its own domain. Self-submit remains the primary path throughout: gasless is a convenience layer, never a dependency.
+
+## Design decisions
+
+- **A parallel system, on purpose.** Pools do not route through `wagerRegistry`, its oracle adapters, or its draw logic — group self-resolution is a genuinely different trust model, and grafting an N-party matrix vote onto a 24 KB-constrained two-facet proxy would have compromised both. The exception is documented platform-wide; the systems share compliance interfaces (`ISanctionsGuard`, `IMembershipManager`) and identical deadline semantics so they can converge later.
+- **Immutable clones over upgradeable pools.** Per-pool proxies would allow post-deploy fixes but would also mean an admin key can rewrite the rules of live escrow. For bounded-lifetime group funds, FairWins chose the stronger promise. The cost is real: a template bug affects every existing pool with no patch path, which is why the template requires a formal security review before going live on any value-bearing network.
+- **Public addresses over zero-knowledge.** The Semaphore design was cryptographically sound and empirically working; it lost to a usability finding. The lesson generalizes: privacy machinery whose secret-handling burden lands on the *winner at claim time* fails exactly when the stakes are highest. Two-word nicknames survive as pure client-side display, derived from the wallet address, never on-chain.
+- **On-chain matrix validation over commit-and-reveal.** Requiring the full matrix at propose time (validated to sum to escrow, emitted in the event) costs calldata but buys the invariant that a locked outcome is always fully claimable — members never approve a hash they cannot verify from chain data alone.
+
+## Sources
+
+- `specs/034-zk-wager-pools/spec.md` — including the round-7 redesign addendum (Semaphore removed, address-based pivot)
+- `specs/034-zk-wager-pools/implementation-notes.md` — tester rounds, gas figures, ETC/Mordor enablement
+- `contracts/pools/WagerPool.sol`, `contracts/pools/WagerPoolFactory.sol`
+- `contracts/pools/interfaces/IWagerPool.sol`, `contracts/pools/interfaces/IWagerPoolFactory.sol`
+- `contracts/upgradeable/SignerIntentBase.sol`, `contracts/upgradeable/UUPSManaged.sol`
+- `docs/developer-guide/zk-wager-pools.md` (documents the pre-pivot Semaphore architecture; historical context)
+- [ERC-1167: Minimal Proxy Contract](https://eips.ethereum.org/EIPS/eip-1167)
+- [EIP-712: Typed structured data hashing and signing](https://eips.ethereum.org/EIPS/eip-712)
+- [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009)
+- [OpenZeppelin Clones library](https://docs.openzeppelin.com/contracts/5.x/api/proxy#Clones)

--- a/docs/blog/posts/17-wager-pools-erc1167/social.md
+++ b/docs/blog/posts/17-wager-pools-erc1167/social.md
@@ -1,0 +1,26 @@
+# Social & Image — Wager Pools: ERC-1167 Clones and Address-Keyed Payouts
+
+## X (Twitter)
+
+Group wager pools as immutable ERC-1167 clones: one UUPS factory, 45-byte proxies, and a payout matrix where the winner's address IS the claim code. We built the ZK version first — testers killed it. 🔗 <link> #Solidity #SmartContracts #ERC1167
+
+## LinkedIn
+
+How do twelve people escrow a season-long fantasy league on-chain when no oracle can answer "who won our league"? Our 1v1 wager registry couldn't express it — so FairWins built wager pools as a deliberately parallel system, and made two choices that run opposite to the registry's architecture.
+
+The new post covers:
+
+- Why each pool is an immutable ERC-1167 minimal-proxy clone (45 bytes of runtime code) stamped out by a single UUPS factory — and why "the rules cannot change under your escrow" beat upgradeability for bounded-lifetime group funds
+- The address-keyed payout matrix: creator proposes, the contract validates sum == escrow on-chain, members approve to a fraction-of-joined threshold (minimum two approvals, so no self-dealing lock), and the winner's public address is the claim code — no secrets to exchange
+- Baking EIP-712 gasless twins and EIP-3009 joins into immutable bytecode, plus factory forwarders that let a relayer whitelist one stable address while on-chain provenance checks constrain reachable targets
+- The honest part: we built and empirically verified the Semaphore/Groth16 anonymous version first. Testers rejected the private claim code, and the spec directory name is the fossil record.
+
+Full write-up: <link>
+
+When have you chosen immutability over upgradeability for value-bearing contracts — and did it hold up?
+
+#Solidity #SmartContracts #Ethereum #Web3 #ProtocolEngineering
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in isometric style: a large central factory structure resembling a precise geometric machine stamping out a row of small identical translucent cubes along a conveyor path, each cube containing a tiny glowing vault; from one cube, thin luminous lines fan out to a circle of twelve abstract figure tokens arranged around it, with a few lines highlighted returning payouts to three of the tokens. Composition balanced left-to-right with the factory on the left and the circle of tokens on the right, generous negative space, subtle grid floor. Deep navy and teal base palette with a single warm amber accent on the highlighted payout lines and vault glows, consistent with a fintech-engineering brand. Soft directional lighting with gentle rim highlights on the cube edges, no harsh shadows. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/18-envelope-encryption/blog.md
+++ b/docs/blog/posts/18-envelope-encryption/blog.md
@@ -1,0 +1,32 @@
+# Private Prediction Markets: Confidential Terms with Trustless Settlement
+
+*How envelope encryption brings the enforceability of smart contracts to confidential peer-to-peer agreements*
+
+| | |
+|---|---|
+| **Series** | Privacy Architecture |
+| **Part** | 1 (published) |
+| **Audience** | Applied cryptographers, fintech engineers |
+| **Tags** | `encryption`, `envelope-encryption`, `privacy`, `prediction-markets` |
+| **Reading time** | ~14 minutes |
+
+> **This post is already published.** Read it here:
+> [Private Prediction Markets: Confidential Terms with Trustless Settlement](../../private-prediction-markets-envelope-encryption.md)
+
+**Abstract.** Two professionals want to back opposing views of a public outcome
+with real money — without broadcasting their firms' positioning to a public
+order book. The published post walks their wager through the five stages of a
+binding contract (creation, offer, consideration, acceptance, execution), and
+shows how envelope encryption makes it work: terms encrypted once with a random
+key, that key wrapped per participant using wallet-derived X-Wing keypairs
+(X25519 + ML-KEM-768 hybrid, ChaCha20-Poly1305 payloads), the envelope stored
+on IPFS with only a 60-byte CID on-chain, and USDC escrow plus oracle-pegged
+resolution making settlement automatic. It closes with honest limitations —
+privacy protects competitive intelligence, not illegal activity; participants
+remain subject to applicable law.
+
+## Sources
+
+- `docs/developer-guide/envelope-encryption-spec.md`
+- `docs/developer-guide/encryption-architecture.md`
+- `specs/002-e2e-encryption-lifecycle/`

--- a/docs/blog/posts/18-envelope-encryption/social.md
+++ b/docs/blog/posts/18-envelope-encryption/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Private Prediction Markets: Confidential Terms with Trustless Settlement
+
+## X (Twitter)
+
+A private bet with public enforceability: wager terms encrypted once, the key wrapped per participant with wallet-derived X-Wing keypairs (X25519 + ML-KEM-768), envelope on IPFS, 60-byte CID on-chain. Escrow + oracle pegging settle it automatically. 🔗 <link> #web3 #privacy
+
+## LinkedIn
+
+Public prediction markets have a problem for professionals: your position is the signal. Two analysts who disagree about a publicly covered outcome — a merger clearing review, a policy decision — can't back their views on a public order book without exposing their firms' thinking. And a bilateral handshake means lawyers, escrow, and counterparty risk.
+
+Our engineering post on FairWins' private prediction markets shows how envelope encryption resolves this tension. It covers:
+
+- The five-stage contract lifecycle — creation, offer, consideration, acceptance, execution — mapped onto smart-contract escrow and automatic settlement
+- Envelope encryption in practice: terms encrypted once with a random key, then that key wrapped per participant using keypairs derived deterministically from each wallet's signature — no central key custody
+- Post-quantum protection via X-Wing (hybrid X25519 + ML-KEM-768) with ChaCha20-Poly1305, defending against harvest-now-decrypt-later attacks
+- Off-chain/on-chain separation: the encrypted envelope lives on IPFS while the chain stores only a CID, addresses, stakes, and outcome — so larger post-quantum ciphertexts cost no extra gas
+
+One thing we're explicit about: this privacy protects competitive intelligence and trading strategies, not illegal activity. Participants remain fully subject to applicable law and professional obligations.
+
+Read the full post: <link>
+
+Where else do you see envelope encryption earning its place in on-chain applications?
+
+#encryption #privacy #predictionmarkets #web3 #fintech
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an abstract-geometric style for a fintech engineering blog banner: a large translucent sealed envelope floating at center, containing a glowing document rendered as unreadable ciphertext blocks, with two smaller sealed key-envelopes orbiting it — each tethered by a thin luminous line to one of two stylized geometric wallet shapes at opposite corners, suggesting two counterparties who each hold their own independent access. Beneath the envelope, a horizontal chain of minimal linked blocks anchors the scene, one block highlighted to imply a tiny on-chain reference to the larger off-chain envelope above. Composition is balanced and symmetrical with generous negative space; deep navy and teal base palette with a single warm amber accent reserved for the key-envelopes and their seals; soft diffuse lighting with subtle rim glow on the envelope edges, faint isometric grid in the background. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/19-multi-recipient-encryption/blog.md
+++ b/docs/blog/posts/19-multi-recipient-encryption/blog.md
@@ -1,0 +1,144 @@
+# One Ciphertext, N Wrapped Keys: Multi-Recipient Encryption for Private Wagers
+
+*How FairWins lets two participants and a neutral arbitrator each decrypt the same payload — without re-encrypting it for anyone*
+
+| | |
+|---|---|
+| **Series** | Privacy Architecture (part 2 of 4) |
+| **Part** | Follows [Envelope encryption for private prediction markets](../../private-prediction-markets-envelope-encryption.md) |
+| **Audience** | Applied cryptography engineers |
+| **Tags** | `encryption`, `key-wrapping`, `privacy`, `cryptography` |
+| **Reading time** | ~9 minutes |
+
+> **Important note**: As in part 1, the private wagers described here are based on publicly available information and legitimate forecasting. Encryption protects competitive intelligence and trading strategies — not illegal activity. All participants remain fully subject to applicable laws and compliance obligations.
+
+## The Third Reader Problem
+
+In part 1 of this series, Sarah and Marcus made a 50,000 USDC private wager on a pharmaceutical merger. Their terms lived encrypted on IPFS; the chain held only a reference. Exactly two people on Earth could read the plaintext, and the smart contract guaranteed settlement anyway.
+
+That design had a quiet casualty: arbitration. Some wagers can't be resolved by an oracle — "the merger closes before Q3" maps cleanly to a Polymarket condition, but "our redesign ships before yours" does not. For those, FairWins supports a `ThirdParty` resolution type where a neutral human declares the winner. And here the two-reader envelope broke down completely. The arbitrator could be *named* on-chain and *authorized* to call `declareWinner` — but they could not read the terms they were supposed to rule on, and they couldn't even enumerate the wagers naming them. The feature was disabled in the app: a resolver who can't see the agreement is worse than no resolver.
+
+The naive fixes are all bad. Re-encrypt the whole payload once per reader, and storage grows linearly while the copies can silently diverge — three ciphertexts that may not decrypt to the same terms is a dispute generator, not a dispute resolver. Share one symmetric key among all readers out-of-band, and you've reinvented the key-distribution problem the system exists to avoid. Give the platform a master key so it can grant access, and you've abandoned end-to-end encryption entirely.
+
+The actual fix — FairWins spec 005 — required zero changes to the cryptography. The envelope format was multi-recipient from day one. What changed is *who gets counted as a recipient*, plus a one-line contract change so arbitrators can find their wagers. This post walks the mechanism that made that a config change instead of a redesign.
+
+## One DEK, a Wrapped Key per Reader
+
+The envelope scheme (implemented in `frontend/src/utils/crypto/envelopeEncryption.js`, entirely client-side) separates *content encryption* from *access grants*:
+
+1. Generate a random 32-byte **data encryption key (DEK)**.
+2. Encrypt the wager terms **once** with the DEK using ChaCha20-Poly1305 (RFC 8439) — an AEAD, so tampering fails authentication rather than yielding garbage plaintext.
+3. For each recipient, **wrap the DEK**: run X25519 ECDH between a fresh ephemeral keypair and the recipient's registered public key, derive a key-encryption key (KEK) with HKDF-SHA256, and encrypt the DEK under that KEK.
+
+Here is the wrap loop, verbatim from `encryptEnvelope`:
+
+```javascript
+const wrappedKeys = recipients.map(recipient => {
+  const ephemeralKeyPair = generateEphemeralKeyPair()
+
+  // ECDH to derive shared secret
+  const sharedSecret = x25519.getSharedSecret(
+    ephemeralKeyPair.privateKey,
+    recipient.publicKey
+  )
+
+  // Derive key encryption key from shared secret
+  const kek = hkdf(sha256, sharedSecret, new Uint8Array(0), ENVELOPE_INFO, 32)
+
+  // Encrypt DEK with KEK
+  const keyNonce = randomBytes(12)
+  const keyCipher = chacha20poly1305(kek, keyNonce)
+  const wrappedDek = keyCipher.encrypt(dek)
+  ...
+})
+```
+
+The resulting JSON envelope has a single `content` block (nonce + ciphertext) and a `keys[]` array with one entry per reader, keyed by lowercase Ethereum address. Everything uses the audited Noble libraries (`@noble/curves`, `@noble/ciphers`, `@noble/hashes`).
+
+The cost model is what makes multi-recipient practical. Content encryption is O(1) in the reader count; each additional reader costs one ephemeral keypair, one ECDH, one HKDF call, and ~60 bytes of wrapped-key entry. A 5 KB terms document shared with three readers is stored once, not three times — and every reader provably decrypts the *same* ciphertext, so there is no "which copy is canonical" question for an arbitrator to litigate.
+
+Decryption is the mirror image: find your entry in `keys[]`, recompute the shared secret against the stored ephemeral public key, derive the KEK, unwrap the DEK, decrypt the content. Each reader's path is fully independent — compromise of one reader's wallet exposes their wrapped key, not the wrapping of anyone else's.
+
+## Where Public Keys Come From
+
+Wrapping a DEK for someone requires their encryption public key, and the creator may never have communicated with the arbitrator directly. That directory is on-chain: `contracts/privacy/KeyRegistry.sol`, a deliberately minimal contract.
+
+```solidity
+contract KeyRegistry {
+    uint256 private constant MIN_KEY_LENGTH = 32;
+    uint256 private constant MAX_KEY_LENGTH = 2048;
+
+    mapping(address => bytes) private _keys;
+
+    event KeyRegistered(address indexed user, bytes key, uint64 timestamp);
+
+    function registerKey(bytes calldata publicKey) external { ... }
+    function getPublicKey(address user) external view returns (bytes memory);
+    function hasKey(address user) external view returns (bool);
+}
+```
+
+Keys are opaque bytes bounded to 32–2048 bytes, which is not an accident: it accommodates both a 32-byte X25519 key and a 1216-byte X-Wing hybrid post-quantum key (more below) without a contract change. Re-registering overwrites — the wallet is the identity, the key is just its current encryption endpoint.
+
+Users never manage these keys. An EOA derives its keypair deterministically from an EIP-191 `personal_sign` of a fixed message; the signature is hashed with Keccak-256 into the private key or seed. Passkey smart accounts (which have no EOA to sign with) derive the same shape of keypair via HKDF from their WebAuthn PRF master seed. Same wallet, same key, every device — nothing to back up, no key server to trust.
+
+## Making the Arbitrator a First-Class Reader
+
+With N-recipient wrapping and an on-chain key directory already in place, spec 005 (`specs/005-multi-recipient-encryption/`) reduced "let the arbitrator read the wager" to recipient assembly at creation time:
+
+```
+recipients = [
+  { address: creator,    publicKey: lookupPublicKey(creator) },
+  { address: opponent,   publicKey: lookupPublicKey(opponent) },
+  // only for ThirdParty wagers with an assigned arbitrator:
+  { address: arbitrator, publicKey: lookupPublicKey(arbitrator) },
+]
+envelope = encryptEnvelope(termsPlaintext, recipients)
+```
+
+Two without an arbitrator, three with. The arbitrator decrypts exactly like a participant — the decryption hooks already key off `keys[].address` and needed no changes. But three surrounding decisions carry the real design weight:
+
+**Fail closed on missing keys (FR-007).** A wager can only be encrypted for a reader whose key is registered. If the named arbitrator has never called `registerKey`, creation is *blocked* with a message naming the missing party — the alternative is silently minting a wager its own resolver can never read, discovered months later at resolution time. The reader set is fixed when the bundle is prepared; late-binding a reader after creation is explicitly out of scope for v1.
+
+**Discovery is on-chain, not cryptographic.** Being able to decrypt a wager is useless if you don't know it exists. The one contract change in spec 005 extends the existing per-user index in `WagerRegistry.createWager`: alongside the creator and opponent, `_userWagerIds[w.arbitrator].add(wagerId)` when an arbitrator is set. Arbitrators enumerate their caseload through the same `getUserWagerIds` reads participants already use — one extra `SSTORE`, no new events or storage variables.
+
+**Integrity binds off-chain to on-chain.** The envelope lives on IPFS; the wager stores `metadataHash = keccak256("encrypted:ipfs://<CID>")` on-chain. A reader recomputes the hash before trusting a fetched bundle, so a substituted or corrupted envelope is *detected*, never displayed as valid. And if IPFS is unreachable, the terms degrade to an honest "unavailable" state — funds and resolution never block on plaintext availability.
+
+One honest-disclosure point mirrors the platform's fee doctrine: when an arbitrator is a reader, the UI says so. Participants should never believe a wager is two-party-private when a third key entry exists.
+
+## Growing and Shrinking the Reader Set
+
+Because access is granted per wrapped key, membership changes don't touch the content ciphertext. `addRecipient` lets *any existing reader* — not only the creator — unwrap the DEK with their own key and wrap it for a newcomer, appending one entry to `keys[]`. Since the envelope lives off-chain, this needs no transaction.
+
+Removal is where the abstraction is honest about its limits. `removeRecipient` filters an entry out of `keys[]`, and its docstring says the quiet part loud: *"This doesn't re-encrypt — they may still have the DEK cached. For true revocation, create a new envelope with new DEK."* Multi-recipient encryption grants access; it cannot un-know a key someone already held. FairWins documents this rather than pretending deletion equals revocation.
+
+## The Post-Quantum Variant
+
+Everything above runs identically under the v2.0 envelope, which swaps the per-recipient X25519 exchange for **X-Wing** — the IETF hybrid KEM combining X25519 with ML-KEM-768. `encryptEnvelopeXWing` calls `xwingEncapsulate` per recipient (a 1120-byte KEM ciphertext replaces the 32-byte ephemeral key) and derives the KEK from the combined shared secret via the spec's SHA3-256 combiner. If *either* component algorithm holds, the wrap holds — protection against harvest-now-decrypt-later adversaries. The wrapping layer absorbed the ~35× ciphertext growth with no change to content encryption or the on-chain footprint: the chain still stores a ~60-byte reference regardless of how heavy the envelope gets. `decryptEnvelopeUnified` dispatches on the envelope's `algorithm` field, so v1.0 and v2.0 bundles coexist.
+
+## Design Decisions
+
+- **Reuse the N-recipient API instead of adding an "observer" role.** The original request asked for participants plus an observer; the spec resolved the observer *as* the arbitrator, who reads and resolves. No new cryptosystem, no new role machinery — a third entry in an array that always supported N.
+- **Block creation on missing keys rather than late-bind.** Fail loudly at creation beats failing silently at resolution. The trade-off is friction — an arbitrator must register a key before being named — accepted for v1.
+- **Discovery via the registry index, not encrypted scanning.** Trial-decrypting every envelope on IPFS would be private but unusable; an on-chain index write is cheap and reuses existing reads. The trade-off: who arbitrates what is public metadata.
+- **Accept visible recipient addresses.** `keys[].address` is plaintext, so the reader set of any bundle is enumerable. Hiding it would break the "find my entry" decryption step; the design accepts this as consistent with blockchain transparency.
+- **No backward secrecy by design.** Removal without DEK rotation is documented as non-revocation. Correct-but-limited, stated plainly, beats an implied guarantee the math doesn't back.
+
+The through-line of the series so far: part 1 encrypted one agreement for two adversarial readers; part 2 shows the same envelope stretching to any reader set the wager's lifecycle demands. Part 3 turns the same machinery inward — syncing a user's own encrypted data across their devices.
+
+## Sources
+
+- `specs/005-multi-recipient-encryption/spec.md` — requirements, edge cases, decisions
+- `specs/005-multi-recipient-encryption/contracts/encryption-bundle-contract.md` — bundle invariants, recipient assembly
+- `specs/005-multi-recipient-encryption/contracts/wager-registry-arbitrator-index.md` — the arbitrator discovery index
+- `docs/developer-guide/envelope-encryption-spec.md` — primitives, envelope formats, security considerations
+- `docs/developer-guide/encryption-architecture.md` — end-to-end flow and key registry integration
+- `contracts/privacy/KeyRegistry.sol` — on-chain public-key directory
+- `frontend/src/utils/crypto/envelopeEncryption.js` — envelope encryption implementation (v1.0 X25519, v2.0 X-Wing)
+- `docs/blog/private-prediction-markets-envelope-encryption.md` — series anchor (part 1)
+- [RFC 7748 — X25519](https://datatracker.ietf.org/doc/html/rfc7748)
+- [RFC 8439 — ChaCha20-Poly1305](https://datatracker.ietf.org/doc/html/rfc8439)
+- [RFC 5869 — HKDF](https://datatracker.ietf.org/doc/html/rfc5869)
+- [EIP-191 — Signed Data Standard](https://eips.ethereum.org/EIPS/eip-191)
+- [IETF X-Wing hybrid KEM draft](https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/)
+- [Noble cryptography libraries](https://paulmillr.com/noble/)

--- a/docs/blog/posts/19-multi-recipient-encryption/social.md
+++ b/docs/blog/posts/19-multi-recipient-encryption/social.md
@@ -1,0 +1,26 @@
+# Social & Image — One Ciphertext, N Wrapped Keys: Multi-Recipient Encryption for Private Wagers
+
+## X (Twitter)
+
+Encrypt once, wrap the key N times: FairWins private wagers keep one ChaCha20-Poly1305 ciphertext plus an X25519-wrapped DEK per reader. Adding a neutral arbitrator was a third array entry — not a redesign. 🔗 <link> #encryption #privacy #web3
+
+## LinkedIn
+
+A resolver who can't read the agreement they're supposed to rule on is worse than no resolver. That was the state of FairWins' third-party arbitration: the arbitrator was named and authorized on-chain, but the wager terms were end-to-end encrypted for exactly two participants. Re-encrypting per reader, sharing keys out-of-band, or holding a platform master key were all non-starters.
+
+The fix required zero new cryptography — the envelope format was multi-recipient from day one. The new post walks the mechanism:
+
+- One DEK encrypts the terms once (ChaCha20-Poly1305 AEAD); each reader gets an X25519 + HKDF wrapped copy of the DEK — ~60 bytes per reader, and everyone provably decrypts the same ciphertext.
+- An on-chain `KeyRegistry` supplies encryption public keys, sized to fit both X25519 and X-Wing hybrid post-quantum keys without a contract change.
+- Fail-closed creation: no registered key for a named arbitrator, no wager — never a wager its own resolver can't read.
+- Honest limits: removing a reader from the envelope is not revocation, and the design says so plainly.
+
+Full write-up: 🔗 <link>
+
+Where do you draw the line between access-grant machinery and true revocation in E2EE systems?
+
+#encryption #cryptography #privacy #web3 #ethereum
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern editorial illustration, isometric composition: a single large sealed glass envelope or crystalline data vault at center containing an abstract glowing document, orbited by three distinct translucent keys on smooth arcs — two matched keys close in and one slightly apart (the neutral third reader), each key connected to the vault by a thin luminous thread. The vault's surface shows a faint layered lattice suggesting encryption without any readable characters. Deep navy background with teal geometric gradients and subtle grid lines; a single warm amber accent glows on the third key and its thread. Soft studio lighting with gentle rim light on the glass edges, shallow depth, minimalist fintech-engineering aesthetic, generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/20-encrypted-data-sync/blog.md
+++ b/docs/blog/posts/20-encrypted-data-sync/blog.md
@@ -1,0 +1,120 @@
+# Client-Side Encrypted Data Sync: Moving Your Data Between Devices Without a Server That Can Read It
+
+*How FairWins backs up a member's address book and preferences to public storage — encrypted with a key only their wallet can reproduce, located by a 40-line contract*
+
+| | |
+|---|---|
+| **Series** | Privacy Architecture (part 3) |
+| **Audience** | Privacy-focused app engineers |
+| **Tags** | `e2ee`, `data-sync`, `privacy`, `client-side-encryption` |
+| **Reading time** | ~8 minutes |
+
+## The data that lives in one browser
+
+A member has been using FairWins on their laptop for six months. They have a curated address book — contacts with nicknames, notes, and saved addresses across Polygon and Mordor. They have tuned preferences: favorite markets, default slippage, saved searches. Then they open the app on their phone. Everything is empty.
+
+This isn't a bug. FairWins deliberately has no application backend — the footprint is client, IPFS, and chain. There is no user database to sync from, which is exactly why the platform can promise it never reads your data: it never holds it. But the flip side is that user-authored state lives in one browser's `localStorage`, scoped to the connected wallet. A second device can't see it, and clearing the browser destroys it permanently.
+
+The conventional fix is a sync server. The server stores each user's data, devices pull it down, everyone is happy — except now there's a database of every member's contact list, and a party that can read, lose, or be compelled to hand over all of it. That trade was never on the table here.
+
+Spec 032's answer keeps the no-backend constraint intact: the client bundles the data, encrypts it with a key **only the member's wallet can reproduce**, pins the ciphertext to IPFS, and records a pointer to it in a tiny on-chain registry. Any device that controls the same wallet can walk that chain backwards — read the pointer, fetch the blob, re-derive the key, decrypt. The "server" in this sync system is public infrastructure that stores only ciphertext and a content hash. Let's walk each stage.
+
+## Keys that travel with the user
+
+The hard problem in client-side encrypted sync isn't the encryption — it's key distribution. If the key is stored on device A, device B can't decrypt. If the key is stored on a server, you've rebuilt the thing you were avoiding. If the user must transcribe a recovery code, they'll lose it.
+
+FairWins sidesteps storage entirely: the key is *derived*, deterministically, from something the member already carries — their wallet. `frontend/src/lib/backup/backupCrypto.js` asks the wallet to sign a fixed domain message and hashes the signature into a 32-byte symmetric key:
+
+```javascript
+export const DATA_BACKUP_MESSAGE_V1 = 'FairWins Data Backup v1'
+
+/** Derive the 32-byte symmetric key from a signature string. Pure + deterministic. */
+export function deriveKeyFromSignature(signature) {
+  return getBytes(keccak256(toUtf8Bytes(signature)))
+}
+
+export async function deriveKey(signer) {
+  const signature = await signer.signMessage(DATA_BACKUP_MESSAGE_V1)
+  return deriveKeyFromSignature(signature)
+}
+```
+
+This works because standard wallets implement RFC 6979 deterministic ECDSA: the same key signing the same message produces the same signature every time, on every device. Sign once on the laptop to encrypt; sign the same message on the phone and you hold the same key. Nothing is stored, transmitted, or escrowed. This is the same pattern part 1 of this series used for wager-content keys — but the domain message is deliberately distinct (`"FairWins Data Backup v1"` vs. the wager and address-book messages), so the backup key can never coincide with any other key the wallet derives.
+
+Passkey accounts (spec 041) don't have an ECDSA signer to prompt, so the same file ships a login-method-agnostic twin: `deriveKeyFromSeed(seed)` hashes the account's PRF-derived master seed together with the same domain message. Both paths are deterministic per account, so a backup made under a wallet session restores under a passkey session for the same account, and vice versa. The determinism assumption is guarded, not assumed silently: spec 032's FR-001a requires that a wallet which cannot reproduce its signature fails *honestly* — a wrong key can only ever produce an AEAD authentication failure, surfaced as "no usable backup," never a garbage restore.
+
+## The bundle: one file, every network
+
+What actually gets encrypted is a single unified bundle per wallet, assembled by `frontend/src/lib/backup/backupBundle.js` from an explicit registry of synced objects (`frontend/src/lib/backup/syncedObjects.js`). Each entry declares how to load itself, how to merge on restore, and — critically — whether it is **network-scoped**. Today the registry holds five objects:
+
+- **Address book** — additive merge keyed on `(address, chainId)`; every saved address carries its chain id.
+- **Preferences** — global scalars and lists (favorite markets, default slippage); last-writer-wins.
+- **Vault references** (spec 043) — custody vault pointers, identity `(chainId, address)`.
+- **Activity ledger** (spec 051) — client-only records that can't be re-derived from chain; both merge and replace modes union by `entryId`, because a "replace" that deleted audit history would violate the ledger's append-only guarantee.
+- **Open-challenge recovery codes** — stored in the bundle as an *opaque, already-encrypted envelope*; the codes never enter the backup channel in cleartext, and restore only writes it when the device has no local vault.
+
+The network tagging matters more than it looks. A backup made while connected to Mordor must restore Polygon contacts to Polygon. Rather than fragmenting backups per network, every network-specific element carries its chain id inside the one bundle, and `parseBundle` rejects any network-scoped element missing its tag — a malformed bundle throws before it can touch local data. Data that re-derives from chain (balances, tier caches, on-chain history) is deliberately excluded: sync user-authored state, not caches.
+
+Adding a future object — tokens, DAOs — is one registry entry declaring its merge rule and scope truthfully. No redesign of the machinery (FR-016).
+
+## Encrypt, pin, point
+
+The backup path in `frontend/src/hooks/useDataBackup.js` is four steps: build the bundle, derive the key, encrypt, then persist twice — once to IPFS, once to chain. Encryption is ChaCha20-Poly1305 (via the audited `@noble/ciphers`, in `frontend/src/utils/crypto/primitives.js`) with a random 96-bit nonce and the format/version string bound as AEAD associated data, so an envelope can't be silently reinterpreted under a different format version.
+
+The ciphertext is pinned to IPFS, which returns a CID. But a CID on its own recreates the recovery-code problem — the phone doesn't know it. So the last step is a transaction to `contracts/privacy/BackupPointerRegistry.sol` on a single canonical network (Polygon mainnet, chain 137), and the contract is almost aggressively boring:
+
+```solidity
+contract BackupPointerRegistry {
+    uint256 private constant MAX_CID_LENGTH = 256;
+    mapping(address => string) private _pointer;
+
+    event BackupPointerSet(address indexed owner, string cid, uint64 timestamp);
+
+    /// @notice Set, overwrite, or clear (with "") the caller's backup pointer.
+    function setPointer(string calldata cid) external {
+        if (bytes(cid).length > MAX_CID_LENGTH) revert CidTooLong();
+        _pointer[msg.sender] = cid;
+        emit BackupPointerSet(msg.sender, cid, uint64(block.timestamp));
+    }
+
+    function getPointer(address owner) external view returns (string memory) { ... }
+}
+```
+
+Value-free, no roles, no external calls, keyed purely on `msg.sender` — only a wallet can set its own pointer. It uses no OpenZeppelin imports so it also compiles on pre-Cancun targets like ETC/Mordor. Writing `""` clears the pointer, which is how "remove my backup" works: the locator is severed and the pin can lapse.
+
+Restore inverts the pipeline with no transaction at all: read `getPointer` through a read-only provider (free, and it works whatever network the member is connected to), fetch the envelope by CID, re-derive the key, decrypt, validate, then apply. Before anything is written, the member chooses **merge** (additive, the default) or **replace** (confirmed, destructive) — a restore that silently overwrote a newer local address book would cause the very loss the feature exists to prevent.
+
+## Honest state, everywhere
+
+A sync feature earns trust through its failure modes. The implementation is strict about three distinctions:
+
+- **"No backup" vs. "couldn't check."** `readPointer` in `frontend/src/lib/backup/backupRegistry.js` returns `""` for a genuinely empty pointer but `null` for an unreachable RPC — the UI says "nothing to restore" for one and "try again later" for the other, and never presents empty-as-truth.
+- **"Backed up" means both writes confirmed.** Success is shown only after the IPFS pin *and* the pointer transaction confirm. No optimistic checkmarks.
+- **Undecryptable means untouched.** A wrong key, tampered envelope, or foreign format fails AEAD authentication or bundle validation and is reported as "no usable backup"; local data — which remains the working source of truth throughout — is never overwritten with garbage.
+
+## Trade-offs
+
+**The pointer is public by design.** Anyone can see that a wallet has a backup, its CID, and when it changed (spec 032, FR-005b). That metadata is the accepted price of trustless retrieval — the alternative locators all reintroduce something worse. IPNS was rejected for resolution reliability; a member-held recovery code is loss-prone; a platform lookup service breaks the no-backend rule. The *content* stays ciphertext, so the metadata never discloses personal data.
+
+**Manual, not automatic.** This is explicit backup/restore, not background sync. Automatic sync would mean gas per change, always-on discovery, and data leaving the device without a deliberate act — spec 032 makes opt-in-by-action a hard requirement (FR-010): nothing leaves the device until the member triggers it, and they're told about the on-chain cost before signing. Background sync remains a possible later evolution, on this same substrate.
+
+**Lose the wallet, lose the backup.** There is no recovery path without the key material, by design. A general social-recovery scheme is explicitly out of scope; the encrypted export/import file from spec 021 remains as a zero-infrastructure offline fallback for members who prefer not to transact.
+
+**One canonical network.** Backups cost cents of gas on Polygon and require switching to it; restore reads are free from anywhere. A soft ~1 MB size cap warns — but never blocks — oversized bundles.
+
+The sum is a sync system where every storage layer is public — IPFS blobs anyone can fetch, a registry anyone can read — and none of it is readable by anyone but the wallet holder. The key never exists at rest; it exists wherever the member is.
+
+## Sources
+
+- `specs/032-encrypted-data-sync/spec.md`, `plan.md` — feature spec and canonical-network decision
+- `contracts/privacy/BackupPointerRegistry.sol` — the on-chain locator
+- `frontend/src/lib/backup/backupCrypto.js`, `backupBundle.js`, `syncedObjects.js`, `backupRegistry.js` — key derivation, bundle, object registry, pointer client
+- `frontend/src/hooks/useDataBackup.js` — backup/restore orchestration
+- `frontend/src/utils/crypto/primitives.js` — ChaCha20-Poly1305 AEAD via `@noble/ciphers`
+- `frontend/src/abis/backupPointerRegistry.js` — ABI + canonical chain id (Polygon, 137)
+- `specs/002-e2e-encryption-lifecycle/`, `docs/developer-guide/encryption-architecture.md` — the wallet-signature key-derivation pattern this feature reuses
+- RFC 6979 — Deterministic ECDSA: https://datatracker.ietf.org/doc/html/rfc6979
+- RFC 8439 — ChaCha20-Poly1305 AEAD: https://datatracker.ietf.org/doc/html/rfc8439
+- EIP-191 — Signed data standard (`personal_sign`): https://eips.ethereum.org/EIPS/eip-191
+- IPFS CIDs: https://docs.ipfs.tech/concepts/content-addressing/

--- a/docs/blog/posts/20-encrypted-data-sync/social.md
+++ b/docs/blog/posts/20-encrypted-data-sync/social.md
@@ -1,0 +1,26 @@
+# Social & Image — Client-Side Encrypted Data Sync: Moving Your Data Between Devices Without a Server That Can Read It
+
+## X (Twitter)
+
+Cross-device sync with zero backend: FairWins derives the backup key from a deterministic wallet signature (RFC 6979), encrypts client-side, pins ciphertext to IPFS, and a tiny value-free contract stores the pointer. 🔗 <link> #e2ee #privacy #web3
+
+## LinkedIn
+
+Your app has no backend — that's the privacy promise. But it also means a member's address book and preferences live in one browser's localStorage. Open the app on a second device: empty. The conventional fix is a sync server, which recreates exactly the database of user data the architecture exists to avoid.
+
+FairWins' answer keeps the no-backend constraint intact, and the new post walks each stage:
+
+- Key derivation with no storage: the wallet signs a fixed domain message, and RFC 6979 deterministic ECDSA means the same wallet reproduces the same 32-byte key on every device. Nothing is stored, transmitted, or escrowed.
+- One unified bundle per wallet — address book, preferences, vault references, activity ledger — with per-object merge rules and network-scoped tagging so Polygon contacts restore to Polygon.
+- ChaCha20-Poly1305 ciphertext pinned to IPFS, located by a value-free on-chain pointer registry keyed purely on `msg.sender`.
+- Honest failure modes: "no backup" vs. "couldn't check" are distinct states, and a wrong key can only fail AEAD authentication — never produce a garbage restore.
+
+Full write-up: 🔗 <link>
+
+Would you trust derived-not-stored keys for user data sync, or is a recovery-code escape hatch non-negotiable?
+
+#e2ee #privacy #web3 #ipfs #encryption
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern abstract-geometric editorial illustration: a laptop and a smartphone rendered as minimal translucent glass silhouettes at opposite sides of the frame, linked not directly but through a high arc of small encrypted cubes flowing up into a stylized distributed-storage constellation — faceted nodes joined by thin luminous lines — with a tiny, solitary beacon marker beneath the arc representing the on-chain pointer. The cubes are visibly sealed and opaque-cored, suggesting ciphertext in transit through public space. Deep navy base with layered teal gradients and a faint isometric grid; one warm amber accent lights the single key glyph hovering beside both devices, identical on each side. Soft diffuse lighting, subtle glow on connection lines, precise fintech-engineering minimalism, ample negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/21-nullifier-system/blog.md
+++ b/docs/blog/posts/21-nullifier-system/blog.md
@@ -1,0 +1,238 @@
+# The Nullifier System: A Privacy-Preserving Blocklist That Never Shipped
+
+*What FairWins built when it needed to revoke bad markets without publishing a
+blacklist — and why the word "nullifier" means something different here than it
+does in Tornado Cash*
+
+| | |
+|---|---|
+| **Series** | Privacy Architecture (part 4) |
+| **Audience** | ZK and privacy engineers |
+| **Tags** | `nullifiers`, `zk`, `privacy`, `rsa-accumulator`, `moderation` |
+| **Reading time** | ~9 minutes |
+
+---
+
+> This post describes a peer-to-peer wager platform built around forecasting on
+> publicly available information. Nothing here is a mechanism for evading law or
+> sanctions screening; the "nullifier" below is a moderation primitive, and it is
+> archived. Participants on any live FairWins surface remain subject to applicable
+> law and to the platform's on-chain sanctions guard.
+
+## A word with two meanings
+
+If you come from the zero-knowledge world, "nullifier" has a precise meaning. In
+Tornado Cash, a nullifier is a value you reveal when you withdraw a note so that
+the same note cannot be withdrawn twice. In Semaphore, a nullifier hash binds a
+signal to an identity and an external topic so a member can prove "I am in this
+group and I have not spoken on this topic before" without revealing which member
+they are. The nullifier is the anti-double-spend, anti-replay half of an
+otherwise anonymous action. You never learn *who*; you only learn *again* — and
+you reject the "again."
+
+FairWins has a "nullifier system" too, documented in `docs/NULLIFIER_SYSTEM.md`
+and `docs/developer-guide/nullifier-system.md`. It is worth being blunt up front:
+it is **not** that. The FairWins nullifier does not prevent replay of a
+privacy-preserving action. It uses "nullify" in the older sense — *to make null,
+to void* — and it is a moderation tool: a way for a platform admin to revoke a
+malicious market or a bad-actor address so the frontend stops displaying it and,
+optionally, contracts stop transacting with it.
+
+What makes it interesting to a ZK engineer is the *shape* of the problem, which
+turns out to be the same shape as a nullifier set. A blocklist is a set. You want
+to answer one question against that set — "is this thing revoked?" — and its dual,
+"prove this thing is *not* revoked." The FairWins design reached for the same
+cryptographic primitive the ZK-mixer literature reaches for when it wants compact,
+privacy-preserving set membership: an **RSA accumulator**. This post walks that
+design, and is honest about the fact that it never reached a live network.
+
+## The problem: revoking without publishing
+
+Consider the moderation problem for a permissionless-feeling market venue. An
+admin discovers a market crafted to defraud participants, or an address that keeps
+seeding abusive markets. They want it gone from the interface, and for
+high-value paths they want the contract itself to refuse to interact with it.
+
+The naive implementation is an on-chain mapping — `mapping(address => bool)
+blocked` — and that is genuinely fine for small sets. But it has two properties
+the designers disliked. First, the blocklist is fully public and fully
+enumerable: anyone can read every entry, which turns a moderation list into a
+published "wall of shame" and leaks the platform's threat model. Second, storage
+and gas grow with the list. The `docs/NULLIFIER_SYSTEM.md` table lays out the
+trade study explicitly: an on-chain mapping is O(n) storage with a public list; a
+Merkle tree gives O(log n) proofs and partial privacy; an RSA accumulator gives
+O(1) storage, O(1) on-chain footprint, and — the headline property — the ability
+to prove that something is **not** in the set without revealing the set.
+
+That last property is exactly what a ZK nullifier set needs, approached from the
+opposite direction. A mixer proves *membership* of a commitment and *non-membership*
+of a nullifier. Here the platform wants to prove *non-membership* in a blocklist:
+"this market is clean, and here is a 256-byte witness that says so, and the witness
+tells you nothing about what else is blocked."
+
+## The design: prime mapping plus an RSA accumulator
+
+The archived contract lives at
+`contracts-archive/security/NullifierRegistry.sol`, with its cryptography in
+`contracts-archive/libraries/RSAAccumulator.sol` and
+`contracts-archive/libraries/PrimeMapping.sol`. It is `AccessControl`,
+`ReentrancyGuard`, `Pausable`, and it supports two modes that share one storage
+layout.
+
+**Simple mode** is the boring, working half — plain mappings with an audit trail:
+
+```solidity
+mapping(bytes32 => bool) public nullifiedMarkets;
+mapping(address => bool) public nullifiedAddresses;
+mapping(bytes32 => uint256) public marketNullifiedAt;
+mapping(bytes32 => address) public marketNullifiedBy;
+```
+
+An admin holding `NULLIFIER_ADMIN_ROLE` calls `nullifyMarket` or `nullifyAddress`
+with a human-readable reason; the mapping flips, a timestamp and the admin address
+are recorded, and an event carries the reason off-chain for indexing. Batch
+variants exist, capped at `MAX_BATCH_SIZE = 50` to bound gas and prevent a
+DoS-by-huge-array. Reads are trivial:
+
+```solidity
+function isAddressNullified(address addr) external view returns (bool) {
+    return nullifiedAddresses[addr];
+}
+```
+
+**Accumulator mode** is where the ZK-adjacent machinery appears. Every element —
+a market hash or an address hash — is deterministically mapped to a prime. The
+mapping starts from the keccak hash, forces it odd, and walks upward by twos until
+a Miller-Rabin test passes:
+
+```solidity
+function hashToPrimeUint(bytes32 hash) internal pure returns (uint256 prime) {
+    uint256 candidate = uint256(hash) | 1;   // ensure odd
+    uint256 iterations = 0;
+    while (!isPrime(candidate) && iterations < 1000) {
+        candidate += 2;                        // only test odd numbers
+        iterations++;
+    }
+    require(iterations < 1000, "Prime search exceeded limit");
+    return candidate;
+}
+```
+
+Deterministic hash-to-prime is the same trick the RSA-accumulator literature uses
+so that the accumulator value is a single group element representing the product
+of all members' primes: `A = g^(p1 * p2 * ... * pn) mod n`. Adding an element is a
+single modular exponentiation, `A_new = A^p mod n`. The whole revoked set — one
+entry or a million — collapses to one 256-byte value stored on-chain.
+
+Non-membership is the payoff. To prove an element `x` is *not* in the set, an
+off-chain prover computes a Bezout witness `(d, b)` such that the accumulator and
+generator satisfy the identity `A^d · g^b ≡ g (mod n)` — which can only hold if
+`gcd(prime(x), product_of_members) = 1`, i.e. `x` was never accumulated. The
+contract verifies it:
+
+```solidity
+function verifyNonMembership(
+    bytes32 elementHash,
+    bytes calldata witnessD,
+    bytes calldata witnessB,
+    bool dNegative
+) external view returns (bool valid);
+```
+
+The frontend can carry a cached accumulator and check a market client-side, and a
+critical on-chain path can demand a proof rather than trusting a mapping read. The
+JavaScript side of this lives in `frontend/src/utils/rsaAccumulator.js` and
+`frontend/src/utils/primeMapping.js`, wired through the React hooks
+`useNullifierContracts` and `useMarketNullification` and surfaced in the admin
+`NullifierTab`.
+
+## The integration points — and the trust model
+
+Two consumers were designed to enforce revocation on-chain. The legacy
+`FriendGroupMarketFactory` imports the registry, holds an `enforceNullification`
+flag, and checks `isAddressNullified` before letting an address create, accept, or
+be added to a market — reverting with `AddressNullified()` if blocked. A
+`TreasuryVault` could refuse withdrawals to a nullified recipient. Both gate the
+check behind an owner-set enforcement toggle that defaults **off**, so the system
+degrades to "frontend filters, chain does not care" unless an operator explicitly
+opts in.
+
+The security of accumulator mode rests entirely on a **trusted setup**: the RSA
+modulus `n` must be the product of two secret safe primes that are destroyed after
+generation. If anyone knows the factorization, they can forge both membership and
+non-membership proofs — add a market to the blocklist that verifies as clean, or
+clear a real one. That is the classic RSA-accumulator caveat, and it is the same
+class of ceremony risk that ZK systems carry for their structured reference
+strings. The docs call for a verifiable ceremony or MPC; nothing in the repo
+performs one.
+
+## Design decisions and trade-offs
+
+- **Accumulator over Merkle tree.** A Merkle blocklist gives non-membership too,
+  but requires sorted leaves and O(log n) proofs that grow with the set, and it
+  still tends to leak neighbors. The accumulator's constant on-chain footprint and
+  set-hiding property were the deciding factors — at the cost of a trusted setup a
+  Merkle tree does not need.
+- **Two modes, one contract.** Simple mode is deployable today with zero ceremony
+  and an obvious audit trail; accumulator mode is the privacy upgrade layered on
+  the same storage. The `docs/developer-guide/nullifier-system.md` guidance is to
+  use simple mode below ~1,000 entries and only reach for the accumulator when the
+  set is large or the privacy of the list itself matters.
+- **Enforcement off by default.** Making on-chain checks opt-in keeps gas and
+  liveness risk out of the common path — a bug or a compromised admin key cannot
+  freeze trading unless an operator turned enforcement on. The flip side is that
+  "revoked" means nothing on-chain until someone flips that switch.
+- **Admin, not governance.** Revocation is a single role, `NULLIFIER_ADMIN_ROLE`,
+  granted by the default admin. The docs themselves flag this as the weak point and
+  list multisig/timelock and a future governance-based path as the mitigation. It
+  is centralized moderation wearing a cryptographic coat.
+
+## Why it is archived — and what a real nullifier looks like here
+
+Grep the active tree and there is no nullifier: `contracts/` has no
+`NullifierRegistry`, no live network in `deployments/` configures one (only a
+`localhost` chain-1337 registries file references a `nullifierRegistry` address),
+and the testnet address that appears in the old dev guide points at Polygon Amoy,
+a network FairWins has since moved off. The whole system sits in
+`contracts-archive/`, which the project guide marks reference-only: never import,
+never deploy. The frontend hooks still exist but soft-fail to a no-op when no
+registry answers.
+
+The honest read is that FairWins pivoted away from an admin-run market blocklist
+toward compliance primitives that are actually wired into the value path — a shared
+`ISanctionsGuard` checked on real wallet addresses across wagers and pools, and
+role-gated participation via `MembershipManager`. Those solve the "keep bad actors
+out" problem without a bespoke accumulator and its ceremony risk.
+
+So if you came looking for a Semaphore-style spend-nullifier preventing replay of
+an anonymous action, the accurate answer is: FairWins designed a *nullification*
+registry, not a *nullifier* in the mixer sense, and then shelved it. What survives
+is a clean, self-contained study in applying an RSA accumulator to a set-membership
+problem — the exact primitive the ZK world uses, pointed at moderation instead of
+anonymity. That is a genuinely useful thing to have read in full, even as reference
+code, precisely because the cryptography is real and the honest limits are on the
+label.
+
+## Sources
+
+- `docs/NULLIFIER_SYSTEM.md` — full RSA-accumulator design, trade study, and
+  security model
+- `docs/developer-guide/nullifier-system.md` — simple vs. accumulator mode, admin
+  workflow, historical deployment notes
+- `contracts-archive/security/NullifierRegistry.sol` — the registry contract
+  (archived, reference-only)
+- `contracts-archive/libraries/RSAAccumulator.sol`,
+  `contracts-archive/libraries/PrimeMapping.sol` — accumulator math and
+  deterministic hash-to-prime
+- `contracts-archive/markets/FriendGroupMarketFactory.sol` — legacy on-chain
+  enforcement integration
+- `frontend/src/hooks/useNullifierContracts.js`,
+  `frontend/src/hooks/useMarketNullification.js`,
+  `frontend/src/utils/rsaAccumulator.js` — client-side filtering and proof
+  verification
+- `deployments/localhost-chain1337-registries-deployment.json` — the only
+  deployment record that references a `nullifierRegistry`
+- Background: Semaphore protocol (semaphore.pse.dev) and Tornado Cash on ZK
+  nullifiers; Camenisch–Lysyanskaya, *Dynamic Accumulators* (2002) and Boneh–Bünz–Fisch,
+  *Batching Techniques for Accumulators* (2018) on RSA accumulators; RFC-style RSA
+  parameter guidance at eips.ethereum.org for on-chain `modExp` (EIP-198)

--- a/docs/blog/posts/21-nullifier-system/social.md
+++ b/docs/blog/posts/21-nullifier-system/social.md
@@ -1,0 +1,30 @@
+# Social & Image — The Nullifier System: A Privacy-Preserving Blocklist That Never Shipped
+
+## X (Twitter)
+
+"Nullifier" in Tornado = anti-double-spend. FairWins' "nullifier" = something else entirely: an RSA-accumulator blocklist that voids bad markets and proves a market is NOT revoked in ~256 bytes — no public blacklist. It's archived, and we explain honestly why. 🔗 <link>
+
+#ZK #privacy #cryptography
+
+## LinkedIn
+
+Moderating a permissionless market venue has an awkward requirement: you sometimes need to revoke a malicious market or a bad-actor address — but publishing a plaintext, fully-enumerable blocklist on-chain leaks your threat model and grows gas with every entry.
+
+FairWins' archived "nullifier system" reached for the same primitive the ZK-mixer world uses for its nullifier sets — an RSA accumulator — and pointed it at moderation instead of anonymity. The latest engineering post walks the design and is candid about the fact that it never reached a live network:
+
+- Why "nullifier" here means *void*, not the Tornado/Semaphore anti-replay value — and where the two ideas genuinely overlap
+- Deterministic hash-to-prime + `A = g^(product of primes) mod n`: the whole revoked set collapses to one 256-byte value
+- Non-membership proofs via a Bezout witness — prove a market is clean without revealing the blocklist
+- The honest limits: a trusted-setup ceremony that was never run, enforcement off by default, and why FairWins shipped a sanctions guard instead
+
+A clean case study in applying real accumulator cryptography to a set-membership problem — with the trade-offs on the label.
+
+🔗 <link>
+
+When does a compact cryptographic accumulator actually beat a plain on-chain mapping for your use case — and is the trusted setup worth it?
+
+#ZeroKnowledge #Cryptography #Blockchain #SmartContracts #Privacy
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in isometric style for a fintech-engineering blog banner. Central subject metaphor: a single glowing sealed vault-node or lockbox that many faint, ghostly geometric tokens flow toward, but instead of being listed on a public ledger they are absorbed and compressed into one small luminous cube — visualizing many blocked items collapsing into a single compact cryptographic value. Around it, a scattering of prime-number motifs and thin mathematical filament lines (modular-arithmetic curves) drift as translucent overlays. Composition: off-center focal cube on the right third, negative space on the left, subtle depth with layered planes. Color mood: deep navy and teal base with a single warm amber accent used only on the compressed cube and one proof-witness beam. Lighting: soft volumetric glow from the cube, cool ambient fill, gentle rim light on the geometric shapes. Slightly muted, precise, engineering-grade aesthetic — not flashy, not neon. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/22-fee-router/blog.md
+++ b/docs/blog/posts/22-fee-router/blog.md
@@ -1,0 +1,116 @@
+# The FeeRouter: One Source of Truth for Platform Fees
+
+*How FairWins centralized every configurable fee into a single capped, disclosed, on-chain registry — without centralizing trust*
+
+| | |
+|---|---|
+| **Series** | Finance Surfaces (part 1) |
+| **Part** | 22 of 34 |
+| **Audience** | Protocol and product engineers |
+| **Tags** | `fees`, `fee-router`, `solidity`, `uups`, `product` |
+| **Reading time** | ~8 minutes |
+
+## Three fee systems walk into a codebase
+
+By mid-2026, FairWins had shipped three integrations that touched revenue, and each had grown its own fee plumbing. The OpenSea referral (Collect) cost members nothing and paid FairWins out of OpenSea's economics. The Polymarket builder fee (Predict) was a real, disclosed taker cost, configured through gateway environment variables. And Earn — Morpho lending vaults behind an ERC-4626 interface — had no native revenue-share program at all, which meant FairWins earned nothing on it.
+
+The plan was to charge a small platform fee on Earn deposits. The obvious implementation was also the wrong one: hardcode 50 bps in the deposit path, add another env var to the gateway, put a matching constant in the frontend so the confirm screen shows the right number. That's three copies of one number, owned by three deploy pipelines. The failure mode writes itself: an operator changes the gateway env var, forgets the frontend constant, and a member confirms a screen that says 0.50% while the backend charges 0.60%. For a platform whose entire fee doctrine is *the member always sees the real cost before signing*, a stale disclosure isn't a display bug — it's a broken promise.
+
+There's a second failure mode that no amount of config discipline fixes: the race. A member reviews a deposit at 50 bps, an admin raises the rate to 75 bps, and the member's transaction lands after the change. Whatever the UI said, the chain charges the live rate. If the fee logic lives in scattered constants, there is nowhere to even express "charge me at most what I was shown."
+
+Spec 060's answer was to make fees a first-class on-chain subsystem: one contract, the `FeeRouter` (`contracts/fees/FeeRouter.sol`, a UUPS proxy recorded under the `feeRouter` / `feeRouterImpl` deployment keys), that is the *only* place a fee rate lives — and to make the charge path enforce the disclosure.
+
+## A registry keyed by keccak
+
+Every configurable fee is a service entry keyed by `bytes32 serviceId = keccak256("<label>")` — `earn.lend`, `polymarket.taker`, `polymarket.maker`. The entry itself is small:
+
+```solidity
+enum ServiceKind {
+    Unregistered,
+    Wrapped,    // chargeable through the router (e.g. earn.lend)
+    ConfigOnly  // read-only rate for off-chain enforcement (e.g. polymarket.taker)
+}
+
+struct Service {
+    uint16 capBps; // hard ceiling for feeBps; 0 => unregistered
+    uint16 feeBps; // live rate, 0..capBps
+    ServiceKind kind;
+}
+```
+
+The `kind` split is what lets one registry cover very different fee mechanics. **Wrapped** services are charged by the router itself, on-chain, atomically. **ConfigOnly** services store a rate that an off-chain enforcer reads — the Polymarket builder bps, which the relay gateway attaches to CLOB orders per spec 057. The router never touches ConfigOnly money; it just holds the number everyone agrees on.
+
+Caps are fixed at registration and can never be edited afterward. `registerService` is one-shot per id, rejects a zero cap, and for wrapped services bounds the cap by an absolute constant:
+
+```solidity
+/// @notice Absolute ceiling for any Wrapped service's cap (2.5%).
+uint16 public constant MAX_WRAPPED_FEE_BPS = 250;
+```
+
+`setFeeBps` — gated by `FEE_ADMIN_ROLE` — enforces `newBps <= capBps`, and the charge path re-checks the cap as defense in depth. The emergency lever is deliberately `setFeeBps(id, 0)`, not a cap change: an operator can always zero a misbehaving fee immediately, but nobody, including admins, can quietly raise the ceiling members were told about. Every change emits `FeeBpsChanged(serviceId, oldBps, newBps, actor)`, and that event stream *is* the audit history — the AdminPanel Fees tab renders it directly rather than keeping a parallel log.
+
+## Atomic charging: fee-for-value or nothing
+
+For wrapped services, the router is also the settlement path. Earn deposits don't call the vault; they call the router:
+
+```solidity
+function depositToVaultWithFee(
+    bytes32 serviceId,
+    address vault,
+    uint256 assets,
+    address receiver,
+    uint16 maxFeeBps
+) external nonReentrant returns (uint256 shares);
+```
+
+In one transaction the router pulls the member's principal, transfers `floor(assets · bps / 10 000)` to the treasury, approves the ERC-4626 vault for the remainder, and deposits it for the member. Any failing leg reverts the whole action, so the treasury can never keep a fee for a deposit that didn't happen. The router holds no balances outside a transaction — there is nothing to drain between calls. And if the vault returns zero shares for a nonzero net deposit, the router reverts `ZeroShares()` rather than letting a vault swallow principal: the fee is only ever payment for value actually delivered.
+
+Two edge cases show the fail-safe posture. Fee math floors, in the member's favor — a fee that rounds to zero in the asset's smallest unit is charged as zero. And if a network's treasury was never configured (`treasury == address(0)`), the router *skips* the fee entirely and emits `FeeSkippedNoTreasury` instead of reverting or parking funds. An ops misconfiguration must never strand a member's deposit; it can only cost FairWins revenue.
+
+## `maxFeeBps`: the disclosure becomes enforceable
+
+The last parameter of `depositToVaultWithFee` is the interesting one. The frontend quotes the live rate before any signature (`frontend/src/lib/fees/feeQuote.js` reads `getService` straight from the router) and passes that *quoted* rate back as `maxFeeBps`. On-chain:
+
+```solidity
+uint16 liveBps = svc.feeBps;
+if (liveBps > svc.capBps) revert CapExceeded(); // defense in depth
+if (liveBps > maxFeeBps) revert FeeAboveQuoted();
+```
+
+This closes the race permanently. If an admin raises the rate while a member's transaction is in flight, the member either pays at most what the confirm screen showed or the transaction reverts and they re-review. The confirm screen is no longer a courtesy; it's a signed ceiling the contract enforces. The one rule integrators must honor is behavioral, not technical: never call the router with a `maxFeeBps` you did not actually display.
+
+## The honest-disclosure doctrine, mechanized
+
+FairWins' fee doctrine predates the router: fees are disclosed before signature, as a named line with the live percentage and absolute amount — never hidden, never folded into a spread, never labeled "free" when they aren't. The router turns that doctrine into code paths with exactly three outcomes, and `fetchFeeQuote` makes integrators handle all of them:
+
+- **No router on this chain** (or service unregistered): `{ available: false, bps: 0 }` — proceed with no fee and no fee line, byte-identical to pre-060 behavior. Zero fee means the feature behaves as if the fee system never existed.
+- **Live rate obtained**: disclose it and pass it as `maxFeeBps`.
+- **Read failed on a network that has a router**: *block the action.* The one thing a surface may never do is proceed on a possibly understated rate. Earn's deposit flow pauses (withdrawals are unaffected) until the read succeeds — fail-safe, not fail-open.
+
+The relay gateway follows the same discipline from the other side. `services/relay-gateway/src/fees/onchain.js` reads the Polymarket bps from the router via a cached `eth_call` (30-second TTL), clamps to the spec-057 caps before serving — a clamp firing is logged as a should-be-impossible warning, since the contract enforces the caps too — serves a stale value for at most 10× the TTL during an RPC outage, and then drops to env-configured fallback bps, honestly labeled `source: "env-fallback"` in the API response. Crucially, the gateway stays *stateless*: no admin API, no persistence, no second fee-config store. An admin edits on-chain; every reader follows.
+
+## Design decisions
+
+**One registry instead of per-feature fee logic.** The alternative — each integration owning its fee — is how the pre-060 sprawl happened. Now a new integration (Lido, Polygon liquid staking, Uniswap are the named candidates) *registers a service* rather than building a fee path: pick a label, `registerService(ethers.id('stake.lido'), capBps, Wrapped)`, wire the standard quote-and-disclose flow. The rate starts at 0; nothing is charged until an operator acts.
+
+**Centralized config is not centralized trust.** Admins got one screen, but members got harder guarantees than before: an immutable per-service cap, an absolute 250 bps ceiling on wrapped services, a contract-enforced consent ceiling, and a public `FeeBpsChanged` history. The admin's power is bounded by constants members can read on-chain.
+
+**Entry-only fees.** Wrapped fees apply to principal at entry; withdrawals are never charged. This keeps the mental model simple ("you saw the cost when you put money in") and keeps the exit path free of any fee-read dependency.
+
+**Floor rounding, member's favor.** A deliberate bias: on tiny principals the fee rounds to zero and is charged as zero — the router still emits a `FeeCharged` event with `feeAmount = 0` so reconciliation counts exactly one router event per deposit. The monthly reconciliation invariant is exact: every `FeeCharged.feeAmount` equals one same-transaction ERC-20 transfer to the treasury (`docs/runbooks/fee-operations.md` treats any divergence as a security incident).
+
+**Known limits.** Fee-on-transfer and rebasing tokens are unsupported — the router assumes the pulled amount equals the requested amount, true for the curated vault assets like USDC. One-shot registration means a mistaken cap can't be fixed, only abandoned for a new service id; that rigidity is the price of caps members can rely on. And the router is a UUPS proxy (`UUPSManaged`, append-only storage with a trailing `__gap`, CI-gated `check:storage-layout`), so new wrapped entrypoints for differently shaped actions — staking, swaps — can ship as in-place upgrades, provided they keep the same accounting, events, cap re-check, and `maxFeeBps` ceiling.
+
+The result is a fee system whose most important property is the one members never see: there is no code path on which the number they were shown and the number they are charged can diverge.
+
+## Sources
+
+- `specs/060-platform-fee-wrapper/spec.md` — feature spec, user stories, acceptance scenarios
+- `contracts/fees/FeeRouter.sol` — router implementation (registry, caps, atomic charging)
+- `contracts/fees/IFeeRouter.sol` — interface, `Service` struct, events, errors
+- `docs/developer-guide/platform-fees.md` — architecture, disclosure rules, service registration
+- `docs/runbooks/fee-operations.md` — rate changes, emergency-zero, treasury reconciliation
+- `services/relay-gateway/src/fees/onchain.js` — stateless cached on-chain rate reader
+- `frontend/src/lib/fees/feeQuote.js` — quote path and the three integrator outcomes
+- [ERC-4626: Tokenized Vaults](https://eips.ethereum.org/EIPS/eip-4626) — the vault interface behind `depositToVaultWithFee`
+- [ERC-1822 / UUPS](https://eips.ethereum.org/EIPS/eip-1822) and [OpenZeppelin upgradeable contracts](https://docs.openzeppelin.com/contracts/5.x/api/proxy) — the proxy pattern the router builds on

--- a/docs/blog/posts/22-fee-router/social.md
+++ b/docs/blog/posts/22-fee-router/social.md
@@ -1,0 +1,26 @@
+# Social & Image — The FeeRouter: One Source of Truth for Platform Fees
+
+## X (Twitter)
+
+One source of truth for every fee: FairWins' FeeRouter keeps each rate under an immutable per-service cap (wrapped ≤ 250 bps), and the quoted rate rides along as maxFeeBps — charge above what the member saw and the tx reverts. 🔗 <link> #solidity #defi #fintech
+
+## LinkedIn
+
+Three integrations, three fee systems: env vars in the gateway, constants in the frontend, nothing on-chain. The failure mode writes itself — an operator updates one copy of the number, a member confirms a screen showing 0.50% while the backend charges 0.60%. For a platform whose fee doctrine is "the member always sees the real cost before signing," a stale disclosure isn't a display bug; it's a broken promise.
+
+FairWins' spec 060 made fees a first-class on-chain subsystem, and the new post walks the design:
+
+- One `FeeRouter` contract holds every configurable rate as a `bytes32` service id — no fee constant lives anywhere else, and the gateway only reads it.
+- Caps are immutable at registration, with an absolute 250 bps ceiling on wrapped services. Admins can zero a fee instantly; nobody can quietly raise a ceiling.
+- `maxFeeBps` turns the confirm screen into an enforceable contract: if the live rate exceeds what the member was shown, the transaction reverts.
+- Atomic fee-for-value charging via `depositToVaultWithFee` — the treasury can never keep a fee for a deposit that didn't happen.
+
+Full write-up: 🔗 <link>
+
+Should fee disclosure be contract-enforced everywhere, or is UI-level disclosure enough for your users?
+
+#solidity #defi #fintech #web3 #smartcontracts
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern isometric editorial illustration: a single transparent routing hub — a faceted glass prism or junction box — at the center of the frame, with several thin conduits entering from the left carrying streams of small geometric tokens; inside the hub each stream visibly splits into a large continuing flow and one small measured sliver diverted to a compact vault, the split governed by a fixed physical gate rendered as a solid immovable bar (the hard cap). Above the hub floats a minimal open ledger panel with abstract bar marks, implying the rate is displayed before anything moves. Deep navy background with teal gradients and a fine engineering grid; a single warm amber accent illuminates the small diverted sliver and the gate, making the fee path the brightest, most visible element in the scene — nothing hidden. Soft precise studio lighting, crisp edges, minimalist fintech-engineering aesthetic, generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/23-earn-erc4626-vaults/blog.md
+++ b/docs/blog/posts/23-earn-erc4626-vaults/blog.md
@@ -1,0 +1,120 @@
+# Earn Without Custody Surprises: Wrapping ERC-4626 Vaults With a Disclosed, Atomic Fee
+
+*How FairWins routes lending deposits into external Morpho vaults, charges its platform fee in the same transaction, and shows the member the exact rate before they sign*
+
+- **Series:** Finance Surfaces (part 2)
+- **Part:** 23 of 34
+- **Audience:** DeFi integrators; protocol and product engineers
+- **Tags:** `erc4626`, `defi`, `lending`, `yield`, `fees`
+- **Reading time:** ~8 minutes
+
+---
+
+## The idle-balance problem, and the two bad answers
+
+FairWins members hold stablecoins in their connected accounts between wagers. Between the moment a payout lands and the moment the next wager is created, that USDC sits idle. Members asked the obvious question — can it earn something in the meantime? — and the team faced the two answers most consumer crypto apps reach for.
+
+The first bad answer is custody: run your own yield product, pool member deposits, and manage the strategy in-house. That turns a wager-escrow platform into an asset manager, with everything that implies — a new value-bearing contract surface, discretionary control over member funds, and a trust model the rest of the platform deliberately avoids.
+
+The second bad answer is the hidden spread: route deposits into someone else's protocol, quietly keep a slice of the yield or the principal, and let the member discover the difference in their statement. Plenty of "earn" features work this way. It's also exactly the kind of quiet skim that FairWins' constitution forbids — every fee on the platform is disclosed before signature, or it doesn't exist.
+
+The Earn section (spec `050-earn-lending-rewards`) is the answer that avoids both: deposits go **directly from the member's account into third-party ERC-4626 vaults** — curated Morpho lending vaults on Ethereum mainnet and Polygon PoS — with FairWins never taking custody, and the platform fee, when one is configured, charged **atomically in the same transaction** by an on-chain router that refuses to charge more than the rate the member was shown. This post walks through both layers: the non-custodial vault integration, and the fee wrapper that monetizes it honestly.
+
+## Layer one: direct ERC-4626 deposits, no FairWins contracts
+
+[ERC-4626](https://eips.ethereum.org/EIPS/eip-4626) is the tokenized-vault standard: `deposit(assets, receiver)` mints shares, `convertToAssets(shares)` values a position, `maxDeposit`/`maxWithdraw` report honest limits, `withdraw`/`redeem` exit. Because Morpho's Vault V1 (MetaMorpho) implements the full surface, the base Earn integration shipped as a **frontend-only** feature — no FairWins contracts, no backend. The client discovers vaults through Morpho's public GraphQL API (`listed: true`, the same curation the Morpho app itself uses), reads positions authoritatively on-chain, and claims protocol rewards through Merkl's distributor.
+
+One curation detail matters for anyone wrapping vaults: only Morpho **Vault V1** is surfaced. Vault V2 returns `0` from `maxDeposit`/`maxWithdraw` by design, which makes honest limit display impossible — and honest limits are load-bearing in this UI, not decoration.
+
+The write path (`frontend/src/lib/earn/vaultActions.js`) applies safety rails before any wallet prompt:
+
+- pure validators reject zero, over-balance, and over-cap amounts with member-facing reasons;
+- approvals are for the **exact amount** — no unlimited allowances;
+- spendable deposits are dry-run with `staticCall` from the member's address, so vault-side rejections (cap reached, paused) surface before anything is signed;
+- withdrawals are bounded by `maxWithdraw`, and full exits use `redeem(shares)` so share dust never strands.
+
+Writes are expressed as `{ target, data, value }` batches through the app's unified `sendCalls` rail: a passkey smart account authorizes the whole approve-plus-deposit batch with one WebAuthn ceremony via a UserOp; a classic wallet signs the legs sequentially. Custody never changes hands — the vault's `deposit` names the member as `receiver`, and shares sit in the member's own account.
+
+Notably, spec 050 shipped with **no platform fee at all**. Morpho has no referral or transaction-source fee parameter (nothing like Aave's referral code), so there was no way to monetize attribution natively — and rather than bolt on a rushed fee mechanism, FR-013 made fee-free operation an explicit, documented decision, with treasury revenue deferred to a future spec.
+
+## Layer two: the FeeRouter, and why the fee is a contract concern
+
+That future spec is `060-platform-fee-wrapper`, and its core decision is that a platform fee on someone else's protocol must be **atomic** — fee and deposit in one transaction, or neither. The naive alternative, two transfers ("send us the fee, then deposit the rest"), can strand a member mid-flow: fee paid, deposit failed, treasury holding money for a service that never happened.
+
+The `FeeRouter` (`contracts/fees/FeeRouter.sol`, a UUPS proxy) is the single on-chain source of truth for every configurable platform fee. Each fee is a `bytes32 serviceId = keccak256("<label>")` — Earn's is `earn.lend` — with a `Service { capBps, feeBps, kind }` entry. `Wrapped` services are charged by the router itself; `ConfigOnly` entries (the Polymarket builder rates) just store rates that off-chain enforcers read. Wrapped caps are fixed at registration and bounded by `MAX_WRAPPED_FEE_BPS = 250` (2.5%); `earn.lend` registers at that cap with a live rate of **zero** until a `FEE_ADMIN_ROLE` holder deliberately sets one.
+
+The member-facing entrypoint is the wrapper deposit:
+
+```solidity
+function depositToVaultWithFee(
+    bytes32 serviceId,
+    address vault,
+    uint256 assets,
+    address receiver,
+    uint16 maxFeeBps
+) external nonReentrant returns (uint256 shares) {
+    // ...service lookup and zero checks elided...
+    uint16 liveBps = svc.feeBps;
+    if (liveBps > svc.capBps) revert CapExceeded(); // defense in depth
+    if (liveBps > maxFeeBps) revert FeeAboveQuoted();
+    // ...fee math elided...
+    asset.safeTransferFrom(msg.sender, address(this), assets);
+    // ...fee transfer + FeeCharged event elided...
+    uint256 netAmount = assets - feeAmount;
+    asset.forceApprove(vault, netAmount);
+    shares = IERC4626(vault).deposit(netAmount, receiver);
+    if (shares == 0) revert ZeroShares();
+    asset.forceApprove(vault, 0);
+}
+```
+
+One call pulls the member's gross principal, sends `floor(assets · bps / 10 000)` to the treasury, and deposits the remainder into the ERC-4626 vault with the member as `receiver`. Any failing leg reverts everything — the treasury can never keep a fee for a deposit that did not happen. The router holds no balance outside a transaction.
+
+Three details in that function carry most of the design's weight:
+
+**`maxFeeBps` is a consent ceiling.** The frontend passes back the exact rate it displayed. If an admin raises `feeBps` while the member's transaction is in flight, the call reverts with `FeeAboveQuoted()` instead of charging the higher rate. A member can never pay more than the number they saw on the confirm screen — enforced by the contract, not by UI politeness.
+
+**A missing treasury skips the fee, never loses funds.** If `treasury` is `address(0)` on some network, the router deposits the full amount and emits `FeeSkippedNoTreasury`. An ops misconfiguration costs FairWins revenue; it never strands a member's principal.
+
+**Zero shares reverts.** The router pulled principal and possibly took a fee; if the vault would mint nothing in return, `ZeroShares()` unwinds the whole action rather than breaking the fee-for-value guarantee.
+
+The math floors in the member's favor — a fee that rounds to zero in the asset's smallest unit is charged as zero — and fee-on-transfer or rebasing tokens are explicitly unsupported, which is fine for the curated vault assets (plain ERC-20s like USDC).
+
+## The disclosure contract: three outcomes, no fourth
+
+The client half lives in `frontend/src/lib/fees/feeQuote.js`. Before the deposit sheet ever shows a confirm button, `fetchFeeQuote({ serviceId, chainId, provider })` reads the live rate from the router and resolves to exactly one of three states:
+
+1. **No router on this chain** (or the service isn't registered): `{ available: false, bps: 0 }`. The flow proceeds fee-free — and `buildDepositCalls` emits a batch **byte-identical** to the pre-fee behavior: approve the vault, `deposit(amount, account)`. No fee line appears, because implying a fee that isn't charged is as dishonest as hiding one that is.
+2. **Live rate obtained**: the `VaultSheet` (`frontend/src/components/earn/VaultSheet.jsx`) renders a named "FairWins platform fee" line — rate as a percent, absolute amount, and the net amount reaching the vault — with an info bubble, before any signature. The deposit reroutes through the router: approve the **router** for the gross amount, then `depositToVaultWithFee(earn.lend, vault, amount, account, quotedBps)`, pinning the transaction to the disclosed rate.
+3. **The read failed on a chain that has a router**: the quote throws, and the sheet **blocks deposits** with an honest "the platform fee rate could not be confirmed right now" message. Proceeding on a possibly understated rate is not an option; neither is silently assuming zero.
+
+There is deliberately no fourth state. The quote helper mirrors the contract's `quoteFee` math exactly — including the treasury-unset skip, so the UI never displays a fee the router would not actually charge.
+
+Every rate change is public history: `FeeBpsChanged(serviceId, oldBps, newBps, actor)` events are the audit log the AdminPanel Fees tab renders, and `FeeCharged` is the reconciliation record — its `feeAmount` equals the ERC-20 transfer to the treasury in the same transaction.
+
+## Design decisions
+
+**Entry-only fee, not a performance fee.** The router skims basis points of the principal at deposit time and touches nothing afterward. A performance or management fee would require FairWins to sit in the yield path — Morpho's documented "distributor revenue" pattern of a treasury-owned wrapper vault does exactly that, and was considered and deferred precisely because it is a new value-bearing contract that would custody member deposits. An entry fee keeps the router stateless between transactions and keeps positions purely member-owned.
+
+**One router, not per-integration fee logic.** The next wrapped integration (Lido, Polygon liquid staking, Uniswap) registers a `serviceId` — config, not code. Anything ERC-4626-shaped reuses `depositToVaultWithFee` as-is; differently shaped actions add a purpose-built entrypoint to the same router with the same cap re-check, consent ceiling, and event discipline. The alternative — each feature inventing its own fee store — is how platforms end up with rates hardcoded in three clients and no audit trail.
+
+**Caps are immovable.** A wrapped service's `capBps` is fixed at registration, bounded at 250 bps, and re-checked on the charge path (defense in depth against a corrupted rate). The emergency lever is `setFeeBps(id, 0)`, not cap surgery. Members and integrators get a hard, on-chain upper bound on what the fee can ever become.
+
+**Honest failure over graceful degradation.** Most of the fee system's complexity is in refusing to guess: a failed rate read blocks the action rather than defaulting to zero; an unregistered service is fee-free rather than fee-unknown; a missing treasury skips rather than reverts. The rule generalizing all of it: the member either sees the true number or the action doesn't happen.
+
+The honest limits of the design are worth naming too. The fee only wraps deposits — withdrawals go straight to the vault, so the router can't ransom an exit, but also can't meter one. And the yield itself remains entirely Morpho's: FairWins guarantees neither APY nor the third-party vault's smart-contract risk, and the Earn UI says so under a mandated "Powered by Morpho" attribution.
+
+## Sources
+
+- `specs/050-earn-lending-rewards/spec.md` — Earn section requirements, custody model, FR-013 fee decision
+- `specs/060-platform-fee-wrapper/spec.md` — fee wrapper requirements, caps, disclosure rules
+- `docs/developer-guide/earn-integration.md` — Earn architecture, vault curation, safety rails
+- `docs/developer-guide/platform-fees.md` — FeeRouter architecture, disclosure rules, service registration
+- `contracts/fees/FeeRouter.sol`, `contracts/fees/IFeeRouter.sol` — router implementation and interface
+- `frontend/src/lib/earn/vaultActions.js` — deposit/withdraw batch construction, fee routing
+- `frontend/src/lib/fees/feeQuote.js` — live-rate quoting and the three-outcome contract
+- `frontend/src/components/earn/VaultSheet.jsx` — fee-line disclosure and blocked-state UI
+- `scripts/deploy/lib/feeServices.js` — `earn.lend` registration (cap 250 bps, Wrapped)
+- ERC-4626 Tokenized Vaults: https://eips.ethereum.org/EIPS/eip-4626
+- OpenZeppelin ERC-4626 / SafeERC20 / UUPS docs: https://docs.openzeppelin.com/contracts
+- Morpho distributor revenue concepts: https://docs.morpho.org/build/earn/concepts/generate-revenue/

--- a/docs/blog/posts/23-earn-erc4626-vaults/social.md
+++ b/docs/blog/posts/23-earn-erc4626-vaults/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Earn Without Custody Surprises
+
+## X (Twitter)
+
+Idle USDC between wagers should earn — without custody and without a hidden skim. FairWins deposits straight into Morpho ERC-4626 vaults, and charges its platform fee atomically via a FeeRouter that reverts if the live rate ever exceeds the bps you saw at signing. 🔗 <link>
+
+#DeFi #ERC4626 #SmartContracts
+
+## LinkedIn
+
+Every consumer crypto "earn" feature faces two tempting shortcuts: take custody and become an asset manager, or route into someone else's protocol and quietly keep a slice of the yield. FairWins refused both.
+
+Our new Earn section (spec 050 + 060) deposits idle stablecoins directly from the member's account into curated Morpho ERC-4626 vaults — FairWins never holds funds — and monetizes it with a single honest fee. The post walks through both layers:
+
+- Non-custodial ERC-4626 integration: exact-amount approvals, staticCall dry-runs, `redeem` on full exits so share dust never strands.
+- The `FeeRouter`: one on-chain source of truth, each fee a `bytes32 serviceId` with an immovable hard cap (250 bps max on wrapped services).
+- Atomic charging: `depositToVaultWithFee` takes the fee and deposits the remainder in one transaction — any failing leg reverts everything.
+- Honest disclosure: `maxFeeBps` is a consent ceiling; a member can never pay more than the rate shown on the confirm screen, and a failed rate read blocks the deposit rather than guessing zero.
+
+The rule that generalizes all of it: the member either sees the true number, or the action doesn't happen.
+
+How does your team handle fee disclosure when integrating third-party DeFi protocols? 🔗 <link>
+
+#DeFi #ERC4626 #SmartContracts #Solidity #FinTech
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration, isometric perspective, of a single stablecoin token flowing along a transparent glass conduit into a stylized vault chamber, with one small precise slice diverting cleanly into a separate side channel — the two paths splitting from a single junction to convey an atomic, all-or-nothing transaction. Set against a deep navy and teal base, with a single warm amber accent lighting the diverted fee slice and the junction node. Soft volumetric lighting from the upper left, subtle depth-of-field, geometric precision, restrained and trustworthy fintech-engineering mood, ample negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/24-predict-polymarket-builder-codes/blog.md
+++ b/docs/blog/posts/24-predict-polymarket-builder-codes/blog.md
@@ -1,0 +1,118 @@
+# Predict: Monetizing Polymarket Order Flow Without Ever Touching an Order
+
+*How FairWins added prediction-market trading with zero contract changes, zero custody, and one honestly disclosed fee line*
+
+---
+
+| | |
+|---|---|
+| **Series** | Finance Surfaces (part 3) |
+| **Part** | 24 of 34 |
+| **Audience** | DeFi / trading integrators |
+| **Tags** | `polymarket`, `clob`, `trading`, `builder-codes`, `non-custodial` |
+| **Reading time** | ~8 minutes |
+
+---
+
+> **Important Note**: This article describes trading on prediction markets based on publicly available information and legitimate forecasting. Nothing here is a mechanism for trading on material non-public information or circumventing securities regulations. All participants remain fully subject to applicable laws, compliance requirements, and Polymarket's own regional restrictions, which FairWins surfaces and never bypasses.
+
+---
+
+## The 401 That Redesigned the Feature
+
+The first design for Predict looked like every other relayer pattern in the FairWins codebase: the member builds an order, the relay gateway holds one shared operator credential, and the gateway submits the order to Polymarket's central limit order book (CLOB) on the member's behalf. Clean, familiar, one secret to manage.
+
+It failed against the live API with a 401: `Invalid api key`.
+
+The reason is a deliberate property of Polymarket's CLOB V2: **every order is bound to its signer**. An API credential is registered under a specific wallet address, and the exchange rejects any order whose signer doesn't match the address that credential was derived for. A single shared key cannot submit trades for other people's wallets — which is exactly the property you want from a non-custodial exchange, and exactly the property that kills the "gateway submits for you" architecture.
+
+That rejection forced the design that shipped, and it turned out to be the better one: the member's own wallet is the only order signer, orders go from the browser straight to `clob.polymarket.com`, and FairWins earns revenue not by intermediating the trade but by *attributing* it — a `bytes32` builder code attached to every order via signed headers. This post walks through how that works, and why the resulting fee had to be disclosed differently from every other integration in the app.
+
+## What Predict Is (and Is Not)
+
+Predict (spec 057) is a frontend section plus a thin relay-gateway proxy, structured exactly like the Collect (OpenSea) feature that preceded it: **no smart-contract changes, no custody, nothing routed through `wagerRegistry`**. There is no FairWins contract in the trade path at all. The pieces:
+
+- **Browse** goes through the gateway proxy (`services/relay-gateway/src/polymarket/`), which fronts Polymarket's Gamma API for market discovery and the Data API for a wallet's positions — both public, read-only, cached, and rate-limited.
+- **Trading** is client-direct. The browser talks to the CLOB itself using credentials only the member holds.
+- **Revenue** is Polymarket's builder-code program: attributed volume earns a builder fee plus a share of the weekly USDC rewards pool.
+
+It is also **Polygon-only**, because Polymarket runs nowhere else. The capability is a one-line set in `frontend/src/config/networks.js`:
+
+```js
+// Predict (spec 057): Polymarket prediction-market trading is available ONLY on
+// Polygon (137) — Polymarket runs nowhere else. Everywhere else the capability
+// is false and the Predict tab hides entirely (FR-018 soft-fail).
+const PREDICT_CHAIN_IDS = new Set([137])
+```
+
+On any other chain the Predict tab doesn't render at all. No greyed-out button, no "coming soon" — the surface simply isn't there.
+
+## Per-User Credentials, Client-Direct Orders
+
+Since the CLOB binds orders to their signer, each member derives their own API credentials. `frontend/src/lib/predict/clobSession.js` wraps the official `@polymarket/clob-client`: `createOrDeriveApiKey()` is deterministic per wallet and costs one gasless L1 EIP-712 signature — a wallet prompt, no transaction. The resulting `{ key, secret, passphrase }` is cached in `sessionStorage` per address, so the member signs at most once per session, and the credentials are **never sent to a FairWins server**. The CLOB serves `Access-Control-Allow-Origin: *`, so the SPA calls it directly; the member's L2 credentials never transit the gateway.
+
+The order itself — the EIP-712 struct, amount rounding, salt, signature, submission — is owned entirely by the SDK. An early attempt to hand-roll the struct produced subtly wrong orders: the real CTF Exchange order is 12 fields under domain `"Polymarket CTF Exchange"` version `"1"`, and notably it contains **no builder field**. Attribution is not part of the signed order at all. It rides on request headers.
+
+## The Attribution Seam: Signing Headers Without Shipping Secrets
+
+FairWins' builder code is a public `bytes32` (`0x6e0316783960e149b53466f0f2c5fdbaf5ce11ba15669491de980f6dedc493a3`). Attribution works by attaching four `POLY_BUILDER_*` headers — key, passphrase, signature, timestamp — to each order submission, HMAC-signed with FairWins' registered builder credentials. Those credentials *are* a shared secret, so they live only in the gateway's environment (`POLYMARKET_API_KEY` / secret / passphrase — server-side configuration, never exposed to the browser).
+
+The bridge between "SDK in the browser" and "secret on the server" is a duck-typed remote signer in `clobSession.js`. The CLOB client only ever calls `isValid()` and `generateBuilderHeaders(method, path, body)`, so `makeBuilderConfig` returns a shim that forwards those three values to the gateway's `POST /v1/polymarket/:chainId/builder-sign` endpoint (`services/relay-gateway/src/polymarket/routes.js`). The gateway — Polygon-gated, origin-locked, killswitched, and write-quota'd like every other write route — computes the HMAC with `@polymarket/builder-signing-sdk` and returns the four headers, which the SDK stacks on top of the member's own L2 auth headers.
+
+Two properties matter here. First, the gateway signs *attribution headers only* — it never sees an order, a credential, or a position. Second, attribution is **best-effort**: if the gateway is down, unconfigured, or the fetch fails, the shim returns `undefined` and the SDK posts the order *unattributed* rather than blocking it. The never-stranded rule (FR-015) applies to revenue too — FairWins losing a fee is never a reason a member can't trade.
+
+## Fees, Honestly
+
+This is where Predict diverges from Collect, and the divergence is the most instructive part of the design. OpenSea's affiliate reward comes out of OpenSea's own fee — zero user cost — so Collect attributes silently. Polymarket's builder fee is **additive**: it stacks on top of Polymarket's own platform taker fee and is a real cost to the taker. The single source for that distinction is `services/relay-gateway/src/polymarket/builderCode.js`:
+
+```js
+/**
+ * KEY DIFFERENCE from the OpenSea `attachReferral` seam: OpenSea's referral
+ * reward comes out of OpenSea's own fee (no user cost), so that seam is a
+ * silent no-op. Polymarket's builder fee is ADDITIVE — it stacks on top of
+ * the platform taker fee and is a REAL cost to the taker — so the fee bps
+ * returned here feed a VISIBLE fee line in the client's cost breakdown.
+ */
+export function attachBuilderCode(config, { chainId, isMaker = false }) { /* … */ }
+```
+
+So the confirm UI treats the fee the way the platform's honest-disclosure doctrine demands: `computeCost` in `frontend/src/lib/predict/clobOrder.js` computes the notional and the builder fee in floored bigint math (no float drift) and emits `"FairWins builder fee"` as its own labelled line — never folded into a total, never described as free. Polymarket's *own* taker fee is a curve over price and size computed by their engine at execution; rather than fabricate a dollar estimate FairWins can't guarantee, the confirm UI discloses it as a separate note. The rule is "shown == charged" for the one fee FairWins controls, and honest uncertainty for the one it doesn't. Makers pay no builder fee at all.
+
+The rates are configuration, not code: default **50 bps taker / 0 maker**, hard-capped at Polymarket's program limits of 100/50. The cap is enforced at the gateway's boot, loudly:
+
+```js
+// services/relay-gateway/src/config/index.js
+const bps = int(env, 'POLYMARKET_BUILDER_TAKER_FEE_BPS', 50)
+if (bps > 100) throw new Error(
+  `[relay-gateway] POLYMARKET_BUILDER_TAKER_FEE_BPS=${bps} exceeds the 100 bps cap`)
+```
+
+A misconfigured fee doesn't silently clamp or quietly overcharge — the gateway refuses to start. For context, total taker cost lands around Polymarket's curved platform fee (~0.75%–1.8% by category) plus the 0.5% builder fee: comparable to Kalshi and mid-pack among third-party Polymarket builders (see `specs/057-predict-polymarket/research.md`, D2–D4).
+
+## The Region Gate
+
+Polymarket blocks order placement from restricted regions as a matter of its own policy. `frontend/src/lib/predict/geoblock.js` checks `polymarket.com/api/geoblock` before fee load and before submit. A blocked member gets an honest region notice and a "Trade on Polymarket ↗" link-out — FairWins never bypasses the block, and never renders a trade button that's going to fail. The same degrade-honestly pattern covers every failure mode: fees unconfirmable ⇒ signing is blocked rather than guessed; killswitch or outage ⇒ message plus a Polymarket link; passkey wallets ⇒ an honest "not available yet" (`PASSKEY_PREDICT_ENABLED = false` until ERC-1271 order binding is verified end-to-end).
+
+## Design Decisions
+
+**Attribution over intermediation.** The CLOB's signer binding made a submitting relayer impossible, but even without that constraint, header-based attribution is the better trade: FairWins earns on volume without holding credentials, orders, or funds — no custody, no broker posture, and the smallest possible secret surface (one builder credential set, used only for HMACs).
+
+**Client-direct trading, gateway reads.** Splitting the paths means the latency- and trust-sensitive leg (signed orders) has no FairWins hop, while the cacheable leg (market browse, positions) gets quotas and a killswitch. The gateway can die and members can still trade.
+
+**Fee as config with a boot-time cap.** Rates in environment config keep bps out of client code; the boot failure turns a fat-fingered `500` into an outage you notice in seconds instead of a fee incident you discover in a support ticket.
+
+**Disclose what you control, admit what you don't.** The additive builder fee gets an exact labelled line; Polymarket's execution-time fee gets an honest note instead of a made-up estimate. The alternative — one blended "total" — would be tidier and less truthful.
+
+The open trade-off is the deferred passkey path: EOA wallets trade today, smart-account signatures wait for verified ERC-1271 support, and the honest answer shipped ahead of the complete one.
+
+## Sources
+
+- `specs/057-predict-polymarket/` — spec, plan, and research (D2–D4 fee benchmarking, D9 builder seam)
+- `docs/developer-guide/predict-polymarket.md` — architecture and operations overview
+- `services/relay-gateway/src/polymarket/` — `builderCode.js`, `routes.js` (builder-sign endpoint), `client.js`, `normalize.js`
+- `services/relay-gateway/src/config/index.js` — fee caps and boot-time validation
+- `frontend/src/lib/predict/` — `clobSession.js`, `clobOrder.js`, `builderFee.js`, `geoblock.js`, `tradeSigner.js`
+- `frontend/src/config/networks.js` — `PREDICT_CHAIN_IDS` Polygon-only capability
+- Polymarket CLOB documentation — https://docs.polymarket.com/
+- `@polymarket/clob-client` — https://www.npmjs.com/package/@polymarket/clob-client
+- EIP-712: Typed structured data hashing and signing — https://eips.ethereum.org/EIPS/eip-712

--- a/docs/blog/posts/24-predict-polymarket-builder-codes/social.md
+++ b/docs/blog/posts/24-predict-polymarket-builder-codes/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Predict: Monetizing Polymarket Order Flow Without Ever Touching an Order
+
+## X (Twitter)
+
+A 401 redesigned our whole feature: Polymarket's CLOB binds every order to its signer, so a shared relayer can't submit for you. FairWins earns by *attributing* trades — a bytes32 builder code in signed headers — and discloses the additive builder fee as its own line, never "free." 🔗 <link>
+
+#PredictionMarkets #Polymarket #Web3
+
+## LinkedIn
+
+The first design for Predict — FairWins' prediction-market trading surface built on publicly available information and skill-based forecasting — looked like every relayer pattern we had: a shared gateway credential submits orders on the member's behalf. It failed against the live API with a 401.
+
+Polymarket's CLOB binds every order to its signer by design. That killed the intermediating-relayer architecture and forced a better one. The post covers:
+
+- Client-direct orders: the member's own wallet is the only order signer; credentials never touch a FairWins server.
+- Attribution over intermediation: a `bytes32` builder code rides on signed request headers, not in the order struct — FairWins earns on volume without holding orders, credentials, or funds.
+- Honest fee disclosure: unlike an OpenSea referral that costs the user nothing, Polymarket's builder fee is *additive* — a real taker cost — so it gets its own labelled "FairWins builder fee" line, never folded into a total.
+- Boot-time cap enforcement: rates are config (default 50 bps taker / 0 maker), hard-capped at the program limits; a misconfigured fee refuses to boot.
+
+Participants remain subject to applicable law and Polymarket's own regional restrictions, which the app surfaces and never bypasses.
+
+How do you decide which fees to itemize versus blend? 🔗 <link>
+
+#PredictionMarkets #Polymarket #Web3 #NonCustodial #FinTech
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean abstract-geometric editorial illustration of a signed order traveling directly from a stylized browser window to a distant exchange node along a single unbroken luminous line, while a small parallel tag — representing an attribution header — branches off to a side beacon without interrupting the main path. Convey non-custodial directness: no intermediary hub sits on the primary line. Deep navy and teal base with a single warm coral accent marking the attribution tag and beacon. Crisp vector-like forms, soft glow, subtle grid texture in the background, precise and trustworthy fintech-engineering mood, generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/25-bitcoin-non-evm/blog.md
+++ b/docs/blog/posts/25-bitcoin-non-evm/blog.md
@@ -1,0 +1,131 @@
+# Bitcoin in an EVM-Native App: Guarding Every Boundary
+
+*How FairWins added its first non-EVM chain — string network ids, seed-derived BIP84/86 keys, and fail-safe UTXO handling — without corrupting a codebase built on numeric chainIds*
+
+| | |
+|---|---|
+| **Series** | Finance Surfaces (part 4) |
+| **Part** | 25 of 34 |
+| **Audience** | Multi-chain and wallet engineers |
+| **Tags** | `bitcoin`, `non-evm`, `bip84`, `bip86`, `hd-wallets`, `multi-chain` |
+| **Reading time** | ~9 minutes |
+
+---
+
+## The Assumption Buried in Every File
+
+Imagine you maintain a mature EVM app. Every network is a numeric chainId: 137 is Polygon, 80002 is Amoy, 61 is Ethereum Classic. That number is a load-bearing key in dozens of places — `getContractAddressForChain(name, chainId)` resolves contract addresses, wagmi builds providers from it, the subgraph router selects endpoints by it, the testnet toggle flips between paired numbers. The assumption "a network is an integer with contracts on it" is not written down anywhere, because it never needed to be. It is simply everywhere.
+
+Then the roadmap says: add Bitcoin. Portfolio, send, receive — a real non-custodial wallet inside the existing passkey account.
+
+Bitcoin breaks every one of those silent assumptions at once. There is no chainId — [EIP-155](https://eips.ethereum.org/EIPS/eip-155) is an Ethereum construct. There are no contracts, so `getContractAddressForChain` is meaningless. There are no accounts or nonces — value lives in UTXOs, addresses are supposed to rotate rather than persist, and fees are priced in sat/vB against a transaction's virtual size, not gas. The tempting shortcut — assign Bitcoin a fake numeric id like `-1` or `99999` and let it flow through the existing plumbing — is exactly how multi-chain codebases rot: every consumer of chainId becomes a landmine that might receive a number that is not actually an EVM chain.
+
+FairWins spec 061 took the opposite approach: Bitcoin is *structurally* different, so it gets a *structurally* different type, and every place the two worlds touch gets an explicit guard. This post walks the four boundaries that made it work.
+
+## Boundary 1: A Parallel Registry, Not a New Row
+
+Bitcoin networks are string ids — `'bitcoin'` and `'bitcoin-testnet'` (testnet4) — in their own registry, `frontend/src/config/bitcoinNetworks.js`, deliberately parallel to and never merged into the numeric `NETWORKS` map:
+
+```js
+export const BITCOIN_NETWORKS = Object.freeze({
+  bitcoin: Object.freeze({
+    id: 'bitcoin',
+    kind: 'bitcoin',
+    isTestnet: false,
+    gatewaySegment: 'mainnet',
+    addressHrp: 'bc',   // bech32 HRP — drives wrong-network rejection
+    coinType: 0,        // BIP44 coin type (hardened)
+    capabilities: CAPABILITIES,
+  }),
+  // 'bitcoin-testnet' → testnet4, hrp 'tb', coinType 1
+})
+
+export function isBitcoinNetworkId(id) {
+  return typeof id === 'string' && Object.prototype.hasOwnProperty.call(BITCOIN_NETWORKS, id)
+}
+```
+
+`isBitcoinNetworkId()` is the boundary type guard. Any shared code path — portfolio aggregation, the network switcher, activity feeds — checks it before handing an id to anything typed on numeric chainIds. A string id must never reach `getContractAddressForChain`, wagmi provider construction, or subgraph routing; the guard makes the crossing impossible to do by accident rather than merely discouraged.
+
+Two details keep the parallel registry honest. First, `BITCOIN_TESTNET_MAINNET_PAIR` mirrors the existing EVM testnet/mainnet toggle semantics, so the app's single global toggle flips Bitcoin between testnet4 and mainnet in lockstep with 80002 ↔ 137 — the two environments never mix. Second, a frozen `capabilities` map (`wagers: false`, `pools: false`, `gasless: false`, `send: true`, …) is the single source of truth for what Bitcoin supports. Everything false hides its surface exactly like a disabled EVM capability. There are no wagers, pools, membership, or gasless transactions on Bitcoin, and the UI never implies otherwise.
+
+## Boundary 2: One Seed, Two Cryptographies
+
+FairWins passkey accounts (spec 041) hold a 32-byte, PRF-recoverable, memory-only master seed. Bitcoin keys derive from that same seed — no separate backup, no new recovery phrase — through a domain-separated subtree defined in `specs/061-bitcoin-transactions/contracts/key-derivation-btc.md`:
+
+```
+btcSeed     = HKDF-SHA256(ikm = masterSeed, salt = 32 zero bytes,
+                          info = "fairwins-btc-seed-v1", length = 64)
+root        = BIP32.fromMasterSeed(btcSeed)
+segwitAcct  = root.derive("m/84'/{coin}'/0'")   // BIP84 → P2WPKH bc1q…
+taprootAcct = root.derive("m/86'/{coin}'/0'")   // BIP86 → P2TR   bc1p…
+receive(i)  = acct/0/i                          // external chain only (v1)
+```
+
+The [HKDF](https://datatracker.ietf.org/doc/html/rfc5869) info string `"fairwins-btc-seed-v1"` is exclusive to this tree, so the Bitcoin subtree can never collide with the spec-041 key-encryption path or any future consumer of the master seed. Native segwit ([BIP-84](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki)) is the default; taproot ([BIP-86](https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki), key-path only, [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)-tweaked) is opt-in. Every constant in that block is marked **wallet-breaking**: funds live at the derived addresses, so changing the info string, paths, or coin-type mapping requires a versioned migration, never an edit.
+
+Two invariants shape everything downstream. *Memory-only:* `btcSeed`, the BIP32 root, account xprvs, and child private keys are never persisted, logged, serialized, or transmitted — `frontend/src/lib/bitcoin/derivation.js` derives transiently and callers drop references after signing. *xpub confinement:* even the account xpubs stay in the client; the relay gateway sees bare addresses (at most 50 per call) and signed raw transactions, nothing else. A server that never holds keys or extended public keys cannot leak the wallet or link its full address graph.
+
+There is also a "no wrong keys" rule: if the master seed is unavailable — a non-PRF authenticator, an injected or WalletConnect EVM wallet — the Bitcoin wallet reports an honest `unavailable` state with the reason. It never falls back to deriving from other material, because a fallback derivation would be a *different wallet* holding someone's funds hostage to an implementation detail.
+
+## Boundary 3: Rotation, Recovery, and Coins That Fail Safe
+
+EVM habits say "your address is your identity." Bitcoin practice says the opposite: `frontend/src/lib/bitcoin/wallet.js` issues a fresh receive address per request and never repeats one. The rotation cursor per (network, address type) only increases, and the persisted ledger is explicitly a cache, never the source of truth. On a new device, gap-limit-20 discovery — scan sequential addresses, stop after 20 consecutive unused ones, the convention descended from [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)/BIP-44 wallets — rebuilds the issued set and resumes the cursor after the highest used index. Recovery needs no Bitcoin-specific backup because the passkey seed plus deterministic derivation *is* the backup.
+
+Spending is where UTXO reality bites hardest. Bitcoin Stamps embed collectible data in specific UTXOs; spend one as ordinary money and the collectible is destroyed. FairWins classifies every coin before it can be selected:
+
+```js
+if ((u.confirmations ?? 0) < 1) {
+  classification = 'pending'
+} else if (!recognitionHealthy) {
+  // Fail safe: nothing is positively stamp-free while recognition is down.
+  classification = 'unverified'
+} else if (stampByOutpoint.has(key)) {
+  classification = 'protected'
+} else {
+  classification = 'spendable'
+}
+```
+
+The polarity is the point: a coin is spendable only when *positively verified* stamp-free. If the stamps indexer is degraded or unreachable, coins classify `unverified` and coin selection treats them exactly like `protected` — excluded from sends and from spendable balance, shown as protected value. Over-protection temporarily shrinks what a member can send; the alternative is irreversibly destroying an asset during an outage.
+
+## Boundary 4: Fees Are a Ceiling, Not an Estimate
+
+On the EVM side, FairWins runs two gasless rails. Bitcoin has neither — there is no relayer and no paymaster for BTC, and the confirm UI says plainly that the member pays the network fee. What the platform *can* guarantee is that the fee the member confirmed is the most they will ever pay.
+
+Fee quotes (sat/vB tiers) expire after 60 seconds; `frontend/src/lib/bitcoin/send.js` rejects a stale quote with `stale_fee_quote` before a plan is even built, so a fee spike between quote and confirmation can never silently reprice a send. The confirmed fee then becomes a hard ceiling enforced at the signing layer in `frontend/src/lib/bitcoin/psbt.js`:
+
+```js
+const feeSats = inSats - outSats
+if (feeSats < 0) throw new Error('psbt: outputs exceed inputs')
+if (feeSats > maxFeeSats) throw new FeeOverrunError(feeSats, maxFeeSats)
+```
+
+`buildAndSignTx` computes the actual fee from inputs minus outputs *before* signing and refuses to produce a signature above `maxFeeSats` — the same shape as the EVM-side `maxFeeBps` rule from the FeeRouter work: the quote shown at confirmation is a binding maximum, not a talking point. Sub-dust change folds into the fee rather than creating an unspendable output, and sends are RBF-signaled per [BIP-125](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) so a stuck transaction has an escape hatch.
+
+The server side, `services/relay-gateway/src/bitcoin/routes.js`, is a deliberately dumb proxy: killswitch check, enable check, parameter validation, per-IP quotas, TTL cache, then Esplora upstream. It never touches intents, funds, or keys. And the whole module is optional — with `BTC_ENABLED=false` or the killswitch active, every Bitcoin surface in the frontend hides or degrades honestly rather than pretending. A total gateway outage leaves every EVM value path untouched.
+
+## Design Decisions
+
+**String ids over a fake chainId.** A synthetic numeric id would have been one line of code and an unbounded audit surface — every chainId consumer forever suspect. Distinct types plus `isBitcoinNetworkId` guards cost more upfront and make the wrong crossing a type error instead of a runtime surprise.
+
+**One seed, domain-separated.** Deriving from the passkey master seed means no second recovery ceremony, at the price of hard coupling: Bitcoin availability requires a PRF-capable passkey. The availability matrix in the derivation contract makes that an honest, explained limitation rather than a silent failure.
+
+**Cache-as-ledger.** Treating persisted state as a rebuildable cache (gap-limit discovery, never-decreasing cursor) trades extra lookups on unlock for a wallet that survives device loss with zero Bitcoin-specific backup.
+
+**Fail-safe over available.** Both the stamps classifier and the fee ceiling prefer refusing to act over acting on unverified data. A blocked send is recoverable; a destroyed Stamp or an unexpectedly expensive transaction is not.
+
+**Scope discipline.** Portfolio, send, receive — nothing else. No wagers, no gasless, no contracts on Bitcoin. The capabilities map turns that scope into enforced configuration instead of tribal knowledge.
+
+## Sources
+
+- `specs/061-bitcoin-transactions/` — spec.md, plan.md, `contracts/key-derivation-btc.md`
+- `docs/developer-guide/bitcoin.md`, `docs/runbooks/bitcoin-operations.md`
+- `frontend/src/config/bitcoinNetworks.js`
+- `frontend/src/lib/bitcoin/` — `derivation.js`, `wallet.js`, `send.js`, `psbt.js`
+- `services/relay-gateway/src/bitcoin/routes.js`
+- [BIP-32: Hierarchical Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
+- [BIP-84: Derivation scheme for P2WPKH](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki)
+- [BIP-86: Key derivation for single-key P2TR outputs](https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki)
+- [BIP-341: Taproot](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) · [BIP-125: Opt-in RBF](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki)
+- [RFC 5869: HKDF](https://datatracker.ietf.org/doc/html/rfc5869) · [EIP-155: Chain ID](https://eips.ethereum.org/EIPS/eip-155)

--- a/docs/blog/posts/25-bitcoin-non-evm/social.md
+++ b/docs/blog/posts/25-bitcoin-non-evm/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Bitcoin in an EVM-Native App: Guarding Every Boundary
+
+## X (Twitter)
+
+Adding Bitcoin to an EVM app: the tempting shortcut is a fake numeric chainId. FairWins gave it string ids + an `isBitcoinNetworkId` guard so a wrong crossing is a type error, not a runtime landmine. BTC sends are never gasless — the member pays the network fee, quoted as a hard ceiling. 🔗 <link>
+
+#Bitcoin #Web3 #MultiChain
+
+## LinkedIn
+
+In a mature EVM codebase, "a network is a numeric chainId with contracts on it" is an assumption baked into dozens of files — and never written down, because it never had to be. Then the roadmap says: add Bitcoin.
+
+Bitcoin breaks all of it at once — no chainId, no contracts, no accounts, value in UTXOs, fees in sat/vB. The post walks the four boundaries that made it work:
+
+- Parallel registry: Bitcoin gets string ids (`'bitcoin'`, `'bitcoin-testnet'`) with an `isBitcoinNetworkId` guard, so a string id can never reach EVM-typed plumbing by accident.
+- One seed, two cryptographies: BIP84/BIP86 keys derive from the same passkey master seed via a domain-separated HKDF subtree — no second recovery phrase, keys and xpubs never leave the client.
+- Fail-safe UTXO handling: a coin is spendable only when positively verified stamp-free; if the stamps indexer degrades, coins are protected, never destroyed.
+- Fees as a ceiling: quotes expire in 60s and the confirmed fee is a hard signing limit. BTC sends are never gasless — the confirm UI says plainly the member pays the network fee.
+
+The theme throughout: fail safe over available, and make the wrong crossing impossible rather than merely discouraged.
+
+How do you keep non-EVM chains from corrupting EVM-shaped abstractions? 🔗 <link>
+
+#Bitcoin #Web3 #MultiChain #HDWallets #FinTech
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean isometric editorial illustration of two distinct architectural districts separated by a clearly defined boundary line: on one side an orderly grid of numbered EVM blocks, on the other a district of rotating, non-repeating UTXO tiles. A single guarded gateway sits precisely on the seam between them, allowing only a narrow, deliberate passage. Deep navy and teal base for both districts, with a single warm amber accent illuminating the guarded gateway on the boundary. Soft directional lighting, geometric precision, subtle depth, a calm and disciplined engineering mood, generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/26-clearpath-dao-registry/blog.md
+++ b/docs/blog/posts/26-clearpath-dao-registry/blog.md
@@ -1,0 +1,247 @@
+# ClearPath: A Registry That Owns Nothing
+
+*How FairWins references external DAOs as first-class, multi-network citizens without taking custody, keys, or authority*
+
+| | |
+|---|---|
+| **Series** | Multi-chain Infra (part 1) |
+| **Audience** | DAO tooling and infrastructure engineers |
+| **Tags** | `dao`, `registry`, `multi-chain`, `interoperability` |
+| **Reading time** | ~9 minutes |
+
+---
+
+## The problem: someone else's DAO, your dashboard
+
+A FairWins member holds a governance position in ENS on Ethereum mainnet, a Uniswap
+delegation on the same chain, and membership in Olympia — an OpenZeppelin Governor DAO
+living on Ethereum Classic. Three DAOs, two frameworks, two networks, and no single
+place to see them together, let alone vote from.
+
+The instinct of most "DAO aggregators" is to become a middleman: deploy a proxy, ask
+members to delegate to it, route votes through a contract you control. That instinct is
+exactly wrong for a platform whose entire product is non-custodial escrow. The moment a
+registry can act *on behalf of* a DAO it references, it becomes a liability — a new
+attack surface, a new trust assumption, a new thing an auditor has to reason about.
+
+ClearPath (specs `030-clearpath-standard-daos` and `042-clearpath-multi-network`) takes
+the opposite position. It treats an external DAO the way a phone book treats a business:
+it records that the DAO exists, who noticed it, and what kind of governance it runs — and
+nothing else. Every action a member takes is signed by that member, against the DAO's own
+contract, gated by the DAO's own rules. The registry is metadata for shared discovery. It
+holds no authority, no keys, and no funds.
+
+This post walks the on-chain registry first, then the multi-network layer that was
+grafted on top of it without touching a single line of Solidity.
+
+## The data model: five fields and a code probe
+
+The on-chain piece is `contracts/clearpath/ExternalDAORegistry.sol`, a UUPS-upgradeable
+contract that inherits the shared `contracts/upgradeable/UUPSManaged.sol` wiring. Its
+entire state is an append-only entry table:
+
+```solidity
+struct Entry {
+    address dao;
+    Framework framework;
+    address registrant;
+    uint64  registeredAt;
+    string  label;
+}
+
+IMembershipManager public membershipManager;
+uint256 public externalCount;
+mapping(uint256 => Entry) private _entries;
+mapping(address => uint256) private _idByDao; // 0 = not registered (ids start at 1)
+mapping(address => uint256[]) private _byRegistrant;
+
+uint256[45] private __gap;
+```
+
+Ids start at 1 so that a zero from `_idByDao` unambiguously means "not registered." The
+trailing `__gap` reserves storage slots for future fields, and the layout is registered in
+`npm run check:storage-layout`, which gates CI — the same discipline every upgradeable
+FairWins contract follows, so an implementation swap can never silently reorder state.
+
+`Framework` is an enum, and today it holds exactly one value:
+
+```solidity
+enum Framework {
+    OZGovernor // 0 — OpenZeppelin Governor (Olympia + any IGovernor DAO)
+}
+```
+
+That single value is deliberate. The registry commits on-chain only to what it can
+actually validate on-chain, and leaves the enum extensible (Aragon, Moloch, Safe named as
+later candidates in the interface comments).
+
+## Validating that an address is really a DAO
+
+Anyone can pass an arbitrary address to a registration call. The registry's job is to
+reject EOAs and random contracts before they pollute shared discovery. It does this with a
+two-tier probe in `_isGovernor`:
+
+```solidity
+function _isGovernor(address dao) internal view returns (bool) {
+    if (dao.code.length == 0) return false; // EOA
+    try IERC165(dao).supportsInterface(type(IGovernor).interfaceId) returns (bool ok) {
+        if (ok) return true;
+    } catch {}
+    // Defensive fallback: a real Governor answers these views; a random contract reverts.
+    try IGovernor(dao).COUNTING_MODE() returns (string memory mode) {
+        if (bytes(mode).length == 0) return false;
+        try IGovernor(dao).votingPeriod() returns (uint256) {
+            return true;
+        } catch {
+            return false;
+        }
+    } catch {
+        return false;
+    }
+}
+```
+
+The primary path is the clean one: [ERC-165](https://eips.ethereum.org/EIPS/eip-165)
+`supportsInterface` against the `IGovernor` interface id. But not every governor implements
+ERC-165 correctly — many older Governor deployments don't — so the fallback probes two
+`IGovernor` views that a real governor answers and a random contract reverts on:
+`COUNTING_MODE()` (with a non-empty-string sanity check) and `votingPeriod()`. Every call
+is wrapped in `try/catch`, so a probe against a hostile contract that reverts, or one that
+returns garbage, degrades to `false` rather than propagating.
+
+Note what the contract imports: `IGovernor` from OpenZeppelin, the *interface only* — never
+the `Governor` implementation. That keeps the registry free of the Cancun `mcopy` opcode
+that OpenZeppelin 5.4.0's `GovernorUpgradeable` pulls in transitively, which is precisely
+why the registry compiles and deploys on pre-Cancun Ethereum Classic / Mordor where a full
+native Governor cannot. Today the registry is deployed only on Mordor (chain 63); its proxy
+and implementation are recorded in `deployments/mordor-chain63-v2.json` as
+`externalDAORegistry` / `externalDAORegistryImpl`.
+
+## Registration is metadata, not power
+
+The public entrypoint is small, and its comments are load-bearing:
+
+```solidity
+function registerExternalDAO(address dao, Framework framework, string calldata label)
+    external
+    returns (uint256 id)
+{
+    if (dao == address(0)) revert ZeroAddress();
+    if (_idByDao[dao] != 0) revert AlreadyRegistered();
+    if (
+        uint8(membershipManager.getActiveTier(msg.sender, DAO_MEMBER_ROLE)) <
+        uint8(IMembershipManager.Tier.Silver)
+    ) revert InsufficientMembershipTier();
+    if (!_isGovernor(dao)) revert NotAGovernor(dao);
+    // ... assign id, store Entry, emit ExternalDAORegistered
+}
+```
+
+Registration is gated by a MembershipManager tier of **Silver or above** — a light spam
+control. But look at what it deliberately does *not* do. There is no sanctions screen and
+no `recordCreate` quota consumption, because registration is read-only metadata: it moves
+no value and confers no power. Screening a signer and burning a creation quota are for
+value-moving actions; recording that a public governance contract exists is neither.
+
+This is invariant **INV-4** from the spec's data model — *no external authority*: the
+registry confers ClearPath no role, key, or call-authority over a registered DAO. The
+`registrant` field records who noticed the DAO, not who owns it. Every governance action a
+member later takes — vote, queue, execute, propose — is constructed as a user-signed
+transaction against the DAO's own contract and authorized by the DAO's own rules. The
+registry is never in the loop. INV-5 pins the other axis: registries are per-network, and
+cross-network registration is rejected — a DAO tracked on one chain never leaks into
+another's scope.
+
+## Layering multi-network on top — without a contract change
+
+Spec 030 shipped the registry but wired ClearPath's *availability* to it: the whole module
+self-disabled anywhere `ExternalDAORegistry` wasn't deployed, which meant everywhere except
+Mordor. That was wrong, because the reads are pure client-side RPC — the gate was
+unnecessary. Spec 042 removed it, and the striking thing is that it did so as a
+**frontend-only** change. There is no new or changed on-chain contract; the registry stays
+deployed only where it already is.
+
+The multi-network layer rests on three moves, all in config and client code:
+
+**1. An open network model.** Networks are declared in
+`frontend/src/config/networks.js`, and each network's `capabilities` getter gained a
+`clearpath` flag. A ClearPath-only network — Ethereum mainnet is the first — sets
+`clearpath: true` while `dex`, `passkeyAccounts`, `polymarketSidebets`, and `friendMarkets`
+are all false and it carries no wager deployment. So mainnet can host governance without the
+app ever implying that wagers or swaps run there; each other feature self-discloses as
+unavailable. Adding a network is pure config: an entry with an RPC URL, USDC address, and
+`clearpath: true`.
+
+**2. Registry-optional tracking, aggregated across every network.** Availability is now
+capability-driven, not registry-gated: `useClearPath().isSupported = capabilities.clearpath
+&& !!reader`. The on-chain registry becomes an *optional shared-discovery overlay* used
+where deployed. On a registry-less network, a member tracks a DAO by address into a
+device-local store (`trackedDaoStore.js`, `localStorage` keyed by `chainId + wallet`).
+`listExternalDAOs()` then scans every `clearpath`-capable chain in parallel via
+`Promise.allSettled`, so an unreachable RPC on one chain degrades that chain honestly
+without blanking the others. For each chain it merges three sources, de-duplicated and
+strictly scoped to that one chain:
+
+```
+on-chain registry entries  (iff a registry is deployed on THAT chain)
++ device-local tracked DAOs (per chainId + wallet, on THAT chain)
++ curated known DAOs        (config/clearpath/knownDaos.js, on THAT chain)
+```
+
+Every row carries its own `chainId`. Tracking needs no transaction and no network switch;
+only a *write* — registering on a registry network, or voting/queueing/executing/proposing
+against a DAO — requires being on that DAO's chain, and those surfaces render a "Switch to
+X" button (via wagmi's `useSwitchChain`) when the connected chain differs.
+
+**3. Pluggable per-framework connectors.** ClearPath reads any OpenZeppelin `IGovernor`
+DAO generically, but Uniswap governance is GovernorBravo/Compound-style — a different
+interface. So the single connector became a connector layer in
+`frontend/src/components/clearpath/connectors/`: `ozGovernor.js` (framework 0) and
+`governorBravo.js` (framework 1, with id-based `queue`/`execute` and `getPriorVotes` voting
+power). `detectFramework(reader, address)` probes OZ via `COUNTING_MODE`, then Bravo via
+`proposalCount` + `quorumVotes`, else `'unknown'`. Adding a framework — Aragon, Morpho — is
+a new module plus one entry in an ordered resolver; the UI, data router, and notifications
+don't change.
+
+Reads resolve subgraph-first (`daoDataSource.js`): a governance subgraph when one is
+configured for `(chainId, dao)` and a gateway key is present, otherwise the connector's
+bounded, chunked on-chain live indexer, otherwise a truthful empty/partial/error state —
+never fabricated data.
+
+## Design decisions
+
+- **Interface over implementation.** Importing only `IGovernor` — not `Governor` — is what
+  lets one registry serve Olympia on pre-Cancun ETC and ENS on mainnet from the same
+  bytecode. It also means the registry never has to know how a governor tallies votes; it
+  only proves the address answers governor-shaped questions.
+
+- **Validate on-chain, extend off-chain.** The Solidity `Framework` enum stays minimal
+  (`OZGovernor` only) because that is all the contract can validate. GovernorBravo support
+  lives in the frontend ABI mirror and connector layer, where framework detection is a
+  client-side probe. The chain commits only to what it can check.
+
+- **Registry-optional, not registry-required.** Making the on-chain registry a shared
+  overlay rather than an on/off switch is what unlocked mainnet with zero deploy. The
+  trade-off is honest: device-local tracking has no cross-device sync in this cut, and a
+  member's tracked list lives in their browser. Shared discovery — the registry's real
+  value — remains available wherever the contract is deployed, and any member can promote a
+  locally-tracked DAO onto a registry network.
+
+- **Degrade honestly.** `Promise.allSettled` across chains, `try/catch` around every probe,
+  and explicit empty/partial/error states are the same doctrine throughout FairWins: a
+  feature that can't reach data says so, rather than showing a plausible lie. A wrong
+  subgraph id is treated as worse than none, since the router simply falls back to the live
+  scan either way.
+
+## Sources
+
+- `contracts/clearpath/ExternalDAORegistry.sol` — the on-chain registry
+- `contracts/clearpath/interfaces/IExternalDAORegistry.sol` — public interface, events, errors
+- `specs/030-clearpath-standard-daos/spec.md`, `.../data-model.md` — pillars, invariants INV-1…INV-5
+- `specs/042-clearpath-multi-network/spec.md`, `.../data-model.md` — network-agnostic layer, connectors
+- `docs/developer-guide/clearpath-multi-network.md` — the three pillars, data sourcing, scoping
+- `deployments/mordor-chain63-v2.json` — recorded `externalDAORegistry` / `externalDAORegistryImpl`
+- `contracts/upgradeable/UUPSManaged.sol` — shared UUPS proxy/auth base
+- [ERC-165: Standard Interface Detection](https://eips.ethereum.org/EIPS/eip-165)
+- [OpenZeppelin Governance (`IGovernor`)](https://docs.openzeppelin.com/contracts/5.x/api/governance)
+- [Compound GovernorBravo](https://docs.compound.finance/v2/governance/)

--- a/docs/blog/posts/26-clearpath-dao-registry/social.md
+++ b/docs/blog/posts/26-clearpath-dao-registry/social.md
@@ -1,0 +1,51 @@
+# Social & Image — ClearPath: A Registry That Owns Nothing
+
+## X (Twitter)
+
+Most "DAO aggregators" make you delegate to a contract they control. ClearPath's
+ExternalDAORegistry owns nothing: an ERC-165 `IGovernor` probe records that a DAO exists —
+no key, no role, no authority. Every vote stays member-signed. 🔗 <link>
+
+#DAO #web3 #interoperability
+
+## LinkedIn
+
+The moment a DAO registry can act *on behalf of* the DAOs it references, it becomes a
+liability — a new key to steal, a new trust assumption, a new thing an auditor has to
+reason about. For a non-custodial platform, that's the wrong default.
+
+ClearPath (FairWins specs 030 + 042) takes the opposite position: a registry that owns
+nothing. The new post walks the design:
+
+- The on-chain `ExternalDAORegistry` — five fields per entry, ids starting at 1, an
+  append-only storage layout gated in CI, and an ERC-165 + defensive-view probe that
+  proves an address is really a Governor before recording it.
+- Why it imports OpenZeppelin's `IGovernor` interface only (never the implementation) — the
+  trick that lets one registry serve DAOs on pre-Cancun Ethereum Classic and Ethereum
+  mainnet from the same bytecode.
+- Invariant INV-4: registration is metadata, not power. No sanctions screen, no quota, no
+  authority. Every governance action stays member-signed against the DAO's own contract.
+- How multi-network support was layered on as a frontend-only change — registry-optional
+  tracking, per-chain aggregation via `Promise.allSettled`, and pluggable per-framework
+  connectors (OZ Governor + GovernorBravo) — with zero new contract deploys.
+
+How do you draw the line between a useful DAO registry and an over-privileged one?
+
+🔗 <link>
+
+#DAO #SmartContracts #web3 #Ethereum #Interoperability
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean, modern editorial illustration in an isometric style depicting a central,
+transparent glass card-catalog or index cabinet floating in space, its drawers open to
+reveal glowing address labels — but the cabinet is visibly hollow, holding no keys, coins,
+or locks, only reference cards. Around it, several distinct governance "buildings" on
+separate floating platforms (each platform a different network) connect to the cabinet with
+thin, one-directional light beams that point *from* the buildings *to* the index — signaling
+the registry reads and references but never controls. Each building has a subtle geometric
+signature marking a different DAO framework. Composition centered and balanced, generous
+negative space, subtle depth-of-field. Color mood: deep navy and teal base with a single
+warm amber accent on the active reference beams and drawer labels. Soft, directional studio
+lighting with gentle rim light on the glass edges. No text, no logos, no watermarks. Aspect
+ratio 16:9.

--- a/docs/blog/posts/27-indexing-without-subgraph/blog.md
+++ b/docs/blog/posts/27-indexing-without-subgraph/blog.md
@@ -1,0 +1,251 @@
+# Indexing Without a Subgraph
+
+*Keeping every read path working on a chain The Graph has never heard of*
+
+| | |
+| --- | --- |
+| **Series** | Multi-chain Infra (part 2) |
+| **Part** | 2 |
+| **Audience** | Data and infrastructure engineers |
+| **Tags** | `the-graph`, `subgraph`, `indexing`, `rpc`, `graceful-degradation` |
+| **Reading time** | ~8 minutes |
+
+## The chain with no indexer
+
+We were deploying FairWins to Ethereum Classic — specifically the Mordor
+testnet, chain 63 — as a step toward broadening past Polygon. The contracts
+compiled, deployed, and verified. A member could create a wager, an opponent
+could accept it, and USDC moved exactly as it did on Polygon. Then someone
+opened the "My Wagers" list and it was empty. Not an error. Just empty, on an
+account that had three live wagers on-chain.
+
+The cause was not in our code. It was that The Graph's hosted and decentralized
+networks do not index Ethereum Classic. There is no provider you can deploy a
+subgraph to for chain 63. We could — and do — keep a subgraph manifest with
+Mordor's addresses and start blocks in `subgraph/networks.json`, but a manifest
+is not an endpoint. Without a running indexer, `SubgraphSource` had nothing to
+POST a GraphQL query to, so the list came back empty.
+
+This is the recurring shape of a multi-chain app: the indexing layer you lean on
+for one network simply does not exist on the next one. You can treat that as a
+hard dependency and let features break on unsupported chains, or you can treat
+the indexer as one of several interchangeable data sources and degrade to a
+slower path that always works. FairWins takes the second route. The rule we
+settled on: **every read path has an RPC-only fallback, and whether a chain uses
+the fast path is per-network metadata, not a global flag.**
+
+## "Does this chain have an indexer?" is per-chain data
+
+The decision is encoded directly on each network. In
+`frontend/src/config/networks.js` every entry declares a `subgraphUrl`, and two
+helpers read it:
+
+```js
+export function getSubgraphUrl(chainId) {
+  const net = getNetwork(chainId)
+  return net?.subgraphUrl || null
+}
+export function hasSubgraph(chainId) {
+  return Boolean(getSubgraphUrl(chainId))
+}
+```
+
+Polygon (137) and Amoy (80002) carry a Studio endpoint; Mordor (63) and local
+Hardhat (1337) carry `null`. Resolution is strictly per-chain, which matters for
+correctness as much as for coverage: a Polygon endpoint is never queried while
+the wallet is connected to Mordor, so a testnet session can never surface
+mainnet wagers. Adding another un-indexed network later is a config change —
+set `subgraphUrl: null` and record the contract addresses — not a code change.
+
+## One boundary, two sources
+
+The UI never talks to a data source directly. It goes through
+`frontend/src/data/wagers/WagerRepository.js`, a thin boundary bound to a chain
+id that picks a source for that chain:
+
+```js
+function resolveSourceKey(explicit, chainId) {
+  if (explicit && SOURCE_REGISTRY[explicit]) return explicit
+  const envSource = import.meta.env?.VITE_WAGER_SOURCE
+  if (envSource && SOURCE_REGISTRY[envSource]) return envSource
+  if (chainId != null) return hasSubgraph(chainId) ? 'subgraph' : 'registry'
+  return 'subgraph'
+}
+```
+
+Two live sources implement the same `WagerSource` interface —
+`listPage`, `getById`, `syncIndex` — and both emit the identical mapped `Wager`
+shape, so the list, detail, and report views are agnostic to which one produced
+a page:
+
+- **`SubgraphSource`** — GraphQL against the chain's `subgraphUrl`. Used when
+  `hasSubgraph(chainId)` is true.
+- **`RegistrySource`** — direct RPC reads of the v2 `WagerRegistry`. The default
+  for any chain without a subgraph.
+
+(A third, `EventsSource`, reads the retired `FriendGroupMarketFactory` and is no
+longer in the automatic path; it survives only behind an explicit
+`VITE_WAGER_SOURCE=events` override.)
+
+## Why RPC reads are usually painful — and how the registry avoids it
+
+The naive way to reconstruct a user's wagers over RPC is to scan event logs:
+`eth_getLogs` for `WagerCreated` filtered by the user, from the deployment block
+to head. This is exactly what breaks on public RPC nodes. Free endpoints for
+Amoy and Mordor reject wide block ranges — "query returned more than N results,"
+"block range too large" — so a from-genesis scan turns into a flood of
+range-limited requests and rate-limit errors. It is the same problem that a
+subgraph exists to solve.
+
+`RegistrySource` sidesteps log scanning entirely because the v2 `WagerRegistry`
+was built with a per-user index on-chain. The contract exposes purpose-built
+pagination views (`contracts/wagers/WagerRegistry.sol`):
+
+```solidity
+function getUserWagerCount(address user) external view returns (uint256);
+function getUserWagerIds(address user, uint256 offset, uint256 limit)
+    external view returns (uint256[] memory);
+function getUserWagers(address user, uint256 offset, uint256 limit)
+    external view returns (Wager[] memory);
+function getWager(uint256 wagerId) external view returns (Wager memory);
+```
+
+These are plain `view` calls — `eth_call`, not `eth_getLogs` — so no node
+rejects them for range. `RegistrySource` reads the count, then pages through the
+structs in fixed windows, capping the total pulled per account so a pathological
+user can't stall the UI:
+
+```js
+async function fetchAllForUser(contract, userAddress) {
+  const total = Number(await contract.getUserWagerCount(userAddress))
+  if (!total) return []
+  const count = Math.min(total, MAX_USER_WAGERS) // 500
+  const wagers = []
+  for (let offset = 0; offset < count; offset += PAGE) { // PAGE = 100
+    const limit = Math.min(PAGE, count - offset)
+    const [ids, structs] = await Promise.all([
+      contract.getUserWagerIds(userAddress, offset, limit),
+      contract.getUserWagers(userAddress, offset, limit),
+    ])
+    for (let i = 0; i < ids.length; i++) wagers.push(toWager(String(ids[i]), structs[i]))
+  }
+  return wagers
+}
+```
+
+Sort, filter, and pagination then happen client-side over this bounded set. One
+detail the RPC path actually improves on: v2 stores explicit `acceptDeadline`
+and `resolveDeadline` on-chain, which the subgraph's events do not carry, so
+`RegistrySource` populates deadlines directly instead of rehydrating them later.
+
+## Fallback is automatic, not just configured
+
+Missing configuration is only one way a subgraph becomes unavailable. The other
+is a configured endpoint that errors or goes down. `SubgraphSource` handles both
+by delegating to `RegistrySource` — and it labels the result so the difference
+is observable in telemetry rather than silent:
+
+```js
+try {
+  const data = await postGraphQL(subgraphUrl, PAGE_QUERY, variables)
+  // ... map rows, return { ..., source: 'subgraph' }
+} catch (err) {
+  console.warn('[SubgraphSource] falling back to RegistrySource (RPC):', err?.message)
+  const fallback = await RegistrySource.listPage({ userAddress, cursor, pageSize, sortKey, filter, chainId })
+  return { ...fallback, source: 'subgraph-fallback' }
+}
+```
+
+So a Mordor user hits `RegistrySource` because the chain has no `subgraphUrl`; a
+Polygon user whose indexer is briefly unreachable transparently falls to
+`subgraph-fallback` over RPC and still sees their wagers. The feature never
+hard-fails on a data-source outage.
+
+## The harder case: reports that need data the RPC can't cheaply give
+
+Not everything degrades this cleanly. The tax/activity report
+(`frontend/src/data/reports/reportDataSource.js`) needs per-transfer transaction
+hashes and gas fees — data the pagination views don't return. On indexed chains
+this is one query: spec 017 added an immutable `WagerTransfer` entity carrying
+txHash, party, direction, token, amount, and timestamp, so `listTransfers` reads
+a user's whole history from the index with no log scan at all.
+
+On an un-indexed chain that path returns `null` and the report falls back to two
+steps. First it *enumerates* the user's wagers over RPC through the same
+`WagerRepository` (so enumeration always works). Then, because it still needs the
+txHash and gas per value movement, it does a **bounded** event scan per wager —
+but never from genesis. Each wager's `createdAt` gives a tight block window, and
+the scan uses adaptive chunking with a hard request budget:
+
+```js
+if (budget.used >= budget.max) { // SCAN_BUDGET = 60 calls per wager
+  throw new Error(
+    'This report period is too large to read from the network without the ' +
+    'indexing subgraph. Try a shorter period, or configure VITE_SUBGRAPH_URL...')
+}
+// on a range/limit error, shrink the chunk and retry; grow it back on success
+if (/range|limit|exceed|too many|big/i.test(msg) && chunk > MIN_CHUNK) {
+  chunk = Math.max(MIN_CHUNK, Math.floor(chunk / 4)); continue
+}
+```
+
+This is degradation that stays honest about its limits: the report works on
+Mordor, but when a requested window genuinely can't be scanned within budget it
+says so and suggests a shorter period, rather than silently returning a partial
+history that a member might file taxes against.
+
+## Degrade honestly, or hide honestly
+
+Some views can't be reconstructed over RPC at a reasonable cost, and the right
+answer there is to tell the truth rather than fake it. The token holders and
+activity panels are aggregate rollups that only a subgraph produces; on Mordor,
+`tokenSubgraph.js` returns `{ available: false }` and `HoldersPanel` /
+`ActivityPanel` render a plain "unavailable on this network" message
+(`docs/developer-guide/token-mint.md`). The underlying balances and events are
+still enforced on-chain — only the aggregated view is absent — so nothing about
+the guarantee changes, only the convenience layer.
+
+Membership and role reads never had this problem: `hasRoleOnChain` and the Quick
+Start banner have always read `MembershipManager` over RPC and are chain-aware,
+so they work identically on indexed and un-indexed networks.
+
+## Design decisions
+
+- **Per-chain source selection over a global switch.** Treating "has an indexer"
+  as network metadata means the same code serves Polygon, Amoy, Mordor, and
+  Hardhat, and a fifth network is a config entry. A global flag would have forced
+  a branch at every call site.
+- **A stable repository boundary.** Because the UI only knows `WagerRepository`
+  and a mapped `Wager` shape, swapping The Graph for Envio, Ponder, or Goldsky
+  later — or falling back to RPC today — is invisible above the data layer.
+- **Contract-supported pagination instead of log scanning.** Investing in
+  on-chain `getUserWager*` views is what makes the RPC path viable on nodes that
+  reject wide `eth_getLogs` ranges. The fallback is only cheap because the
+  contract was designed to be read directly.
+- **Bounded work with honest failure.** The report scan carries an explicit
+  request budget and a windowed range; when a request genuinely exceeds what a
+  public RPC can serve, it surfaces an actionable error instead of a silent
+  partial result. Correctness of a financial report outranks always returning
+  something.
+
+The trade-off is real: RPC reads are slower and coarser than an indexed query,
+client-side pagination is bounded rather than unlimited, and a few aggregate
+views are simply absent off the indexed chains. What we buy is that no member on
+an un-indexed network hits a broken screen. Every feature either works, works
+slower, or says plainly that it can't — and which of those happens is a property
+of the network config, not a bug waiting on a chain The Graph may never support.
+
+## Sources
+
+- `docs/developer-guide/networks-without-subgraph.md` — the per-chain data-source strategy
+- `frontend/src/data/wagers/WagerRepository.js` — the source-selection boundary
+- `frontend/src/data/wagers/RegistrySource.js` — RPC reads via registry pagination views
+- `frontend/src/data/wagers/SubgraphSource.js` — GraphQL source with automatic RPC fallback
+- `frontend/src/data/reports/reportDataSource.js` — indexed vs. bounded-scan report paths
+- `frontend/src/config/networks.js` — `subgraphUrl`, `getSubgraphUrl`, `hasSubgraph`
+- `contracts/wagers/WagerRegistry.sol`, `contracts/interfaces/IWagerRegistry.sol` — `getUserWagerCount` / `getUserWagerIds` / `getUserWagers` / `getWager`
+- `subgraph/README.md`, `subgraph/networks.json`, `subgraph/schema.graphql` — what the subgraph provides (`Wager`, `WagerTransfer`)
+- `specs/017-subgraph-v2-wager-transfers/` — the `WagerTransfer` entity for reports
+- `specs/015-mordor-network-deployment/` — Ethereum Classic / Mordor deployment
+- `docs/developer-guide/token-mint.md` — truthful "unavailable here" fallback for aggregate panels
+- The Graph documentation — supported networks and subgraph deployment: https://thegraph.com/docs/

--- a/docs/blog/posts/27-indexing-without-subgraph/social.md
+++ b/docs/blog/posts/27-indexing-without-subgraph/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Indexing Without a Subgraph
+
+## X (Twitter)
+
+We deployed FairWins to Ethereum Classic and "My Wagers" came back empty — The Graph doesn't index chain 63. Fix: treat the indexer as one swappable source. No subgraph? Read the registry's on-chain pagination views over RPC. eth_call, not eth_getLogs. 🔗 <link>
+
+#TheGraph #web3 #multichain
+
+## LinkedIn
+
+Most multi-chain dApps lean on The Graph for reads — until they deploy to a chain no Graph provider indexes. For us that was Ethereum Classic (chain 63): contracts worked perfectly, but the wager list was empty because there was no indexer to query.
+
+Our new post walks through how FairWins keeps every read path working when the subgraph isn't there:
+
+- Source selection as per-network metadata (`hasSubgraph(chainId)`), not a global flag — a fifth network is a config entry, not a code change.
+- A stable repository boundary so the UI is agnostic to whether a page came from The Graph or direct RPC.
+- Why we read purpose-built on-chain pagination views (`getUserWagerCount` / `getUserWagerIds` / `getUserWagers`) instead of `eth_getLogs` — public RPCs reject wide log ranges.
+- Automatic fallback when a configured indexer errors, and honest degradation for aggregate views that RPC can't cheaply rebuild.
+
+The theme: features should either work, work slower, or say plainly that they can't — and which one happens should be a property of the network config, not a bug.
+
+How do you handle chains your indexing layer doesn't support? 🔗 <link>
+
+#TheGraph #web3 #blockchain #infrastructure #multichain
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in isometric style depicting a branching data pipeline: a glowing central conduit splits into two parallel paths that both arrive at the same destination node — one path routed through a stylized indexed-database lattice (ordered, fast, structured), the other a more rugged direct pipe made of stacked hexagonal blockchain segments bypassing the lattice entirely. A small junction switch sits where the split occurs, suggesting per-route selection. Deep navy and teal base palette with a single warm amber accent highlighting the fallback path and the shared endpoint, conveying that both routes reach the same result. Soft volumetric lighting from the upper left, subtle depth of field, precise geometric linework, fintech-engineering mood, uncluttered negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/28-unified-activity-ledger/blog.md
+++ b/docs/blog/posts/28-unified-activity-ledger/blog.md
@@ -1,0 +1,142 @@
+# The Unified Activity Ledger: One Timeline From Five Disagreeing Sources
+
+*How FairWins merges wagers, transfers, pools, earn, and memberships from subgraph and RPC into a single chronological feed that the dashboard, the transfer list, and the tax report can never contradict.*
+
+| | |
+|---|---|
+| **Series** | Multi-chain Infrastructure (part 3) |
+| **Audience** | Full-stack and data engineers |
+| **Tags** | `activity-feed`, `indexing`, `data-modeling`, `the-graph`, `rpc`, `full-stack` |
+| **Reading time** | ~9 minutes |
+
+---
+
+## The bug that only a ledger could kill
+
+A member opens the Account tab and sees a wager payout dated "20645d ago." Fifty-six years in the future, more or less — the classic Unix epoch-zero timestamp rendered as a relative time. On the same screen, the running profit-and-loss tile disagrees with the number at the top of the tax report they downloaded ten minutes earlier. Neither figure is wrong, exactly; they were computed by two different code paths reading two different sources, and the paths had quietly drifted.
+
+This is the ordinary fate of an activity feed that grows one feature at a time. FairWins accumulated six surfaces that each answered "what happened to my money?" in isolation: the Account dashboard derived wager transfers from cached wager state; the Pay & Transfer activity tab read a local `transferStore`; the tax report enumerated `WagerTransfer` rows from the subgraph; pools, earn, and membership purchases each had their own read path. The dashboard used synthetic timestamps and empty transaction hashes because deriving-from-state is all it had. The report used real block times and real hashes because the subgraph gives you those. When the two are supposed to sum to the same P&L, they can't — not reliably, not across a subgraph-less network like Mordor where one of them has no data at all.
+
+Spec 051 — the unified activity ledger — replaces all six read paths with exactly one. The Account tab, the transfer activity list, `useAccountStats`, and the CSV/PDF tax report now consume the same normalized entry stream. That is the whole point of the design: **their line items and totals are structurally incapable of disagreeing, because there is only one place the numbers come from.** No new backend, no new subgraph entity, no contract change. The entire feature is a client-side aggregation layer living in `frontend/src/data/ledger/`.
+
+## The shape of one entry
+
+Everything the ledger does hangs off a single canonical value object, the `LedgerEntry`. Heterogeneous events — a USDC send, a wager payout, a pool refund, a failed gasless UserOp — all normalize into the same fields so downstream code never branches on "what kind of thing is this." The vocabulary is frozen in one file, `frontend/src/data/ledger/constants.js`, and shared by sources, repository, UI, and report:
+
+```js
+export const LEDGER_CLASS = Object.freeze({
+  WAGER: 'wager', TRANSFER: 'transfer', EARN: 'earn',
+  POOL: 'pool', MEMBERSHIP: 'membership',
+})
+export const LEDGER_STATUS = Object.freeze({
+  SETTLED: 'settled', PENDING: 'pending',
+  FAILED: 'failed', CANCELLED: 'cancelled',
+})
+export const PROVENANCE = Object.freeze({
+  ONCHAIN: 'onchain', DERIVED: 'derived', CLIENT: 'client',
+})
+```
+
+An entry carries a `class` and a class-specific `kind` (`deposit`, `payout`, `refund`, `send`, `pool_claim`, `voucher_purchase`, and so on), a `direction` (`in` / `out` / `none`), a `status`, the exact `amountRaw` in chain units, an optional `valueUsd` with a `valuationStatus`, a `txHash` and `timestamp` where they exist, and — crucially — a `provenance`. Provenance is not decoration. It is how the merge layer decides which of two rows describing the same event wins.
+
+## Three namespaces, one identity
+
+Reconciliation begins with identity. Every entry gets a stable `entryId` in a namespace that mirrors its provenance, built by pure functions in `frontend/src/data/ledger/identity.js`:
+
+```js
+export function onchainEntryId({ chainId, txHash, logIndex }) {
+  return `oc:${Number(chainId)}:${txHash}:${logIndex ?? 'x'}`
+}
+export function derivedWagerEntryId({ chainId, wagerId, kind, party }) {
+  return `dv:${Number(chainId)}:wager:${String(wagerId)}:${kind}:${String(party || '').toLowerCase()}`
+}
+export function clientEntryId(uuid) {
+  return `cl:${uuid}`
+}
+```
+
+- `oc:` — on-chain, re-derivable, always carries a `txHash`. The high-fidelity truth.
+- `dv:` — derived from on-chain *state* when there is no indexed event to read (a subgraph-less network). Deterministic, so re-deriving on the next poll produces a byte-identical id and nothing duplicates.
+- `cl:` — client-only, existing solely on this device. A failed UserOp the chain never recorded lives here.
+
+The derived id is the subtle one. Because it hashes only `(chainId, wagerId, kind, party)` — not a timestamp, not a nonce — calling `list()` twice yields the same id both times. Re-derivation is idempotent, which is what makes an append-only, poll-driven system safe.
+
+## The merge: precedence, not reconciliation
+
+The hard part of any unified feed is what to do when the same real-world event shows up from two sources. FairWins does not "reconcile" in the sense of comparing and patching; it applies a fixed precedence and drops or folds the losers. The logic is in `mergeEntries` in `identity.js`, and it runs in three passes:
+
+1. **Union by `entryId`.** First occurrence wins. Append-only records with the same id are identical by construction, so this is a set union.
+2. **`oc:` beats `dv:` for the same underlying event.** Both the subgraph row and the derived fallback stamp the same `refs.dedupKey` — `wager:{wagerId}:{kind}` — so when a real indexed event exists, the derived stand-in for that event is filtered out entirely.
+3. **`cl:` folds into `oc:` by `txHash`.** A client record that later matches a confirmed on-chain entry is not shown twice: the on-chain entry wins the financial fields and gains the client record's context (its `route`, its linked id) as annotations.
+
+```js
+merged = merged.filter(
+  (e) => !(namespaceOf(e.entryId) === 'dv'
+        && e.refs?.dedupKey
+        && onchainDedupKeys.has(e.refs.dedupKey)),
+)
+```
+
+That single filter is the antidote to the original bug. The old Account tab made the derived path primary everywhere; the ledger inverts it — subgraph transfers are primary (they carry the `txHash` and real block time the tax report needs), and the derived path is a clearly flagged fallback that yields the moment real data arrives. Dashboard and report agree because they read the *same* merged output, with the *same* precedence, from the same query.
+
+## Sources that fail without failing the ledger
+
+Each activity domain is a `LedgerSource` adapter under `frontend/src/data/ledger/sources/`, implementing a deliberately small contract: a `class` string and an async `list(ctx)` that performs reads only, never writes a store, never throws on empty history, and never returns an entry for a chain other than the one queried. The wager source (`wagerLedgerSource.js`) is the richest — it tries the subgraph's `WagerTransfer` rows first and, on a subgraph-less network, falls back to `deriveTransfersFromWagers` with block times hydrated by a bounded RPC scan:
+
+```js
+const indexed = await listTransfers({ account })
+if (indexed !== null && indexed !== undefined) {
+  return indexed.map((row) => wagerTransferToEntry(row, { chainId, account }))
+}
+// Subgraph-less network — derive from wager state (the My Wagers truth).
+let wagers = await listWagers({ account, chainId })
+wagers = await hydrate(wagers, chainId)   // real block times, bounded scan
+const derived = deriveTransfersFromWagers({ wagers, address: account })
+return derived.map((row) => derivedTransferToEntry(row, { chainId, account }))
+```
+
+The repository (`ledgerRepository.js`) assembles all sources with `Promise.allSettled`. A source that rejects does not blank the feed — its class is added to `staleClasses`, which the UI discloses honestly rather than hiding:
+
+```js
+settled.forEach((res, i) => {
+  if (res.status === 'fulfilled') collected.push(...res.value)
+  else staleClasses.push(sources[i].class)
+})
+```
+
+So if the subgraph is down but the local transfer store is healthy, you still see your transfers, with a visible note that pool and membership history is temporarily stale. Graceful degradation is a property of the whole ledger, earned one source boundary at a time.
+
+## Invariants that make the numbers honest
+
+Normalization (`normalize.js`) is where pre-items become validated entries, and it enforces the guarantees that kill the original defects:
+
+- **`timestamp` is real epoch milliseconds or `null` — the value `0` never survives.** A missing or zero time becomes `null` with `timestampProvenance: 'unavailable'`, and `formatRelativeTime` returns `null` for invalid input so the UI renders an explicit "date unavailable." The "20645d ago" render is now unreachable.
+- **`status: 'failed'` forces `direction: 'none'`.** Failed operations moved no value. They are *listed everywhere* — a failed gasless send with its verbatim bundler reason is first-class history — but excluded from every total by the summary helpers, not by omission.
+- **`valuationStatus: 'unvalued'` entries are flagged, never zeroed or dropped.** An asset with no price source is honestly marked, so it can't silently distort a P&L.
+- **Entries are strictly scoped to the queried `chainId`;** normalization throws if a source leaks a cross-chain row.
+
+Because the repository returns immutable value objects and never mutates a returned entry, these invariants hold all the way to the render layer.
+
+## Durability without a dossier
+
+On-chain and derived entries are never persisted — they re-derive from public data on any device, which keeps backups small. Only the `cl:` records (failed UserOps, in-flight sends) need durable storage, and they live in an append-only `ledgerClientStore`: a status transition appends a superseding record via `refs.supersedes` rather than mutating history. That store rides along in the spec-032 encrypted backup as the `activityLedger` synced object, merged by `entryId` union in both restore modes — a destructive replace would violate the audit guarantee. A one-time, marker-guarded `migrate.js` imports the legacy `fairwins.transfers.v1` log with id-stable mapping, so pre- and post-migration data dedup cleanly.
+
+## Design decisions
+
+- **Client-side aggregation over a server ledger.** A relay-gateway ledger would only ever see relayed traffic, would add an availability dependency, and would violate the platform's no-dossier privacy stance. Every source the ledger needs already had a client read path; what was missing was one normalization and merge layer.
+- **Precedence over reconciliation.** Rather than compare-and-patch, the merge assigns each event to a namespace and applies a fixed `oc: > dv:`, `cl:`-folds-into-`oc:` order. Deterministic derived ids make this idempotent under polling.
+- **Subgraph primary, derived fallback — the inverse of the old dashboard.** This is the single change that lets the report and the dashboard agree: both consume the same merged stream where the high-fidelity source always wins.
+- **Honest degradation as a first-class output.** `staleClasses`, `prunedBefore`, `valuationStatus`, and `timestampProvenance` are all returned to the UI so limits are disclosed, never hidden. Pruning can never touch the current or previous tax year.
+- **Known limits, stated plainly.** Earn actions made outside the app aren't in the ledger (there's no fixed vault registry to scan); pool and membership history require the chain's subgraph and return an honest empty list on RPC-only networks.
+
+The result is boring in the best way. One read path, five classes, three provenance namespaces, and a merge that a test suite can pin down completely because every function in it is pure.
+
+## Sources
+
+- `specs/051-unified-activity-ledger/spec.md`, `plan.md`, `research.md` (decisions D1–D9), `data-model.md`
+- `specs/051-unified-activity-ledger/contracts/ledger-source.md`, `ledger-entry.md`, `backup-object.md`
+- `docs/developer-guide/activity-ledger.md`
+- `frontend/src/data/ledger/`: `ledgerRepository.js`, `identity.js`, `normalize.js`, `constants.js`, `ledgerClientStore.js`, `migrate.js`, `timestamps.js`
+- `frontend/src/data/ledger/sources/`: `wagerLedgerSource.js`, `transferLedgerSource.js`, `poolLedgerSource.js`, `earnLedgerSource.js`, `membershipLedgerSource.js`
+- The Graph documentation — https://thegraph.com/docs/
+- Unix epoch / timestamp conventions — https://en.wikipedia.org/wiki/Unix_time

--- a/docs/blog/posts/28-unified-activity-ledger/social.md
+++ b/docs/blog/posts/28-unified-activity-ledger/social.md
@@ -1,0 +1,30 @@
+# Social & Image — The Unified Activity Ledger
+
+## X (Twitter)
+
+Your dashboard says one P&L, your tax report says another. Both read different sources. We killed the drift with ONE ledger: 5 activity classes, 3 provenance namespaces (oc:/dv:/cl:), a merge where the on-chain row always beats the derived one. 🔗 <link>
+
+#web3 #datamodeling #thegraph
+
+## LinkedIn
+
+An activity feed that grows one feature at a time eventually lies to you. At FairWins we had six read paths each answering "what happened to my money?" — the dashboard derived wager transfers from cached state, the tax report read real subgraph events, transfers lived in a local store. Predictably, the totals drifted, and one path even rendered a payout dated "20645d ago" from a zero timestamp.
+
+Spec 051 replaces all six with a single client-side activity ledger. The new engineering post walks through:
+
+- The canonical LedgerEntry: five activity classes (wager, transfer, earn, pool, membership) normalized into one value object.
+- Three identity namespaces — on-chain, derived, client-only — and a merge that applies fixed precedence instead of fragile reconciliation.
+- Source adapters that degrade honestly: a failing subgraph marks its class stale, it doesn't blank the feed.
+- Invariants that make totals trustworthy: zero timestamps become "date unavailable," failed operations are listed but never totaled, unpriced assets are flagged not zeroed.
+
+No new backend, no subgraph change, no contract change — just one read path the dashboard and the tax report both consume, so they can't disagree.
+
+🔗 <link>
+
+How do you keep a multi-source activity feed from quietly contradicting itself?
+
+#Web3 #DataEngineering #TheGraph #Blockchain #FullStack
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in isometric perspective: five distinct streams of small geometric tokens — each stream a slightly different shape and hue (representing wagers, transfers, pools, earn, memberships) — flowing from separate origins on the left and converging through a precise faceted funnel or merge-junction into a single ordered vertical timeline of uniform stacked cards on the right. Where two streams carry a duplicate token, show one clearly passing through and its twin dissolving into faint particles, conveying deduplication and precedence. Background is deep navy with teal structural lines forming a subtle grid; a single warm amber accent highlights the converged timeline and the merge point. Soft directional lighting from the upper left, gentle depth-of-field, subtle glow on the accent elements, high contrast, minimalist and technical. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/29-ai-security-review-ci/blog.md
+++ b/docs/blog/posts/29-ai-security-review-ci/blog.md
@@ -1,0 +1,110 @@
+# The LLM Reviewer That Never Merges Your Code
+
+*How FairWins wires an AI smart-contract security reviewer into CI as one layer among many — advisory by design, never the gate*
+
+| | |
+|---|---|
+| **Series** | Security & DevOps (Part 1 of 4) |
+| **Audience** | Security engineers, AI-curious contract devs |
+| **Tags** | smart-contract-security, ci-cd, llm, static-analysis, solidity |
+| **Reading time** | ~9 minutes |
+
+---
+
+A developer opens a pull request that touches `contracts/wagers/WagerRegistry.sol`. It adds a new refund path: if a wager expires unaccepted, the maker can pull their stake back. Straightforward — twelve lines, one external token transfer, one storage write.
+
+Within a few minutes, three different things look at that diff, and they disagree about what matters.
+
+Slither, running in GitHub Actions, flags a reentrancy pattern on the transfer and notes the external call ordering. The coverage job reports that the new branch is exercised by exactly one test. And a fourth reviewer — an AI teammate configured in `.github/agents/smart-contract-security.agent.md` — leaves a PR comment that reads less like a linter and more like a colleague: it points out that the refund emits no event, that the maker-only check should be spelled out against `msg.sender` rather than inferred, and that the new path pushes the contract's storage layout in a way that deserves a second look given `WagerRegistry` is a UUPS proxy.
+
+None of these three is authoritative. The static analyzer produces false positives on patterns it can't fully model. The coverage number is a proxy, not proof. And the AI reviewer is a language model — confident, fluent, and occasionally wrong in ways that are harder to spot precisely *because* it writes so plausibly. The interesting engineering problem is not "can an LLM find bugs in Solidity." It's: **how do you place an LLM reviewer into a pipeline so that it adds signal without adding noise, and without anyone mistaking its output for a guarantee?**
+
+This is how FairWins does it.
+
+## Three layers, three failure modes
+
+FairWins treats every line of on-chain code as adversarial-by-default — it handles user funds in escrow. The project constitution (`.specify/memory/constitution.md`, Principle I) makes the security bar non-negotiable, and it names *four distinct mechanisms*, not one:
+
+- Static analysis (Slither) must pass with no new high/critical findings.
+- Stateful logic must survive fuzzing (Medusa) and, weekly, symbolic execution (Manticore).
+- Every `contracts/` change must be reviewed against the smart-contract security agent.
+- Human security review and, for the highest-risk paths, external audit remain the final word.
+
+Each of these has a *different* failure mode, and that's the entire point of stacking them. Slither is deterministic and fast but pattern-bound: it catches what its detectors encode and stays silent on novel logic errors. Medusa and Manticore explore state space but are expensive and fragile — Manticore is a best-effort weekly job precisely because its install is brittle and its runs are slow. Human review is the deepest but the scarcest resource, and it fatigues.
+
+The LLM reviewer occupies a specific gap. It reads a diff the way a reviewer does — in context, with intent — and it reasons about things a detector doesn't model well: is this event missing, is this NatSpec wrong, does this access-control comment actually match the modifier, is this refund path consistent with how the *rest* of `WagerRegistry` handles deadlines? It is good at the "a careful teammate would raise an eyebrow here" category. It is bad, unavoidably, at determinism.
+
+## What the agent actually is
+
+The agent is not a bespoke model or a fine-tune. It's a GitHub Copilot coding-agent configuration — a single markdown file that defines a persona, a review methodology, and a strict scope. It triggers on pull requests that modify `.sol` files under `contracts/` and posts review comments inline, the same surface a human reviewer uses.
+
+The configuration is deliberately opinionated about *how* to speak. Every finding is forced into one shape (`.github/agents/smart-contract-security.agent.md`):
+
+```
+**[SEVERITY] Issue Title**
+
+**Location**: `contracts/Example.sol:123-145`
+
+**Description**: [what and why]
+**Impact**: [what happens if exploited]
+**Recommendation**: [specific fix, with code]
+**Reference**: [standard / EthTrust-SL level requirement]
+```
+
+That template is a noise-control mechanism. An unconstrained LLM asked to "review this contract" will happily generate paragraphs of generic advice. Forcing every comment to carry a severity, a precise location, a concrete impact, and an actionable fix means a comment that can't be pinned to a line and an exploit path tends not to get written at all. Severity is drawn from a fixed taxonomy — Critical, High, Medium, Low, Informational — with worked definitions, so "Critical" means "loss of funds or complete compromise," not "the model felt strongly."
+
+The methodology mirrors the same checklist a security engineer would run: access control, reentrancy and checks-effects-interactions, integer operations, unchecked external calls, oracle manipulation, DoS via unbounded loops, timestamp dependence, and — relevant to FairWins specifically — proxy initialization and delegatecall safety, because `WagerRegistry` and `MembershipManager` are UUPS proxies with append-only storage. Findings are framed against the [EthTrust Security Levels](https://entethalliance.org/specs/ethtrust-sl/), which gives severity a shared external vocabulary instead of a per-reviewer gut call.
+
+## Scoped to be signal, not noise
+
+The single most important configuration choice is what the agent *refuses* to review. Its scope section is explicit: Solidity contracts, deployment scripts, and contract-adjacent integration code — and **not** React/TypeScript frontend, backend APIs, generic CI/CD config, non-Ethereum code, or documentation-only changes.
+
+This narrowing does real work. An LLM that comments on everything trains reviewers to ignore it; the tenth reflexive "consider adding a comment here" on a docs PR is the one that gets the whole bot muted. By binding the agent to the highest-value, highest-risk file type and staying quiet elsewhere, its comments stay dense. The configuration guide (`docs/developer-guide/ethereum-security-agent-configuration.md`) goes further, letting a project exclude `contracts/mocks/` and test contracts, and tune review depth per contract — a full analysis on fund-custody paths, a lighter pass on interfaces and libraries. In FairWins' repo map, `mocks/` is test-only and `contracts-archive/` is reference-only; there's no value in an AI reviewer litigating code that never ships.
+
+## The line we do not cross: advisory, never the gate
+
+Here is the design decision that matters most, and the one most easily gotten wrong.
+
+The AI reviewer does **not** have a merge-blocking status check of its own. Look at `.github/workflows/security-testing.yml` and you'll find the deterministic layers — Hardhat tests, coverage, and Slither — wired as jobs. Slither runs `slither . --config-file slither.config.json --checklist`; its output is deterministic and reproducible, which is what lets it be a gate. The LLM's output is not in that workflow. It posts comments; it does not set a required check that turns the merge button red.
+
+That asymmetry is intentional. A gate has to be *reproducible* — run it twice on the same commit and get the same answer — or it becomes a flaky, resented obstacle. LLM output is non-deterministic by construction; the same diff can yield differently-worded findings, or a finding on one run and silence on the next. Wiring that into a required check would either block merges arbitrarily or, worse, teach the team that a green "AI security" check means the code is safe. It doesn't. It means one probabilistic reviewer didn't object this time.
+
+So the enforcement structure is: Slither and the test suite are gates. Medusa and Manticore are scheduled deep-dives. The AI agent is a reviewer whose comments a human must still read and adjudicate — exactly like a human colleague's comments. The constitution requires that a change *be reviewed against* the agent, not that the agent *approve* it. Human security review remains the merge authority.
+
+## Being honest about what an LLM reviewer can't do
+
+Any team adopting this should say the quiet parts out loud:
+
+- **It hallucinates with confidence.** The failure mode isn't silence; it's a fluent, well-formatted finding that cites a real-sounding standard for a vulnerability that isn't there. The structured template curbs this but does not eliminate it. Every finding still needs a human to confirm the exploit path is real.
+- **No ground truth, no recall guarantee.** Unlike Slither, whose detector set is enumerable, you cannot say what the LLM will and won't catch. A missed vulnerability leaves no trace. Absence of comments is not evidence of safety.
+- **It sees the diff, not the system.** It reasons well about local patterns and less well about cross-contract invariants, economic attacks, and multi-transaction state machines — precisely where Medusa's fuzzing and Manticore's symbolic execution earn their keep, and where human auditors are irreplaceable.
+- **It is not adversarial.** A real attacker composes flash loans, reorderings, and oracle manipulation across calls. The agent is a careful reviewer, not a red team.
+
+The right mental model is a tireless, well-read junior security engineer who reviews every single PR without fatigue, writes tidy comments, and must never be trusted as the last line of defense. Its value is catching the *ordinary* issues early — the missing event, the unchecked return value, the CEI violation, the undocumented access-control assumption — so that human reviewers and the deterministic tooling spend their scarce attention on the hard, systemic, economic questions that no current LLM can be trusted to answer.
+
+## Trade-offs
+
+- **Non-deterministic reviewer, deterministic gates.** We accept that the AI layer can't block merges, in exchange for never letting a probabilistic pass masquerade as a safety guarantee.
+- **Narrow scope over broad coverage.** Restricting the agent to Solidity keeps its signal-to-noise high at the cost of ignoring frontend and infra — which are covered by their own tooling.
+- **Structured comments over free-form insight.** Forcing severity/location/impact/fix reduces the occasional brilliant tangent but makes the median comment actionable and auditable.
+- **A layer that complements, never replaces.** The agent is cheap and continuous; Slither is reproducible; fuzzing and symbolic execution are deep; humans and auditors are final. Removing any one weakens the stack, but no single layer — least of all the LLM — is sufficient alone.
+
+---
+
+> **A note on responsible use:** FairWins is a platform for peer-to-peer wagers on public-information forecasting. The security tooling described here protects escrowed user funds; it is not a substitute for professional audit, and participants remain subject to applicable law.
+
+## Sources
+
+- `.github/agents/smart-contract-security.agent.md` — agent persona, methodology, severity taxonomy, comment template, scope limits
+- `.github/agents/README.md` — trigger conditions and team-member framing
+- `docs/developer-guide/ethereum-security-agent.md` — full agent guide, how PR review works
+- `docs/developer-guide/ethereum-security-agent-configuration.md` — severity thresholds, exclusions, per-contract review depth, CI integration options
+- `docs/developer-guide/ethereum-security-quickstart.md` — developer workflow and the explicit "not a replacement for audits/human review" note
+- `docs/developer-guide/ethereum-security-agent-examples.md` — worked example findings
+- `.github/workflows/security-testing.yml` — deterministic CI gates (Hardhat tests, coverage, Slither)
+- `.github/workflows/torture-test.yml` — weekly Manticore symbolic execution and Medusa fuzzing
+- `.specify/memory/constitution.md` — Principle I, Security-First Smart Contracts (non-negotiable multi-mechanism requirement)
+- [EthTrust Security Levels](https://entethalliance.org/specs/ethtrust-sl/) — Enterprise Ethereum Alliance
+- [SWC Registry](https://swcregistry.io/) — Smart Contract Weakness Classification
+- [Slither](https://github.com/crytic/slither) and [building-secure-contracts](https://github.com/crytic/building-secure-contracts) — Trail of Bits
+- [Consensys Smart Contract Best Practices](https://consensys.github.io/smart-contract-best-practices/)

--- a/docs/blog/posts/29-ai-security-review-ci/social.md
+++ b/docs/blog/posts/29-ai-security-review-ci/social.md
@@ -1,0 +1,30 @@
+# Social & Image — The LLM Reviewer That Never Merges Your Code
+
+## X (Twitter)
+
+We put an AI security reviewer in CI for our Solidity contracts. The key design call: it can NEVER block a merge. LLM output is non-deterministic — a green "AI-passed" check would be a lie. It's an advisory layer alongside Slither, fuzzing + humans. 🔗 <link>
+
+#SmartContractSecurity #Solidity #DevOps
+
+## LinkedIn
+
+An LLM will happily "review" your smart contract. The hard part isn't getting findings — it's placing that reviewer in your pipeline so it adds signal instead of noise, and so nobody mistakes its output for a guarantee.
+
+Part 1 of our Security & DevOps series walks through how FairWins wires an AI smart-contract security reviewer into CI alongside — never in place of — the deterministic tooling. What the post covers:
+
+- Why the AI reviewer is advisory only, with no merge-blocking status check, while Slither and the test suite are the actual gates (reproducibility is the dividing line).
+- How a strict comment template — severity, location, impact, fix, standard — turns a chatty model into an auditable reviewer.
+- Scoping it to Solidity only, so its comments stay dense and don't get muted.
+- An honest accounting of what LLM review can't do: confident hallucinations, no recall guarantee, no adversarial reasoning across transactions.
+
+Four layers, four different failure modes — static analysis, fuzzing/symbolic execution, an LLM reviewer, and human audit. The LLM is the tireless junior engineer on that team, never the last line of defense.
+
+🔗 <link>
+
+How are you drawing the line between AI assistance and AI authority in your security pipeline?
+
+#SmartContractSecurity #AISecurity #Solidity #DevSecOps #Web3
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean, modern editorial illustration in isometric style depicting a smart-contract pull request passing through four distinct inspection stations arranged in a row along a conveyor belt: a rigid geometric scanner grid (deterministic static analysis), a turbulent particle field (fuzzing and symbolic execution), a softly glowing translucent lens shaped like a speech bubble that hovers and observes but does not touch the belt (the advisory AI reviewer), and a solid human-scale gatekeeping arch at the end (human review, the real gate). A stylized code block travels left to right; only the final arch has a physical barrier, while the glowing lens leaves gentle annotations floating beside the code. Deep navy and teal base palette with a single warm amber accent used only on the glowing AI lens and its floating notes. Soft directional lighting from upper left, subtle depth and long clean shadows, minimal background, plenty of negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/30-coverage-audit-gates/blog.md
+++ b/docs/blog/posts/30-coverage-audit-gates/blog.md
@@ -1,0 +1,121 @@
+# Coverage and Audit Gates That Fail Loudly
+
+*How a false 0% on the escrow contract taught us to wire quality gates so a regression physically cannot merge*
+
+---
+
+| | |
+|---|---|
+| **Series** | Security & DevOps (part 2) |
+| **Part** | 30 of 34 |
+| **Audience** | Engineering leads, security-minded teams |
+| **Tags** | `ci`, `test-coverage`, `audit`, `quality-gates`, `slither` |
+| **Reading time** | ~8 minutes |
+
+---
+
+## A green suite that was quietly lying
+
+On July 6, 2026, the Weekly Torture Test went red. The Coverage Analysis job exited with code **182** — not a coincidence, a count: **182 contract tests had failed with "Transaction ran out of gas."** The tests that failed were exactly the ones exercising the core escrow contracts. So the report that landed in the run summary showed the wager escrow family — `WagerRegistry`, `WagerRegistryCore`, `WagerRegistryIntents`, the contracts that hold every participant's stake — sitting at a flat **0%**. The blended coverage total had dropped from **56.68%** the previous week to **31.21%**.
+
+Here is the uncomfortable part. Nothing had actually broken in the contracts. The escrow logic was fine, its unit tests passed under a normal `npm test`, and funds were never at risk. What had broken was the *measurement*. Coverage instrumentation rewrites bytecode to record which lines execute, and that rewrite inflates code size and per-transaction gas. Several recently landed contracts — the passkey smart accounts with their elliptic-curve libraries, group wager pools, and the two-facet gasless registry that already sits against the 24 KB EVM code-size limit — pushed the instrumented bytecode past the run's gas headroom. Under instrumentation they ran out of gas before their tests could touch the escrow paths.
+
+The failure mode is worse than a broken test. A broken test is loud. This was a *safety net reporting a false negative*: the single most important contract in the system read as untested, and the number was low enough that a real coverage regression could have hidden inside the noise and merged unnoticed. Spec `046-contract-audit-coverage` exists to fix both problems at once — restore a measurement you can trust, then wire it so a genuine regression fails the build loudly instead of drifting.
+
+This post is about the gates, not the tests they protect. The interesting engineering is not "write more tests." It is: how do you build a quality gate that (a) measures the right thing, (b) can't be gamed into a false pass, and (c) blocks a merge rather than filing a complaint nobody reads.
+
+## Fixing the measurement before trusting the number
+
+The first job was to get instrumented tests to run at all. The fix is narrow on purpose. `npm run test:coverage` sets `COVERAGE=true`, and only under that flag does Hardhat apply coverage-scoped network settings — a raised `blockGasLimit` and adjusted `initialBaseFeePerGas` — so instrumented contracts have the headroom to execute:
+
+```
+test:coverage = COVERAGE=true TZ=UTC hardhat coverage --testfiles '{test/*.test.js,test/access/**,test/account/**,...}'
+```
+
+Because those relaxed limits are gated behind `COVERAGE=true`, a normal `npm test` and the gas report keep realistic mainnet-like limits. We restored instrumentation headroom without pretending production gas is unlimited. The result, captured on July 10, was a green run: **674 passing, zero out-of-gas failures**, and the escrow family reporting real numbers again.
+
+The second problem was subtler: *what* to measure. The blended 31.21% was meaningless even when green, because it averaged in vendored third-party code — FreshCryptoLib, solady, webauthn-sol, the account-abstraction libraries under `contracts/account/lib/**` — plus test-only fuzz harnesses. None of that is code the project owns or should be judged on.
+
+The obvious fix, adding those paths to solidity-coverage's `skipFiles`, is a trap, and `.solcover.js` carries a long comment explaining why. Skipping a directory that first-party contracts *import* corrupts source-map attribution for the importers. Skip `contracts/test/**` and `WagerRegistry`'s own coverage collapses to ~5%, because the harnesses that drive it are what map execution back to its source. So instrumentation stays deliberately broad, and all first-party filtering happens in **post-processing** instead:
+
+```
+scripts/coverage/lib/first-party.js   # pure helpers over istanbul's coverage-summary.json
+scripts/coverage/check-thresholds.js  # the gate that reads them
+```
+
+The separation matters. Measurement instruments everything (correct source maps); accounting excludes the vendored and test-only paths (honest headline number). One deliberate exception survives the exclusion: the deployed wallet contracts at the top of `contracts/account/` — `CoinbaseSmartWallet`, `ERC1271`, `MultiOwnable`, `CoinbaseSmartWalletFactory`. They are Coinbase/Solady-adapted, but they are deployed live and custody funds on Polygon, so they *are* counted, gated on the integration surface FairWins actually invokes. Only the deeper crypto libraries under `account/lib/**` stay excluded.
+
+## The policy file is the whole argument
+
+Every threshold lives in one auditable place: `coverage-threshold-policy.json`, edited only by PR. There is no coverage config scattered across workflow YAML. The gate reads three risk-based tiers:
+
+- **Tier A** — funds custody and settlement: the `WagerRegistry` family, group pools (`WagerPool` / `WagerPoolFactory`), `MembershipVoucher` redemption, oracle auto-resolution. **≥95% statements / ≥90% branches.**
+- **Tier B** — security-critical supporting: the deployed `account/*` wallets, oracle adapters, access control, gasless-intent plumbing, the upgradeable base, `TokenFactory`. **≥90% / ≥80%.**
+- **Tier C** — other first-party. **≥80% / ≥70%.**
+
+Each gated contract carries its tier and, optionally, a per-contract `min` floor:
+
+```json
+{ "path": "contracts/wagers/WagerRegistry.sol",       "tier": "A", "min": { "statements": 92, "branches": 67 } },
+{ "path": "contracts/wagers/WagerRegistryCore.sol",   "tier": "A" },
+{ "path": "contracts/access/MembershipVoucher.sol",   "tier": "A", "min": { "statements": 76, "branches": 45 } }
+```
+
+The `min` is a **ratchet**. `tier` is the audit-readiness target; `min` is the currently-enforced floor for a contract that hasn't reached target yet. The gate fails below `min` — so coverage can never regress — while the target stays visible as the number to raise toward. As gaps close, you bump `min` up and eventually delete it, at which point the full tier is enforced. A contract with no `min` is held to its tier immediately. `MembershipVoucher` at `76/45` is honest about being mid-climb toward `95/90`; it just can't slide backward.
+
+Two more lists complete the policy. `reportOnly` contracts (unlaunched token templates, `ExternalDAORegistry`) are measured and printed but **never** fail the gate — each with a written `rationale` — so not-yet-shipped code is visible without blocking PRs. `excluded` drops vendored and test-only paths from first-party accounting entirely. The doctrine is explicit: never leave a shipped fund-handling contract in `reportOnly`. When `custody/SafeProposalHub.sol` or a token template goes live, it moves into `gated`, tests come up to tier, and only then does the gate go green.
+
+## The gate itself: three exit codes, no negotiation
+
+`scripts/coverage/check-thresholds.js` reads istanbul's `coverage-summary.json` and the policy, then exits with one of three codes:
+
+```
+0 — all gated contracts meet their tier AND first-party total >= baseline
+1 — one or more gated contracts below tier, or a baseline regression
+2 — bad input (missing/invalid summary or policy, unresolved gated path)
+```
+
+Two design choices make it hard to fool. First, a gated contract that is **absent** from the coverage summary is treated as a failure, not an omission — "file present, ~0% covered" in a security-critical area is exactly the July 6 scenario, and the gate now calls it what it is (FR-012). You cannot make the gate pass by deleting a contract's tests so it drops out of the report. Second, beyond per-contract tiers, the gate enforces a `baseline` on the first-party total that ratchets upward: after the fix it was raised to `91.51/73.04/89.76/91.14`, up from the old-baseline `56.68/48.88/58.05/62.28`. The blended total can only go up.
+
+The gate runs in two places, with two scopes:
+
+- **Per-PR** — `.github/workflows/test.yml`, the *Smart Contract Tests* job runs `--scope gated`. Coverage generation is a blocking step (no `continue-on-error`), then the gate blocks the merge if any security-critical contract is below its floor. A regression is caught before merge, not a week later.
+- **Weekly** — `.github/workflows/torture-test.yml`, the *Coverage Analysis* job runs `--scope all`, printing the full first-party table (report-only rows included) into the run summary and failing on any gated breach.
+
+The weekly job uses one careful shell idiom worth stealing: it tees the gate's output into the step summary but captures the exit code so the summary is always written *and* a non-zero exit still fails the job.
+
+```bash
+node scripts/coverage/check-thresholds.js --summary coverage/coverage-summary.json \
+  --policy coverage-threshold-policy.json --scope all | tee -a "$GITHUB_STEP_SUMMARY"; rc=${PIPESTATUS[0]}
+exit $rc
+```
+
+## The storage-layout gate rides alongside
+
+Coverage is not the only thing that fails loudly on every PR. FairWins runs several contracts as UUPS proxies — `WagerRegistry`, `MembershipManager`, `WagerPoolFactory`, `FeeRouter`, and others — where logic is swappable but state must be preserved. A well-meaning refactor that reorders a storage variable is invisible to a coverage number and catastrophic to a live proxy. So `npm run check:storage-layout` runs in the same *Smart Contract Tests* job, before the tests, and blocks the pipeline on any storage-incompatible or upgrade-unsafe implementation (`scripts/deploy/check-storage-layout.js`, spec 025). It even handles the two-facet registry: `WagerRegistry` and `WagerRegistryIntents` share one proxy's storage, so the check treats the facet as if it were an upgrade of the main implementation and diffs the layouts. Same doctrine, different invariant.
+
+## Design decisions and trade-offs
+
+**Post-processing over `skipFiles`.** Filtering vendored code in accounting rather than at instrumentation costs a little complexity (`first-party.js` plus a documented exclusion list) but is the only way to get an honest number *and* uncorrupted source maps. The alternative silently reports the escrow contract at 5% — the exact failure we were trying to eliminate.
+
+**A ratchet, not a cliff.** We could have demanded every Tier A contract hit 95/90 on day one. Instead the `min` floor locks in current coverage and lets targets rise over time. This is the difference between a gate teams route around and one they live with: it never blocks a green PR for coverage that already exists, only for coverage that *drops*.
+
+**Honest about what actually blocks.** Coverage thresholds, storage layout, unit tests, lint, and the frontend build are hard gates — no `continue-on-error`. Slither and Medusa, by contrast, run in the weekly torture test and the security workflow as **informational** steps: they run on every relevant push, their findings are uploaded as artifacts and reviewed (the security agents under `.github/agents/`), but a raw Slither finding does not auto-fail the pipeline, because its false-positive rate would make the gate noise. That is a deliberate line: gate on the checks with a crisp pass/fail (does coverage meet the floor? is storage append-only?), and treat the heuristic analyzers as review inputs rather than merge blockers. Calling that out honestly is the point — a "fail loudly" culture is credible only when you're precise about which checks are loud and which are advisory.
+
+The measurable outcome: 182 instrumentation-induced out-of-gas failures went to zero, the escrow family reports real coverage instead of a false 0%, and a deliberately weakened test on a security-critical contract now fails the gate with a message naming the contract and the metric — before it can merge, not a week after.
+
+## Sources
+
+- `specs/046-contract-audit-coverage/spec.md` — feature spec, failure narrative (run `28764296740`), tiers, FR-001 through FR-019
+- `docs/developer-guide/coverage-and-audit-gates.md` — how the gate works, policy-file reference, common tasks
+- `docs/security/ci-configuration.md` — security workflow structure, tool versions, gating vs. informational jobs
+- `coverage-threshold-policy.json` — the tiered policy: `tiers`, `gated`, `reportOnly`, `excluded`, `baseline`
+- `scripts/coverage/check-thresholds.js` and `scripts/coverage/lib/first-party.js` — the gate and first-party accounting
+- `.solcover.js` — instrumentation config and the `skipFiles` source-map-corruption note
+- `.github/workflows/test.yml` (per-PR gate) and `.github/workflows/torture-test.yml` (weekly `--scope all`)
+- `scripts/deploy/check-storage-layout.js` — the upgrade-safety / storage-layout gate (spec 025)
+- `package.json` — `test:coverage`, `check:storage-layout` scripts
+- Istanbul / nyc coverage summary format: https://github.com/istanbuljs/istanbuljs
+- solidity-coverage: https://github.com/sc-forks/solidity-coverage
+- Slither: https://github.com/crytic/slither — Medusa: https://github.com/crytic/medusa
+- OpenZeppelin Upgrades (storage-layout safety): https://docs.openzeppelin.com/upgrades-plugins/

--- a/docs/blog/posts/30-coverage-audit-gates/social.md
+++ b/docs/blog/posts/30-coverage-audit-gates/social.md
@@ -1,0 +1,30 @@
+# Social & Image — Coverage and Audit Gates That Fail Loudly
+
+## X (Twitter)
+
+Our escrow contract once reported 0% coverage in CI. Nothing was broken — instrumentation ran the tests out of gas and the safety net lied. Fixing it meant a gate that fails a merge when coverage *drops*, not a report nobody reads. 🔗 <link>
+
+#SmartContracts #DevSecOps #Solidity
+
+## LinkedIn
+
+A test suite that reports a false negative is more dangerous than one that fails outright — a broken test is loud, but a safety net quietly reporting your most critical contract as "untested" lets a real regression slip through unnoticed.
+
+That happened to us. Coverage instrumentation inflated bytecode past the gas limit, 182 tests ran out of gas, and our funds-handling escrow contract read as 0% covered while the actual logic was fine. The blended coverage number dropped by half and meant nothing either way.
+
+The fix wasn't "write more tests." It was building quality gates that can't be gamed into a false pass. The new post walks through:
+
+- Restoring a trustworthy measurement (instrumentation headroom gated behind a COVERAGE flag, so production gas stays realistic)
+- First-party accounting in post-processing — not skipFiles — to avoid corrupting source maps while excluding vendored code
+- A tiered, ratcheting threshold policy in one auditable file, where coverage can only go up
+- Being honest about which checks hard-block a merge (coverage, storage layout) vs. which are advisory review inputs (Slither, Medusa)
+
+The theme running through all of it: a "fail loudly" culture is only credible when you're precise about which checks are loud.
+
+How does your team draw the line between a blocking gate and an advisory one? 🔗 <link>
+
+#SmartContracts #DevSecOps #CodeCoverage #Solidity #EngineeringLeadership
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in isometric style depicting a security gate or turnstile mechanism on a circuit-board pathway: a stylized data pipeline flows left to right as glowing conduits carrying small geometric packets (representing code commits), and a prominent gate structure in the middle physically halts one red-tinted packet while letting verified green-tinted packets pass through. The gate has a subtle shield or checkmark motif built into its architecture. Emphasize the idea of a hard barrier, not a soft filter. Composition: wide 16:9 with the gate slightly right of center, generous negative space, shallow depth of field. Color mood: deep navy and teal base palette with a single warm amber-orange accent used only on the blocked packet and the gate's active indicator light, giving a precise fintech-engineering feel. Lighting: soft directional glow from the conduits, cool ambient with warm rim light on the gate. Flat vector shading with subtle gradients, crisp edges, no clutter. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/31-symbolic-execution-fuzzing/blog.md
+++ b/docs/blog/posts/31-symbolic-execution-fuzzing/blog.md
@@ -1,0 +1,148 @@
+# Three Ways to Break an Escrow: Slither, Manticore, and Medusa on a Wager Protocol
+
+*A layered verification stack for peer-to-peer escrow — and the bug each layer is uniquely positioned to catch*
+
+---
+
+> **Important Note**: FairWins is a platform for peer-to-peer wagers based on publicly available information and legitimate forecasting. Nothing here is a mechanism for trading on material non-public information or circumventing applicable law. All participants remain fully subject to applicable regulations and compliance requirements. This post is about verifying escrow code, not about the wagers themselves.
+
+---
+
+## The function that can never be wrong
+
+Here is the single function in `WagerRegistry` that moves money to a winner. Two people staked USDC, an oracle (or a counterparty) declared an outcome, and now the winner claims the pot:
+
+```solidity
+function _claimPayout(address actor, uint256 wagerId) internal {
+    Wager storage w = _wagers[wagerId];
+    if (w.status != Status.Resolved) revert NotResolved();
+    if (actor != w.winner) revert NotWinner();
+    if (w.paid) revert AlreadyPaid();
+
+    w.paid = true;
+    // Compute as uint256 to avoid uint128 overflow on sum
+    uint256 payout = uint256(w.creatorStake) + uint256(w.opponentStake);
+    IERC20(w.token).safeTransfer(w.winner, payout);
+
+    emit PayoutClaimed(wagerId, w.winner, payout);
+}
+```
+
+Twelve lines, and every one of them is load-bearing. The three `if` checks are the *checks*. Setting `w.paid = true` before the transfer is the *effect*. The `safeTransfer` is the *interaction*. That ordering — checks-effects-interactions — is the difference between a contract that pays each winner once and a contract that a reentrant token can drain. The `uint256` cast on the sum is the difference between a correct payout and a silent `uint128` overflow. The `actor != w.winner` check is the difference between a winner claiming their pot and anyone claiming everyone's.
+
+No single testing technique gives you confidence across all of those failure modes at once. A pattern matcher can see that `w.paid = true` sits before the transfer, but it has no idea whether `payout` is arithmetically correct. A path explorer can prove the arithmetic never overflows, but it will time out before it can reason about ten wagers created and settled in an arbitrary order. A fuzzer can hammer that arbitrary order until the escrow goes insolvent, but it will never *prove* anything — only fail to disprove it.
+
+So `contracts/wagers/WagerRegistry.sol` sits under three tools that catch different things. This is a tour of what each one actually does to the escrow and payout logic, grounded in the configuration and harnesses that ship in the repo.
+
+## Layer 1: Slither, on every pull request
+
+Slither is static analysis — it reads the compiled contract without ever executing it, and matches known-bad shapes. It is the cheap, fast layer, so it runs on every PR as the `slither-analysis` job in `.github/workflows/security-testing.yml`, gating merges alongside the Hardhat suite and coverage.
+
+The configuration is deliberately un-permissive (`slither.config.json`):
+
+```json
+{
+  "filter_paths": "node_modules|test|contracts/mocks",
+  "exclude_dependencies": true,
+  "exclude_informational": false,
+  "exclude_low": false,
+  "exclude_medium": false,
+  "exclude_high": false,
+  "compile_force_framework": "hardhat"
+}
+```
+
+Nothing below high severity is filtered out. Dependencies and mocks are excluded so the signal is about *our* code, but every severity band on our code is surfaced.
+
+What Slither is good at, on `_claimPayout`, is exactly the class of bug that is visible in the *shape* of the code: a reentrancy detector notices when a function makes an external call before it finishes updating state. Point it at a version of this function where `w.paid = true` came *after* the `safeTransfer` and it flags the ordering immediately — the reentrancy-eth detector exists precisely for that. It also catches unprotected state-changing functions (a `setOwner` with no modifier), missing zero-address validation on constructor and setter inputs, and dangerous strict equalities like `require(msg.value == bondAmount)`.
+
+What Slither cannot do is tell you whether the payout is *right*. `uint256(w.creatorStake) + uint256(w.opponentStake)` and `uint256(w.creatorStake)` on its own are the same shape to a pattern matcher. Static analysis sees syntax and control-flow, not the semantics of "the winner should receive both stakes and no more." That is the gap the next two layers exist to close.
+
+## Layer 2: Manticore, and the fix that made it real
+
+Manticore is symbolic execution. Instead of running the contract with concrete inputs, it runs it with *symbolic* ones — each input is an unknown, and at every branch it forks the world, accumulating the constraints that lead down each path. Where a unit test asks "does it work for `amount = 100`?", Manticore asks "is there *any* `amount` for which this assertion can fail, this arithmetic can overflow, or this path can revert unexpectedly?" For a bounded number of transactions it explores paths exhaustively, which is why it is aimed at the highest-risk contracts: it runs weekly in the `torture-test.yml` workflow against `WagerRegistry`, `MembershipManager`, `KeyRegistry`, and every oracle adapter (Polymarket, both Chainlink adapters, and UMA).
+
+That weekly run existed for a while before it was actually doing anything — and that is the most instructive part of the story. Manticore drives its own Solidity compiler, and it did not know where FairWins keeps its dependencies. Every run died on:
+
+```
+Error: Source "@openzeppelin/contracts/access/Ownable.sol" not found: File not found.
+```
+
+followed, in the finalizer, by an `AttributeError: 'NoneType' object has no attribute 'result'`. That second error is the tell: when compilation fails, Manticore has no transaction objects to finalize, so it crashes trying to read results that never existed. The CI step was catching the failure and moving on. The verification tool was green and inert — the worst state a security tool can be in, because it manufactures confidence it hasn't earned.
+
+The fix, documented in `docs/MANTICORE_FIX.md`, is unglamorous and exactly right. A `remappings.txt` at the repo root tells the compiler where the imports live:
+
+```
+@openzeppelin/=node_modules/@openzeppelin/
+@chainlink/=node_modules/@chainlink/
+@uma/=node_modules/@uma/
+```
+
+And a wrapper script, `scripts/run-manticore.py`, reads those remappings and passes them through to Manticore as `--solc-remaps` arguments, validates the environment before it starts, and handles timeouts gracefully so a partial exploration still yields artifacts. The workflow calls the wrapper instead of the bare binary:
+
+```bash
+timeout 600 python scripts/run-manticore.py contracts/wagers/WagerRegistry.sol \
+  --contract WagerRegistry --timeout 600
+```
+
+With imports resolving, Manticore compiles the registry and starts forking paths through `_claimPayout` and its siblings. Now the `uint256` cast earns its comment: symbolic execution reasons about the full `2^128` range of each stake and confirms the sum can't overflow the way a naive `uint128` addition would. It checks that the three guard clauses have no satisfiable path that skips them. This is the layer that turns "I'm pretty sure the arithmetic is fine" into "there is no input for which it isn't."
+
+Its limits are honest and documented: state explosion means it struggles with deep multi-transaction sequences, unbounded loops, and external calls into contracts it can't model. Manticore proves things about a *bounded* exploration of one contract. It will not, on its own, discover a bug that only emerges after ten interleaved wagers.
+
+## Layer 3: Medusa, on the whole stack at once
+
+That interleaving is Medusa's entire job. Medusa is a property-based fuzzer: it deploys a harness, then throws long, random sequences of real transactions at it — up to 100 calls per sequence, per `medusa.json` — and after every call it re-checks a set of invariants. It is looking for the emergent bug: the one that no single transaction causes, but some *order* of transactions does.
+
+The harness for the escrow is `contracts/test/WagerRegistryFuzzTest.sol`, and critically it deploys the *production* stack the way production does — the real `MembershipManager` and `WagerRegistry` behind ERC-1967 proxies, initialized through the proxy, with tiers configured and memberships purchased. Medusa then fuzzes against the proxy. The invariants are plain `bool`-returning functions with a `property_` prefix (declared in `medusa.json` under `testPrefixes`). The one that matters most is escrow solvency:
+
+```solidity
+function property_escrow_covers_active_stakes() public view returns (bool) {
+    uint256 totalLocked = 0;
+    uint256 count = registry.nextWagerId();
+    for (uint256 i = 1; i < count; i++) {
+        IWagerRegistryTypes.Wager memory w = registry.getWager(i);
+        if (w.status == IWagerRegistryTypes.Status.Open) {
+            totalLocked += w.creatorStake;
+        } else if (w.status == IWagerRegistryTypes.Status.Active && !w.paid) {
+            totalLocked += uint256(w.creatorStake) + uint256(w.opponentStake);
+        } else if (w.status == IWagerRegistryTypes.Status.Resolved && !w.paid) {
+            totalLocked += uint256(w.creatorStake) + uint256(w.opponentStake);
+        }
+    }
+    return token.balanceOf(address(registry)) >= totalLocked;
+}
+```
+
+This is a claim no static or symbolic tool made: *at every point in any transaction history, the registry holds at least enough tokens to cover every stake it still owes.* If some sequence of create / accept / claim / refund / cancel ever pays out twice, or refunds a stake it already released, or leaks tokens on the open-challenge path, this property goes false and Medusa hands you the exact failing call sequence.
+
+The rest of the harness fences the state machine from every angle: `property_no_double_claim` asserts the `paid` flag is irreversible; `property_state_only_progresses_forward` tracks per-wager status across calls and rejects any backward transition (`Resolved` and `Refunded` are terminal); `property_winner_is_participant` requires every resolved winner to be the creator or the opponent; `property_payout_equals_total_stakes` guards the arithmetic that Manticore proved, now under live sequences; and `property_cannot_reinitialize` confirms the UUPS proxy's one-time initializer can never be called again to seize roles.
+
+There is a genuinely clever bit in the open-challenge invariants. The harness holds no private key for any claim authority, so it *cannot* forge the EIP-712 signature that accepts an open wager. `property_open_never_active_without_signature` turns that into a test: none of the harness's open wagers may ever reach `Active`, because reaching `Active` would require a signature the fuzzer can't produce. If Medusa ever finds a path that activates one anyway, the signature gate is broken.
+
+Medusa's weakness is the mirror of Manticore's strength: it is random, not exhaustive. A passing run means "no counterexample found in this campaign," never "no counterexample exists." That is precisely why the arithmetic invariant lives in *both* the fuzzer and the symbolic layer.
+
+## Design decisions
+
+**Cost-order the layers.** Slither is cheap and runs on every PR; Manticore and Medusa are expensive and run weekly in `torture-test.yml`. You get fast pattern feedback on the critical path and heavyweight proof/fuzzing off it. Nobody waits ten minutes per push for a symbolic run.
+
+**Overlap the arithmetic on purpose.** Payout correctness is checked by Manticore (exhaustive over inputs, one transaction) *and* Medusa (random over sequences, many transactions). Neither subsumes the other: one proves the sum never overflows, the other proves no ordering of settlements ever breaks solvency. The redundancy is the point.
+
+**Fuzz the real deployment shape.** The Medusa harness stands up UUPS proxies and buys memberships instead of poking a bare logic contract. An invariant that only holds for a contract you don't ship is worthless; the escrow-solvency property is only meaningful against the proxy users actually transact with.
+
+**Treat a silent security tool as a failure.** The Manticore import bug is the lesson that generalizes past this repo: a verification tool that green-lights because it never compiled your code is worse than no tool, because it launders false confidence. The fix wasn't cleverness — it was noticing the tool wasn't running and making it run.
+
+## Sources
+
+- `contracts/wagers/WagerRegistryCore.sol` — `_claimPayout` (checks-effects-interactions, payout formula)
+- `contracts/wagers/WagerRegistry.sol` — `claimPayout` / `claimRefund` / `createWager` externals
+- `contracts/test/WagerRegistryFuzzTest.sol` — Medusa invariant harness (escrow solvency, forward-only state, open-challenge signature gate)
+- `medusa.json` — fuzzing config (target contracts, `property_` prefixes, sequence length)
+- `slither.config.json` — Slither configuration (severity bands, remaps, filtered paths)
+- `remappings.txt` — OpenZeppelin / Chainlink / UMA import remaps
+- `docs/MANTICORE_FIX.md` — the import-resolution fix and the `run-manticore.py` wrapper
+- `docs/security/index.md`, `static-analysis.md`, `symbolic-execution.md`, `fuzz-testing.md` — the layered testing overview
+- `.github/workflows/security-testing.yml` — PR-gating Slither job
+- `.github/workflows/torture-test.yml` — weekly Manticore + Medusa runs
+- [Slither](https://github.com/crytic/slither), [Manticore](https://github.com/trailofbits/manticore), [Medusa](https://github.com/crytic/medusa) — Trail of Bits / crytic tooling
+- [SWC Registry](https://swcregistry.io/), [Smart Contract Best Practices](https://consensys.github.io/smart-contract-best-practices/)
+- ERC-1167 minimal proxy and EIP-712 typed-data signing — [eips.ethereum.org](https://eips.ethereum.org)

--- a/docs/blog/posts/31-symbolic-execution-fuzzing/social.md
+++ b/docs/blog/posts/31-symbolic-execution-fuzzing/social.md
@@ -1,0 +1,26 @@
+# Social & Image — Three Ways to Break an Escrow
+
+## X (Twitter)
+
+12 lines move money to a wager winner. Slither checks the shape, Manticore proves the sum can't overflow, Medusa hammers 100-tx sequences at escrow solvency. Each catches what the others miss — and Manticore silently ran on nothing until we fixed one import. 🔗 <link>
+
+#SmartContractSecurity #Solidity #Fuzzing
+
+## LinkedIn
+
+A payout function in a peer-to-peer wager protocol has to be right on every axis at once: checks-effects-interactions ordering so a reentrant token can't drain it, an irreversible paid flag so no one claims twice, and arithmetic that sums two stakes without overflowing. No single testing technique gives you confidence across all of that — so FairWins runs three, and this post is a tour of what each one actually catches on the escrow code.
+
+The post covers:
+
+- **Slither** (static analysis, every PR): catches the reentrancy ordering, missing access control, and zero-address gaps that are visible in the shape of the code — but can't tell you whether a payout is arithmetically correct.
+- **Manticore** (symbolic execution, weekly): explores paths with symbolic inputs to prove the payout sum can't overflow for any input — plus the story of the OpenZeppelin import bug that left it silently running on nothing.
+- **Medusa** (property fuzzing, weekly): throws 100-transaction sequences at the real proxy-deployed stack and re-checks escrow solvency after every call, hunting the emergent bug no single transaction causes.
+- **Why the layers overlap on purpose** — and why a green-but-inert security tool is worse than none.
+
+How do you order your verification stack by cost vs. depth? 🔗 <link>
+
+#SmartContractSecurity #Solidity #Fuzzing #SymbolicExecution #Web3Security
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean, modern editorial illustration in isometric style: a single translucent glass vault or escrow box at the center holding two glowing coin-stacks, being examined simultaneously by three distinct abstract instruments arriving from three sides — a fast-scanning grid of light (static analysis) sweeping the surface, a branching tree of luminous forked paths (symbolic execution) wrapping around one face, and a dense swarm of small directional arrows or particles (fuzzing) probing from below. Each instrument rendered in a visually separable treatment so the "three layers" read instantly. Deep navy and teal base palette with a single warm amber accent used only on the coins and the point where each tool touches the vault. Soft volumetric lighting, subtle depth of field, precise geometric linework, fintech-engineering mood, high detail, no text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/32-spec-driven-development/blog.md
+++ b/docs/blog/posts/32-spec-driven-development/blog.md
@@ -1,0 +1,131 @@
+# Sixty-Three Features, One Constitution: Spec-Driven Development on a Money Contract
+
+*How FairWins ships complex, security-critical crypto features repeatably — with coding agents in the loop and a binding constitution every plan must pass*
+
+| | |
+|---|---|
+| **Series** | Security & DevOps (part 4) |
+| **Audience** | Engineering leaders, agent/tooling developers |
+| **Tags** | `spec-driven-development`, `spec-kit`, `process`, `ai-agents` |
+| **Reading time** | ~9 minutes |
+
+---
+
+## The problem with "just prompt the agent"
+
+A coding agent will happily write you a fee-charging smart contract in one shot. It will look plausible. It will compile. It might even pass a couple of tests the agent invents on the way. And then it will custody user funds on a public network where a single missed `nonReentrant` modifier, an inverted rounding direction, or a fee cap checked at write-time-but-not-charge-time is a permanent, on-chain, adversarially-exploitable mistake.
+
+The FairWins repository is a peer-to-peer wager platform: Solidity contracts that escrow stakes and resolve them against external oracles, a React frontend that is the trust surface for non-technical users, a relay gateway for gasless flows, and a subgraph for indexing. At the time of writing it holds **63 feature specifications** under `specs/`, numbered through `061-bitcoin-transactions`. Many of them touch funds, access control, or oracle resolution — exactly the surfaces where an unstructured "describe it and let the agent cook" workflow fails quietly and expensively.
+
+The interesting question isn't *can an agent write this feature?* It's *how do you ship the sixtieth feature to the same standard as the first, when a mix of humans and agents are writing them, and the codebase is already large enough that no one holds all of it in their head?*
+
+FairWins' answer is process, made executable. The repo runs on [GitHub's Spec Kit](https://github.com/github/spec-kit) with a project constitution that no plan is allowed to skip.
+
+## The pipeline: constitution → specify → clarify → plan → tasks → analyze → implement
+
+Spec Kit turns "build a feature" into a sequence of named, reviewable artifacts rather than a single conversation. Each stage is a `/speckit-*` skill the agent invokes, and each produces a file that outlives the chat:
+
+1. **`/speckit-constitution`** — establish or amend the binding standards.
+2. **`/speckit-specify`** — capture *what* and *why*, with **no technology choices yet**.
+3. **`/speckit-clarify`** — ask up to five targeted questions to kill ambiguity before design (optional).
+4. **`/speckit-plan`** — design the implementation against the chosen stack.
+5. **`/speckit-tasks`** — break the plan into ordered, actionable tasks.
+6. **`/speckit-analyze`** — cross-check spec, plan, and tasks for consistency (optional).
+7. **`/speckit-implement`** — execute the tasks.
+
+The separation is the point. Forcing the spec to describe behavior *before* anyone names a contract or a library keeps the "what" honest — you can't hide a design decision inside a requirement. A representative feature directory shows the full paper trail:
+
+```text
+specs/060-platform-fee-wrapper/
+├── spec.md          # what & why: user stories, acceptance scenarios, FRs
+├── plan.md          # how: technical context + constitution check
+├── research.md      # decision log for the plan
+├── data-model.md    # entities and state
+├── quickstart.md    # phase-1 design output
+├── contracts/       # interface sketches
+├── checklists/      # generated review checklists
+└── tasks.md         # ordered, dependency-aware task list
+```
+
+That is not documentation written after the fact. It is the input the implementing agent (or engineer) reads to do the work, and the record a reviewer reads to check it.
+
+## The constitution is a gate, not a README
+
+The reason this scales past a handful of features is `.specify/memory/constitution.md` — a versioned document (currently `1.0.0`, ratified 2026-06-05) that opens by declaring itself binding: *"When guidance here conflicts with convenience, this document wins."* It codifies five principles, two of them marked **NON-NEGOTIABLE**:
+
+- **I. Security-First Smart Contracts** — checks-effects-interactions, reentrancy and overflow guards, EthTrust Security Level L2 targets for new value-bearing contracts, and a mandatory review against `.github/agents/smart-contract-security.agent.md` before merge. Static analysis (Slither) and, for stateful logic, fuzzing (Medusa) must pass with no new high/critical findings.
+- **II. Test-First and Comprehensive Coverage** — behavior isn't "done" until tests prove it; resolution, claim, refund, and timeout paths must be tested *including their failure cases*.
+- **III. Honest State, No Mocks in Shipped Paths** — no stubbed responses or placeholder finality in production; the UI never implies a finality the chain hasn't reached.
+- **IV. Fail Loudly in CI** — `continue-on-error: true` is forbidden on lint, type-check, build, and test steps.
+- **V. Accessible, Consistent Frontend** — WCAG 2.1 AA, axe/Lighthouse in CI, no hand-copied contract addresses.
+
+What makes this more than a wish list is where it plugs into the pipeline. **Every `plan.md` begins with a Constitution Check that must pass before design proceeds.** In the fee-router feature that check is a table mapping each principle to a status and the concrete reasoning for it — for the security principle:
+
+```text
+| I. Security-first contracts | PASS (design gate) | FeeRouter is value-bearing
+  (custodies funds transiently within one tx). CEI + `nonReentrant` on
+  depositToVaultWithFee; SafeERC20 everywhere; caps enforced in the setter AND
+  re-checked at charge time; maxFeeBps protects members from admin front-running;
+  role-gated setters; Slither + security-agent review before merge. |
+```
+
+The plan template (`.specify/templates/plan-template.md`) also carries a **Complexity Tracking** section that exists solely to catch deviations: if a design violates a principle, it must be listed here with *why it's needed* and *why the simpler alternative was rejected*. An empty Complexity Tracking table is the happy path. A non-empty one is a design smell you have to argue for in writing — before you write code, not in a post-mortem.
+
+## Tasks that encode test-first and parallelism
+
+`/speckit-tasks` turns the approved plan into `tasks.md`: a phased, checkbox-tracked list where the constitution's rules are visible in the structure itself. The fee-router tasks open by declaring the test posture, then order the work so foundations block stories:
+
+```text
+**Tests**: Included — the constitution makes test-first non-negotiable (Principle II).
+
+## Phase 2: Foundational (blocking all stories)
+- [X] T003 contracts/fees/FeeRouter.sol — UUPS via UUPSManaged; append-only
+      storage; atomic depositToVaultWithFee (nonReentrant, CEI, maxFeeBps consent)
+- [X] T004 test/feeRouter.test.js — fee math incl. floor-to-zero, cap enforcement,
+      maxFeeBps revert, atomic revert, role gating, events
+- [X] T006 [P] test/upgradeable/FeeRouter.upgrade.test.js + register in
+      scripts/deploy/check-storage-layout.js
+```
+
+Two details do a lot of work. `[X]` gives implementers and reviewers a shared, resumable state — an agent picking up the feature mid-stream knows exactly what's left. `[P]` marks tasks that touch disjoint files and can run in parallel, which matters when you fan work out to multiple agents. And the *ordering* is a policy: the contract and its tests land together (Principle II), storage-layout verification is registered in the same phase because these are UUPS proxies where a reordered storage slot corrupts live state.
+
+## Coding agents in the loop — bounded by artifacts
+
+FairWins is built with agents, not just for them, and Spec Kit is what keeps that safe. An agent asked to "implement spec 060" doesn't improvise; it reads `spec.md` for the requirements, `plan.md` for the design and its constitution check, and `tasks.md` for the ordered work — the same artifacts a human implementer would. The agent's freedom is bounded by documents a human already reviewed and approved.
+
+The review gates are literally encoded. The Spec Kit workflow definition (`.specify/workflows/speckit/workflow.yml`) inserts human approval between machine stages:
+
+```yaml
+- id: review-plan
+  type: gate
+  message: "Review the plan before generating tasks."
+  options: [approve, reject]
+  on_reject: abort
+```
+
+There is one such gate after the spec and another after the plan. A rejected gate aborts the run. So the expensive, hard-to-reverse decisions — *what are we building* and *how* — get a human sign-off before any task is generated or a line of Solidity is written.
+
+Agents also participate in review, not just authoring. The constitution requires every `contracts/` change to be reviewed against `.github/agents/smart-contract-security.agent.md` — a dedicated security-review agent — before merge. And the repo keeps its own agent context honest: the `speckit-agent-context-update` extension (`.specify/extensions/agent-context/scripts/bash/update-agent-context.sh`) regenerates the managed Spec Kit section of `CLAUDE.md` so the guidance every agent reads at the start of a session stays in sync with the specs. The humans set the standards; the tooling makes them impossible to quietly ignore.
+
+## Design decisions and trade-offs
+
+**Why a heavyweight process for a fast-moving crypto project?** The cost of the pipeline is real: seven stages, several artifacts, two human gates per feature. The payoff is that the *variance* between the first feature and the sixty-third collapses. When the standard lives in a gate rather than a reviewer's memory, it applies whether the author is a senior engineer or an agent on its third attempt.
+
+**Why make the constitution binding rather than advisory?** Advisory standards degrade under deadline pressure — that's precisely when a fund-custody bug ships. By making the Constitution Check a precondition of the plan and forcing violations into an explicit Complexity Tracking table, the process converts "we should probably..." into "we cannot proceed until...". The friction is deliberate and lands on the highest-risk paths.
+
+**What the process doesn't do.** It doesn't verify correctness — a plan can pass the Constitution Check and still be wrong. That's why the constitution *also* mandates test-first coverage, Slither, Medusa, a security-agent review, and fail-loud CI. Spec Kit is the scaffolding that makes sure those gates get built into every feature; the gates themselves are what catch the bugs. The lightweight stages (`clarify`, `analyze`) are marked optional, and the constitution permits skipping steps for genuinely trivial changes — but *never* skipping the spec for anything touching funds, access control, or oracle resolution.
+
+The result is a codebase where "build with agents" and "handle user money safely" aren't in tension. The process is the thing that reconciles them.
+
+## Sources
+
+- `CLAUDE.md` — Spec Kit workflow section and repository guardrails
+- `.specify/memory/constitution.md` — the binding standards (v1.0.0)
+- `.specify/templates/plan-template.md`, `.specify/templates/spec-template.md`, `.specify/templates/tasks-template.md` — the artifact templates
+- `.specify/workflows/speckit/workflow.yml` — pipeline steps and human review gates
+- `.specify/extensions/agent-context/scripts/bash/update-agent-context.sh` — managed agent-context refresh
+- `specs/060-platform-fee-wrapper/{spec,plan,tasks}.md` — representative feature artifacts (Constitution Check, phased tasks)
+- `.github/agents/smart-contract-security.agent.md` — the security-review agent
+- `package.json` — `compile`, `test`, `check:storage-layout`, `test:fork`, `test:coverage` scripts
+- GitHub Spec Kit — https://github.com/github/spec-kit
+- EthTrust Security Levels — https://entethalliance.org/

--- a/docs/blog/posts/32-spec-driven-development/social.md
+++ b/docs/blog/posts/32-spec-driven-development/social.md
@@ -1,0 +1,30 @@
+# Social & Image — Sixty-Three Features, One Constitution
+
+## X (Twitter)
+
+63 features on a fund-custody crypto codebase, shipped to one standard — because every plan must pass a binding Constitution Check before design begins. A rejected review gate aborts the run. How Spec Kit + agents actually work: 🔗 <link>
+
+#SpecDrivenDevelopment #AIagents #web3
+
+## LinkedIn
+
+A coding agent will write you a fee-charging smart contract in one shot. It'll compile. It might pass a couple of tests it invented along the way. Then it custodies user funds on a public network, where one missed reentrancy guard is permanent.
+
+So how do you ship the 63rd feature to the same standard as the first, when humans and agents are both writing them?
+
+FairWins' answer is process made executable — GitHub's Spec Kit plus a binding project constitution. The new post walks through:
+
+- The pipeline: constitution → specify → clarify → plan → tasks → analyze → implement, each stage a reviewable artifact that outlives the chat.
+- The constitution as a gate, not a README: every plan.md opens with a Constitution Check that must pass before design proceeds — and any deviation goes in an explicit Complexity Tracking table.
+- Tasks that encode test-first: contracts and their tests land together, storage-layout checks in the same phase, parallel-safe work marked for fan-out.
+- Agents in the loop, bounded by artifacts: human approval gates after the spec and after the plan; a dedicated security-review agent required on every contract change.
+
+The takeaway: "build with agents" and "handle user money safely" stop being in tension when the standard lives in a gate instead of a reviewer's memory.
+
+How are you keeping quality constant as agents take on more of the authoring in your codebase? 🔗 <link>
+
+#SpecDrivenDevelopment #SmartContracts #AIagents #DevOps #Web3
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an isometric style depicting a factory assembly line where identical, precisely-formed geometric artifacts (representing software features as crystalline blocks) move along a conveyor belt, each one passing through a single glowing gate-arch that inspects and stamps it before it continues — the gate as the metaphor for a binding constitution check that every feature must pass. Show several blocks queued behind the gate and a uniform, orderly stream of approved blocks flowing out the other side, emphasizing consistency and repeatability at scale. Composition is wide and horizontal with the gate as the focal point slightly left of center, subtle depth-of-field falloff toward the edges. Color mood: deep navy and teal base tones with a single warm amber accent used only on the gate's glow and its stamp of approval. Soft directional lighting from upper left, gentle ambient occlusion, crisp vector-like edges, minimal texture. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/33-callsign-registry/blog.md
+++ b/docs/blog/posts/33-callsign-registry/blog.md
@@ -1,0 +1,119 @@
+# CallsignRegistry: An In-House ENS-Style Naming System That Nothing Depends On
+
+*How FairWins built a commit–reveal naming registry as an optional perk — and kept it strictly off the value path*
+
+---
+
+- **Series:** Standalone
+- **Part:** 33 of 34
+- **Audience:** Naming/identity engineers, product teams, Solidity engineers
+- **Tags:** `naming`, `ens`, `commit-reveal`, `identity`, `uups`
+- **Reading time:** ~9 minutes
+
+---
+
+## The Forty-Character Problem
+
+Maya wants to invite her friend Dev to a wager on Sunday's match. The invite form wants a wallet address. Dev's address is `0x7f3a…` — forty-two characters of hex that Maya has to fetch from a chat thread, paste, and then squint at, because a wrong character means the invite (and eventually the stake) goes to a stranger.
+
+Every crypto product hits this wall, and the ecosystem's standard answer is ENS: register `dev.eth`, type a name instead of hex. But ENS is an Ethereum-mainnet system, and FairWins runs its wager escrow on Polygon and the Mordor testnet. More importantly, FairWins already has an identity spine ENS knows nothing about: an on-chain `MembershipManager` with tiers, sanctions screening, and role-gated access. A name that resolves to "some wallet somewhere" is less useful than a name that resolves to "a screened, top-tier member of this platform."
+
+So spec 054 built the thing in-house: the **CallsignRegistry** (`contracts/naming/CallsignRegistry.sol`), a UUPS-proxied naming contract where a Gold-tier-or-above member may optionally register a `%callsign` — `%chipprbots`, say — that resolves trustlessly to their wallet across every address-entry and display surface in the app.
+
+The interesting part isn't that FairWins built an ENS-lite. It's the two disciplines wrapped around it: the registry borrows ENS's hardest-won mechanism (commit–reveal registration) while deliberately rejecting its most flexible one (separating name controller from resolution target), and the whole system is engineered so that *nothing of value ever depends on it*. A member can create, accept, and settle every wager they'll ever make with a raw address and never touch the registry. That optionality is a tested invariant, not a marketing line.
+
+## A Name Format Chosen for Safety, Not Expressiveness
+
+A callsign is 3–20 characters of `a-z0-9` plus single interior hyphens — no leading, trailing, or consecutive hyphens, no uppercase, no Unicode. The on-chain validator (`_validate` in `CallsignRegistry.sol`) enforces this byte by byte, and the frontend mirrors it in `frontend/src/lib/callsigns/normalizeCallsign.js`.
+
+The ASCII whitelist is the impersonation defense. ENS supports Unicode names and inherits an entire research area of homoglyph attacks — Cyrillic `а` versus Latin `a`, and thousands of confusable pairs that ENSIP-15 normalization tries to tame. Spec 054's research explicitly rejected Unicode normalization in favor of the blunter tool: if the only registrable characters are lowercase ASCII letters, digits, and hyphens, there is no confusable pair to defend against. Names are keyed by `keccak256` of the canonical string, and case variants normalize to the same lookup before they reach the chain.
+
+## Commit → Reveal, Plus a Griefing Fix
+
+Naming registries have a classic front-running problem: you broadcast `register("chipprbots")`, a mempool observer sees it, and their bot registers the name one block ahead of you. ENS's `.eth` registrar solved this with commit–reveal, and CallsignRegistry adopts the same pattern:
+
+1. `makeCommitment(callsign, owner, salt)` — a pure function returning `keccak256(abi.encode(callsignHash, owner, salt))`.
+2. `commit(commitment)` — stores only the opaque hash on-chain. Observers learn nothing.
+3. Wait at least `minCommitmentAge` (default 1 minute).
+4. `register(callsign, salt)` — the reveal. By the time the name is visible, your priority is already locked; a sniper's own commitment can't be old enough.
+
+Commitments expire after `maxCommitmentAge` (default 1 day), which prevents commitment squatting. But the implementation also closes a subtler hole that the naive version of this pattern leaves open. A commitment hash is public calldata — anyone can see it once you've committed. If `commit` blindly overwrote the stored timestamp, an attacker could replay *your* commitment every few blocks, perpetually resetting its age so your reveal forever fails with `CommitmentTooNew`:
+
+```solidity
+function _commit(bytes32 commitment) internal {
+    // Reject re-committing a still-unexpired commitment — re-commit is
+    // allowed only once the prior one has expired (ENS anti-snipe pattern).
+    uint64 existing = commitments[commitment];
+    if (existing != 0 && block.timestamp <= uint256(existing) + maxCommitmentAge) {
+        revert CommitmentPending();
+    }
+    commitments[commitment] = uint64(block.timestamp);
+    emit CallsignCommitted(commitment, uint64(block.timestamp));
+}
+```
+
+This reveal-griefing fix was one of two MEDIUM findings hardened during the spec's security review; the other appears below in the repoint flow.
+
+## The Gold Gate — and the Optionality Doctrine
+
+Registration is gated on membership: `_requireEligible` checks `membershipManager.getActiveTier(user, membershipRole) >= minTier`, where the role is `WAGER_PARTICIPANT_ROLE` and `minTier` initializes to Gold. The gate is tunable but only upward — `setMembershipGate` reverts with `TierBelowFloor` if an admin tries to drop it below Gold. A hard floor in code, not a policy document. Sanctions screening rides along in the same check when a guard is configured.
+
+The mirror-image rule is the one that shapes the whole design: **nothing on the value path may require a callsign** (FR-001a). No wager creation, pool join, transfer, or claim reads the registry as a precondition. This isn't left to convention — the integration suite (`test/integration/callsignRegistry.membership.test.js`) includes a below-Gold, callsign-less account completing a full wager end to end. The registry can be undeployed on a chain, unreachable, or paused, and every dollar-moving flow works identically.
+
+That's also why the registry is a *standalone* UUPS proxy. It is not routed through `WagerRegistry`, holds no funds — there are no payable functions and no token custody, so its worst-case failure is cosmetic — and it lives at a stable address with append-only storage, a trailing `__gap`, and the CI-gated `npm run check:storage-layout` shared by the platform's other proxies. Deployment keys are `callsignRegistry` / `callsignRegistryImpl` in `deployments/<network>.json`, resolved in app code via `getContractAddressForChain('callsignRegistry', chainId)`.
+
+## Lifecycle: Quarantine, Cooldown, Repoint, Lapse
+
+A name that routes payments needs a careful lifecycle. Callsigns move through six statuses — `NONE`, `ACTIVE`, `REPOINTING`, `QUARANTINED`, `SUSPENDED`, `LAPSED_RECLAIMABLE` — governed by bounded, operator-tunable policy parameters:
+
+- **Release and change enter quarantine.** A released or replaced callsign is unregistrable by *anyone* — including its former owner — for `quarantinePeriod` (default 90 days). Payments and invitations aimed at the old name cannot be silently captured by a stranger who re-registers it. Changes are additionally rate-limited by `changeCooldown` (default 30 days).
+- **Repointing is delayed, visible, and cancellable.** Here's where the design diverges from ENS on purpose. ENS separates the name's owner from its resolver record, which is flexible — and is exactly the payout-redirect vector spec 054 guards against. A callsign points at one address, and moving it (`requestRepoint` → wait `repointDelay`, default 48 hours → `finalizeRepoint`) puts the name into `REPOINTING`, during which it is refused for value-bearing resolution and surfaces show an honest "address changing" state. A compromised session that requests a repoint gives the real owner two days of visible warning to `cancelRepoint`. Requesting is tier-exempt (a downgraded owner is never stranded holding their own identity), but the security review added a second hardening: `finalizeRepoint` requires the *incoming* owner to be Gold-eligible — otherwise a lapsed member could repoint names around a ring of wallets to reset the lapse clock and hoard them for free. Finalizing also clears the `verified` marker, because verification was granted to a reviewed identity, not to a name. Suspension, deliberately, persists across a repoint.
+- **Lapse is grace-then-release.** If Gold coverage ends, the callsign stays `ACTIVE` until the membership term expires, then survives a `lapseGrace` window (default 365 days). Only after that does the permissionless `reclaimLapsed` push it into standard quarantine.
+
+Moderation follows least privilege: `REGISTRY_CURATOR_ROLE` reserves terms (brand names, `admin`, `support`), `MODERATOR_ROLE` suspends, `VERIFIER_ROLE` marks business callsigns verified. None of these roles — nor the platform operator — can ever reassign a callsign to a different wallet. Suspension stops resolution; it never moves a name or touches funds.
+
+## Resolution: Exact-Match Forward, Guarded Reverse
+
+Forward resolution (`resolve(string)`) is exact-match only — no fuzzy matching, no "did you mean," because a near-match substitution on an address-entry field is a payment misdirection bug. Reverse resolution is guarded by a forward==reverse invariant: an address's displayed callsign must currently resolve back to that address.
+
+```solidity
+function callsignOf(address account) external view returns (string memory) {
+    bytes32 h = callsignHashOf[account];
+    if (h == bytes32(0)) return "";
+    // Reverse only reports a callsign whose forward resolution is ACTIVE.
+    if (_statusOf(h) != CallsignStatus.ACTIVE) return "";
+    return _records[h].callsign;
+}
+```
+
+A suspended, repointing, or lapsed callsign simply disappears from display rather than telling a stale story.
+
+On the frontend, callsigns slot into an existing name-resolution chain rather than replacing it. `frontend/src/hooks/useOpponentName.js` resolves any counterparty in priority order: **address book > callsign > ENS > generated**. Your own private nickname for an address always wins; a registered `%callsign` beats an ENS name; and a deterministic two-word generated name is always available synchronously so no card ever shows a spinner or raw hex. Every step soft-fails — if the registry is undeployed on the current chain or a lookup times out, the chain falls through silently. Address entry (`frontend/src/components/ui/AddressInput.jsx`) accepts `%callsign` input, resolves it, and shows the full resolved address plus verification status for explicit confirmation before anything is committed. Only an `ACTIVE` callsign is committable.
+
+## Gasless Twins, Same Three-Way Sync
+
+Like every actor-facing contract on the platform, each callsign action has an EIP-712 `…WithSig` twin via `SignerIntentBase`: `commitWithSig`, `registerWithSig`, `changeCallsignWithSig`, `releaseWithSig`, `requestRepointWithSig`, `cancelRepointWithSig`, under the domain `"FairWins CallsignRegistry"` / version `"1"`. The six intent structs must stay byte-identical in three places — the contract typehashes, `frontend/src/lib/relay/intentTypes.js`, and `services/relay-gateway/src/intent/intentTypes.js` — and the release/repoint intents pin the exact `callsignHash` so a relayed signature can't be applied to a different name. `finalizeRepoint` and `reclaimLapsed` are permissionless and need no signed twin. Per the platform's never-stranded rule, every gasless path keeps a self-submit fallback.
+
+## Design Decisions
+
+- **In-house over ENS integration.** The registry needed membership gating, sanctions screening, role-based moderation, and presence on chains where ENS doesn't live. ENS still participates — as step three of the display chain — but the platform-native handle is anchored to platform-native identity.
+- **ASCII whitelist over Unicode normalization.** Less expressive, categorically safer. The homoglyph attack surface is eliminated rather than mitigated.
+- **One name, one address — no resolver indirection.** Splitting controller from target invites payout-redirect fraud; FairWins' passkey smart accounts already keep their address across credential recovery, so repointing is a rare migration action worth a 48-hour delay, not an everyday record edit.
+- **Direct chain reads over a subgraph.** Callsign→address routes value; an indexer would add a second, laggier source of truth. The trade-off shows up in the admin console: with no on-chain counters, registry metrics come from a bounded client-side event scan with an honest "recent window only" banner.
+- **Perk, not primitive.** Gating registration at Gold makes the callsign a membership benefit; hard-flooring the gate and testing the no-callsign wager path keeps it from ever hardening into a requirement.
+
+The result is a naming system with ENS's registration security, a narrower and safer resolution model, and a blast radius engineered to zero: if the CallsignRegistry vanished tomorrow, every wager would still settle — some screens would just show hex again.
+
+## Sources
+
+- `specs/054-callsign-registry/spec.md`, `plan.md`, `research.md`, `data-model.md`
+- `contracts/naming/CallsignRegistry.sol` (interface: `contracts/interfaces/ICallsignRegistry.sol`)
+- `docs/developer-guide/callsigns.md`
+- `docs/developer-guide/upgradeable-contracts.md`
+- `frontend/src/hooks/useOpponentName.js`, `frontend/src/lib/callsigns/normalizeCallsign.js`, `frontend/src/components/ui/AddressInput.jsx`
+- `frontend/src/lib/relay/intentTypes.js`, `services/relay-gateway/src/intent/intentTypes.js`
+- `test/integration/callsignRegistry.membership.test.js`
+- ENS `.eth` registrar commit–reveal registration: https://docs.ens.domains/
+- ENSIP-15 (ENS name normalization): https://docs.ens.domains/ensip/15
+- EIP-712 (typed structured data signing): https://eips.ethereum.org/EIPS/eip-712
+- ERC-1822 / UUPS proxies: https://eips.ethereum.org/EIPS/eip-1822 and OpenZeppelin upgradeable contracts docs: https://docs.openzeppelin.com/contracts/5.x/api/proxy

--- a/docs/blog/posts/33-callsign-registry/social.md
+++ b/docs/blog/posts/33-callsign-registry/social.md
@@ -1,0 +1,28 @@
+# Social & Image — CallsignRegistry: An In-House ENS-Style Naming System That Nothing Depends On
+
+## X (Twitter)
+
+FairWins built an ENS-style naming registry — commit–reveal, ASCII-only to kill homoglyph attacks — then engineered its blast radius to zero. A callsign is optional and never gates the value path: undeploy the registry and every wager still settles, some screens just show hex again. 🔗 <link>
+
+#Ethereum #Solidity #Identity
+
+## LinkedIn
+
+A forty-two-character hex address is a payment-misdirection bug waiting to happen. The ecosystem's answer is ENS — but ENS is Ethereum-mainnet-only, and FairWins runs on Polygon and Mordor with an on-chain membership spine ENS knows nothing about.
+
+So spec 054 built the CallsignRegistry in-house — and wrapped two disciplines around it. The post covers:
+
+- Commit–reveal registration borrowed from ENS, plus a hardening fix that stops an attacker from replaying your public commitment to perpetually reset its age.
+- An ASCII-only name format (`a-z0-9`, interior hyphens): less expressive, but the homoglyph attack surface is eliminated rather than mitigated.
+- One name, one address — deliberately rejecting ENS's controller/resolver split, the classic payout-redirect vector; repointing is a delayed, cancellable migration, not an everyday edit.
+- The optionality doctrine: nothing on the value path may require a callsign (FR-001a). A below-Gold, callsign-less account completing a full wager is a tested invariant, not a marketing line.
+
+The result: ENS's registration security, a narrower resolution model, and a blast radius engineered to zero. If the registry vanished tomorrow, every wager would still settle.
+
+Where's the line for you between a nice-to-have perk and a load-bearing primitive? 🔗 <link>
+
+#Ethereum #Solidity #Identity #ENS #SmartContracts
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean abstract-geometric editorial illustration of a single elegant nameplate token resolving via one clear arrow to exactly one wallet node — deliberately one-to-one, no branching resolver indirection. The nameplate floats slightly apart from a dense core lattice of value-carrying nodes below it, connected by only a thin, clearly detachable thread, conveying that it is an optional layer nothing structurally depends on. Deep navy and teal base, with a single warm gold accent highlighting the nameplate and its single resolution arrow. Soft glow, precise vector forms, subtle background grid, restrained and trustworthy fintech-engineering mood, generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/34-token-factory/blog.md
+++ b/docs/blog/posts/34-token-factory/blog.md
@@ -1,0 +1,140 @@
+# TokenFactory: Minting From Vetted Templates, Not Arbitrary Bytecode
+
+*How FairWins lets authorized issuers mint their own ERC-20s, ERC-721s, and restricted tokens without ever deploying unaudited code — and what that constraint buys you*
+
+| | |
+|---|---|
+| **Series** | FairWins Engineering |
+| **Part** | 34 — TokenFactory: templated token minting |
+| **Audience** | Solidity / web3 engineers, protocol integrators |
+| **Tags** | solidity, erc20, erc1404, minimal-proxy, upgradeable, factory-pattern |
+| **Reading time** | ~9 minutes |
+
+---
+
+## The token nobody audited
+
+An issuer on the platform wants to spin up a fungible token — say, a points balance for a community, or a restricted instrument that only vetted wallets can hold. The naive path is familiar: write a Solidity contract, compile it, deploy the bytecode, hope it does what the constructor comment claims.
+
+That path is a problem the moment more than one person relies on it. Whose eyes were on the transfer hook? Did the `mint` function check the sanctions list, or did it quietly skip it? When the platform's frontend later renders a "Holders" tab or an "Activity" feed for that token, is it reading a real ERC-20, or something that *looks* like one until the third `transferFrom`? Arbitrary bytecode deployment means every new token is a fresh, un-reviewed attack surface, and every downstream consumer — the subgraph, the wallet UI, the sanctions screen — has to defensively assume the worst.
+
+FairWins takes the opposite stance. There is exactly one contract on each network authorized to bring tokens into existence: `contracts/tokens/TokenFactory.sol`. It does not accept bytecode. It does not `CREATE2` whatever an issuer hands it. It clones from a small, fixed set of implementation templates that the platform team wrote, audited, and pinned — and it stamps a sanctions screen into every one on the way out the door.
+
+This post walks through what that template model constrains, why the constraint is worth it, and how a new template gets added when the fixed set needs to grow.
+
+## One authority, a handful of templates
+
+The factory is the single upgradeable, state-bearing contract for token issuance. Everything it emits is an immutable minimal-proxy clone. The design splits cleanly along that line: the *authority* can be upgraded and re-templated; the *tokens* it produces can never change their own logic.
+
+The template set is deliberately short. Each supported standard has a v1 (Ownable) template and a v2 (role-based) template:
+
+| Standard | v1 template | v2 template | Character |
+|---|---|---|---|
+| Open ERC-20 | `OpenERC20` | `OpenERC20V2` | Fungible; burnable/pausable flags; optional supply cap (v2) |
+| Open ERC-721 | `OpenERC721` | `OpenERC721V2` | NFT; per-token URIs; batch mint |
+| Restricted ERC-1404 | `RestrictedERC20` | `RestrictedERC20V2` | Eligibility allowlist + restriction codes + freeze |
+| Permissioned ERC-3643 (T-REX) | — | — | **Deferred** (see below) |
+
+That is the entire menu. An issuer picks a standard and a few parameters — name, symbol, decimals, supply, a cap, an eligibility list — and gets back a token address. They never choose *code*. The `TokenStandard` enum in `contracts/tokens/interfaces/ITokenFactory.sol` enumerates exactly what can be minted, and a value with no configured template simply reverts.
+
+The clone mechanism is OpenZeppelin's EIP-1167 minimal proxy (`Clones.clone`). Each `create*` call deploys a ~45-byte proxy that `DELEGATECALL`s a shared, already-audited implementation, then calls a one-time `initialize` to set the token's own storage. The implementation itself is initialization-locked in its constructor (`_disableInitializers()`), so the master copy can never be hijacked — only cloned.
+
+## What gets stamped in on the way out
+
+The factory's issuance path is not a pass-through. Before any clone happens, `_beforeCreate` runs three checks that no issuer can opt out of:
+
+```solidity
+function _beforeCreate(
+    string calldata name,
+    string calldata symbol,
+    address impl,
+    TokenStandard standard
+) internal view {
+    if (bytes(name).length == 0 || bytes(symbol).length == 0) revert EmptyMetadata();
+    if (impl == address(0)) revert TemplateNotSet(standard);
+    ISanctionsGuard guard = sanctionsGuard;
+    if (address(guard) != address(0) && !guard.isAllowed(msg.sender)) revert SanctionedAddress(msg.sender);
+}
+```
+
+Metadata must be non-empty. A template must be configured for the requested standard. And the issuer must pass the platform's shared `ISanctionsGuard` — fail-closed, the same screen the rest of FairWins uses, not a parallel bespoke one. Issuance itself is gated behind `TOKEN_ISSUER_ROLE`, granted out-of-band by the platform admin; holding a wallet is not enough to mint.
+
+The screen does not stop at creation. Every template injects that same `sanctionsGuard` reference into the token it clones, and every token re-checks it on every transfer inside its `_update` hook — skipping only the zero endpoint so mints and burns are screened on their one real party. Here is the open ERC-20's hook:
+
+```solidity
+function _update(address from, address to, uint256 value)
+    internal override(ERC20Upgradeable, ERC20PausableUpgradeable)
+{
+    ISanctionsGuard guard = sanctionsGuard;
+    if (address(guard) != address(0)) {
+        if (from != address(0) && !guard.isAllowed(from)) revert SanctionedAddress(from);
+        if (to != address(0) && !guard.isAllowed(to)) revert SanctionedAddress(to);
+    }
+    super._update(from, to, value);
+}
+```
+
+Because the template is the only code an issuer can deploy, the platform *knows* this check exists in every token it has ever minted. That is the whole point of refusing arbitrary bytecode: a property proven once on the template holds for the entire population of clones. Sanctions are non-bypassable not because of policy, but because there is no code path that omits them.
+
+The restricted ERC-1404 template pushes the same idea further. It evaluates a transfer policy most-restrictive-first — sanctioned, then frozen, then not-eligible — and, critically, the pre-transfer detector and the enforcing hook call the *same* internal function:
+
+```solidity
+function _detect(address from, address to) internal view returns (uint8) {
+    ISanctionsGuard guard = sanctionsGuard;
+    if (address(guard) != address(0)) {
+        if (from != address(0) && !guard.isAllowed(from)) return SANCTIONED;
+        if (to != address(0) && !guard.isAllowed(to)) return SANCTIONED;
+    }
+    if (from != address(0) && frozen[from]) return SENDER_FROZEN;
+    if (from != address(0) && !eligible[from]) return SENDER_NOT_ELIGIBLE;
+    if (to != address(0) && !eligible[to]) return RECIPIENT_NOT_ELIGIBLE;
+    return SUCCESS;
+}
+```
+
+`detectTransferRestriction` (the ERC-1404 view a UI calls before offering a transfer) and `_update` (the hook that actually reverts) both route through `_detect`. A pre-check that says "this will succeed" and a transfer that then fails is a whole class of bug the template design forecloses by construction.
+
+## The registry: discovery without trusting the tokens
+
+Cloning solves creation. Discovery is the other half. If tokens are just addresses floating on-chain, how does a frontend enumerate "everything this issuer minted" without an indexer, and how does anything know a given address came from the factory at all?
+
+The factory keeps a network-scoped registry. Every successful creation appends a `TokenRecord` — id, standard, address, issuer, metadata, flags, timestamp — and updates a reverse lookup:
+
+```solidity
+id = ++tokenCount;
+_tokens[id] = TokenRecord({ /* ...standard, tokenAddress, issuer, name, symbol... */ });
+_issuerTokens[msg.sender].push(id);
+tokenAddressToId[token] = id;
+emit TokenCreated(id, standard, token, msg.sender, name, symbol);
+```
+
+`getTokenIdByAddress(token)` returning non-zero is a provenance proof: this address is a factory clone, not an impostor. `getTokensByIssuer(issuer)` powers the "My Tokens" view directly from chain on networks without a subgraph. And the registry write happens *after* the clone-and-init succeeds — checks-effects-interactions applied to issuance, so a revert mid-creation never leaves a phantom row.
+
+## Design decisions
+
+**Templates over arbitrary bytecode.** The obvious cost is flexibility: an issuer cannot ship a token with a novel bonding curve or a custom rebasing rule. The obvious benefit is that the platform can make and keep guarantees across *every* token it has issued — sanctions are enforced, the ERC-1404 detector matches its hook, the ABI the frontend loads is the ABI the contract actually has. For a platform whose wallet, subgraph, and compliance surface all consume these tokens, that uniformity is worth more than open-ended expressiveness. Arbitrary deployment would push the audit burden onto every reader; templates pay it once.
+
+**Immutable tokens, upgradeable factory.** Only `TokenFactory` is UUPS-upgradeable (via the shared `UUPSManaged` base, with append-only storage gated by `npm run check:storage-layout` in CI). Issued clones are immutable — a holder's token cannot have its rules changed out from under them by a later upgrade. Fixing template logic means registering a *new* template for *future* mints, never rewriting existing tokens. The v2 role-based templates were added exactly this way: three new implementation slots appended to storage (consuming reserved `__gap` space), new `create*V2` entrypoints, and a `setV2Template` admin call. Existing v1 Ownable tokens were untouched.
+
+**Adding or replacing a template is an admin operation, not a user one.** `setTemplate` and `setV2Template` are `onlyRole(DEFAULT_ADMIN_ROLE)` and reject `address(0)`. A new template class is a deliberate, reviewed, append-only factory upgrade — the implementation is written, audited (Slither and Medusa run in CI with clone/proxy/UUPS/AccessControl detectors), deployed once as a locked master, and only then registered. The audit story is *because* the surface is small: three standards, two variants each, is a set a human can actually review, unlike an open firehose of user bytecode.
+
+**Deferring rather than faking ERC-3643.** The permissioned security-token class is intentionally *not* shipped. The canonical T-REX suite pins OpenZeppelin 4.x and Solidity 0.8.17, incompatible with this repo's OZ 5.4.0 pin (chosen as the newest ETC/Mordor-compatible release — OZ ≥ 5.5 needs the Cancun `mcopy` opcode pre-Cancun ETC lacks). Rather than ship a broken or downgraded implementation, the `PERMISSIONED_ERC3643` enum value and the `TokenRecord.suite` field are *reserved* so the registry layout stays forward-stable, and the class lands only when an OZ-5-native suite exists. Honest absence beats a template nobody can stand behind.
+
+## Where it runs
+
+`TokenFactory` is deployed behind a UUPS proxy on Mordor (ETC testnet, chain 63) and Polygon (chain 137); the proxy and implementation addresses are recorded in `deployments/`, which is the source of truth. The frontend self-disables its Tokens tab on any network without a deployed `tokenFactory`, so there is no UI promising issuance where the authority does not exist.
+
+The template model is not glamorous. It says no to a lot of things an issuer might want to do. But it is precisely that refusal — no arbitrary code, one screened path in, a short auditable menu of what comes out — that lets everything downstream treat a FairWins-minted token as a known quantity.
+
+## Sources
+
+- `contracts/tokens/TokenFactory.sol` — factory authority, registry, `create*`/`setTemplate`/`_beforeCreate`
+- `contracts/tokens/interfaces/ITokenFactory.sol` — `TokenStandard` enum, `TokenRecord`, events, errors
+- `contracts/tokens/templates/OpenERC20.sol` — open fungible clone template + `_update` sanctions hook
+- `contracts/tokens/templates/RestrictedERC20.sol` — ERC-1404 template, `_detect` shared policy
+- `docs/developer-guide/token-mint.md` — standards table, v2 roles/caps, deploy/sync, deferral notes
+- `specs/028-token-mint/` — spec, `contracts/token-factory.md`, `data-model.md`
+- `deployments/mordor-chain63-v2.json`, `deployments/polygon-chain137-v2.json` — recorded proxy/impl addresses
+- EIP-1167 Minimal Proxy Contract — https://eips.ethereum.org/EIPS/eip-1167
+- ERC-1404 Simple Restricted Token Standard — https://erc1404.org / https://github.com/ethereum/EIPs
+- OpenZeppelin Contracts (Clones, ERC20, AccessControl, UUPS) — https://docs.openzeppelin.com/contracts/5.x/

--- a/docs/blog/posts/34-token-factory/social.md
+++ b/docs/blog/posts/34-token-factory/social.md
@@ -1,0 +1,30 @@
+# Social & Image — TokenFactory: Minting From Vetted Templates, Not Arbitrary Bytecode
+
+## X (Twitter)
+
+FairWins' TokenFactory never deploys issuer bytecode. It clones from a short, audited set of EIP-1167 templates and stamps the same sanctions screen into every one. A property proven on the template holds for every clone ever minted. 🔗 <link>
+
+#Solidity #web3 #smartcontracts
+
+## LinkedIn
+
+Every time a platform lets someone deploy arbitrary token bytecode, it inherits a fresh un-reviewed attack surface — and every downstream consumer (the wallet UI, the indexer, the compliance screen) has to defensively assume the worst.
+
+FairWins' TokenFactory takes the opposite stance: one authorized contract per network, and it does not accept bytecode. It clones from a small, fixed set of templates the team wrote, audited, and pinned. Our latest engineering post walks through what that constraint buys you:
+
+- EIP-1167 minimal-proxy clones of immutable, initialization-locked templates — issuers pick a standard and parameters, never code.
+- A shared sanctions screen injected into every token and re-checked on every transfer, non-bypassable by construction.
+- A short auditable menu (Open ERC-20, ERC-721, Restricted ERC-1404 — each with v1 Ownable and v2 role-based variants) instead of an open firehose.
+- An on-chain registry that doubles as provenance: a non-zero id proves an address is a real factory clone.
+
+The immutable-token / upgradeable-factory split means fixes ship as new templates for future mints — existing holders' rules never change underneath them.
+
+Read the full breakdown: 🔗 <link>
+
+Where do you draw the line between issuer flexibility and platform-wide guarantees?
+
+#Solidity #Ethereum #SmartContracts #web3 #TokenEngineering
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in isometric style: a single precision-machined metal mold or stamping die at center, from which several identical glowing token discs emerge on a conveyor, each disc bearing an identical embossed shield emblem to suggest a built-in safety check. In the background, a discarded pile of mismatched, irregular hand-scrawled blueprint fragments sits in shadow, rejected — contrasting the uniform minted tokens against chaotic arbitrary code. Composition balanced left-to-right showing the flow from mold to finished tokens. Deep navy and teal base palette with a single warm amber accent lighting the emerging tokens and the mold's active edge. Soft directional lighting, subtle depth of field, precise geometric shapes, restrained and technical mood befitting a fintech-engineering brand. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/README.md
+++ b/docs/blog/posts/README.md
@@ -1,0 +1,65 @@
+# FairWins Engineering Blog — Post Drafts
+
+This directory holds the draft content for the 34-topic blockchain-architecture
+blog program scoped in [`../blog-topics-inventory.md`](../blog-topics-inventory.md).
+
+Each post lives in its own numbered directory with two files:
+
+- `blog.md` — the full post (~1,200–1,900 words): a concrete opening scenario,
+  the architecture walked stage by stage, real code excerpts drawn from the
+  repo, a design-decisions / trade-offs section, and a **Sources** section
+  citing the specs, docs, and contracts of record plus external standards.
+- `social.md` — the promotion kit: an X (Twitter) post, a LinkedIn post, and a
+  16:9 banner **image prompt** for Gemini / Nano Banana.
+
+Every technical claim was researched against the repository's source of truth
+(specs under `specs/`, developer guides under `docs/developer-guide/`, runbooks
+under `docs/runbooks/`, and the Solidity / service code itself). Where the repo
+contradicted the inventory's original blurb, the repo won — see topic 21 for a
+notable correction.
+
+## Index
+
+| # | Post | Series |
+|---|------|--------|
+| 01 | [Role-based access control & the operations control plane](01-rbac-operations-control-plane/blog.md) | Identity & Access |
+| 02 | [Soulbound memberships + transferable vouchers](02-soulbound-memberships-vouchers/blog.md) | Identity & Access |
+| 03 | [Sanctions & compliance gating as a contract primitive](03-sanctions-compliance-gating/blog.md) | Identity & Access |
+| 04 | [Passkey smart accounts (ERC-4337 + WebAuthn)](04-passkey-smart-accounts/blog.md) | Accounts & Keys |
+| 05 | [Account recovery & unified connect](05-account-recovery-unified-connect/blog.md) | Accounts & Keys |
+| 06 | [Sponsored gas with a self-hosted verifying paymaster (ERC-7677)](06-sponsored-gas-verifying-paymaster/blog.md) | Accounts & Keys |
+| 07 | [Safe multisig custody integration](07-safe-multisig-custody/blog.md) | Custody & Multisig |
+| 08 | [On-chain multisig policy engine (transaction guards)](08-multisig-policy-engine/blog.md) | Custody & Multisig |
+| 09 | [Intent-based gasless payments (EIP-712 + EIP-3009)](09-intent-based-gasless-payments/blog.md) | Gasless Rails |
+| 10 | [Relayer gateway architecture (policy + engine split)](10-relayer-gateway-architecture/blog.md) | Gasless Rails |
+| 11 | [UUPS upgrades & storage-layout safety](11-uups-upgrades-storage-safety/blog.md) | Contract Architecture |
+| 12 | [The two-facet proxy: beating the 24 KB limit](12-two-facet-proxy-24kb/blog.md) | Contract Architecture |
+| 13 | [Deterministic / singleton deployment across chains](13-deterministic-singleton-deployment/blog.md) | Contract Architecture |
+| 14 | [The wager lifecycle contract](14-wager-lifecycle-contract/blog.md) | Prediction Markets |
+| 15 | [Oracle adapter abstraction (Polymarket / Chainlink / UMA)](15-oracle-adapter-abstraction/blog.md) | Prediction Markets |
+| 16 | [Draw resolution & open-challenge wagers](16-draw-resolution-open-challenges/blog.md) | Prediction Markets |
+| 17 | [Wager pools: ERC-1167 clones & address-keyed payouts](17-wager-pools-erc1167/blog.md) | Prediction Markets |
+| 18 | [Envelope encryption for private prediction markets](18-envelope-encryption/blog.md) *(pointer to published post)* | Privacy Architecture |
+| 19 | [Multi-recipient encryption](19-multi-recipient-encryption/blog.md) | Privacy Architecture |
+| 20 | [Client-side encrypted data sync](20-encrypted-data-sync/blog.md) | Privacy Architecture |
+| 21 | [The nullifier system](21-nullifier-system/blog.md) *(design history)* | Privacy Architecture |
+| 22 | [The FeeRouter: one source of truth for platform fees](22-fee-router/blog.md) | Finance Surfaces |
+| 23 | [Earn: wrapping ERC-4626 lending vaults with fee disclosure](23-earn-erc4626-vaults/blog.md) | Finance Surfaces |
+| 24 | [Predict: Polymarket trading via builder codes](24-predict-polymarket-builder-codes/blog.md) | Finance Surfaces |
+| 25 | [Bitcoin: adding a non-EVM chain to an EVM app](25-bitcoin-non-evm/blog.md) | Finance Surfaces |
+| 26 | [ClearPath: a multi-network external DAO registry](26-clearpath-dao-registry/blog.md) | Multi-chain Infra |
+| 27 | [Indexing without a subgraph (graceful degradation)](27-indexing-without-subgraph/blog.md) | Multi-chain Infra |
+| 28 | [The unified activity ledger](28-unified-activity-ledger/blog.md) | Multi-chain Infra |
+| 29 | [AI-driven smart-contract security review in CI](29-ai-security-review-ci/blog.md) | Security & DevOps |
+| 30 | [Coverage & audit gates that fail loudly](30-coverage-audit-gates/blog.md) | Security & DevOps |
+| 31 | [Symbolic execution & fuzzing a wager protocol](31-symbolic-execution-fuzzing/blog.md) | Security & DevOps |
+| 32 | [Spec-driven development with Spec Kit](32-spec-driven-development/blog.md) | Security & DevOps |
+| 33 | [CallsignRegistry: an in-house ENS-style naming system](33-callsign-registry/blog.md) | Standalone |
+| 34 | [TokenFactory: templated token minting](34-token-factory/blog.md) | Standalone |
+
+## Suggested publishing order
+
+Lead with the highest-demand, most-differentiated pieces (see the inventory's
+rationale): **04** (passkeys) → **12** (two-facet proxy) → **15** (oracle
+adapters) → **06** (paymaster) → **29** (AI security review) → **25** (Bitcoin),
+then fill in each series around those anchors.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,59 @@ nav:
     - API Reference: reference/api.md
     - Contract Interfaces: reference/contracts.md
     - Configuration: reference/configuration.md
+  - Engineering Blog:
+    - Overview: blog/posts/README.md
+    - Topic Inventory: blog/blog-topics-inventory.md
+    - Identity & Access:
+      - Role-Based Access Control: blog/posts/01-rbac-operations-control-plane/blog.md
+      - Soulbound Memberships & Vouchers: blog/posts/02-soulbound-memberships-vouchers/blog.md
+      - Sanctions & Compliance Gating: blog/posts/03-sanctions-compliance-gating/blog.md
+    - Accounts & Keys:
+      - Passkey Smart Accounts: blog/posts/04-passkey-smart-accounts/blog.md
+      - Account Recovery & Unified Connect: blog/posts/05-account-recovery-unified-connect/blog.md
+      - Sponsored Gas & Verifying Paymaster: blog/posts/06-sponsored-gas-verifying-paymaster/blog.md
+    - Custody & Multisig:
+      - Safe Multisig Custody: blog/posts/07-safe-multisig-custody/blog.md
+      - Multisig Policy Engine: blog/posts/08-multisig-policy-engine/blog.md
+    - Gasless Rails:
+      - Intent-Based Gasless Payments: blog/posts/09-intent-based-gasless-payments/blog.md
+      - Relayer Gateway Architecture: blog/posts/10-relayer-gateway-architecture/blog.md
+    - Contract Architecture:
+      - UUPS Upgrades & Storage Safety: blog/posts/11-uups-upgrades-storage-safety/blog.md
+      - The Two-Facet Proxy (24 KB Limit): blog/posts/12-two-facet-proxy-24kb/blog.md
+      - Deterministic Singleton Deployment: blog/posts/13-deterministic-singleton-deployment/blog.md
+    - Prediction Markets:
+      - The Wager Lifecycle Contract: blog/posts/14-wager-lifecycle-contract/blog.md
+      - Oracle Adapter Abstraction: blog/posts/15-oracle-adapter-abstraction/blog.md
+      - Draw Resolution & Open Challenges: blog/posts/16-draw-resolution-open-challenges/blog.md
+      - Wager Pools (ERC-1167 Clones): blog/posts/17-wager-pools-erc1167/blog.md
+    - Privacy Architecture:
+      - Envelope Encryption (Published): blog/posts/18-envelope-encryption/blog.md
+      - Multi-Recipient Encryption: blog/posts/19-multi-recipient-encryption/blog.md
+      - Encrypted Data Sync: blog/posts/20-encrypted-data-sync/blog.md
+      - The Nullifier System (Design History): blog/posts/21-nullifier-system/blog.md
+    - Finance Surfaces:
+      - The FeeRouter: blog/posts/22-fee-router/blog.md
+      - Earn (ERC-4626 Vaults): blog/posts/23-earn-erc4626-vaults/blog.md
+      - Predict (Polymarket Builder Codes): blog/posts/24-predict-polymarket-builder-codes/blog.md
+      - Bitcoin (Non-EVM): blog/posts/25-bitcoin-non-evm/blog.md
+    - Multi-Chain Infrastructure:
+      - ClearPath DAO Registry: blog/posts/26-clearpath-dao-registry/blog.md
+      - Indexing Without a Subgraph: blog/posts/27-indexing-without-subgraph/blog.md
+      - The Unified Activity Ledger: blog/posts/28-unified-activity-ledger/blog.md
+    - Security & DevOps:
+      - AI-Driven Security Review in CI: blog/posts/29-ai-security-review-ci/blog.md
+      - Coverage & Audit Gates: blog/posts/30-coverage-audit-gates/blog.md
+      - Symbolic Execution & Fuzzing: blog/posts/31-symbolic-execution-fuzzing/blog.md
+      - Spec-Driven Development: blog/posts/32-spec-driven-development/blog.md
+    - Standalone:
+      - CallsignRegistry (ENS-Style Naming): blog/posts/33-callsign-registry/blog.md
+      - TokenFactory (Templated Minting): blog/posts/34-token-factory/blog.md
+
+# Companion social/image-prompt assets live beside each post but are not nav pages.
+not_in_nav: |
+  /blog/posts/*/social.md
+  /blog/private-prediction-markets-envelope-encryption.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary

Establishes a full engineering-blog program for the FairWins platform, aimed at the crypto / digital-asset developer ecosystem:

1. **`docs/blog/blog-topics-inventory.md`** — an editorial backlog of 34 candidate topics across 10 thematic series plus standalones, each with a description, intended audience, category tags, series-vs-standalone placement, and a 1–5 quality evaluation, plus a summary matrix and suggested publishing order.
2. **`docs/blog/posts/<NN>-<slug>/`** — for every one of the 34 topics, a drafted **`blog.md`** (~1,200–1,900 words) **and** a **`social.md`** promotion kit (X post, LinkedIn post, and a Gemini / Nano Banana 16:9 image prompt).
3. **`docs/blog/posts/README.md`** — a navigable index of all 34 drafts with series grouping and publishing order.

## How the posts were produced

Each post was researched and written against the repository's sources of truth — specs under `specs/`, developer guides under `docs/developer-guide/`, runbooks under `docs/runbooks/`, and the Solidity / service code itself. Every post ends with a **Sources** section citing the repo paths used plus external standards (EIPs, BIPs, OpenZeppelin, Safe, The Graph, Polymarket, etc.). Where the repo contradicted the inventory's original blurb, the repo won — most notably topic 21 (see below).

Guardrails applied throughout:
- Prediction-market posts (14, 15, 16, 17, 24) carry the responsible-use note (skill-based forecasting on public information; participants remain subject to applicable law).
- Fee-related posts (22, 23, 24, 60-lineage) reflect the honest-disclosure doctrine (fees always shown before signature; hard per-service caps).
- No secrets, private keys, live endpoints, or internal hostnames — architecture only.

## The 34 posts by series

- **Identity & Access** — 01 RBAC + ops console · 02 soulbound memberships + vouchers · 03 sanctions/compliance gating
- **Accounts & Keys** — 04 passkey smart accounts (ERC-4337/WebAuthn) · 05 account recovery · 06 sponsored gas / verifying paymaster (ERC-7677)
- **Custody & Multisig** — 07 Safe custody · 08 on-chain multisig policy engine
- **Gasless Rails** — 09 intent-based payments (EIP-712/3009) · 10 relayer gateway architecture
- **Contract Architecture** — 11 UUPS + storage-layout safety · 12 two-facet proxy vs the 24 KB limit · 13 deterministic deployment
- **Prediction Markets** — 14 wager lifecycle · 15 oracle adapter abstraction · 16 draws/open challenges · 17 ERC-1167 wager pools
- **Privacy Architecture** — 18 envelope encryption (pointer to the published post) · 19 multi-recipient encryption · 20 encrypted sync · 21 nullifier system *(design history — see note)*
- **Finance Surfaces** — 22 FeeRouter · 23 Earn (ERC-4626) · 24 Predict (Polymarket builder codes) · 25 Bitcoin (non-EVM)
- **Multi-chain Infra** — 26 ClearPath DAO registry · 27 indexing without a subgraph · 28 unified activity ledger
- **Security & DevOps** — 29 AI-driven security review in CI · 30 coverage/audit gates · 31 symbolic execution & fuzzing · 32 spec-driven development
- **Standalone** — 33 CallsignRegistry · 34 TokenFactory

### Research correction worth flagging

Topic **21 (nullifier system)** was reframed during drafting. The inventory assumed a ZK-style anti-replay nullifier, but the repo tells a different story: FairWins' nullifier system is an **archived moderation/blocklist primitive** (RSA accumulator + deterministic hash-to-prime, `contracts-archive/security/NullifierRegistry.sol`) with **no live deployment**, superseded by the `SanctionsGuard` + `MembershipManager` compliance path. The post is written as an honest design-history explainer, and the inventory entry was corrected to match.

## Notes

- Docs-only change; no code, contracts, or config touched.
- Post 18 is a short pointer to the already-published envelope-encryption article (with a full social kit) rather than a duplicate.
- These are drafts for editorial review, not auto-published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)