### PR TITLE
Fix passkey transactions reverting at "Prepare" on rotated/recovered accounts

### DIFF
--- a/frontend/src/lib/passkey/__tests__/smartAccount.test.js
+++ b/frontend/src/lib/passkey/__tests__/smartAccount.test.js
@@ -4,6 +4,19 @@
  * batch composition, guard refusals, capability gating per network.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { decodeAbiParameters } from 'viem'
+
+const SIGNATURE_WRAPPER_ABI = [
+  {
+    type: 'tuple',
+    components: [
+      { name: 'ownerIndex', type: 'uint8' },
+      { name: 'signatureData', type: 'bytes' },
+    ],
+  },
+]
+const stubOwnerIndex = (sig) => Number(decodeAbiParameters(SIGNATURE_WRAPPER_ABI, sig)[0].ownerIndex)
+const stubSignatureData = (sig) => decodeAbiParameters(SIGNATURE_WRAPPER_ABI, sig)[0].signatureData
 
 vi.mock('../../../config/networks', () => ({
   getNetwork: vi.fn((chainId) => {
@@ -40,6 +53,13 @@ vi.mock('../../../config/contracts', () => ({
   }),
 }))
 
+// viem 2.53's `toCoinbaseSmartAccount.getStubSignature()` for a WebAuthn owner:
+// a SignatureWrapper with a HARDCODED ownerIndex 0 (word[1] == 0) wrapping a
+// dummy WebAuthnAuth. Estimation validates this against slot 0 (see the
+// stub-index override under test).
+const VIEM_WEBAUTHN_STUB =
+  '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000000170000000000000000000000000000000000000000000000000000000000000001949fc7c88032b9fcb5f6efc7a7b8c63668eae9871b765e23123bb473ff57aa831a7c0d9276168ebcc29f2875a0239cffdf2a9cd1c2007c5c77c071db9264df1d000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008a7b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a2273496a396e6164474850596759334b7156384f7a4a666c726275504b474f716d59576f4d57516869467773222c226f726967696e223a2268747470733a2f2f7369676e2e636f696e626173652e636f6d222c2263726f73734f726967696e223a66616c73657d00000000000000000000000000000000000000000000'
+
 vi.mock('viem/account-abstraction', async () => {
   const actual = await vi.importActual('viem/account-abstraction')
   return {
@@ -47,9 +67,12 @@ vi.mock('viem/account-abstraction', async () => {
     toWebAuthnAccount: vi.fn(() => ({ type: 'webAuthnAccount' })),
     // Echo the pinned `address` param (the factory-mismatch fix pins the sender) and expose an
     // isDeployed the getFactoryArgs override consults; default counterfactual.
+    // getStubSignature mirrors viem's WebAuthn stub (hardcoded ownerIndex 0) so the
+    // stub-index override in buildAccount can be exercised.
     toCoinbaseSmartAccount: vi.fn(async (params) => ({
       address: params?.address ?? '0xACC0000000000000000000000000000000000001',
       isDeployed: vi.fn().mockResolvedValue(false),
+      getStubSignature: vi.fn().mockResolvedValue(VIEM_WEBAUTHN_STUB),
     })),
     createBundlerClient: vi.fn((opts) => opts),
     createPaymasterClient: vi.fn((opts) => ({ __isPaymasterClient: true, ...opts })),
@@ -62,6 +85,7 @@ import {
   addressToOwnerBytes,
   buildAction,
   buildAccount,
+  rewrapStubOwnerIndex,
   resolveOwnerIndex,
   encodeRemoveOwner,
   encodeAddWalletOwner,
@@ -336,5 +360,47 @@ describe('resolveOwnerIndex (spec 045 FR-009)', () => {
     await expect(
       resolveOwnerIndex({ chainId: 80002, accountAddress: '0xACC', credential, deps: { readControllers } })
     ).rejects.toBeInstanceOf(CredentialNotControllerError)
+  })
+})
+
+describe('rewrapStubOwnerIndex (estimation stub validates the signing owner slot)', () => {
+  it('viem’s WebAuthn stub really does hardcode ownerIndex 0 (the bug it fixes)', () => {
+    expect(stubOwnerIndex(VIEM_WEBAUTHN_STUB)).toBe(0)
+  })
+
+  it('re-points the stub at a non-zero index, preserving the dummy signatureData', () => {
+    const rewrapped = rewrapStubOwnerIndex(VIEM_WEBAUTHN_STUB, 2)
+    expect(stubOwnerIndex(rewrapped)).toBe(2)
+    // Only the index changes — the dummy WebAuthnAuth payload is untouched.
+    expect(stubSignatureData(rewrapped)).toBe(stubSignatureData(VIEM_WEBAUTHN_STUB))
+  })
+
+  it('is a byte-for-byte no-op for slot 0 (pristine single-passkey accounts unchanged)', () => {
+    expect(rewrapStubOwnerIndex(VIEM_WEBAUTHN_STUB, 0)).toBe(VIEM_WEBAUTHN_STUB)
+  })
+
+  it('returns an undecodable stub untouched (never blocks a send)', () => {
+    expect(rewrapStubOwnerIndex('0xdeadbeef', 3)).toBe('0xdeadbeef')
+  })
+})
+
+describe('buildAccount stub-index override (validateUserOp-reverts-on-Prepare fix)', () => {
+  const credential = { credentialId: 'c1', publicKey: { x: X, y: Y } }
+  const publicClient = { readContract: vi.fn(), getCode: vi.fn() }
+
+  it('re-points the estimation stub at the credential’s real owner index (slot 1)', async () => {
+    const out = await buildAccount({ chainId: 137, credential, accountAddress: '0xACC', ownerIndex: 1, deps: { publicClient } })
+    const stub = await out.account.getStubSignature()
+    // Without the override this is 0 → validateUserOp reverts (InvalidOwnerBytesLength)
+    // during estimation on an account whose slot 0 was removed. With it, estimation
+    // validates the SAME live slot signUserOperation signs with.
+    expect(stubOwnerIndex(stub)).toBe(1)
+  })
+
+  it('leaves the stub untouched for slot 0 (no override installed)', async () => {
+    const out = await buildAccount({ chainId: 137, credential, accountAddress: '0xACC', ownerIndex: 0, deps: { publicClient } })
+    const stub = await out.account.getStubSignature()
+    expect(stub).toBe(VIEM_WEBAUTHN_STUB)
+    expect(stubOwnerIndex(stub)).toBe(0)
   })
 })

--- a/frontend/src/lib/passkey/smartAccount.js
+++ b/frontend/src/lib/passkey/smartAccount.js
@@ -11,7 +11,14 @@
  * so `deriveAddress` is chain-independent by construction.
  */
 
-import { http, createPublicClient, encodeFunctionData, parseAbi } from 'viem'
+import {
+  http,
+  createPublicClient,
+  encodeFunctionData,
+  encodeAbiParameters,
+  decodeAbiParameters,
+  parseAbi,
+} from 'viem'
 import {
   toWebAuthnAccount,
   toCoinbaseSmartAccount,
@@ -81,6 +88,51 @@ export const ACCOUNT_ABI = parseAbi([
   'function replaySafeHash(bytes32 hash) view returns (bytes32)',
   'function executeBatch((address target, uint256 value, bytes data)[] calls) payable',
 ])
+
+/**
+ * The `CoinbaseSmartWallet.SignatureWrapper` tuple — `(uint8 ownerIndex, bytes
+ * signatureData)`. Byte-identical to what viem's internal `wrapSignature` emits
+ * (a small `uint8` right-aligns in a 32-byte word exactly like the contract's
+ * `uint256 ownerIndex`), so decode/re-encode round-trips cleanly.
+ */
+const SIGNATURE_WRAPPER_ABI = [
+  {
+    type: 'tuple',
+    components: [
+      { name: 'ownerIndex', type: 'uint8' },
+      { name: 'signatureData', type: 'bytes' },
+    ],
+  },
+]
+
+/**
+ * Re-point a stub `SignatureWrapper` at `ownerIndex`, preserving its dummy
+ * `signatureData`.
+ *
+ * viem 2.53's `toCoinbaseSmartAccount.getStubSignature()` hardcodes
+ * `ownerIndex = 0` for WebAuthn owners (its constant WebAuthn stub) — unlike
+ * `signUserOperation`, which wraps the REAL index. Gas estimation
+ * (`eth_estimateUserOperationGas`, the UI "Prepare" step) therefore validates
+ * the stub against owner slot 0. On an account whose slot 0 was removed
+ * (passkey rotation / recovery, spec 045), `ownerAtIndex(0)` is empty and the
+ * account's `validateUserOp` reverts (`InvalidOwnerBytesLength`) — surfaced as
+ * "The `validateUserOp` function on the Smart Account reverted." BEFORE the user
+ * is ever prompted to sign, on every transaction. Re-wrapping the stub under the
+ * credential's real, live owner index makes estimation and signing agree.
+ *
+ * `ownerIndex` 0 is returned unchanged (viem's stub already targets slot 0 — the
+ * pristine single-passkey case, byte-for-byte unchanged). A stub that does not
+ * decode as a `SignatureWrapper` is returned as-is (defensive; never blocks a send).
+ */
+export function rewrapStubOwnerIndex(stub, ownerIndex) {
+  if (!ownerIndex) return stub
+  try {
+    const [{ signatureData }] = decodeAbiParameters(SIGNATURE_WRAPPER_ABI, stub)
+    return encodeAbiParameters(SIGNATURE_WRAPPER_ABI, [{ ownerIndex, signatureData }])
+  } catch {
+    return stub
+  }
+}
 
 /** Resolve the passkey stack config for a chain, or throw ChainNotSupportedError (FR-022). */
 export function requirePasskeySupport(chainId) {
@@ -226,18 +278,32 @@ export async function buildAccount({ chainId, credential, accountAddress, ownerI
     accountAddress ??
     (await deriveAddress({ chainId, ownersBytes: [initialOwnerBytes], nonce, deps: { publicClient: client } }))
 
+  // ownerIndex of THIS owner inside the account's owner list. Resolved from the
+  // chain by callers (resolveOwnerIndex); 0 is the initial credential's slot.
+  // Controller additions never reindex (append-only).
+  const resolvedOwnerIndex = ownerIndex ?? deps.ownerIndex ?? 0
+
   const account = await toCoinbaseSmartAccount({
     client,
     owners: [owner],
-    // ownerIndex of THIS owner inside the account's owner list. Resolved from
-    // the chain by callers (resolveOwnerIndex); 0 is the initial credential's
-    // slot. Controller additions never reindex (append-only).
-    ownerIndex: ownerIndex ?? deps.ownerIndex ?? 0,
+    ownerIndex: resolvedOwnerIndex,
     nonce,
     // Pin the sender: viem returns this verbatim from getAddress() instead of querying its
     // own (wrong) factory. Signing (replaySafeHash/ERC-1271) binds this same address + chainId.
     address,
   })
+
+  // Gas estimation runs the account's `validateUserOp` against a STUB signature.
+  // viem's WebAuthn stub hardcodes ownerIndex 0 (see rewrapStubOwnerIndex), so an
+  // account whose slot 0 was removed reverts during estimation — before the user
+  // can sign. Re-point the stub at the credential's real index so estimation
+  // validates the same live owner slot that `signUserOperation` will. No-op for
+  // slot 0 (viem's stub already targets it) and for a mock without the method.
+  if (resolvedOwnerIndex && typeof account.getStubSignature === 'function') {
+    const originalGetStubSignature = account.getStubSignature.bind(account)
+    account.getStubSignature = async (...args) =>
+      rewrapStubOwnerIndex(await originalGetStubSignature(...args), resolvedOwnerIndex)
+  }
 
   // First-use deployment must land the account code at `address`, so the initCode MUST call the
   // FairWins factory's createAccount — not viem's hardwired Coinbase factory (which would deploy a


### PR DESCRIPTION
## Summary

Passkey users whose smart account no longer keeps its original owner at **slot 0** — i.e. anyone who has rotated or recovered their passkey (spec 045, PRs #939–#941) — could not submit **any** transaction. Both a Resolve Wager and a plain USDC send fail identically at the **"Prepare"** step, *before* the signing ceremony, with:

> The `validateUserOp` function on the Smart Account reverted.

## Root cause

The failure happens during **gas estimation** (`eth_estimateUserOperationGas`), which runs the account's `validateUserOp` against a *stub* signature — this is the "Prepare" step, ahead of the WebAuthn "Sign" ceremony.

viem 2.53's `toCoinbaseSmartAccount.getStubSignature()` returns a **constant that hardcodes `ownerIndex = 0`** for WebAuthn owners. It ignores the configured owner index — only `signUserOperation` wraps the *real* one. So estimation always validates the stub against owner **slot 0**.

`CoinbaseSmartWallet._isValidSignature` then does:

```solidity
bytes memory ownerBytes = ownerAtIndex(0);
if (ownerBytes.length == 32) { /* ECDSA path → returns false, no revert */ }
if (ownerBytes.length == 64) { /* WebAuthn path → returns false, no revert */ }
revert InvalidOwnerBytesLength(ownerBytes);   // length 0 → REVERT
```

On an account whose slot 0 was **removed** during rotation/recovery, `ownerAtIndex(0)` is empty → `validateUserOp` reverts → estimation fails on every transaction, before the user is ever prompted to sign. Real signing uses the correct resolved index, which is exactly why the flow never reaches the "Sign" step.

## Fix

Override `account.getStubSignature` in `buildAccount` (mirroring the existing `getFactoryArgs` override) to re-wrap viem's own dummy WebAuthn assertion under the credential's **resolved** owner index, so estimation and signing validate the same live owner slot.

- **No-op for slot 0** — pristine single-passkey accounts are byte-for-byte unchanged.
- Defensively returns any undecodable stub as-is, so it can never block a send.
- The rewrap only swaps the `ownerIndex` word; the dummy `signatureData` payload is preserved.

## Testing

- New unit tests for `rewrapStubOwnerIndex` (asserts viem's stub really hardcodes index 0, correct re-point, slot-0 no-op, undecodable pass-through) and for the `buildAccount` override installation.
- Full passkey suite green: **91/91** tests pass; ESLint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7WiYHkJxC39BGkVaWjm9z)_