### PR TITLE
docs(blog): rewrite all 34 posts for a semi-technical audience

### DIFF
--- a/docs/blog/posts/01-rbac-operations-control-plane/blog.md
+++ b/docs/blog/posts/01-rbac-operations-control-plane/blog.md
@@ -1,158 +1,76 @@
-# One Action, One Role: RBAC and the Operations Control Plane
+# One Action, One Role: Access Control That the Admin Console Actually Reflects
 
-*How FairWins maps every privileged action to exactly one on-chain role — and makes the admin console prove it*
+*How FairWins maps every privileged action to exactly one permission — and makes the operator dashboard prove it*
 
 | | |
 |---|---|
 | **Series** | Identity & Access (part 1) |
 | **Part** | 1 of 34 |
-| **Audience** | Protocol/backend engineers, technical founders |
-| **Tags** | `access-control`, `rbac`, `solidity`, `openzeppelin`, `admin-ux` |
-| **Reading time** | ~8 minutes |
+| **Audience** | Product managers, technical founders, junior engineers, the crypto-curious |
+| **Tags** | `access-control`, `permissions`, `admin-tools`, `security` |
+| **Reading time** | ~6 minutes |
 
 ## The compliance officer who couldn't reach her own tool
 
-Picture a compliance officer at a wagering platform. Her job is narrow and serious: when an address needs to be blocked from the protocol, she adds it to an on-chain deny-list, with a reason recorded on-chain. The smart contract is ready for her — `SanctionsGuard.setDenied` is gated on a dedicated `SANCTIONS_ADMIN_ROLE`, and her multisig holds that role. Nothing else. She cannot pause the protocol, cannot touch the treasury, cannot freeze a wager account.
+Picture a compliance officer at a wagering platform. Her job is narrow and serious: when an address needs to be blocked from the protocol, she adds it to a block-list, and the reason is recorded permanently on the blockchain. The system was built for exactly this. She holds one specific permission — the one that lets her edit the block-list — and nothing more. She cannot pause the platform, cannot touch the treasury, cannot freeze anyone's account.
 
-Then she opens the admin panel and the deny-list tab isn't there.
+Then she opens the admin panel, and the block-list tab isn't there.
 
-This was a real gap in FairWins' control-surface audit (G5 in `docs/system-overview/control-surface-audit.md`): the contract defined `SANCTIONS_ADMIN_ROLE`, but the frontend's role model didn't know it existed, so the deny-list view was gated on `DEFAULT_ADMIN_ROLE` instead. The on-chain access control was correct — and operationally useless. To do her job, the compliance officer would have needed full protocol admin, which is exactly the privilege escalation the role was designed to prevent. The alternative was worse: quietly granting her `DEFAULT_ADMIN_ROLE` "just so the tab shows up."
+This was a real gap FairWins found while auditing its own controls. The permission existed on the blockchain, and her account held it. But the admin dashboard had never been taught that this permission existed, so it hid the block-list behind the top-level "full administrator" permission instead. The underlying security was correct — and completely useless in practice. To do her narrow job, she would have needed to be handed the keys to everything, which is precisely the over-reach the narrow permission was designed to prevent.
 
-The lesson generalizes. Role-based access control isn't only a Solidity problem. A role that exists on-chain but not in the operator's UI creates pressure to over-grant, and over-granting is how least privilege dies in practice. This post walks through both halves of FairWins' answer: the on-chain role discipline ("one action, one role") and the `/admin` operations control plane that mirrors it, view by view.
+The lesson generalizes. Access control isn't only a smart-contract problem. A permission that exists on-chain but not in the operator's screen creates quiet pressure to over-grant, and over-granting is how "least privilege" — the principle that every account should hold the minimum power it needs — dies in real life. This post walks through both halves of FairWins' answer: the on-chain discipline of "one action, one role," and the admin console built to mirror it, screen by screen.
 
-## The role inventory: one paid role, six operator roles
+## The permission inventory: one paid role, six operator roles
 
-FairWins is a peer-to-peer wager platform — smart contracts escrow stakes and resolve wagers from external oracles. Its access model, documented in `docs/system-overview/roles-and-tiers.md`, is deliberately small: **one user-purchasable role and six core operator roles**, all enforced with [OpenZeppelin AccessControl](https://docs.openzeppelin.com/contracts/5.x/access-control).
+FairWins is a peer-to-peer wager platform. Smart contracts hold each side's stake in escrow and settle the bet against a trusted outside source of truth. Its permission model is deliberately small: **one permission that members buy, and six that operators hold.** All of them use a plain, well-audited access-control library from OpenZeppelin, an industry-standard toolkit for smart contracts — nothing exotic, nothing homegrown.
 
-The paid role is `WAGER_PARTICIPANT_ROLE`, defined in `contracts/wagers/WagerRegistryCore.sol`. It's required to create or accept wagers and is sold in USDC by `MembershipManager` as a soulbound, time-bound tier (Bronze through Platinum). That's a topic for part 2 of this series. This post is about the other six — the operator roles:
+The paid one lets a member create and accept wagers; members buy it as a time-limited membership tier, and it's the subject of part 2 in this series. The other six are the operator permissions, and each maps to a single, clearly bounded job:
 
-| Role | Defined in | Authority |
-|---|---|---|
-| `DEFAULT_ADMIN_ROLE` | OZ AccessControl (`0x00`) | Protocol wiring, tier config, treasury withdrawal, role administration |
-| `GUARDIAN_ROLE` | `contracts/wagers/WagerRegistryCore.sol` | `pause()` / `unpause()` the registry |
-| `ACCOUNT_MODERATOR_ROLE` | `contracts/wagers/WagerRegistryCore.sol` | `freezeAccount` / `unfreezeAccount` |
-| `ROLE_MANAGER_ROLE` | `contracts/access/MembershipManager.sol` | Grant/revoke memberships out-of-band |
-| `SANCTIONS_ADMIN_ROLE` | `contracts/access/SanctionsGuard.sol` | Discretionary deny-list (`setDenied`) |
-| `UPGRADER_ROLE` | `contracts/upgradeable/UUPSManaged.sol` | Replace UUPS proxy implementations |
+- **Full administrator** — protocol wiring, tier pricing, treasury withdrawals, and handing out or revoking the other permissions.
+- **Guardian** — can pause and un-pause the whole platform in an emergency. Nothing else.
+- **Account moderator** — can freeze and unfreeze an individual account. Cannot pause the platform.
+- **Membership manager** — can grant or revoke memberships directly. Cannot touch admin permissions.
+- **Sanctions admin** — can edit the compliance block-list. This is the compliance officer's role.
+- **Upgrader** — can ship new versions of the upgradeable contracts. Cannot grant itself anything.
 
-Every role is a plain `bytes32` keccak hash — no registry contract, no role NFTs, no bespoke permission language:
-
-```solidity
-// contracts/wagers/WagerRegistryCore.sol
-bytes32 public constant WAGER_PARTICIPANT_ROLE = keccak256("WAGER_PARTICIPANT_ROLE");
-bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
-bytes32 public constant ACCOUNT_MODERATOR_ROLE = keccak256("ACCOUNT_MODERATOR_ROLE");
-```
-
-Beyond the core six, individual registries define narrow roles for their own surface: `TOKEN_ISSUER_ROLE` on `contracts/tokens/TokenFactory.sol`, `FEE_ADMIN_ROLE` on `contracts/fees/FeeRouter.sol`, and `REGISTRY_CURATOR_ROLE` / `MODERATOR_ROLE` / `VERIFIER_ROLE` on `contracts/naming/CallsignRegistry.sol`. Same pattern, scoped to one contract each.
+A handful of narrower, single-purpose permissions exist for individual subsystems — issuing tokens, setting fees, curating the naming registry — but they follow the exact same pattern, each scoped to one job.
 
 ## One action, one role
 
-The discipline that holds the model together: **every privileged function is gated by exactly one role**. Not "admin or guardian," not a points system — one `onlyRole` modifier per entrypoint. The emergency controls in `contracts/wagers/WagerRegistry.sol` are the cleanest illustration:
+The discipline that holds the whole model together is simple to state: **every privileged action is guarded by exactly one permission.** Not "admin or guardian." Not a points system where enough small permissions add up to a big one. One gate per door.
 
-```solidity
-function pause() external onlyRole(GUARDIAN_ROLE) { _pause(); }
-function unpause() external onlyRole(GUARDIAN_ROLE) { _unpause(); }
+Pausing the platform requires the guardian permission, full stop. Freezing an account requires the account-moderator permission, full stop. Changing pricing or protocol wiring requires the full-administrator permission. There's one instructive exception that actually proves the rule: swapping out a piece of the wager engine's code is treated as an upgrade — because it changes what code runs — so it requires the *upgrader* permission rather than the administrator one. The gate matches the true weight of the action.
 
-function freezeAccount(address user, string calldata reason)
-    external
-    onlyRole(ACCOUNT_MODERATOR_ROLE)
-```
-
-Configuration setters (`setOracleAdapter`, `setSanctionsGuard`, `setTokenAllowed`, `setMembershipManager`) all take `onlyRole(DEFAULT_ADMIN_ROLE)`. The one interesting exception proves the rule: `setIntentExtension` — which swaps the registry's second facet, and is therefore upgrade-equivalent — is gated on `UPGRADER_ROLE`, not admin, because it changes what code runs behind the proxy.
-
-Upgrades themselves live in a shared base every upgradeable contract inherits:
-
-```solidity
-// contracts/upgradeable/UUPSManaged.sol
-bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
-
-function __UUPSManaged_init(address admin) internal onlyInitializing {
-    __UUPSUpgradeable_init();
-    __AccessControl_init();
-    _grantRole(DEFAULT_ADMIN_ROLE, admin);
-    _grantRole(UPGRADER_ROLE, admin);
-}
-
-function _authorizeUpgrade(address newImplementation)
-    internal override onlyRole(UPGRADER_ROLE) {}
-```
-
-`UPGRADER_ROLE` is separated from `DEFAULT_ADMIN_ROLE` on purpose: it can later be reassigned to a timelock or multisig with no code change, and because `_authorizeUpgrade` is defined once in the base and never removed by an upgrade, the ability to perform *future* upgrades is always preserved.
+The upgrader permission is kept separate from the top administrator permission on purpose. It can later be reassigned to a time-locked multi-signature wallet without changing any code, and the ability to perform future upgrades is wired in permanently, so an upgrade can never accidentally strip away the platform's own ability to be upgraded again.
 
 ### The negative space matters as much
 
-`docs/system-overview/roles-and-tiers.md` maintains a table of what each role **cannot** do, and it's worth internalizing why that table exists. A guardian can stop the whole protocol but cannot seize an account. An account moderator can freeze an account but cannot pause the protocol or move treasury funds. A role manager can hand out memberships but cannot revoke admin roles. The compliance officer can block an address but holds no other privilege. The upgrader can ship new logic but cannot grant itself anything. Even `DEFAULT_ADMIN_ROLE` has hard limits: it cannot create wagers on behalf of users, cannot resolve wagers, and cannot move escrowed stakes — there is simply no function for it. When you design a role, write the "cannot" list first; it tells you whether the role is actually narrow or just labeled that way.
+FairWins keeps a table of what each role explicitly **cannot** do, and that table earns its keep. A guardian can stop the whole platform but cannot seize an account. A moderator can freeze an account but cannot pause the platform or move money. A membership manager can hand out memberships but cannot revoke anyone's admin powers. The compliance officer can block an address and do nothing else. Even the full administrator has hard limits baked into the code: it cannot create wagers on someone's behalf, cannot decide who wins, and cannot move staked funds — there is simply no button for any of those, because no such function was ever written.
 
-## The control plane: role checks flow from contract to UI
+When you design a permission, write its "cannot" list first. It tells you whether the role is genuinely narrow or just labeled that way.
 
-The operator side lives at `/admin` (`frontend/src/components/AdminPanel.jsx`), consolidated after the control-surface audit into a grouped **operations control plane**: Control Room, Incident Response, Compliance, Membership & Revenue, Protocol Config, Identity, Access Control, Infrastructure.
+## The control plane: permissions flow from the contract to the screen
 
-The core UI rule mirrors the contract rule: **each view is gated by the on-chain role its actions require, and a group renders only if the operator holds at least one usable view inside it.** The frontend computes role hashes exactly the way the contracts do —
+The operator side is a single admin console, reorganized after that audit into clear groups: a control room, incident response, compliance, membership and revenue, protocol config, identity, access control, and infrastructure.
 
-```js
-// frontend/src/components/AdminPanel.jsx
-const ROLE_HASHES = {
-  GUARDIAN: ethers.keccak256(ethers.toUtf8Bytes('GUARDIAN_ROLE')),
-  SANCTIONS_ADMIN: ethers.keccak256(ethers.toUtf8Bytes('SANCTIONS_ADMIN_ROLE')),
-  DEFAULT_ADMIN: ethers.ZeroHash,
-  // ...
-}
-```
+The core rule of the interface mirrors the core rule of the contracts: **each screen is shown only to operators who hold the on-chain permission its actions require, and a group of screens appears only if the operator can actually use at least one screen inside it.** The dashboard calculates permissions the exact same way the contracts do and checks them against the live blockchain, so what an operator sees is a faithful picture of what they can actually do.
 
-— and checks them via `hasRole(bytes32, address)` against the live contracts. The grouping/gating model itself is a pure function in `frontend/src/components/admin/adminNav.js`, so it's unit-testable without rendering anything:
+A guardian signing in sees the control room, incident response, and infrastructure — nothing else. The compliance officer from the opening now sees the control room and compliance. Crucially, the dashboard isn't *enforcing* security — the contracts do that, and they can't be fooled by a hidden or shown button. The dashboard's job is to make the permission set *legible*, so nobody is ever tempted to over-grant a big role just to make a screen appear.
 
-```js
-{
-  label: 'Incident Response',
-  items: [
-    isGuardian && item('emergency', 'Emergency'),
-    isAccountModerator && item('moderation', 'Account Moderation'),
-  ].filter(Boolean),
-},
-{
-  label: 'Compliance',
-  items: [
-    (isSanctionsAdmin || isAdmin) && item('deny-list', 'Deny-list'),
-  ].filter(Boolean),
-},
-```
-
-A guardian signing in sees Control Room, Incident Response, and Infrastructure — nothing else. The compliance officer from the opening now sees Control Room and Compliance. The panel isn't enforcing security (the contracts do that); it's making the on-chain permission set legible, so nobody needs to over-grant a role just to make a screen appear.
-
-One subtlety the panel gets right: roles live on different contracts, so grants must be routed to the contract that *defines* the role, not blanket-sent to one registry:
-
-```js
-// frontend/src/components/AdminPanel.jsx
-const roleHomeContract = (role) => {
-  if (role === 'ROLE_MANAGER') return membershipManagerAddr
-  if (role === 'SANCTIONS_ADMIN') return sanctionsGuardAddr
-  if (role === 'TOKEN_ISSUER') return tokenFactoryAddr
-  return wagerRegistryAddr
-}
-```
-
-The Control Room's Overview tile answers the operator's first question on any bad day: is the protocol live, is the gateway live, is anything paused or killswitched, and *who am I signed in as, with which powers*.
+One subtlety the console gets right: different permissions live on different contracts, so when an operator grants a permission, the request has to be routed to the specific contract that defines it — not blanket-sent to one place and hoped for the best.
 
 ## Design decisions
 
-**Why plain OpenZeppelin AccessControl and nothing fancier?** `bytes32` role hashes checked with `onlyRole` are boring, audited, and universally understood by tooling and reviewers. The one-role-per-action discipline gives you most of what elaborate permission systems promise, without a new trust surface. The cost is granularity: `withdrawFees` today requires full `DEFAULT_ADMIN_ROLE`, and splitting out a dedicated `TREASURER_ROLE` would need a contract upgrade — a documented future candidate, not a config change.
+**Why a plain, boring access-control library?** Standard, audited permission checks are understood by every reviewer and every tool in the ecosystem. The "one action, one role" discipline delivers most of what elaborate custom permission systems promise, without introducing a new thing that can break or be attacked. The cost is granularity: withdrawing fees currently requires the full administrator permission, and splitting out a dedicated "treasurer" would take a contract upgrade — a noted future option, not a quick setting.
 
-**Why does the UI gate on roles at all if contracts enforce them?** Because the failure mode of a role-blind UI isn't a security hole — it's privilege creep. The G5 gap showed that when the frontend doesn't model a role, operators get granted a bigger one. Modeling every role in the panel is what keeps the on-chain least-privilege design honest in day-to-day operations.
+**Why gate the UI on permissions at all, if the contracts already enforce them?** Because the failure mode of a permission-blind dashboard isn't a break-in — it's privilege creep. The gap that started this story showed that when the interface doesn't know about a permission, operators get handed a bigger one to compensate. Modeling every permission in the console is what keeps the on-chain least-privilege design honest in day-to-day operations.
 
-**What's deliberately *not* in the control plane.** Two categories are excluded by policy, not oversight. Anything requiring the air-gapped floppy keystore — UUPS upgrades, `UPGRADER_ROLE` actions — stays on scripted, offline paths (`docs/runbooks/contract-upgrades.md`). And the relay gateway's killswitch and quotas are env/signal-driven with **no remote admin API on purpose**: an authenticated web killswitch would be a new attack surface, and the gateway's worst case is designed to be "refuses to relay," never "steals funds." The panel shows their state read-only and links the runbook.
+**What deliberately stays off the console.** Two things are excluded by policy, not by accident. Anything touching the most sensitive keys — the ones that authorize upgrades — stays on offline, air-gapped, scripted paths that never touch a web form. And the optional relay service that can sponsor gasless transactions has no remote admin controls at all, on purpose: an internet-facing kill switch would be a brand-new attack surface, and the relay's worst case is designed to be "refuses to help," never "loses funds." The console shows the state of both, read-only, and links to the written procedures.
 
-**Not everything needs a role.** Maintenance sweeps (`batchExpireOpen`, `autoResolveFromPolymarket`, `autoResolveFromOracle`) are permissionless on-chain — anyone can run them, so the Maintenance view is open to any operator. And some contracts (`WagerPool` clones, `MembershipVoucher`, `KeyRegistry`) have **no admin surface by design**: no role can drain or redirect funds because no function exists to do it. The strongest access control is the entrypoint you never wrote.
+**Not everything needs a permission.** Routine housekeeping — sweeping up expired wagers, settling ones whose outcome is already known — is open to anyone by design, so those screens are open to any operator. And some contracts have no admin controls whatsoever: no permission can drain or redirect their funds because no function to do so exists. The strongest access control is the door you never build.
 
-## Sources
+## Further reading
 
-- `docs/system-overview/roles-and-tiers.md` — role inventory, tier table, "cannot do" matrix
-- `docs/system-overview/control-surface-audit.md` — full control-surface inventory, gap analysis (G1–G10), control-plane grouping
-- `contracts/wagers/WagerRegistryCore.sol`, `contracts/wagers/WagerRegistry.sol` — role constants, `pause`/`freezeAccount` gating
-- `contracts/access/MembershipManager.sol` — `ROLE_MANAGER_ROLE`, admin setters, `initialize`
-- `contracts/access/SanctionsGuard.sol` — `SANCTIONS_ADMIN_ROLE`, `setDenied`
-- `contracts/upgradeable/UUPSManaged.sol` — `UPGRADER_ROLE`, `_authorizeUpgrade`
-- `contracts/fees/FeeRouter.sol`, `contracts/tokens/TokenFactory.sol`, `contracts/naming/CallsignRegistry.sol` — registry-scoped roles
-- `frontend/src/components/AdminPanel.jsx`, `frontend/src/components/admin/adminNav.js` — role hashes, view gating, role→contract grant routing
-- OpenZeppelin AccessControl documentation — https://docs.openzeppelin.com/contracts/5.x/access-control
-- OpenZeppelin UUPS / proxy documentation — https://docs.openzeppelin.com/contracts/5.x/api/proxy
+- OpenZeppelin Access Control — the standard permission library described here: https://docs.openzeppelin.com/contracts/5.x/access-control
+- OpenZeppelin Proxies and upgradeable contracts: https://docs.openzeppelin.com/contracts/5.x/api/proxy
+- The principle of least privilege (background concept): https://en.wikipedia.org/wiki/Principle_of_least_privilege

--- a/docs/blog/posts/01-rbac-operations-control-plane/social.md
+++ b/docs/blog/posts/01-rbac-operations-control-plane/social.md
@@ -2,28 +2,28 @@
 
 ## X (Twitter)
 
-Your on-chain RBAC is only as good as your admin UI. We found a role (`SANCTIONS_ADMIN_ROLE`) that existed in Solidity but not in the frontend — so the operator's tab was gated on full admin. How FairWins fixed it: one action, one role, contract to console. 🔗 <link> #solidity #web3 #rbac
+Your on-chain access control is only as good as your admin dashboard. We found a compliance permission that existed on the blockchain but not in the operator's screen — so the tab was hidden behind full admin. How FairWins fixed it: one action, one role, contract to console. 🔗 <link> #web3 #accesscontrol #security
 
 ## LinkedIn
 
-Least privilege dies quietly: not when a contract is exploited, but when an operator gets granted a bigger role "just so the tab shows up."
+Least privilege dies quietly: not when a contract is exploited, but when an operator gets handed a bigger role "just so the tab shows up."
 
-During FairWins' control-surface audit we found exactly that. Our compliance deny-list was gated on-chain by a dedicated `SANCTIONS_ADMIN_ROLE` — correct, narrow, auditable. But the frontend's role model didn't know the role existed, so the deny-list view required full `DEFAULT_ADMIN_ROLE`. The compliance officer couldn't reach her own tool without protocol-wide admin.
+While auditing its own controls, FairWins found exactly that. Our compliance block-list was guarded on-chain by a dedicated, narrow permission — correct and auditable. But the admin dashboard didn't know that permission existed, so the block-list screen required full administrator access. The compliance officer couldn't reach her own tool without being handed the keys to everything.
 
 The new post covers how we rebuilt both halves:
 
-- The role inventory: one user-purchasable role and six operator roles, all plain OpenZeppelin AccessControl `bytes32` hashes — no bespoke permission system
+- The permission inventory: one membership members buy, and six clearly bounded operator roles, all built on a standard, audited access-control library — no homegrown permission system
 - The "one action, one role" discipline, including the negative-space table of what each role explicitly cannot do
-- The `/admin` operations control plane: each view gated by the exact on-chain role its actions require, with a unit-testable pure-function nav model and per-contract grant routing
-- What deliberately stays off the panel: air-gapped upgrade keys, and a relay gateway with no remote admin API by design
+- The admin console that mirrors it: each screen shown only to operators who hold the exact permission its actions require
+- What deliberately stays off the console: air-gapped upgrade keys, and a relay service with no remote admin controls by design
 
-If you run privileged operations against smart contracts, the reusable idea is simple: model every on-chain role in your operator UI, or watch over-granting erode your least-privilege design.
+If you run privileged operations against smart contracts, the reusable idea is simple: model every on-chain permission in your operator UI, or watch over-granting erode your least-privilege design.
 
 Read it here: <link>
 
-How does your team keep operator UIs in sync with on-chain roles?
+How does your team keep operator dashboards in sync with real permissions?
 
-#smartcontracts #solidity #accesscontrol #web3 #platformengineering
+#smartcontracts #accesscontrol #web3 #platformengineering #security
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/02-soulbound-memberships-vouchers/blog.md
+++ b/docs/blog/posts/02-soulbound-memberships-vouchers/blog.md
@@ -5,112 +5,79 @@
 | | |
 |---|---|
 | **Series** | Identity & Access, part 2 |
-| **Audience** | Token designers, product engineers, growth |
-| **Tags** | `soulbound`, `erc721`, `tokenomics`, `memberships`, `access-control` |
-| **Reading time** | ~8 minutes |
+| **Audience** | Product managers, founders, growth teams, junior engineers |
+| **Tags** | `memberships`, `token-design`, `gifting`, `access-control` |
+| **Reading time** | ~7 minutes |
 
-> **Responsible use.** FairWins wagers are based on publicly available information and legitimate forecasting. Memberships gate access to that activity; they are not a mechanism for circumventing any law. All participants remain fully subject to applicable laws and compliance requirements, and every membership grant — however acquired — passes sanctions screening.
+> **Responsible use.** FairWins wagers are based on publicly available information and legitimate forecasting. Memberships gate access to that activity; they are not a mechanism for circumventing any law. All participants remain fully subject to applicable laws and compliance requirements, and every membership — however acquired — passes sanctions screening.
 
 ## The gift you can't give
 
-A FairWins membership is deliberately boring. You pay USDC — $2 for Bronze, $8 Silver, $25 Gold, $100 Platinum — and for 30 days your wallet can create and accept wagers, up to a per-tier throughput limit. The membership is **soulbound**: it lives at your address, it cannot be transferred, and there is no market for it. That's a feature. Access records that can move are access records that can be stolen, rented to sanctioned parties, or flash-loaned through a compliance check.
+A FairWins membership is deliberately boring. You pay in USDC — $2 for Bronze, $8 for Silver, $25 for Gold, $100 for Platinum — and for the next 30 days your wallet can create and accept wagers, up to a limit set by your tier. The membership is **soulbound**, a term for something permanently bound to a single wallet: it lives at your address, it can't be transferred, and there's no market for it. That's a feature, not a limitation. An access record that can move is an access record that can be stolen, rented out to a sanctioned party, or briefly borrowed to sneak past a compliance check.
 
-Then a product request landed: *let me buy a membership for a friend.* And its sibling: *let me resell the one I bought and don't want.* Both are completely reasonable — gift cards and secondary markets are table stakes for any paid product — and both are, on their face, impossible. A soulbound record keyed to an address has nothing to hand over. Making it transferable would torch the properties the platform depends on: sanctions screening happens when membership is granted, usage limits are tracked per address, and `WagerRegistry` trusts that the address holding a membership is the address that was screened.
+Then a product request landed: *let me buy a membership for a friend.* And its sibling: *let me resell the one I bought and don't want.* Both are completely reasonable — gift cards and resale markets are table stakes for any paid product — and both are, on their face, impossible. A record welded to your address has nothing to hand over. And making it movable would destroy the very properties the platform relies on: sanctions screening happens when membership is granted, usage limits are tracked per wallet, and the wager engine trusts that the wallet holding a membership is the one that was screened.
 
-The wrong fix is a "transfer with re-screening" function on the membership itself — a mutable access record with a moving owner, special-cased through every downstream read. The fix FairWins shipped in spec 026 is cleaner: don't make the membership transferable. Make the *right to claim one* transferable, and keep the two ideas in separate contracts with separate lifecycles.
+The tempting-but-wrong fix is to bolt a "transfer, and re-screen the new owner" button onto the membership itself — turning a fixed access record into a moving target every other part of the system has to special-case. The fix FairWins shipped is cleaner: don't make the *membership* transferable. Make the *right to claim one* transferable, and keep the two ideas in completely separate contracts.
 
 ## Two rails, one membership
 
-The first thing to notice is what "soulbound" means here. A FairWins membership is not an NFT with transfers disabled — it is not a token at all. It's a plain storage record inside `MembershipManager` (a UUPS proxy, spec 027), keyed by `(address, role)`:
+Start with what "soulbound" actually means here. A FairWins membership isn't an NFT with transfers switched off — it isn't a token at all. It's just a record in the platform's membership ledger, filed under your wallet address: which tier you have, when it expires, and how much of your usage limit you've used this month. There's no "transfer" button to disable because there's nothing to hand over — non-transferability simply falls out of how the data is shaped.
 
-```solidity
-// contracts/interfaces/IMembershipManager.sol
-struct Membership {
-    Tier    tier;        // None, Bronze, Silver, Gold, Platinum
-    uint64  expiresAt;
-    uint32  monthCount;  // rolling 30-day wager-creation counter
-    uint32  activeCount; // concurrent open wagers
-    uint64  monthAnchor;
-}
-```
+It's worth contrasting this with the popular "soulbound token" — a standard for NFTs permanently locked to a wallet but still visible in it. FairWins didn't need the token part at all: memberships are read by contracts, not shown off in wallets, so a plain ledger entry is simpler, cheaper, and has no transfer machinery to audit.
 
-There is no `transfer` to disable because there is nothing to transfer — non-transferability falls out of the data model rather than being enforced against it. (This is worth contrasting with the soulbound-token discourse around [EIP-5192](https://eips.ethereum.org/EIPS/eip-5192), which standardizes *locked* ERC-721s. EIP-5192 solves the problem of making a token non-transferable while keeping it wallet-visible. FairWins didn't need the token part at all: memberships are read by contracts, not displayed in wallets, so a mapping is simpler, cheaper, and has no transfer surface to audit.)
+Buying a membership directly writes that record: it screens the buyer against sanctions lists, pulls the tier's price in USDC, marks the tier and its expiry, and resets the usage counters. Thirty days later, it lapses.
 
-Direct purchase (`purchaseTier` / `purchaseTierWithTerms`) writes that record: sanctions screen the buyer, pull the tier's USDC price, set `tier` and `expiresAt`, reset the counters. Thirty days later it lapses.
+The new idea adds a **second way in** that lands on the exact same record. A **membership voucher** is a real, freely transferable NFT — think of it as a prepaid gift card for a membership — minted for the tier's normal price. The whole trick is in what a voucher *doesn't* do:
 
-Spec 026 adds a **second acquisition rail** that converges on the exact same record. `contracts/access/MembershipVoucher.sol` is a real, freely transferable ERC-721 — "FairWins Membership Voucher", symbol `FWMV` — minted for the tier's configured USDC price. The critical property is what a voucher *doesn't* do:
+- It grants **no membership** while you hold it. No clock is running, no usage limits accrue, your wallet has no access.
+- It **never expires.** A voucher is a bearer claim you can sit on for a year and still redeem into a fresh, full 30-day membership.
+- It **locks in its tier and duration at the moment it's minted.** If the team later reprices or retires that tier, the voucher still delivers exactly what it was bought for.
 
-- It confers **no membership** while held. `hasActiveRole` on the holder stays false; no clock starts, no limits accrue.
-- It never expires. A voucher is a bearer claim you can hold for a year and still redeem into a full 30-day membership.
-- It snapshots its `(role, tier, durationDays)` at mint. If the admin later reprices or deactivates the tier, the voucher still grants exactly what it was minted for.
-
-Because the voucher is inert, it is safe to trade. Gifting is a `transferFrom`. Reselling is any standard NFT marketplace — the contract advertises a best-effort [EIP-2981](https://eips.ethereum.org/EIPS/eip-2981) royalty to the treasury (2.5% default, hard-capped at 5% by `MAX_ROYALTY_BPS`; `setRoyaltyBps` reverts above it). Nothing about a transfer touches compliance, because nothing about a transfer grants access.
+Because the voucher is inert — it confers nothing until redeemed — it is completely safe to trade. Gifting it is an ordinary transfer. Reselling it works on any standard NFT marketplace. The contract even suggests a small resale royalty back to the treasury (2.5% by default, capped in the code at 5% so it can never be cranked higher). None of that touches compliance, because none of it grants anyone access.
 
 ## Redemption: where the rails converge
 
-The voucher becomes a membership through `redeemVoucher(uint256 voucherId, bytes32 acceptedTermsHash)` on `MembershipManager`. This is the single control point where everything a direct purchaser faces is imposed on the redeemer:
+A voucher becomes a membership at one moment: redemption. This is the single control point where everything a direct buyer faces gets applied to the person redeeming.
 
-```solidity
-// contracts/access/MembershipManager.sol — _redeemVoucher (abridged)
-if (IMembershipVoucher(v).ownerOf(voucherId) != actor) revert NotVoucherOwner();
-IMembershipVoucher.VoucherInfo memory info = IMembershipVoucher(v).voucherInfo(voucherId);
+In plain terms, the redemption does this, in order:
 
-Membership storage m = _memberships[actor][info.role];
-if (m.tier != Tier.None && m.expiresAt > block.timestamp) revert AlreadyActive();
+1. Confirm the person redeeming actually owns the voucher.
+2. Confirm they don't already have an active membership for that role.
+3. Screen them against the sanctions lists — and if they're listed, stop everything right here.
+4. Write the membership: grant the exact tier and duration the voucher locked in, reset the usage counters, record which terms they agreed to.
+5. Only then, as the very last step, burn the voucher.
 
-_screen(actor); // sanctions screen — fail-closed, before effects
+The ordering carries the product's failure semantics. If the redeemer is sanctioned, or already holds an active membership, the entire call is undone and the voucher is left **completely untouched** — still owned, still tradable. A legitimate buyer is never punished because some previous holder couldn't redeem, and because the voucher is destroyed only at the very end, any earlier failure rolls the whole thing back safely.
 
-m.tier = info.tier;                    // grant the snapshotted (role, tier)
-m.expiresAt = uint64(block.timestamp) + uint64(info.durationDays) * 1 days;
-m.monthCount = 0;
-m.monthAnchor = uint64(block.timestamp);
-_recordTerms(actor, info.role, acceptedTermsHash);
+Notice *who* gets screened: **only the person redeeming, and only at the moment of redemption.** Minters and resale buyers are deliberately not screened. That's a conscious trade-off: a sanctioned party could profit by reselling a voucher they never redeem. What they can never do is turn one into actual platform access, because the screen sits exactly where access is granted. Compliance lives at the point of *use*, not the point of *trade*.
 
-IMembershipVoucher(v).burn(voucherId); // interaction LAST — reverts roll everything back
-```
-
-The ordering is strict checks-effects-interactions, and it carries the product's failure semantics: if the redeemer is sanctioned, or already has an active membership for the role, the whole call reverts and the voucher is **untouched** — still owned, still tradable. A legitimate buyer is never punished because a previous holder couldn't redeem. The burn is the only external call, performed last, against a contract the manager itself was wired to via `setVoucher`.
-
-Note who gets screened: **only the redeemer, only at redemption.** Minters and secondary buyers are deliberately unscreened. That's an explicitly accepted tradeoff, recorded in the spec: a sanctioned party could profit from reselling a voucher without ever redeeming it. What they can never do is convert one into platform access, because the screen sits exactly where standing is granted — the same non-bypassable choke point the direct rail uses. Compliance lives at the point of *use*, not the point of *trade*.
-
-After redemption, the two rails are indistinguishable. `WagerRegistry` reads the same `Membership` struct either way and has no idea how it was acquired — spec 026's FR-008 makes that a hard requirement, verified by running the full membership and wager suites against both rails.
+After redemption, the two routes are indistinguishable. The wager engine reads the same membership record either way and has no idea how it was obtained — and that's a hard requirement, verified by running the full test suite against both routes.
 
 ## The economics are deliberately flat
 
-A voucher costs exactly the tier's configured price — the same `TierConfig.priceUSDC` the direct rail charges — so neither rail is cheaper and there's no mint-vs-purchase arbitrage. Proceeds go to the treasury **at mint** (the voucher does `token.safeTransferFrom(msg.sender, treasury_, cfg.priceUSDC)` before `_safeMint`), which works because granting a membership at redemption costs the platform nothing on-chain; no escrow or solvency reserve is needed for outstanding vouchers. There is no primary refund: minter's remorse is resolved by reselling or redeeming. And the on-chain `tokenURI` — self-contained JSON plus SVG, no IPFS dependency — literally says "Utility access token, not an investment" in the token description.
+A voucher costs exactly the tier's normal price — the same amount the direct route charges — so neither path is cheaper and there's no buy-here-redeem-there arbitrage to game. The money goes to the treasury the moment the voucher is minted, which works because granting the membership later costs the platform essentially nothing, so there's no need to hold reserves against outstanding vouchers. There are no primary refunds: buyer's remorse is resolved by reselling or redeeming. And the voucher's own artwork and description — generated entirely on-chain — literally reads "utility access token, not an investment."
 
-Batch buying and direct gifting arrive via a third contract, `contracts/access/VoucherBatchMinter.sol`, because the voucher is immutable and only ever mints one token to `msg.sender`. The helper's `mintBatch(role, tier, quantity, recipient)` pulls exactly `quantity × price` in one approval, loops the mints (capped at `MAX_QUANTITY = 50`), and forwards every token to the recipient in the same transaction. It is stateless and custody-free — no funds or NFTs at rest, allowance reset to zero after the loop via `forceApprove`, no admin, no withdrawal path, no upgradeability. If it isn't deployed on a network, single self-mint still works and the UI degrades honestly.
+Buying a batch of vouchers as gifts and sending them straight to a recipient is handled by a small, separate helper, since the voucher itself only mints one at a time. The helper pulls the exact total, mints the batch, and forwards every one to the recipient in a single transaction. It holds no funds at rest and has no admin or withdrawal path. If it isn't deployed on a given network, buying one at a time still works.
 
 ## Privacy: pseudonymity, stated plainly
 
-The voucher rail has a quiet second use. Because redemption only checks that the redeemer *owns* the voucher — never that they minted it — a holder can transfer a voucher to a fresh wallet and redeem there. The resulting membership record stores no back-reference to the mint or trade history, so wagering activity isn't on-chain-linked to the wallet that bought the voucher. The relayed twin `redeemVoucherWithSig` (spec 035's EIP-712 intent rail) goes further: since redemption moves no money, a relayer can submit it, so even the gas payer needn't be the trading wallet.
+The voucher route has a quiet second use. Because redemption only checks that you *own* the voucher — never that you *minted* it — you can move a voucher to a fresh wallet and redeem it there. The resulting membership keeps no back-reference to who bought it or how it changed hands, so your wagering activity isn't chained on the public ledger to the wallet that originally paid. A gasless version goes further: since redeeming moves no money, a helper service can submit the transaction for you, so even the wallet paying the network fee needn't be your trading wallet.
 
-The spec is emphatic about not overselling this. Mints, transfers, and burns are public ERC-721 events; anyone can watch a voucher move. What fresh-wallet redemption provides is **pseudonymity, not cryptographic unlinkability**, and FR-020 requires the UI to say exactly that. Zero-knowledge redemption was considered and explicitly scoped out.
+FairWins is careful not to oversell this. Voucher mints, transfers, and burns are all public events — anyone can watch a voucher move. What redeeming from a fresh wallet buys you is **pseudonymity, not cryptographic unlinkability**, and the interface is required to say exactly that.
 
 ## Design decisions
 
-**Mutable logic upgradeable, bearer asset immutable.** `MembershipManager` is a UUPS proxy — spec 026's redemption capability shipped as the first in-place, append-only upgrade of the spec 027 proxy (the `voucher` address slot consumed one `__gap` slot; `check:storage-layout` gates it in CI). The voucher is the opposite: intentionally *not* upgradeable, because a tradable bearer asset's rules must not change after purchase, and an immutable contract minimizes the attack surface on a USDC-taking token. Screening, Terms, and grant logic — the parts that must evolve — live behind the proxy; the thing people pay for is frozen.
+**Changeable logic, frozen asset.** The membership ledger can be upgraded in place — the voucher feature itself arrived as one such upgrade — because screening, terms, and grant logic must be able to evolve. The voucher is the opposite: deliberately *not* upgradeable, because the rules of a tradable, paid-for bearer asset must not change after someone buys it. The thing people pay for stays fixed; the machinery around it can improve.
 
-**The membership is a mapping, not a locked NFT.** No transfer function to disable, no operator approvals to reason about, no EIP-5192 lock semantics to implement. The cost is wallet invisibility, which doesn't matter for a record only contracts read.
+**The membership is a ledger entry, not a locked NFT.** No transfer function to disable, no locked-token standard to implement. The only cost is that it's invisible in your wallet — which doesn't matter for something only contracts ever read.
 
-**Least privilege at the seam.** The manager never gets broad minting rights over vouchers, and the voucher never writes memberships. The voucher's `burn` accepts exactly two callers — the owner (or approved operator) and the `membershipManager` address — so redemption authority is scoped to the one action redemption needs (FR-025).
+**Royalty as a hint, not a cage.** Forcing royalties would mean whitelisting marketplaces or running our own, killing open trading and the trade privacy that comes with it. A flat, capped suggestion keeps the utility framing honest, accepts that some marketplaces will ignore it, and lets the platform earn reliably on the first sale.
 
-**Royalty as a hint, not a cage.** Enforced royalties would mean allowlisted operators or a platform marketplace, killing open composability and trade privacy. A flat 2.5% EIP-2981 hint with a contract-enforced 5% ceiling keeps the utility framing defensible and accepts that some marketplaces will ignore it — the platform earns reliably on the primary mint.
+The general pattern travels well. When you need a token to be *both* non-transferable (for compliance and integrity) *and* transferable (for gifting and resale), you don't need one token that does both badly. You need two artifacts — an inert, tradable *claim* and a soulbound *grant* — joined by a single, guarded redemption that burns one and writes the other.
 
-**Screening only where standing is granted.** One choke point, identical for both rails, fail-closed, with the documented residual that unredeemed vouchers trade unscreened.
+## Further reading
 
-The general pattern travels well: when you need a token to be both non-transferable (for compliance and integrity) and transferable (for gifting and resale), you don't need one token that does both badly. You need two artifacts — an inert, tradable *claim* and a soulbound *grant* — joined by a single, guarded redemption that burns one and writes the other.
-
-## Sources
-
-- `specs/026-membership-vouchers/spec.md` — voucher rail requirements, clarifications, accepted tradeoffs
-- `specs/027-upgradeable-membership/` — UUPS migration of the membership authority
-- `contracts/access/MembershipManager.sol` — `_purchaseTier`, `_redeemVoucher`, `redeemVoucherWithSig`, storage layout and `__gap`
-- `contracts/access/MembershipVoucher.sol` — mint, snapshot, burn authorization, EIP-2981, on-chain `tokenURI`
-- `contracts/access/VoucherBatchMinter.sol` — custody-free batch/gift helper
-- `contracts/interfaces/IMembershipManager.sol` — `Membership`, `TierConfig`, `Tier`
-- `docs/system-overview/roles-and-tiers.md` — tier table ($2/$8/$25/$100, 30-day terms) and role model
-- [ERC-721: Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721)
-- [EIP-2981: NFT Royalty Standard](https://eips.ethereum.org/EIPS/eip-2981)
-- [EIP-5192: Minimal Soulbound NFTs](https://eips.ethereum.org/EIPS/eip-5192)
-- [OpenZeppelin Contracts — ERC721, ERC2981, AccessControl](https://docs.openzeppelin.com/contracts)
+- ERC-721, the non-fungible token standard the voucher is built on: https://eips.ethereum.org/EIPS/eip-721
+- EIP-2981, the NFT royalty standard: https://eips.ethereum.org/EIPS/eip-2981
+- EIP-5192, the minimal soulbound (locked) NFT standard discussed above: https://eips.ethereum.org/EIPS/eip-5192
+- OpenZeppelin Contracts, the audited building blocks behind the token and access logic: https://docs.openzeppelin.com/contracts

--- a/docs/blog/posts/02-soulbound-memberships-vouchers/social.md
+++ b/docs/blog/posts/02-soulbound-memberships-vouchers/social.md
@@ -2,24 +2,24 @@
 
 ## X (Twitter)
 
-How do you gift a non-transferable membership? Split the token in two: an inert ERC-721 voucher that trades freely + a soulbound access record it burns into. Sanctions screening happens once — at redemption, where standing is granted. 🎟️ 🔗 <link> #Solidity #tokendesign #web3
+How do you gift a non-transferable membership? Split the token in two: an inert voucher (a prepaid gift card, really) that trades freely, plus a soulbound access record it burns into. Sanctions screening happens once — at redemption, where access is granted. 🎟️ 🔗 <link> #tokendesign #web3
 
 ## LinkedIn
 
-"Make the membership transferable" is the obvious answer to gifting and resale — and the wrong one when your access records feed compliance checks and per-address usage limits.
+"Just make the membership transferable" is the obvious answer to gifting and resale — and the wrong one when your access records feed compliance checks and per-wallet usage limits.
 
-FairWins memberships are soulbound by construction: not a locked NFT, just a storage record keyed to an address, with nothing to transfer. So how do you build a gift-and-resale market on top of that? By making the *right to claim* a membership transferable instead. The new post walks through the split:
+FairWins memberships are soulbound by construction: not a locked NFT, just a ledger entry tied to a wallet, with nothing to hand over. So how do you build a gift-and-resale market on top of that? By making the *right to claim* a membership transferable instead. The new post walks through the split:
 
-- A membership voucher as a plain ERC-721 bearer claim: minted at the tier's USDC price, confers zero access while held, never expires, snapshots its (role, tier) at mint so later config changes can't touch it
-- Redemption as the single control point: strict checks-effects-interactions, sanctions screening fail-closed on the redeemer only, voucher burned last so a failed redemption leaves it intact and re-tradable
-- Why the tradable asset is immutable while the redemption logic lives behind a UUPS proxy — and why the mapping beat an EIP-5192 locked token
-- Honest privacy: fresh-wallet redemption gives pseudonymity, not unlinkability, and the UI is required to say so
+- A membership voucher as a plain bearer claim — a prepaid gift card, essentially: bought at the tier's normal price, grants zero access while held, never expires, and locks in its tier at mint so later pricing changes can't touch it
+- Redemption as the single control point: sanctions screening applies to the person redeeming, and the voucher is burned last, so a failed redemption leaves it intact and re-tradable
+- Why the tradable asset is frozen while the redemption logic stays upgradeable — and why a plain ledger entry beat a locked token
+- Honest privacy: redeeming from a fresh wallet gives pseudonymity, not unlinkability, and the interface is required to say so
 
 If you're designing a token that "should" be both transferable and soulbound, the answer may be two artifacts joined by a burn.
 
 Read it here: <link>
 
-Where do you put the compliance choke point in a two-token design — mint, transfer, or redemption? #Solidity #tokenomics #smartcontracts #NFT #accesscontrol
+Where do you put the compliance checkpoint in a two-token design — mint, transfer, or redemption? #tokendesign #smartcontracts #NFT #accesscontrol
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/03-sanctions-compliance-gating/blog.md
+++ b/docs/blog/posts/03-sanctions-compliance-gating/blog.md
@@ -1,130 +1,82 @@
-# Sanctions Screening as a Contract Primitive: One Guard, Every Value Path
+# Sanctions Screening as a Shared Building Block: One Guard, Every Money Path
 
-*Why FairWins moved compliance from a frontend check into a shared, fail-closed on-chain guard — and how the same 100 lines of Solidity thread through wagers, pools, memberships, and token issuance*
+*Why FairWins moved compliance out of the frontend and into a single, fail-closed on-chain gate — and how the same small piece of code protects wagers, pools, memberships, and token issuance*
 
 ---
 
-> **Important Note**: This article describes prediction markets based on publicly available information and legitimate forecasting. Nothing here is a mechanism for trading on material non-public information or circumventing securities regulations. All participants remain fully subject to applicable laws, compliance requirements, and fiduciary obligations.
+> **Important note.** This article describes prediction markets based on publicly available information and legitimate forecasting. Nothing here is a mechanism for trading on material non-public information or circumventing securities regulations. All participants remain fully subject to applicable laws, compliance requirements, and fiduciary obligations.
 
 ---
 
 | | |
 |---|---|
 | **Series** | Identity & Access, part 3 |
-| **Audience** | Compliance engineers, regulated-product founders, Solidity engineers |
-| **Tags** | `compliance`, `sanctions`, `access-control`, `solidity`, `fail-closed` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Compliance-minded founders, product managers, junior engineers |
+| **Tags** | `compliance`, `sanctions`, `fail-closed`, `security` |
+| **Reading time** | ~7 minutes |
 
 ## The check that wasn't there
 
-Picture the code review. Your team ships wallet screening for a peer-to-peer wager platform: when a user connects, the frontend reads the Chainalysis sanctions oracle over RPC, and if the address is listed, the UI refuses to proceed. The compliance box is ticked. The demo looks great.
+Picture the code review. Your team ships wallet screening for a peer-to-peer wager platform: when a user connects, the website checks their address against a sanctions list, and if the address is listed, the interface refuses to proceed. The compliance box is ticked. The demo looks great.
 
-A week later someone on the security review asks the obvious question: *what happens if a sanctioned address never opens your frontend?* The contracts are publicly callable on Polygon. Anyone with a script and an ABI can call `createWager` directly. Your screening layer — the one your Terms of Service describe as a control — is a suggestion.
+A week later, someone on the security review asks the obvious question: *what happens if a sanctioned address never opens your website?* The contracts live on a public blockchain. Anyone with a script can call them directly, bypassing your site entirely. Your screening layer — the one your Terms of Service describe as a control — turns out to be a polite suggestion.
 
-This is the trap that catches most "compliance-aware" dApps. OFAC sanctions exposure is strict liability: it does not matter that you *intended* to block the address, or that your UI *would have* blocked it. If your smart contract accepted escrow from a listed address, the transaction happened. A screen that lives only in the client is not a control; it's theater with good intentions.
+This is the trap that catches most "compliance-aware" crypto apps. Sanctions exposure under US law is *strict liability*: it doesn't matter that you *intended* to block the address, or that your interface *would have* blocked it. If your contract accepted money from a listed address, the violation happened. A check that lives only in the website is not a control; it's theater with good intentions.
 
-FairWins' answer, built in spec `007-compliance-gating`, is to treat sanctions screening the way you'd treat reentrancy protection: as a contract primitive. One small, shared contract — `SanctionsGuard` — is consulted by every value-bearing entry point across the platform. The frontend still pre-checks (fast UX, no wasted gas), but the layer that actually enforces is the one nobody can route around.
+FairWins' answer is to treat sanctions screening the way a careful team treats any core safety check: as a shared building block baked into the contracts themselves. One small, shared piece of code — call it **the sanctions guard** — is consulted by every entry point on the platform where money moves. The website still checks first, for fast feedback and to avoid wasting anyone's gas, but the layer that actually *enforces* is the one nobody can route around.
 
 ## The guard itself
 
-`contracts/access/SanctionsGuard.sol` is deliberately small: about 100 lines, no proxy, no funds, no upgradeability. It composes two lists behind a single verdict:
+The guard is deliberately tiny: about a hundred lines, holds no funds, and can't be upgraded. It combines two lists into a single yes-or-no verdict:
 
-1. **The Chainalysis on-chain Sanctions Oracle** — a public contract Chainalysis maintains that answers `isSanctioned(address)` against the OFAC SDN set (deployed on Polygon mainnet at `0x40C57923924B5c5c5455c48D93317139ADDaC8fb`).
-2. **An operator-maintained discretionary deny-list** — a plain `mapping(address => bool)` for addresses associated with illicit finance beyond SDN membership, mutated only by `SANCTIONS_ADMIN_ROLE`.
+1. **A public sanctions oracle maintained by Chainalysis** — an on-chain service that answers, for any address, whether it appears on the US Treasury's sanctions list.
+2. **A discretionary block-list the operator maintains** — a simple list for addresses tied to illicit finance beyond the official set, editable only by the holder of the narrow compliance permission described in part 1 of this series.
 
-The interface (`contracts/interfaces/ISanctionsGuard.sol`) exposes exactly what consumers need:
+Consumers get two ways to ask the guard a question. One returns a plain yes-or-no, for callers that want to branch on it — that's what the website's advisory check uses. The other simply stops the transaction cold if the address is blocked, which is the form the contracts use, because refusing to let a transaction complete is the cheapest and safest way to make sure a forbidden action never happens.
 
-```solidity
-interface ISanctionsGuard {
-    function isAllowed(address account) external view returns (bool);
-    function checkBlocked(address account) external view; // reverts SanctionedAddress(account)
-    function isDenied(address account) external view returns (bool);
-    function sanctionsOracle() external view returns (address);
-
-    function setDenied(address account, bool denied, string calldata reason) external;
-    function setSanctionsOracle(address oracle) external;
-
-    event DenyListUpdated(address indexed account, bool denied, address indexed actor, string reason);
-    event SanctionsOracleUpdated(address indexed oracle);
-
-    error SanctionedAddress(address account);
-}
-```
-
-Two views matter. `isAllowed` returns a boolean for callers that want to branch (the frontend's advisory read uses this). `checkBlocked` reverts with `SanctionedAddress(account)` — the form contracts consume, because in Solidity a revert in the Checks phase is the cheapest, safest way to make a whole transaction never happen.
-
-Note what the admin surface records. `setDenied` takes a human-readable `reason` and emits `DenyListUpdated` with the account, the direction of the change, the acting admin, and the reason — so the deny-list's entire history is an on-chain audit trail: who blocked whom, when, and why. There is no off-chain compliance database to subpoena or lose; the event log *is* the record. The admin keys behind both roles follow the platform's air-gapped floppy-keystore flow, so list mutations require a deliberate offline signing ceremony.
+The block-list editing has one nice property worth calling out: every change records who made it, which address was affected, in which direction, and a human-readable reason — all written permanently to the blockchain. So the block-list's entire history is a built-in audit trail. There's no separate off-chain compliance database to subpoena or lose; the on-chain event log *is* the record. And the keys that can edit those lists follow the platform's air-gapped, offline signing process, so no change happens casually.
 
 ## Fail-closed, for real
 
-The interesting engineering is in how the guard talks to the oracle. The naive version — `oracle.isSanctioned(account)` inside a `try/catch` — has a sharp edge: if the configured oracle address has no code (a bad deploy config, a selfdestructed target, the wrong chain), a high-level Solidity call doesn't behave the way you'd hope, and return-data decoding failures aren't reliably swallowed by `catch`. The guard instead does the query by hand:
+The interesting engineering is in how the guard talks to the outside sanctions oracle. The naive version — just call the oracle and wrap it in a try/catch — has a sharp edge. If the oracle address is misconfigured, pointing at nothing or at the wrong network, that kind of failure isn't reliably caught, and the system can silently start treating everyone as clean.
 
-```solidity
-function _queryOracle(address account) internal view returns (bool sanctioned, bool ok) {
-    address oracle = address(_oracle);
-    if (oracle == address(0)) return (false, true); // deny-list-only
-    (bool success, bytes memory data) = oracle.staticcall(
-        abi.encodeWithSelector(IChainalysisSanctionsOracle.isSanctioned.selector, account)
-    );
-    if (!success || data.length < 32) return (false, false); // fail-closed
-    return (abi.decode(data, (bool)), true);
-}
-```
+So the guard makes the query in a careful, low-level way that gives it full control over every possible failure: the oracle reverts, runs out of gas, returns nothing, or returns garbage. Anything short of a clean, well-formed "yes" or "no" is treated as *the oracle gave no usable answer* — and in that case the guard blocks **every** address. The rule is stated plainly in the platform's requirements: if the screening source is unavailable, refuse the action rather than allow it unscreened. This is what "fail-closed" means — when in doubt, deny.
 
-A low-level `staticcall` gives the guard full control over every failure mode: revert, out-of-gas bubble-up, empty return data from a codeless address, malformed return data. Anything short of a well-formed 32-byte answer means the configured oracle "gave no usable answer," and `isAllowed` returns false for *every* account. Spec 007's FR-019 states the invariant plainly: if the screening source is unavailable, refuse the screened action rather than allow it unscreened.
-
-There is one deliberate exception, and it's a configuration, not a failure. An oracle set to `address(0)` means *deny-list-only enforcement* — the posture for networks where Chainalysis simply doesn't deploy (Polygon Amoy gets a `MockSanctionsOracle` in tests; production injects the real mainnet address at deploy time, never hardcoded, per FR-022/FR-055). The distinction is precise: a **configured but broken** oracle blocks everyone; an **unset** oracle blocks only the deny-list. Confusing those two states is how fail-closed systems quietly become fail-open.
+There's exactly one deliberate exception, and it's a *configuration*, not a failure. Setting the oracle to "none" means *block-list-only enforcement* — the intended posture for networks where Chainalysis simply doesn't operate. Test networks get a stand-in; production gets the real oracle address injected at deployment, never hardcoded. The distinction is precise: a **configured but broken** oracle blocks everyone, while an **intentionally unset** oracle blocks only the block-list. Confusing those two states is exactly how fail-closed systems quietly turn fail-open.
 
 ## One guard, four subsystems
 
-What makes this a *primitive* rather than a feature is reuse. A grep for `ISanctionsGuard` across `contracts/` finds the same pattern in four independent subsystems:
+What makes this a reusable *building block* rather than a one-off feature is that the same guard protects four independent parts of the platform in the same way:
 
-**Wagers** (`contracts/wagers/WagerRegistryCore.sol`): every escrow entry point starts its Checks phase with a three-line helper —
+**Wagers.** Every escrow entry point screens first. Creating a wager screens the creator. Accepting one screens *both* sides — the person accepting and the original creator — because acceptance is the moment the second stake enters escrow, and the creator might have been added to a sanctions list since they first posted the wager. Screen at every entry, every time.
 
-```solidity
-function _screen(address account) internal view {
-    ISanctionsGuard guard = sanctionsGuard;
-    if (address(guard) != address(0)) guard.checkBlocked(account);
-}
-```
+**Memberships.** Buying, upgrading, extending, or redeeming a voucher into a membership all screen the person before any USDC moves. Even the admin-only path that grants a membership directly screens the recipient — the guard can't be bypassed *even by operators*, so a permission-holder can't accidentally hand access to a listed address.
 
-`createWager` screens the creator as its first check. The accept path screens *both* sides — the taker **and** the original creator — because acceptance is the moment the second stake enters escrow, and the creator may have been listed since they posted the wager. This implements spec 007's FR-021: re-screen at wager entry, every time.
+**Wager pools.** Group pools screen creators and joiners through the same guard, with one extra safeguard worth stealing: on production networks the pool factory *refuses to run at all* if screening is supposed to be on but no guard is configured. The "unset means off" convenience that's fine on a laptop becomes an impossible, boot-blocking state in production.
 
-**Memberships** (`contracts/access/MembershipManager.sol`): `purchaseTier`, `upgradeTier`, `extendMembership`, and voucher redemption (`redeemVoucher`, spec 026) all call `_screen(actor)` before any USDC moves. Even the admin-only `grantMembership` screens the grantee — the guard is non-bypassable *including by operators*, so a role-holder can't hand standing to a listed address by accident.
+**Token issuance and naming.** Issuing a token screens the issuer and passes the same guard into every token it creates. The naming registry checks the guard before letting anyone claim a name.
 
-**Wager pools** (`contracts/pools/WagerPoolFactory.sol`): pools screen creators and joiners through the same guard, with one extra invariant worth stealing: a `screeningRequired` flag set at initialization. On production networks the factory *refuses to run unconfigured* — `screen()` reverts `ScreeningNotConfigured` if the flag is set but the guard address is zero. The "unset means disabled" convenience that's fine for local development becomes an impossible state in production.
-
-**Token issuance** (`contracts/tokens/TokenFactory.sol`, spec 028) screens issuers and injects the guard into the tokens it clones, and the callsign registry (`contracts/naming/CallsignRegistry.sol`, spec 054) checks `isAllowed` before letting anyone register a name.
-
-Each consumer holds its own settable reference (`setSanctionsGuard`, admin-gated), so the guard can be rewired without upgrading any consumer — and a single `setDenied` call propagates instantly to every subsystem. One list, one admin surface, one event stream, four enforcement points.
+Each of these holds its own pointer to the guard, so the guard can be swapped out without touching any of them — and a single block-list update propagates instantly to all four. One list, one place to edit it, one event stream, four enforcement points.
 
 ## What is deliberately *not* screened
 
-The consumption table in `specs/007-compliance-gating/contracts/ISanctionsGuard.md` has a line that's easy to read past: exit and refund paths — `claimRefund`, `claimPayout`, `batchExpireOpen`, `declareDraw` — are **not** screened.
+Here's the design decision most teams get backwards: the exit paths — claiming a refund, claiming a payout, sweeping up expired wagers — are **not** screened.
 
-This is the design decision most teams get wrong in the other direction. If a party is added to the deny-list *after* their stake enters escrow, screening the exit path would permanently trap their funds in your contract. That converts a screening control into an asset freeze — a materially different (and much heavier) legal act than refusing new business, and one that turns your escrow contract into a custodian of blocked property. FairWins draws the line where the spec draws it: a listed address can take no *new* action that moves value in, but can always recover what is already theirs. The guard gates entry, never exit.
+The reasoning matters. If an address is added to the block-list *after* their stake is already sitting in escrow, screening the exit would permanently trap their funds inside your contract. That turns a screening control into an *asset freeze* — a much heavier and legally distinct act than simply refusing new business, and one that effectively makes your escrow contract a custodian of blocked property. FairWins draws the line cleanly: a listed address can take no *new* action that moves value in, but can always recover what's already theirs. **The guard gates entry, never exit.**
 
 ## Trade-offs
 
-**Gas on every entry.** Each screened action pays for a cross-contract `staticcall`, and (when the oracle is set) a second one into Chainalysis. That's real overhead on the hot path. The team judged it acceptable because the alternative — screening only at membership time — leaves the FR-021 gap: an address listed mid-membership could keep wagering until renewal.
+**A little gas on every entry.** Each screened action pays for an extra cross-contract call, plus a second one into the oracle when it's set. That's real overhead on the busy path. The team judged it worth it, because the alternative — screening only once, at membership time — leaves a gap: an address listed mid-membership could keep wagering until renewal. Re-screening at every entry closes it.
 
-**Trusting an external oracle.** The Chainalysis oracle is a centralized, permissioned data source; FairWins takes its answers as ground truth. The mitigations are structural rather than trust-minimized: the oracle is read-only from the guard's perspective, it can be swapped by `DEFAULT_ADMIN_ROLE` if compromised or deprecated, and the discretionary deny-list works even with the oracle unset. This is an honest trade — no decentralized OFAC feed exists, and pretending otherwise doesn't help anyone.
+**Trusting an outside oracle.** The Chainalysis oracle is a centralized, permissioned data source, and FairWins takes its answers as ground truth. The safeguards are structural rather than trustless: the guard only ever *reads* from it, it can be swapped out if it's ever compromised or retired, and the discretionary block-list keeps working even with the oracle unset. This is an honest trade — no decentralized sanctions feed exists, and pretending otherwise helps no one.
 
-**Fail-closed can mean downtime.** If Chainalysis' contract ever reverted for everyone, every screened FairWins entry point would halt until an admin re-pointed or unset the oracle. That's the cost of FR-019, accepted with eyes open: brief unavailability is recoverable; a strict-liability violation is not.
+**Fail-closed can mean downtime.** If the oracle ever broke for everyone, every screened entry point would halt until an operator re-pointed or unset it. That's the accepted cost of failing closed: a brief outage is recoverable; a strict-liability violation is not.
 
-**Defense in depth, not defense in one place.** The on-chain guard is one layer of spec 007's stack: a Cloudflare edge geo-gate (HTTP 451 with an origin-lock header so the gate can't be bypassed by hitting the origin), an advisory app-layer oracle read for fast UX, versioned hash-addressed legal documents, and on-chain consent records. The guard is the layer that holds when every other layer is skipped — because on a public chain, one of them always can be.
+**Defense in depth, not defense in one place.** The on-chain guard is one layer of several: an edge network geo-gate that blocks restricted regions before a request even reaches the app, the website's fast advisory check, versioned legal documents, and on-chain records of user consent. The guard is the layer that holds *when every other layer is skipped* — because on a public blockchain, one of them always can be.
 
-## Sources
+## Further reading
 
-- `specs/007-compliance-gating/spec.md` — compliance & legal gating layer (FR-016–FR-022, FR-054–FR-055)
-- `specs/007-compliance-gating/contracts/ISanctionsGuard.md` — behavior contract and consumption table
-- `contracts/access/SanctionsGuard.sol` — guard implementation (fail-closed staticcall, deny-list, roles)
-- `contracts/interfaces/ISanctionsGuard.sol`, `contracts/interfaces/IChainalysisSanctionsOracle.sol`
-- `contracts/wagers/WagerRegistryCore.sol`, `contracts/wagers/WagerRegistry.sol` — `_screen` in create/accept paths
-- `contracts/access/MembershipManager.sol` — screening on purchase/upgrade/extend/grant/voucher redemption
-- `contracts/pools/WagerPoolFactory.sol` — `screeningRequired` invariant, `ScreeningNotConfigured`
-- `contracts/tokens/TokenFactory.sol`, `contracts/naming/CallsignRegistry.sol` — additional consumers
-- Chainalysis on-chain sanctions oracle: https://go.chainalysis.com/chainalysis-oracle-docs.html
-- OFAC SDN list: https://ofac.treasury.gov/sanctions-list-service
-- OpenZeppelin AccessControl: https://docs.openzeppelin.com/contracts/5.x/access-control
-- RFC 7725 (HTTP 451 Unavailable For Legal Reasons): https://www.rfc-editor.org/rfc/rfc7725
+- Chainalysis on-chain sanctions oracle documentation: https://go.chainalysis.com/chainalysis-oracle-docs.html
+- The US Treasury OFAC sanctions list: https://ofac.treasury.gov/sanctions-list-service
+- OpenZeppelin Access Control, the permission library behind the block-list roles: https://docs.openzeppelin.com/contracts/5.x/access-control
+- RFC 7725, the "HTTP 451 Unavailable For Legal Reasons" standard used by the geo-gate: https://www.rfc-editor.org/rfc/rfc7725

--- a/docs/blog/posts/03-sanctions-compliance-gating/social.md
+++ b/docs/blog/posts/03-sanctions-compliance-gating/social.md
@@ -2,26 +2,26 @@
 
 ## X (Twitter)
 
-Frontend sanctions screening on a public chain is theater — anyone can call your contracts directly. We made screening a contract primitive: one fail-closed SanctionsGuard consulted by wagers, pools, memberships & token issuance. Entry is gated; exit never is. 🔗 <link> #Solidity #web3 #compliance
+Frontend sanctions screening on a public blockchain is theater — anyone can call your contracts directly. We made screening a shared building block baked into the contracts: one fail-closed guard consulted by wagers, pools, memberships & token issuance. Entry is gated; exit never is. 🔗 <link> #web3 #compliance
 
 ## LinkedIn
 
-If your smart contracts are publicly callable, a sanctions check that lives only in your frontend is not a control — it's a suggestion. OFAC exposure is strict liability: it doesn't matter that your UI *would have* blocked the address if the contract accepted its escrow anyway.
+If your smart contracts are publicly callable, a sanctions check that lives only in your website is not a control — it's a suggestion. Sanctions exposure is strict liability: it doesn't matter that your interface *would have* blocked the address if the contract accepted its money anyway.
 
-In part 3 of our Identity & Access series, we walk through how FairWins turned sanctions screening into a shared on-chain primitive instead of an off-chain afterthought:
+In part 3 of our Identity & Access series, we walk through how FairWins turned sanctions screening into a shared on-chain building block instead of an off-chain afterthought:
 
-- A ~100-line SanctionsGuard combining the Chainalysis on-chain oracle with an operator deny-list whose full history (actor, reason, timestamp) lives in event logs
-- Fail-closed by construction: a low-level staticcall treats a broken, codeless, or malformed oracle as "block everyone" — while an intentionally unset oracle degrades to deny-list-only
-- One guard threading through four independent subsystems — wagers, pools, memberships, token issuance — with re-screening at every value entry point
+- A ~100-line sanctions guard combining a public Chainalysis oracle with an operator block-list whose full history — who, why, when — lives permanently in the on-chain event log
+- Fail-closed by construction: a broken or misconfigured oracle means "block everyone," while an intentionally unset oracle degrades to block-list-only
+- One guard threading through four independent subsystems — wagers, pools, memberships, token issuance — with re-screening at every money entry point
 - The line most teams draw wrong: refund and payout paths are deliberately unscreened, so a newly listed address can always recover its own escrowed funds. Screening gates entry, never exit
 
-We also cover the honest trade-offs: gas on the hot path, trusting a centralized oracle, and accepting downtime as the price of fail-closed.
+We also cover the honest trade-offs: gas on the busy path, trusting a centralized oracle, and accepting brief downtime as the price of failing closed.
 
 Read the full post: <link>
 
-Where do you draw the line between screening new business and freezing existing funds? 
+Where do you draw the line between screening new business and freezing existing funds?
 
-#SmartContracts #Compliance #Solidity #web3 #Sanctions
+#SmartContracts #Compliance #web3 #Sanctions #security
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/04-passkey-smart-accounts/blog.md
+++ b/docs/blog/posts/04-passkey-smart-accounts/blog.md
@@ -1,119 +1,63 @@
-# Passkey Smart Accounts: Putting WebAuthn Signatures on an ERC-4337 Wallet
+# Passkey Smart Accounts: A Wallet You Open With Your Fingerprint
 
-*How FairWins turned Face ID into a self-custodial Ethereum account — no seed phrase, no browser extension, and a P-256 verifier that runs on-chain*
+*How FairWins turned Face ID into a real, self-custodial crypto account — no seed phrase, no browser extension, nothing to write down*
 
 | | |
 |---|---|
 | **Series** | Accounts & Keys (part 1) |
-| **Audience** | Wallet developers, account-abstraction engineers |
-| **Tags** | `account-abstraction`, `erc4337`, `passkeys`, `webauthn`, `p256`, `erc1271` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product folks, founders, crypto-curious readers, and developers new to wallets |
+| **Tags** | `passkeys`, `wallets`, `self-custody`, `onboarding`, `account-abstraction` |
+| **Reading time** | ~7 minutes |
 
-## The curve nobody asked for
+## The twelve words nobody wants to write down
 
-Picture the onboarding funnel for a peer-to-peer wager platform. A friend sends you a wager link. You have never installed MetaMask, you have never written twelve words on paper, and you are not going to start tonight. What you do have is a phone with a fingerprint sensor and a secure enclave that has been signing things for you — payments, logins — for years.
+Picture how someone joins a peer-to-peer wager app. A friend sends a link. You have never installed a crypto wallet, you have never copied twelve recovery words onto a scrap of paper, and you are not about to start tonight. What you *do* have is a phone with a fingerprint sensor and a small, tamper-resistant security chip that has been quietly signing things for you — payments, app logins — for years.
 
-That enclave speaks WebAuthn. When you register a passkey, the authenticator mints a keypair and will sign challenges after a biometric check, without the private key ever leaving the hardware. This is exactly the custody model crypto wallets have been chasing: keys that cannot be exported, phished, or pasted into a fake support chat.
+That chip speaks a standard called **passkeys** — the same WebAuthn technology behind Face ID and fingerprint sign-in on the sites you already use. When you create a passkey, your device generates a private key that it never hands out. It will only prove who you are after a biometric check, and the secret itself never leaves the hardware. That is exactly the security model crypto wallets have chased for a decade: a key that can't be exported, phished, or pasted into a fake support chat.
 
-There is one problem, and it is a stubborn one: the curve. Secure enclaves and platform authenticators sign on **secp256r1** (P-256, the NIST curve). Ethereum externally-owned accounts recover signatures on **secp256k1**. There is no way to make a passkey pretend to be an EOA — `ecrecover` will never accept a P-256 signature. If you want passkeys to control funds, the account itself has to become a smart contract that knows how to verify P-256, and something other than the user has to be able to feed it transactions, because a passkey cannot pay gas from an address that does not exist yet.
+There is one stubborn catch. Passkeys and Ethereum accounts speak different mathematical "dialects" for signatures. The security chip in your phone signs using one type of cryptographic curve; ordinary Ethereum accounts expect a different one. They simply don't recognize each other's signatures, and no amount of interface polish papers over that. If you want a passkey to control real funds, the account itself has to become a small smart contract — a program on the blockchain — that knows how to read the passkey's dialect. And something other than the user has to be able to submit that first transaction, because a brand-new passkey can't pay a network fee from an account that doesn't exist on-chain yet.
 
-That is the shape of FairWins spec 041: an **ERC-4337 smart account** owned by a WebAuthn credential, with on-chain P-256 verification, deterministic counterfactual addresses, and first-use deployment. This post walks the contract stack in `contracts/account/` — what we vendored, what we wired around it, and where the sharp edges were.
+That is the whole idea behind FairWins passkey accounts: a smart-contract wallet controlled by a passkey, able to verify the phone's signatures directly, living at an address that's known before the wallet is ever deployed.
 
-## An account is a set of owners, not a key
+## An account is a list of owners, not a single key
 
-The account contract is a vendored **Coinbase Smart Wallet v1.1.0** — `contracts/account/CoinbaseSmartWallet.sol` plus its pinned dependency closure (`webauthn-sol`, `FreshCryptoLib`, Solady, `account-abstraction`). The vendoring rule, documented in `contracts/account/README.md`, is strict: no logic modifications, path-only import rewrites. We wanted an audited, widely deployed account implementation, not a fork we would have to re-audit forever.
+Rather than build this from scratch, FairWins uses a widely deployed, professionally audited smart-wallet design — Coinbase's Smart Wallet — and adopts it as-is, without rewriting its logic. The rule is deliberate: an audited contract is only worth something if you don't quietly fork and change it. Reusing it unmodified means those outside audits still apply.
 
-The foundation is `contracts/account/MultiOwnable.sol`, and its central trick is that an owner is just `bytes`:
+The clever part of that design is how it defines ownership. An "owner" of the account isn't one fixed key; it's simply an entry in a list, and each entry can be one of two things:
 
-- a 32-byte ABI-encoded Ethereum address (a linked EOA), or
-- a 64-byte P-256 public key — the `(x, y)` coordinates of a passkey.
+- a linked ordinary Ethereum wallet address (say, a MetaMask you already have), or
+- a passkey — represented by the two numbers that make up its public key.
 
-Both kinds sit in the same index-addressed mapping and are interchangeable controllers. Adding or removing one (`addOwnerPublicKey(bytes32 x, bytes32 y)`, `addOwnerAddress(address)`, `removeOwnerAtIndex`) is an owner-authorized self-call, and `removeOwnerAtIndex` reverts with `LastOwner()` rather than let an account brick itself by removing its final controller.
+Both kinds sit in the same list and carry equal authority. Any owner can add or remove other owners, and the contract refuses to remove the *last* one — so an account can never accidentally lock itself out by deleting its only controller. When a signature arrives, the account looks at which owner produced it and checks it the right way: the passkey path for a passkey, the ordinary path for a linked wallet. One mechanism covers both signing in for transactions and approving off-chain messages.
 
-Signature validation dispatches on the owner's byte length. Every signature arrives wrapped with the index of the owner that produced it:
+## Checking a passkey signature on the blockchain
 
-```solidity
-struct SignatureWrapper {
-    /// @dev The index of the owner that signed, see `MultiOwnable.ownerAtIndex`
-    uint256 ownerIndex;
-    /// @dev If `MultiOwnable.ownerAtIndex` is an Ethereum address, this should be `abi.encodePacked(r, s, v)`
-    ///      If `MultiOwnable.ownerAtIndex` is a public key, this should be `abi.encode(WebAuthnAuth)`.
-    bytes signatureData;
-}
-```
+A passkey signature is more than a scribble over some data. When your device signs, it wraps the thing you're approving inside a small standardized bundle that also records details like "this was a genuine WebAuthn sign-in" and "a user was present." To trust that signature, the contract re-runs the important checks from the official WebAuthn specification right on-chain: it confirms the bundle is the expected kind, that the challenge inside it matches what was really being approved, that a user was actually present, and it rejects a known signature-tampering trick. It deliberately skips a few checks that the phone and the app's site association already enforce — an honest trade that keeps verification affordable.
 
-In `CoinbaseSmartWallet._isValidSignature`, 32-byte owners go through Solady's `SignatureCheckerLib` (ECDSA or nested ERC-1271); 64-byte owners take the WebAuthn path:
+Then there's the heavy math of actually verifying the signature, which is expensive to do on a blockchain. Where the network offers a fast built-in helper for exactly this kind of signature, the contract uses it (cheap — a few thousand units of gas). Where a network doesn't, the same contract quietly falls back to doing the math the slow, pure-software way. Same code, both worlds — which is why supporting a new network later is a configuration change, not a contract rewrite.
 
-```solidity
-if (ownerBytes.length == 64) {
-    (uint256 x, uint256 y) = abi.decode(ownerBytes, (uint256, uint256));
+## An address before there's an account
 
-    WebAuthn.WebAuthnAuth memory auth = abi.decode(sigWrapper.signatureData, (WebAuthn.WebAuthnAuth));
+Here's a nice trick that makes onboarding feel instant: your account address exists *before* the wallet is actually deployed. The address is calculated purely from your initial list of owners, so the app can show it — and a friend can send funds to it — while the contract itself is still just a plan. FairWins deploys the piece that mints these addresses in an identical way on every supported network, so your address is the same everywhere.
 
-    return WebAuthn.verify({challenge: abi.encode(hash), requireUV: false, webAuthnAuth: auth, x: x, y: y});
-}
-```
+Deployment happens lazily, the first time you actually do something. That first action carries a little bundle of setup instructions: the network deploys your account and performs your transaction together, in one shot. (One hard-won lesson from building this: a popular off-the-shelf toolkit assumed a *different* deployment source than the one FairWins uses, which quietly produced the wrong predicted address and made every early transaction fail. The fix was to pin everything to the exact same source. If you ever wire a custom wallet into a generic toolkit, check its address assumptions first.)
 
-This one function backs both ERC-4337 `validateUserOp` and ERC-1271 `isValidSignature` — one verification path for transactions and off-chain signatures alike.
+## No seed phrase doesn't mean no keys
 
-## Verifying WebAuthn where gas is real
+Passkeys are great at signing but they don't encrypt. Some FairWins features — the private ones — need encryption keys too. So the app uses a companion capability of the passkey standard to derive a stable secret from your authenticator, stretch it into an encryption key, and use that to wrap a single master seed. Every owner on the account unwraps the *same* seed, which is why your encrypted data survives switching devices. If an authenticator doesn't support this capability, the app says so plainly rather than silently generating the wrong keys.
 
-A WebAuthn assertion is not a bare signature over a hash. The authenticator signs `sha256(authenticatorData || sha256(clientDataJSON))`, where `clientDataJSON` embeds the challenge (base64url-encoded) and a ceremony type. `contracts/account/lib/webauthn-sol/WebAuthn.sol` re-runs the relevant verification steps from the W3C spec on-chain: it checks the client data `type` is `"webauthn.get"`, that the encoded challenge in the JSON matches the expected hash, that the User Present flag is set in `authenticatorData`, and it rejects high-`s` P-256 signatures to close the malleability hole. The library's NatSpec is refreshingly explicit about what it deliberately does *not* verify — origin, `rpIdHash`, signature counters — trusting platform authenticators and app-site association to enforce those, which is the honest trade for keeping verification affordable.
+## Why we built it this way
 
-Then comes the actual curve math. P-256 verification in pure EVM is expensive, so the library tries the **RIP-7212 precompile** at address `0x100` first — about 3,450 gas on Polygon and Amoy, where FairWins runs passkeys today. On chains without the precompile, the `staticcall` returns empty and the code falls back to `FCL_ecdsa.ecdsa_verify` from FreshCryptoLib, a Solidity implementation costing a couple hundred thousand gas. The same bytecode serves both worlds — which is precisely why the deferred ETC/Mordor increment needs no contract changes, only a self-hosted bundler.
+- **Reuse an audited design, don't fork it.** Using the Coinbase Smart Wallet unmodified keeps its outside security audits meaningful. A private fork would need re-auditing forever.
+- **Upgrades belong to the user.** These accounts can be upgraded, but only the account's own owner can authorize that. FairWins holds no override switch over anyone's wallet — which is what makes this genuinely self-custodial, not "self-custodial" in scare quotes.
+- **Fast where possible, correct everywhere.** Using the network's built-in signature helper where it exists, and falling back to software elsewhere, costs a bit more on some chains but means one single codebase runs everywhere.
+- **Honest about fees.** The confirm screen only says a transaction is sponsored when it truly is; otherwise it says you pay the network fee. (A later post covers how sponsorship works.)
 
-## An address before an account
+The result is an account you open with a thumbprint, funded at an address that exists before the contract does, and controlled by keys that no server — including ours — ever holds.
 
-The user's account address must exist before any contract does — it is where a friend sends their stake. `contracts/account/CoinbaseSmartWalletFactory.sol` makes the address a pure function of the initial owners:
+## Further reading
 
-```solidity
-function createAccount(bytes[] calldata owners, uint256 nonce)
-    external payable virtual returns (CoinbaseSmartWallet account)
-{
-    if (owners.length == 0) revert OwnerRequired();
-
-    (bool alreadyDeployed, address accountAddress) =
-        LibClone.createDeterministicERC1967(msg.value, implementation, _getSalt(owners, nonce));
-    ...
-}
-```
-
-The salt is `keccak256(abi.encode(owners, nonce))`, and the account is a deterministic ERC-1967 proxy over the shared implementation. `getAddress(owners, nonce)` predicts the address without deploying anything. FairWins deploys the factory itself through a canonical CREATE2 deployer with a pinned salt (`scripts/deploy/deploy-account-stack.js`), so the factory — and therefore every account address — is identical on every supported network. Recorded deployment keys: `entryPoint`, `accountFactory`, `accountImpl`.
-
-Deployment happens lazily. The first time the user acts, the frontend (`frontend/src/lib/passkey/sendBatch.js`) attaches ERC-4337 `initCode` that calls `createAccount`; the EntryPoint deploys the account and executes the operation in the same transaction. One war story worth passing on, preserved as a comment in `frontend/src/lib/passkey/smartAccount.js`: viem's smart-account helper defaults to the *canonical Coinbase factory address*, which derives a **different** counterfactual address than the FairWins-deployed factory. Left unpinned, every UserOp was built for an empty account and reverted with "exceeds balance". The fix is to pin the sender to the address returned by the FairWins factory's `getAddress` and generate `initCode` against that same factory. If you integrate any vendored factory with a generic AA SDK, audit its address-derivation defaults first.
-
-## ERC-1271, with a seatbelt
-
-Wagering on FairWins mostly rides gasless EIP-712 intents (specs 035/036), and USDC moves via EIP-3009 authorizations — both off-chain signatures. A contract account signs those through **ERC-1271**: verifiers call `isValidSignature(hash, signature)` and expect the `0x1626ba7e` magic value.
-
-The vendored `contracts/account/ERC1271.sol` adds one crucial layer: an anti-cross-account-replay wrapper. Because the same passkey can own several accounts, a naive implementation would let a signature approved for account A validate on account B. So the contract never verifies the raw hash — it verifies `replaySafeHash(hash)`, an EIP-712 hash of `CoinbaseSmartWalletMessage(bytes32 hash)` under a domain separator bound to `block.chainid` and `address(this)`. A signature is valid for exactly one account on exactly one chain. On the platform side, spec 041 extended `contracts/upgradeable/SignerIntentBase.sol` with an ECDSA-then-ERC-1271 check so intent verification accepts contract signers, with a matching fail-closed `eth_call` fallback in `services/relay-gateway/src/intent/verify.js`. One honest scope note: the EIP-3009 payment leg is still ECDSA-only in the intent twins, so passkey stake-moving actions ride `executeBatch` UserOps until the ERC-7598 bytes-signature leg is plumbed through — `test/fork/usdc-erc1271-authorization.test.js` already proves native USDC accepts the contract-account authorization.
-
-`executeBatch(Call[] calldata calls)` matters for UX too: approve-and-act becomes one biometric ceremony instead of two.
-
-## No seed phrase does not mean no keys
-
-Passkeys sign; they do not encrypt. FairWins' private-market features need deterministic encryption keys, so `frontend/src/lib/passkey/prfKeys.js` uses the WebAuthn **PRF extension**: a fixed, versioned evaluation point (`fairwins.prf.salt.v1`) is fed through the authenticator's PRF, the output through HKDF-SHA256 (`info="fairwins-kek-v1"`) into a key-encryption key, which wraps a random 32-byte master seed with AES-GCM. Every controller on the account unwraps the *same* master seed, so encryption keys survive device changes. Authenticators without PRF degrade explicitly — the UI reports encryption unavailable rather than deriving silently wrong keys.
-
-## Design decisions
-
-- **Vendor, don't fork.** Coinbase Smart Wallet v1.1.0 is battle-tested and audited; the repo's rule of zero logic modifications means upstream audits remain meaningful. The one deviation is documented in `MultiOwnable.sol` itself: an ERC-7201 NatSpec annotation removed because tooling choked on it — a comment, not bytecode.
-- **User-sovereign upgrades.** The account is UUPS-upgradeable, but `_authorizeUpgrade` is `onlyOwner`. FairWins holds no authority over deployed instances — deliberately outside the platform's `UUPSManaged` regime, and the reason this is genuinely self-custodial rather than "self-custodial."
-- **`requireUV: false`.** The account checks User Present, not User Verified, at the contract layer, matching upstream. Platform authenticators enforce biometrics at the ceremony; hard-requiring UV on-chain would strand security keys that report UP only.
-- **Precompile-first, fallback-always.** RIP-7212 where available, FreshCryptoLib elsewhere. Costlier on precompile-less chains, but one bytecode everywhere beats per-chain builds.
-- **Gas honesty.** Spec 041 shipped with users paying their own UserOp gas (FR-015); spec 050 later superseded that with a self-hosted verifying paymaster — but the confirm UI only ever claims "sponsored" when a sponsorship was actually obtained, and the self-funded fallback keeps users never stranded.
-
-The result: an account a user opens with a thumbprint, funds at an address that exists before the contract does, and controls through keys that no server — including ours — ever holds.
-
-## Sources
-
-- `specs/041-passkey-wallet-login/` — feature spec and plan
-- `docs/developer-guide/passkey-accounts.md` — architecture guide
-- `contracts/account/CoinbaseSmartWallet.sol`, `contracts/account/MultiOwnable.sol`, `contracts/account/CoinbaseSmartWalletFactory.sol`, `contracts/account/ERC1271.sol`
-- `contracts/account/lib/webauthn-sol/WebAuthn.sol`, `contracts/account/lib/FreshCryptoLib/`
-- `frontend/src/lib/passkey/smartAccount.js`, `frontend/src/lib/passkey/prfKeys.js`
-- ERC-4337: <https://eips.ethereum.org/EIPS/eip-4337>
-- ERC-1271: <https://eips.ethereum.org/EIPS/eip-1271>
-- EIP-712: <https://eips.ethereum.org/EIPS/eip-712>
-- RIP-7212 (secp256r1 precompile): <https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md>
-- WebAuthn Level 2 (W3C): <https://www.w3.org/TR/webauthn-2/>
-- Coinbase Smart Wallet: <https://github.com/coinbase/smart-wallet>
+- Passkeys / WebAuthn (W3C): <https://www.w3.org/TR/webauthn-2/>
+- What passkeys are, in plain terms (FIDO Alliance): <https://fidoalliance.org/passkeys/>
+- The ERC-4337 account-abstraction standard (smart-contract wallets): <https://eips.ethereum.org/EIPS/eip-4337>
+- Coinbase Smart Wallet (open source): <https://github.com/coinbase/smart-wallet>

--- a/docs/blog/posts/04-passkey-smart-accounts/social.md
+++ b/docs/blog/posts/04-passkey-smart-accounts/social.md
@@ -1,27 +1,27 @@
-# Social & Image — Passkey Smart Accounts: Putting WebAuthn Signatures on an ERC-4337 Wallet
+# Social & Image — Passkey Smart Accounts: A Wallet You Open With Your Fingerprint
 
 ## X (Twitter)
 
-Your phone's secure enclave signs P-256. Ethereum recovers secp256k1. No amount of UX polish fixes a curve mismatch — so we made the account a contract. ERC-4337 + WebAuthn, RIP-7212 precompile at ~3,450 gas, no seed phrase. 🔗 <link> #AccountAbstraction #passkeys #ERC4337
+Most crypto onboarding still starts with "write down these twelve words." Your phone already has better: the same Face ID / fingerprint tech you use to log in everywhere. We turned it into a real, self-custodial wallet — no seed phrase, nothing to lose. 🔗 <link> #passkeys #wallets #selfcustody
 
 ## LinkedIn
 
-Most crypto onboarding still starts with "write down these twelve words." The hardware to do better has been in everyone's pocket for years — but secure enclaves sign on secp256r1 (P-256), and Ethereum EOAs only understand secp256k1. You cannot bridge that gap at the key level; you have to bridge it at the account level.
+Most crypto onboarding still starts with "write down these twelve words." The hardware to do better has been in everyone's pocket for years — it's the same passkey technology behind Face ID and fingerprint login. The catch is that phones and blockchains speak different signature "dialects," so you can't just plug one into the other. You have to make the account itself a small smart contract that understands your phone.
 
-Our new engineering post walks through how FairWins ships self-custodial passkey wallets on ERC-4337 smart accounts, built on the vendored Coinbase Smart Wallet stack:
+Our new post walks through how FairWins ships self-custodial passkey wallets, built on the audited, open-source Coinbase Smart Wallet design:
 
-- How `MultiOwnable` treats a 64-byte P-256 public key and a 20-byte EOA as interchangeable account controllers
-- Verifying full WebAuthn assertions on-chain: clientDataJSON checks, malleability guards, and the RIP-7212 precompile with a FreshCryptoLib fallback
-- Deterministic counterfactual addresses and first-use deployment via ERC-4337 initCode — including a real bug from an SDK's hardwired factory address
-- ERC-1271 replay-safe hashing, so one passkey owning multiple accounts can never have a signature replayed across them
+- Why an account is a *list of owners* — a passkey and an ordinary wallet can be equal controllers of the same account
+- How the contract checks a real passkey signature on-chain, using the network's fast built-in helper where it exists
+- Why your account address exists before the wallet is even deployed — so a friend can fund it instantly — plus a real bug from a toolkit that assumed the wrong address
+- Why "no seed phrase" still doesn't mean "no keys"
 
-Honest trade-offs included: what the on-chain verifier deliberately skips, and why account upgrades belong to users, not the platform.
+Honest trade-offs included: what the on-chain check deliberately skips, and why account upgrades belong to users, not the platform.
 
 Read the full post: <link>
 
-If you are building on account abstraction — where did passkey integration bite you first: the curve, the factory, or the gas?
+If you're building onboarding for crypto — what's the first thing that scares off new users: the seed phrase, the wallet install, or the fees?
 
-#AccountAbstraction #ERC4337 #WebAuthn #passkeys #web3
+#passkeys #wallets #selfcustody #web3 #fintech
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/05-account-recovery-unified-connect/blog.md
+++ b/docs/blog/posts/05-account-recovery-unified-connect/blog.md
@@ -1,120 +1,79 @@
 # Losing Every Passkey Shouldn't Mean Losing the Account
 
-*How FairWins merged wallet connection and account recovery into one surface — and made passkey accounts recoverable without reintroducing a seed phrase*
+*How FairWins made passkey accounts recoverable — without bringing back the seed phrase — and folded connecting, controlling, and recovering into one simple screen*
 
 | | |
 |---|---|
 | **Series** | Accounts & Keys (part 2) |
-| **Part** | 5 of 34 |
-| **Audience** | Wallet/UX engineers, account-abstraction developers, product designers |
-| **Tags** | `account-recovery`, `passkeys`, `self-custody`, `ux`, `account-abstraction` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product folks, designers, founders, and developers new to wallets |
+| **Tags** | `account-recovery`, `passkeys`, `self-custody`, `ux`, `onboarding` |
+| **Reading time** | ~7 minutes |
 
 ## The phone in the river
 
-A member signs up for FairWins with a passkey. No seed phrase, no extension — Face ID creates a P-256 credential, and an ERC-4337 smart account derives from it. It's the onboarding passkeys promised: nothing to write down, nothing to lose.
+Someone signs up for FairWins with a passkey. No seed phrase, no browser extension — Face ID creates the credential, and a smart-contract account springs from it. The onboarding passkeys always promised: nothing to write down, nothing to lose.
 
-Then the phone goes in the river. Or the browser profile gets wiped, or the laptop dies. Platform sync (iCloud Keychain, Google Password Manager) catches most of these cases — but not all. A passkey created in an unsynced browser profile is simply gone. With a seed-phrase wallet, the answer was brutal but well understood: type the twelve words back in. Passkeys deliberately removed those twelve words. So what's the recovery story?
+Then the phone goes in the river. Or the browser profile gets wiped, or the laptop dies. Most of the time your phone's built-in sync (iCloud Keychain, Google Password Manager) has quietly backed the passkey up and you're fine — but not always. A passkey created in a browser profile that wasn't syncing is simply gone. With an old-style wallet, recovery was brutal but obvious: retype your twelve words. Passkeys deliberately removed those words. So what's the recovery story now?
 
-At the same time, our pre-consolidation frontend had a quieter problem that made any recovery story moot: *connecting* was already broken in three different ways. Three surfaces offered connection — the header button, the wallet page, and the dashboard welcome screen — each with different options and ordering (one couldn't reach passkey at all), and parallel attempts could race a background session restore into a stuck state. Worse, two shipped defects blocked passkey users outright: on Chrome and Brave, signing back in could leave a session that crashed every transaction with `Cannot read properties of undefined (reading 'id')`, and Brave silently signed users into their *first* passkey no matter which account they picked.
+There was a second, quieter problem that made the recovery question moot: even *connecting* was broken. The app offered three different places to connect, each with different options, and one couldn't even reach the passkey option. Worse, two real bugs locked passkey users out: on some browsers, signing back in left every transaction crashing, and one browser would silently sign you into your *first* passkey no matter which account you picked.
 
-Spec 045 (`specs/045-unified-connect-recovery/`) treats these as one problem: connection, controller management, and recovery are the same lifecycle, and they should live behind one surface. This post walks through how it works — and why the contract layer needed zero changes.
+The insight was to treat all of this as one thing. Connecting, managing who controls your account, and recovering after a lost device are really the same lifecycle — so they should live behind one door. This post walks through how that works, and why none of it touched the account contracts.
 
-## The account layer already had the answer
+## The account already knew how to be recovered
 
-FairWins passkey accounts (spec 041) are vendored Coinbase Smart Wallet contracts. Their auth core, `contracts/account/MultiOwnable.sol`, stores owners as raw bytes in ERC-7201 namespaced storage: a 32-byte ABI-encoded Ethereum address *or* a 64-byte P-256 public key. A passkey and a MetaMask address are interchangeable controllers of the same account:
+Remember from the previous post: a FairWins passkey account doesn't have a single owner. It keeps a *list* of owners, each of which can be a passkey or an ordinary wallet address. They're equal peers — any one can add or remove the others.
 
-```solidity
-/// @notice Adds a new Ethereum-address owner.
-function addOwnerAddress(address owner) external virtual onlyOwner {
-    _addOwnerAtIndex(abi.encode(owner), _getMultiOwnableStorage().nextOwnerIndex++);
-}
+That is the entire recovery mechanism, hiding in plain sight. If a second controller exists when your phone dies, recovery is a single action: that controller adds a fresh passkey. And because a linked ordinary wallet can do this with a plain everyday transaction, recovery needs no special infrastructure — no relayer, no service, nobody's permission but your own. The account also protects itself: it refuses to remove its last remaining owner, and it only accepts changes from a genuine current owner.
 
-/// @notice Adds a new public-key owner.
-function addOwnerPublicKey(bytes32 x, bytes32 y) external virtual onlyOwner {
-    _addOwnerAtIndex(abi.encode(x, y), _getMultiOwnableStorage().nextOwnerIndex++);
-}
-```
+So the real work was never in the contracts. It was in getting people to actually *have* that second controller before disaster, and making the app honest and reliable enough to use it.
 
-Every owner is a full 1-of-N peer: any single controller can add or remove the others. Two invariants matter for recovery. First, `removeOwnerAtIndex` reverts with `LastOwner()` when only one owner remains, so an account can never be stranded controllerless. Second, `_checkOwner` accepts any registered owner (or the account itself), so an EOA owner can call `addOwnerPublicKey` with an *ordinary transaction* — no bundler, no UserOp, no relayer.
+## One front door for connecting
 
-That's the entire recovery primitive. If a second controller exists when disaster strikes, recovery is one contract call. The 045 plan (`specs/045-unified-connect-recovery/plan.md`) says it plainly: **no contract changes** — the work is making people actually *have* that second controller, and making the client honest enough to use it.
+The first fix was a single connect screen. Every entry point now opens the same dialog; nothing else renders its own list of choices. The options are ordered passkey first, then WalletConnect, then browser-extension wallets, and the app checks up front whether each is actually available — showing an honest "not detected" or "not supported" instead of failing after you tap.
 
-## One connect surface, serialized
-
-The first deliverable is `frontend/src/components/wallet/ConnectModal.jsx`: the single connect surface. Every entry point — header button, wallet page, dashboard welcome — opens the same dialog via `WalletContext.openConnectModal()`; no other component renders connector choices (FR-001). Options are ordered Passkey → WalletConnect → browser extension wallets, with the first two featured — all three fully supported. Availability is probed and shown honestly ("not detected", "not supported") before the user commits, rather than failing on tap (FR-003).
-
-`WalletContext` serializes attempts: at most one connect flow in flight, and a background session restore can never override a user-initiated connection (FR-004). A first-time passkey explainer renders inside the modal exactly once per browser, tracked by a `fairwins.passkey.explainer.v1` localStorage marker — and if storage is blocked, the explainer may repeat but never blocks connecting.
+It also runs only one connection attempt at a time, so a background attempt to restore your previous session can never barge in and override one you started yourself — which is what used to produce those stuck states.
 
 ## The two bugs that made passkeys unusable
 
-The unified surface only matters if the passkey path underneath it is sound. Two root-cause fixes shipped with it.
+A single front door only helps if the passkey path behind it is solid. Two root-cause fixes shipped alongside it, both app-side bugs against perfectly correct contracts.
 
-**The incomplete credential record.** The connector's sign-*in* branch never recorded the asserted credential the way sign-*up* did. The local credential book (`fairwins.passkey.credentials.v1`) is what the transaction path feeds into viem's WebAuthn account; an incomplete record meant `buildAccount` dereferenced `undefined` deep inside the signer — the infamous `reading 'id'` crash. The fix is layered: the connector (`frontend/src/connectors/passkey.js`) now remembers and, when possible, repairs the record on every sign-in (FR-005), and `frontend/src/lib/passkey/smartAccount.js` refuses incomplete records *before* any ceremony with a typed `CredentialRecordIncomplete` error that the UI turns into "sign in again with your passkey" (FR-006). Validate at the boundary; never let storage shape leak into a WebAuthn stack trace.
+**The half-saved credential.** When you first *signed up*, the app recorded everything it needed about your passkey. When you later *signed back in*, it didn't record the same details — and that missing information was exactly what the transaction machinery needed, causing the crash-on-every-transaction bug. The fix: repair the record on every sign-in, and if it's still incomplete, catch it early with a clear "please sign in again with your passkey" message instead of letting it explode deep in the signing code later.
 
-**The unpinned ceremony.** A bare WebAuthn `get()` lets the platform pick any discoverable credential — and Brave/Chromium silently assert the *first* one, locking multi-account users out of everything but account one. `getAssertion` in `frontend/src/lib/passkey/credentials.js` now pins every session-bound ceremony to the session's `credentialId` (FR-008), and when the browser knows several passkeys, the app presents its own account picker before the ceremony rather than trusting the platform chooser (FR-007). A deliberate `discoverable: true` escape hatch still issues a bare request for passkeys the browser has never recorded — the platform's own chooser makes that pick, so the app never guesses.
+**The passkey the app didn't choose.** When a browser holds several passkeys and the app makes an unspecific request, some browsers just grab the *first* one — locking multi-account users into account number one. The fix was to always tell the browser exactly which passkey this session should use, and, when several exist, show the app's own account picker before the biometric prompt rather than letting the browser guess.
 
-A subtler third fix follows directly from recovery: once accounts can gain controllers, signatures can no longer assume owner slot zero. `resolveOwnerIndex` reads the on-chain owner list and matches the credential's owner bytes to its real index (FR-009):
-
-```js
-export async function resolveOwnerIndex({ chainId, accountAddress, credential, deps = {} }) {
-  // ...
-  const ownerBytes = publicKeyToOwnerBytes(credential.publicKey).toLowerCase()
-  const match = result.controllers.find((c) => c.ownerBytes?.toLowerCase() === ownerBytes)
-  if (!match) throw new CredentialNotControllerError()
-  return Number(match.index)
-}
-```
-
-Counterfactual accounts fall back to index 0; a deployed account that no longer lists the credential throws, because signing would be guessing.
+A third, subtler fix falls out of recovery: once an account can gain new controllers, the app can no longer assume your passkey is "owner number one." It now reads the account's real owner list on-chain and matches your credential to its actual position — and if your credential isn't in the list, it stops rather than sign blindly.
 
 ## Linking before disaster
 
-Recovery requires a second controller linked *while you still have passkey access*. `frontend/src/components/account/ControllersPanel.jsx` lists every controller from the on-chain owner set (with local-only labels), and supports adding a second passkey, linking an external wallet, and removing controllers — each mutation an owner-authorized self-call through `sendCalls`, one ceremony each.
+Recovery depends on having a second controller *while you still have passkey access*. So the account screen lists every current controller and lets you add a second passkey, link an external wallet, or remove one — each a single biometric approval.
 
-Two policies gate linking. The UI states explicitly that a linked wallet gains *full control* of the account — 1-of-N means full peer, and pretending otherwise would be dishonest. And every candidate address is sanctions-screened before the on-chain call, fail-closed: flagged *or unscreenable* means refused (FR-011). Accounts with a single controller get a persistent device-loss warning pointing at the fix (FR-013).
+Two honesty rules govern linking. First, the app states plainly that a linked wallet gains **full control** — equal peers means equal power. Second, every wallet you try to link is screened against sanctions lists before anything goes on-chain, and it fails closed: flagged *or* impossible to screen means refused. Any account still down to a single controller gets a persistent "link a backup before you lose this device" warning.
 
 ## Recovery without FairWins
 
-`frontend/src/components/account/RecoverAccountPanel.jsx` is the wallet-only path (FR-014). The user connects the linked wallet — no passkey anywhere — and walks a guided flow:
+There's also a wallet-only recovery flow for the worst case: your passkeys are gone, but you linked a wallet earlier. You connect that wallet — no passkey anywhere — and the app walks you through it:
 
-1. **Which account?** No reverse owner→accounts index exists on-chain, so the app asks for the account address, hinted by addresses the browser has previously associated with passkeys. (The alternative — an indexer dependency on the recovery path — would violate the point of the exercise.)
-2. **Verify ownership.** The panel first checks `getCode` on the target — a counterfactual or wrong-network address used to surface as a cryptic `BAD_DATA` decode error; now it's a plain-language explanation. Then it calls `isOwnerAddress(wallet)` and refuses to continue unless the wallet is a controller.
-3. **Create and authorize.** A fresh passkey ceremony on the new device, then one ordinary ethers v6 transaction: `addOwnerPublicKey(x, y)` straight from the EOA signer. Only after the receipt confirms does the app record the credential locally — so the very next passkey sign-in can transact.
+1. **Which account?** The blockchain has no "look up my accounts by owner" index, so the app asks for the account address, suggesting ones your browser has previously associated with passkeys.
+2. **Prove ownership.** The app confirms the address is a real, deployed account, then that your connected wallet really is an owner, before letting you continue.
+3. **Create and authorize.** You make a fresh passkey on the new device, and your linked wallet sends one ordinary transaction adding it as an owner. Only once that confirms does the app save the new credential — so your very next sign-in can transact.
 
-Because the account is a standard, publicly documented contract, the same recovery works with generic tools if FairWins the service disappears. The runbook (`docs/runbooks/passkey-account-recovery.md`) shows it with Foundry's `cast`:
+Because the account is a standard, publicly documented smart contract, this same recovery works with generic, off-the-shelf tools even if FairWins the company vanished. Your funds were never dependent on us being around.
 
-```bash
-cast call $ACCOUNT "isOwnerAddress(address)(bool)" $WALLET --rpc-url $RPC
-cast send $ACCOUNT "addOwnerAddress(address)" $NEW_WALLET --rpc-url $RPC --private-key ...
-```
+## Why we built it this way
 
-For a pure-CLI recovery the runbook recommends `addOwnerAddress` with a fresh wallet (a P-256 key is awkward to produce outside the app), then linking a new passkey from the app later.
+**No guardians, no social recovery.** Recovery is strictly "any controller you linked ahead of time can act." An account whose only passkey lived on a lost, un-synced device is unrecoverable *by design* — no one, including FairWins, can help. That's a hard trade, made on purpose: guardian schemes reintroduce trusted third parties, and phone sync already covers the common case. The answer is gentle pressure to link a backup early, not a custodial safety net that would compromise self-custody.
 
-## Design decisions
+**Equal owners, not thresholds.** Every controller is a full peer. That's simpler to reason about and it's what makes wallet-only recovery a single transaction — but it means linking a wallet hands over full control, which the app says out loud. People who want "2-of-3"-style shared custody have a separate multisig option.
 
-**No guardians, no social recovery.** Recovery is strictly "any pre-linked controller can act." An account whose only passkey lived on a lost, unsynced device is unrecoverable *by design* — no one, including FairWins, can help. That's a hard trade, made deliberately: guardian schemes reintroduce trusted parties and timelock complexity, and platform passkey sync already covers the common device-loss case. The mitigation is UX pressure to link a second controller early, not a custodial backstop.
+**Recovery restores control, not secrets.** The owner list guards your funds, but encrypted private features use a separate master seed. A freshly recovered controller that never held that seed can't read old encrypted data until the keys are re-shared to it. Getting your funds back and getting your encrypted history back are two different steps, and the app is upfront about that.
 
-**1-of-N, not thresholds.** Every controller is a full peer. Simpler to reason about, and it's what makes wallet-only recovery a single transaction — but it means linking a wallet is a full grant of custody, which the UI must (and does) say out loud. Members who want threshold custody have the separate Safe multisig feature (spec 043); it's explicitly out of scope here.
+**A frontend fix for a frontend problem.** Fixing both bugs in the app — with clear error messages instead of crashes — kept the audited account contracts untouched.
 
-**Recovery restores control, not secrets.** The owner list gates funds, but encrypted-feature keys derive from a master seed wrapped per-controller (`lib/passkey/prfKeys.js`). A recovered controller that never held the seed can't decrypt old data until keys are re-wrapped from a controller that has it — the runbook calls this out. On-chain, encrypted-backup *pointers* live in `contracts/privacy/BackupPointerRegistry.sol` (spec 002), but that's a separate lifecycle: spec 045 recovery never touches it.
+The result: connecting has one front door, every passkey prompt is pinned to the account you actually chose, and losing every passkey becomes an inconvenience instead of an ending — as long as you linked a backup first. Making sure you did is the app's whole job.
 
-**Frontend-only fix for a frontend-caused outage.** Both shipped defects were client bugs against a correct contract. Fixing them at the storage-record and ceremony-request layers — with typed errors instead of crashes — kept the blast radius in `frontend/src` and let the audited vendored contracts stay untouched.
+## Further reading
 
-The result: connection has one front door, every passkey ceremony is pinned to a credential the user actually chose, and losing every passkey is an inconvenience instead of an ending — provided you linked something first. The app's whole job is making sure you did.
-
-## Sources
-
-- `specs/045-unified-connect-recovery/spec.md`, `plan.md` — requirements (FR-001–FR-016) and implementation plan
-- `specs/041-passkey-wallet-login/` — the underlying passkey account feature
-- `docs/developer-guide/passkey-accounts.md` — contract stack and frontend architecture
-- `docs/runbooks/passkey-account-recovery.md` — in-app and generic-tools recovery paths
-- `contracts/account/MultiOwnable.sol` — owner list, `addOwnerPublicKey`, `LastOwner()` invariant
-- `frontend/src/components/wallet/ConnectModal.jsx`, `frontend/src/connectors/passkey.js` — unified surface and sign-in record repair
-- `frontend/src/lib/passkey/credentials.js`, `frontend/src/lib/passkey/smartAccount.js` — ceremony pinning, `resolveOwnerIndex`, credential validation
-- `frontend/src/components/account/ControllersPanel.jsx`, `RecoverAccountPanel.jsx` — controller management and wallet-only recovery
-- ERC-4337 (Account Abstraction): https://eips.ethereum.org/EIPS/eip-4337
-- ERC-7201 (Namespaced Storage Layout): https://eips.ethereum.org/EIPS/eip-7201
-- ERC-1271 (Contract Signature Validation): https://eips.ethereum.org/EIPS/eip-1271
-- WebAuthn Level 2: https://www.w3.org/TR/webauthn-2/
-- Coinbase Smart Wallet: https://github.com/coinbase/smart-wallet
+- Passkeys / WebAuthn (W3C): <https://www.w3.org/TR/webauthn-2/>
+- What passkeys are, in plain terms (FIDO Alliance): <https://fidoalliance.org/passkeys/>
+- The ERC-4337 account-abstraction standard (smart-contract wallets): <https://eips.ethereum.org/EIPS/eip-4337>
+- Coinbase Smart Wallet (open source): <https://github.com/coinbase/smart-wallet>

--- a/docs/blog/posts/05-account-recovery-unified-connect/social.md
+++ b/docs/blog/posts/05-account-recovery-unified-connect/social.md
@@ -2,32 +2,32 @@
 
 ## X (Twitter)
 
-Passkeys killed the seed phrase. So what happens when the phone dies?
+Passkeys killed the seed phrase. So what happens when the phone goes in the river?
 
-Our answer: any linked wallet is a full 1-of-N owner — recovery is one plain `addOwnerPublicKey(x, y)` tx to the smart account. No bundler, no relayer, no us.
+Our answer: any wallet you linked ahead of time is a full, equal owner of your account — so recovery is one ordinary transaction. No relayer, no service, no us required.
 
 🔗 <link>
 
-#passkeys #AccountAbstraction #selfcustody
+#passkeys #selfcustody #wallets
 
 ## LinkedIn
 
-Recovery is the make-or-break problem for passkey wallets. Seed phrases were brutal, but everyone knew the recovery story. Passkeys deleted the twelve words — and if your credential lived in an unsynced browser profile, platform sync won't save you.
+Recovery is the make-or-break problem for passkey wallets. Seed phrases were brutal, but everyone understood the recovery story. Passkeys deleted the twelve words — and if your credential lived in a browser profile that wasn't syncing, phone backup won't save you.
 
-Our latest engineering post covers how FairWins made passkey smart accounts recoverable without reintroducing a seed phrase — and why the contracts needed zero changes:
+Our latest post covers how FairWins made passkey accounts recoverable without bringing back the seed phrase — and why the contracts needed zero changes:
 
-- One connect surface for passkey, WalletConnect, and browser wallets, with serialized attempts so parallel connects and background session restores can never race into a stuck state
-- Root-causing two shipped defects: the Chrome/Brave "reading 'id'" crash (an incomplete local credential record) and Brave silently asserting the first passkey (an unpinned WebAuthn ceremony — fixed with allowCredentials pinning plus an in-app account picker)
-- Linking an external wallet as a full 1-of-N controller on the vendored Coinbase Smart Wallet MultiOwnable owner list, sanctions-screened fail-closed, with honest "this wallet gains full control" consent
-- Wallet-only recovery: verify isOwnerAddress on-chain, create a fresh passkey, authorize it with one ordinary transaction — reproducible with Foundry's cast even if our service disappears
+- One connect screen for passkey, WalletConnect, and browser wallets, with one attempt at a time so a background session restore can't race you into a stuck state
+- Root-causing two real bugs: a crash-on-every-transaction from a half-saved credential, and a browser silently signing users into the wrong passkey (fixed by always naming the exact credential, plus an in-app account picker)
+- Linking an external wallet as a full, equal owner — sanctions-screened, fail-closed, with honest "this wallet gains full control" consent
+- Wallet-only recovery: confirm ownership on-chain, create a fresh passkey, authorize it with one ordinary transaction — reproducible with generic tools even if our service disappeared
 
-The hard trade: no guardians, no custodial backstop. An account that never linked a second controller is unrecoverable by design.
+The hard trade: no guardians, no custodial backstop. An account that never linked a backup is unrecoverable by design.
 
 Read the full post: <link>
 
-How is your team handling passkey recovery — pre-linked controllers, guardians, or something else?
+How is your team handling passkey recovery — pre-linked backups, guardians, or something else?
 
-#AccountAbstraction #passkeys #selfcustody #web3 #walletengineering
+#passkeys #selfcustody #wallets #web3 #ux
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/06-sponsored-gas-verifying-paymaster/blog.md
+++ b/docs/blog/posts/06-sponsored-gas-verifying-paymaster/blog.md
@@ -1,97 +1,72 @@
-# Sponsored Gas Without a Vendor: A Self-Hosted ERC-7677 Verifying Paymaster
+# Sponsored Gas Without a Vendor: How "No Network Fee" Became True
 
-*How FairWins made "no network fee" true — with a 173-line contract, a KMS key, and the relay gateway it already ran*
+*How FairWins made "no network fee" an honest promise — by quietly covering the fee itself, using infrastructure it already ran*
 
-- **Series:** Accounts & Keys, part 3
-- **Part:** 6 of 34
-- **Audience:** Account-abstraction and infrastructure developers
-- **Tags:** `paymaster`, `erc7677`, `erc4337`, `gasless`, `bundler`, `kms`
-- **Reading time:** ~9 minutes
-
----
+| | |
+|---|---|
+| **Series** | Accounts & Keys (part 3) |
+| **Audience** | Product folks, founders, and developers curious how gasless apps work |
+| **Tags** | `gasless`, `sponsored-gas`, `wallets`, `self-custody`, `onboarding` |
+| **Reading time** | ~7 minutes |
 
 ## The lie in the confirm screen
 
 A member creates a FairWins passkey account, receives 40 USDC from a friend, and tries to send 10 of it onward. The confirm screen says "Gasless · sponsored — no network fee." They tap confirm with their fingerprint. The transfer fails.
 
-Under the hood, the EntryPoint rejected the UserOperation with `AA21 — Smart Account does not have sufficient funds`. The account held USDC and zero POL. With no paymaster configured, every ERC-4337 UserOperation must prefund its own gas from the account's native balance — and a stablecoin-only account has none. Worse, on the account's very first action the prefund also covers on-chain deployment, so during a gas spike even an account holding *some* native token could fail.
+Here's why. Every blockchain transaction costs a small network fee, paid in the chain's own native token — not in the stablecoin the member actually holds. This account had 40 USDC and zero native token, so there was nothing to pay the fee with, and the transaction was rejected. It's worse on a member's very first action, which also has to pay to deploy their account on-chain — so during a busy period even an account holding *some* native token could come up short.
 
-The product had promised sponsorship before the infrastructure existed. That violated one of FairWins' standing principles — the UI must never claim a state that isn't true — and there were two ways to fix it: change the copy, or make the claim true. Spec 050 chose the second, with a constraint the product owner set explicitly: no third-party paymaster service. No Pimlico, no Circle. FairWins already ran its own ERC-4337 bundler (pimlico's alto, self-hosted on Cloud Run) and its own relay gateway for gasless intents. Sponsorship had to be built from those parts.
+In other words, the product had promised "sponsored" before the machinery to sponsor anything existed. That broke a standing FairWins principle: the interface must never claim something that isn't true. There were two ways to fix it — change the words, or make them true. FairWins chose to make them true, with one firm constraint: no third-party sponsorship service. The company already ran the plumbing that submits these gasless transactions and the gateway that screens them, so sponsorship had to be built from those parts.
 
-This post walks through what that took: a deliberately minimal verifying paymaster contract on EntryPoint v0.6, an ERC-7677 endpoint bolted onto the existing policy gateway, a KMS-held signing key, and — because the platform's never-stranded rule is non-negotiable — a fallback that keeps every user able to act even when sponsorship is down.
+This post walks through what that took: a deliberately tiny "paymaster" contract, an approval service bolted onto the gateway FairWins already ran, a securely held signing key, and — because nobody may ever be stranded — a fallback that keeps every member able to act even when sponsorship is down.
 
-## What a verifying paymaster actually is
+## What sponsoring a fee actually means
 
-ERC-4337 lets a UserOperation name a paymaster: a contract that tells the EntryPoint "I'll pay for this one." The EntryPoint deducts the actual gas cost from the paymaster's deposit and reimburses the bundler's beneficiary. The whole design question is *how the paymaster decides which ops to pay for*.
+The smart-account standard these wallets use lets a transaction name a **paymaster**: a contract that tells the network, "I'll cover the fee for this one." The network then charges the fee to the paymaster's pre-funded balance instead of the user's. The entire design question is *how the paymaster decides which transactions to pay for.*
 
-A *verifying* paymaster answers with a signature. An off-chain service inspects each operation, and if it approves, signs a digest binding that exact op. The contract's only job is to recover the signer:
+A *verifying* paymaster answers that with a signature. An off-chain service looks at each transaction and, if it approves, signs a stamp of approval tied to that exact transaction. The contract's only on-chain job is to check the stamp is genuine — signed by the one authorized signer — and, if so, cover the fee.
 
-```solidity
-function validatePaymasterUserOp(UserOperation calldata userOp, bytes32, uint256)
-    external view override onlyEntryPoint
-    returns (bytes memory context, uint256 validationData)
-{
-    (uint48 validUntil, uint48 validAfter, bytes calldata signature) =
-        _parsePaymasterAndData(userOp.paymasterAndData);
+The FairWins paymaster is intentionally minimal: its approval stamp is bound to the specific transaction — its sender, its exact contents, the fee ceiling, the network, the paymaster's own address, and a short expiry window. Because the stamp is nailed to all of that, an approval can't be reused on a different transaction, on a different network, or after it expires. And it needs no memory of past transactions: the account's own built-in transaction counter already makes each one single-use. A contract that checks a signature and stores no state is the simplest and safest kind, and stays portable to other networks later.
 
-    bytes32 digest = MessageHashUtils.toEthSignedMessageHash(
-        getHash(userOp, validUntil, validAfter));
-    (address recovered, ECDSA.RecoverError err,) = ECDSA.tryRecover(digest, signature);
-    bool sigFailed = err != ECDSA.RecoverError.NoError || recovered != verifyingSigner;
+The economics are just as simple. The paymaster holds a pre-funded deposit with the network, and that deposit *is* both the sponsorship pool and the hard cap on how much can ever be lost. When the network runs a sponsored transaction, it draws the fee from that deposit — FairWins paying its own gas back, one transaction at a time, all accounted for on-chain.
 
-    // context "" => EntryPoint skips postOp (pure sponsoring, no settlement).
-    return ("", _packValidationData(sigFailed, validUntil, validAfter));
-}
-```
+## The decision half: an approval service on the gateway FairWins already ran
 
-That is the heart of `contracts/account/FairWinsVerifyingPaymaster.sol` — 173 lines including the interface it vendors. The digest from `getHash` commits to the op's sender, nonce, `initCode`, `callData`, all five gas fields, the chain id, the paymaster's own address, and a validity window. An approval therefore cannot be replayed on a different op, a different chain, a different paymaster, or after its TTL. Notably absent: any `senderNonce` mapping. Replay of the *same* op is already impossible — the account's own EntryPoint nonce makes each UserOperation single-use — so the paymaster's validation touches no storage at all. Zero-storage, external-call-free validation is the safest posture under ERC-7562's validation rules, which means the contract stays portable to any public bundler later, even though FairWins' own bundler doesn't enforce them.
+The approval signature has to come from somewhere, and *where* is the real policy decision. There's an open standard for exactly this handshake — how a wallet asks a sponsorship service for approval — with two steps: a dummy approval so the wallet can estimate the transaction size, then the real, signed one. Because the FairWins frontend already builds transactions with standard tooling, adopting it made the client-side work nearly free.
 
-The approval travels in `paymasterAndData` with the v0.6 layout: `[paymaster (20)] [validUntil (6)] [validAfter (6)] [signature (65)]` — 97 bytes.
+Rather than stand up a whole new service, FairWins added a sponsorship route to the gateway that already fronts its other gasless features. That gateway already had the three controls sponsorship needs, and the new route reuses them instead of reinventing them:
 
-The economics are equally simple. The contract holds a deposit at the EntryPoint (`deposit()` is permissionless; `withdrawTo` is owner-only), and that deposit *is* the sponsorship pool and the hard loss cap. Polygon mainnet runs at `0xe14554D14eB5DeC47f7824ebeeDa6C9f3A50d105` against the canonical v0.6 EntryPoint (`0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789`), recorded in `deployments/`. When the EntryPoint executes a sponsored op, it draws the gas cost from that deposit and reimburses the alto bundler's executor — FairWins pays FairWins's bundler back, per-op, with on-chain accounting.
+1. **A kill switch** — one setting halts all sponsorship instantly; clients quietly fall back to paying their own fee.
+2. **Sanctions screening** — the account is checked against sanctions lists, and it fails closed: if it can't be screened, it isn't sponsored.
+3. **Quotas** — per-account and platform-wide rate limits, so no one account and no single day can drain the pool.
 
-## The decision half: ERC-7677 on the existing gateway
+Two extra ceilings are new, because sponsorship spends real money on every transaction: a sanity limit on transaction size and a worst-case cost cap, so a single deliberately expensive transaction can't burn a big slice of the deposit. Every refusal happens *before* anything is signed, so a rejected request costs the operator nothing.
 
-The signature has to come from somewhere, and *where* is the real policy decision. ERC-7677 standardizes how a wallet client asks a paymaster service for sponsorship: two JSON-RPC methods, `pm_getPaymasterStubData` (a dummy-signature stub so gas estimation sizes `verificationGasLimit` correctly) and `pm_getPaymasterData` (the real, signed approval). Because the frontend already builds UserOps with viem, adopting the standard meant the client work was nearly free — `createPaymasterClient` pointed at the endpoint, unmodified.
+That signature comes from a securely managed cloud key service — the gateway never holds the raw signing key. Critically, the gateway **refuses to start** if its signing key doesn't match the signer the on-chain contract expects. A mismatch that would otherwise silently break every sponsorship instead fails loudly at deploy time, where someone will notice.
 
-Rather than stand up a paymaster microservice, spec 050 added `POST /v1/paymaster` to the relay gateway that already fronts FairWins' relayed-intent rail (spec 036). That gateway already had the three controls sponsorship needs, and the paymaster route composes the *same modules* rather than reimplementing them (`services/relay-gateway/src/paymaster/policy.js`):
-
-1. **Killswitch** — one env flag halts all sponsorship within a single request cycle; clients fall back to self-submit.
-2. **Sanctions screening** — keyed off the smart-account address, fail-closed, same screen the intent path uses.
-3. **Quotas** — per-account (6 ops/min, 25/day) and global (500/day) rate limits.
-
-Two ceilings are new, because sponsorship spends real money per op: a gas-units sanity cap (3M gas; a deploy-plus-transfer runs under ~2M) and a worst-case cost cap (`totalGas × maxFeePerGas ≤ 2 POL`), so a single deliberately expensive op can't burn a large slice of the deposit. Every refusal happens *before* signing — a refused request costs the operator nothing. Only a granted op reaches step nine of the pipeline: the actual signature.
-
-That signature comes from Google Cloud KMS. The gateway holds no key material; `services/relay-gateway/src/paymaster/sign.js` derives the signer's Ethereum address from the KMS public key at boot, then signs each approval digest via `asymmetricSign`, normalizing the DER output to a low-S 65-byte `{r,s,v}` signature. The contract's `verifyingSigner` is set to that derived address, and the gateway **refuses to boot** if its KMS key doesn't match the on-chain signer — a config drift that would silently break every sponsorship instead fails loudly at deploy time.
-
-One discipline deserves its own paragraph: the digest is computed in two codebases. `FairWinsVerifyingPaymaster.getHash` (Solidity) and `getHash` in `services/relay-gateway/src/paymaster/build.js` (JS) must stay byte-identical — thirteen ABI-encoded fields in exact order — or every sponsored op fails with an opaque `AA34`. A cross-check test deploys the real contract and asserts the two implementations agree, the same struct-sync discipline FairWins already applies to its EIP-712 intent types.
+One discipline is worth calling out: the "stamp" being signed is computed in two separate codebases — the contract and the gateway — and they must produce byte-for-byte identical results, or every sponsored transaction fails. A cross-check test deploys the real contract and asserts the two agree.
 
 ## Never stranded, never dishonest
 
-Sponsorship is best-effort infrastructure, and the platform rule is that optional infrastructure never strands a user. The frontend treats *any* failure to obtain sponsorship — endpoint down, killswitch, quota, sanctions refusal, network error — identically: rebuild the bundler client without a paymaster and retry once, self-funded (`frontend/src/lib/passkey/sendBatch.js`). There's a subtle trap here the code comments call out: an op that reverts in bundler *simulation* (say, a transfer exceeding the account's balance) must be surfaced, not retried — a self-funded retry would revert identically and mask the real error behind a confusing `AA21`. So the fallback classifier lets only genuine sponsorship/transport failures through.
+Sponsorship is a nice-to-have, and the platform rule is that a nice-to-have must never strand a member. So the app treats *every* failure to get sponsorship — service down, kill switch on, quota hit, screening refusal, network blip — identically: rebuild the transaction to pay its own fee and quietly retry once.
 
-The disclosure follows the same honesty rule that produced this feature in the first place. The account builder returns a `sponsored` boolean — true only when a paymaster is actually wired for this attempt — and the confirm UI renders from it: "Gasless — no network fee" when true, "You pay the POL network fee" when false, including the exact shortfall if the account lacks the native token to self-fund. On networks with no deployed paymaster, the config simply omits the sponsor URL and the path behaves exactly as before, honest copy included. Spec 050's success criteria demand the disclosure match the outcome in 100% of cases; the mechanism makes that structural rather than aspirational.
+There's a subtle trap the code is careful about. If a transaction would fail on its own merits — say, sending more than the account holds — that's not a sponsorship failure and must not be silently retried, because the retry would fail identically and hide the real reason. So the fallback only kicks in for genuine sponsorship or network failures.
 
-## Design decisions
+The disclosure follows the same honesty rule that created this feature. The system tracks a single fact: was this transaction actually sponsored? The confirm screen renders straight from it — "Gasless — no network fee" when true, "You pay the network fee" when false, including the exact shortfall when the account can't cover it. The rule that the words must match reality is built into the mechanism, not left to good intentions.
 
-**Stay on EntryPoint v0.6.** EntryPoint v0.7 is newer, but the deployed account factory, the Coinbase smart-account implementation, and alto are all v0.6 — and migrating changes every deterministic account *address*, orphaning deployed accounts and any funds sent to their counterfactual addresses. Not worth it for a paymaster. The v0.6 verifying pattern is the most well-trodden path in AA.
+## Why we built it this way
 
-**Verifying, not ERC-20.** A fee-in-USDC paymaster was considered and rejected: it needs a price oracle, token-pull-and-refund accounting, and an approval in the first op — more contract surface, more failure modes, for an outcome where the user still pays. Sponsoring is the smallest pattern and the only one that makes "no network fee" literally true.
+**Sponsor the fee, don't charge it in stablecoin.** An alternative was a paymaster that quietly takes a little USDC to cover the fee — but that needs price feeds, extra accounting, and an approval step, all for an outcome where the member still pays. Sponsoring is the smallest pattern and the only one that makes "no network fee" literally true.
 
-**Self-hosted, eyes open.** Rejecting vendor paymasters costs real work — KMS plumbing, quota design, runway monitoring — and buys independence: no vendor coupling of bundler to paymaster, no per-op markup, and policy (sanctions, quotas, killswitch) enforced in FairWins' own gateway rather than a third party's dashboard.
+**Self-hosted, eyes open.** Refusing outside vendors costs real work — key management, quota design, watching the runway — and buys independence: no vendor lock-in, no per-transaction markup, and every policy decision enforced in FairWins' own gateway.
 
-**Bounded compromise blast radius.** A stolen `verifyingSigner` key can approve sponsorships — spending the deposit on other people's gas — but *cannot withdraw funds*; withdrawal is owner-only, and the owner key lives on FairWins' air-gapped floppy keystore. Worst-case loss is the deposit, throttled by quotas, cut off by the killswitch, and recovered by rotating the signer via `setVerifyingSigner` (`docs/runbooks/paymaster-operations.md`). Never overfunding the deposit — topping up on a 48-hour runway alert instead — keeps that worst case small by policy, not hope.
+**A small, bounded blast radius.** If the approval-signing key were ever stolen, the thief could approve sponsorships — wasting the deposit on other people's fees — but *could not withdraw a cent*: withdrawal is restricted to a separate owner key kept in offline, air-gapped storage. The worst case is capped at the deposit, throttled by quotas, cut off by the kill switch, and cleaned up by rotating to a new signer. Keeping the deposit deliberately small keeps that worst case small by policy, not by hope.
 
-**Identity-open eligibility.** Sponsorship isn't gated on membership tier. Any passkey account that passes screening and is within quota qualifies; spend is bounded by the ceilings, the pool, and the killswitch rather than by narrowing who benefits.
+**Open to everyone.** Sponsorship isn't reserved for higher membership tiers. Any passkey account that passes screening and stays within quota qualifies — spend is bounded by the ceilings, the pool, and the kill switch, not by narrowing who benefits.
 
-## Sources
+The result: when the confirm screen says "no network fee," it's telling the truth — the app quietly covered it — and when it can't, it says so plainly.
 
-- `specs/050-sponsored-paymaster/spec.md`, `research.md`, `contracts/gateway-paymaster-api.md`
-- `contracts/account/FairWinsVerifyingPaymaster.sol`
-- `services/relay-gateway/src/paymaster/build.js`, `sign.js`, `policy.js`
-- `services/alto-bundler/README.md`
-- `frontend/src/lib/passkey/smartAccount.js`, `frontend/src/lib/passkey/sendBatch.js`
-- `docs/runbooks/paymaster-operations.md`
-- ERC-4337: Account Abstraction Using Alt Mempool — https://eips.ethereum.org/EIPS/eip-4337
-- ERC-7677: Paymaster Web Service Capability — https://eips.ethereum.org/EIPS/eip-7677
-- ERC-7562: Account Abstraction Validation Scope Rules — https://eips.ethereum.org/EIPS/eip-7562
+## Further reading
+
+- The ERC-4337 account-abstraction standard (smart-contract wallets): <https://eips.ethereum.org/EIPS/eip-4337>
+- ERC-7677, the paymaster / sponsorship web-service standard: <https://eips.ethereum.org/EIPS/eip-7677>
+- What "gas" is, in plain terms (ethereum.org): <https://ethereum.org/en/developers/docs/gas/>

--- a/docs/blog/posts/06-sponsored-gas-verifying-paymaster/social.md
+++ b/docs/blog/posts/06-sponsored-gas-verifying-paymaster/social.md
@@ -1,27 +1,25 @@
-# Social & Image — Sponsored Gas Without a Vendor: A Self-Hosted ERC-7677 Verifying Paymaster
+# Social & Image — Sponsored Gas Without a Vendor: How "No Network Fee" Became True
 
 ## X (Twitter)
 
-We rejected every vendor paymaster and built our own: a 173-line ERC-4337 v0.6 verifying paymaster with zero-storage validation, an ERC-7677 endpoint on our existing relay gateway, and a KMS-held signer. Worst-case loss = the deposit. Here's the full writeup 🔗 <link>
-
-#ERC4337 #AccountAbstraction #paymaster
+Our confirm screen said "no network fee" before that was actually true. Two options: change the words, or make them true. We made them true — quietly covering the fee ourselves, no third-party service, worst-case loss capped at the deposit. Here's how 🔗 <link> #gasless #wallets #web3
 
 ## LinkedIn
 
-Our passkey smart accounts had a broken promise: the confirm screen said "sponsored — no network fee," but with no paymaster configured, every UserOperation from a USDC-only account failed with AA21. We had two options — change the copy, or make it true. We made it true, without a third-party paymaster service.
+Our passkey wallets had a broken promise: the confirm screen said "sponsored — no network fee," but with nothing set up to cover it, a member holding only USDC couldn't pay the fee, and the transfer failed. We had two options — change the words, or make them true. We made them true, without any third-party sponsorship service.
 
 The new post walks through how FairWins ships sponsored gas on infrastructure it already runs:
 
-- A minimal EntryPoint v0.6 verifying paymaster whose validation is signature-only and zero-storage — ERC-7562-safe, portable to any bundler, with the EntryPoint deposit as a hard loss cap.
-- An ERC-7677 endpoint (pm_getPaymasterStubData / pm_getPaymasterData) added to the existing relay gateway, reusing its sanctions screening, per-account and global quotas, and killswitch — plus per-op gas and cost ceilings so one expensive op can't drain the pool.
-- A Cloud KMS signing key whose derived address must match the on-chain verifyingSigner, enforced by a fail-loud boot check; a compromised signer can grief the deposit but can never withdraw it.
-- A never-stranded fallback: any sponsorship failure degrades to self-funded submission with honest fee disclosure — the UI never claims "free" unless it is.
+- A deliberately tiny paymaster contract: it just checks an approval "stamp" and covers the fee, keeps no memory of past transactions, and caps worst-case loss at its own deposit
+- An approval service added to the gateway FairWins already ran, reusing its sanctions screening, per-account and platform-wide quotas, and kill switch — plus new size and cost ceilings so one expensive transaction can't drain the pool
+- A securely managed signing key whose identity must match what the contract expects, enforced by a fail-loud startup check; a stolen key can waste the deposit but can never withdraw it
+- A never-stranded fallback: any sponsorship failure quietly degrades to member-paid fees, with honest disclosure — the screen never says "free" unless it is
 
-Full architecture and trade-offs (why v0.6, why verifying over ERC-20, why self-hosted): <link>
+Full architecture and trade-offs (why sponsor rather than charge in stablecoin, why self-host): <link>
 
-If you run account abstraction in production — would you self-host the paymaster, or is a vendor the right call at your scale?
+If you run gasless flows in production — would you self-host the sponsorship, or is a vendor the right call at your scale?
 
-#AccountAbstraction #ERC4337 #ERC7677 #web3infrastructure #Ethereum
+#gasless #wallets #selfcustody #web3 #fintech
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/07-safe-multisig-custody/blog.md
+++ b/docs/blog/posts/07-safe-multisig-custody/blog.md
@@ -1,6 +1,6 @@
-# Integrating Safe as a Custody Layer — Without Running Safe's Backend
+# Shared Vaults Where No One Person Can Move the Money
 
-*How FairWins wires Safe v1.4.1 multisig vaults into a serverless app: on-chain approvals, an events-only proposal hub, and one "operate as" seam*
+*How FairWins lets a group hold a shared treasury and act as the group — using battle-tested multisig wallets, and nothing but the blockchain to coordinate*
 
 ---
 
@@ -8,121 +8,75 @@
 |---|---|
 | **Series** | Custody & Multisig (part 1 of 2) |
 | **Part** | 7 of 34 |
-| **Audience** | Treasury engineers, DAO tooling builders |
-| **Tags** | `safe`, `multisig`, `custody`, `treasury` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Founders, product managers, and the crypto-curious |
+| **Tags** | `multisig`, `shared-treasury`, `custody`, `self-custody` |
+| **Reading time** | ~7 minutes |
 
-> **Note**: FairWins wagers are peer-to-peer forecasts on publicly available information. Nothing here changes that: vault-originated wagers pass the same sanctions and membership checks as personal-wallet actions, and all participants remain subject to applicable law.
+> **Note**: FairWins wagers are peer-to-peer forecasts on publicly available information. Nothing here changes that: money that moves out of a shared vault passes the same sanctions and membership checks as a personal-wallet action, and everyone involved remains subject to applicable law.
 
 ---
 
-## Three Signers, One Vault, Zero Servers
+## Several People, One Vault, No Server
 
-The Ethereum Classic Cooperative holds its funds the way most serious on-chain organizations do: in a Safe multisig, where no single keyholder can move money. When we set out to support that pattern inside FairWins — so a group could hold a shared treasury and place wagers or send payments *as the group*, under an M-of-N approval threshold — the multisig itself was the easy part. Safe's contracts are battle-tested, audited for years, and already deployed on our target chains. Rolling our own multisig would have been the single worst security decision available to us.
+The Ethereum Classic Cooperative holds its money the way most serious on-chain organizations do: in a **multisig** — a shared wallet where several people must approve before any money moves. No single keyholder can drain it. If one laptop is stolen or one person goes rogue, the funds are still safe, because a spend needs, say, two of the three owners to sign off.
 
-The hard part was everything around the contracts. The Safe ecosystem's coordination story assumes a hosted backend: the Safe Transaction Service stores proposed transactions and collected signatures off-chain, a client gateway serves them to the wallet UI, and a config service describes each chain. The ETC Cooperative's own fork of the Safe wallet, `etclabscore/web-core`, self-hosts that entire stack pointed at Ethereum Classic.
+We wanted groups to do exactly this inside FairWins: hold a shared treasury, then place a wager or send a payment *as the group*, with a spend only going through once enough co-owners approve. The shared wallet itself was the easy part. We use **Safe**, the most widely used multisig on Ethereum and its cousins — audited for years, already deployed on the networks we care about. Rolling our own would have been the single worst security decision available to us.
 
-FairWins has a constitutional rule that forbids exactly this: **no app backend**. The app must keep working — and members must never be stranded — if every piece of FairWins-operated infrastructure disappears. A custody feature whose approvals live in a database we run would violate that on day one.
+The hard part was everything around the wallet. The usual way people coordinate a Safe assumes a hosted server in the middle: it stores proposed transactions, collects approvals, and feeds them to the wallet's screen. FairWins has a firm rule against exactly this — **no company server the app depends on**. The app has to keep working, and members must never be locked out of their own money, even if every piece of FairWins-run infrastructure disappeared tomorrow.
 
-So the integration question became: how do co-owners of a Safe discover a pending transaction, verify it, approve it, and execute it, using nothing but the chain? Spec 043 is the answer, and it required writing surprisingly little Solidity — one 66-line contract with no state, no funds, and no authority.
+So the real question was: how do the co-owners of a shared vault discover a pending transaction, check that it's legitimate, approve it, and execute it — using nothing but the blockchain itself? The answer needed surprisingly little new code: one tiny contract that holds no money and has no power.
 
-## Why Safe, and Which Safe
+## Why Safe, and Which Version
 
-"Vault" in FairWins means a stock **Safe v1.4.1** proxy — not a fork, not a wrapper. Vaults created in FairWins are interoperable with the rest of the Safe ecosystem, and existing Safes (like the Cooperative's) can be loaded by address.
+A "vault" in FairWins is a standard Safe multisig — not a fork, not a wrapper. Vaults you create work with the rest of the Safe ecosystem, and an existing Safe (like the Cooperative's) can be loaded just by its address.
 
-Version choice mattered more than expected. Safe v1.4.1 was deployed everywhere through the per-chain Safe Singleton Factory, so its canonical addresses are **byte-identical across Ethereum Classic (61), Mordor (63), and Polygon (137)**: one `SafeProxyFactory` at `0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67`, one `SafeL2` singleton at `0x29fcB43b46531BcA003ddC8FCB67FFE91900C762`, one `MultiSendCallOnly`, one fallback handler — the same six addresses on every target chain. (v1.3.0 is also live on ETC, but its ETC/Mordor deployment uses the `eip155` address set while Polygon uses `canonical` — a per-chain config matrix we didn't want.) We verified presence with live `eth_getCode` calls, not just the `safe-deployments` JSON; the addresses live in `frontend/src/config/safeContracts.js`, and `getSafeContracts(chainId)` returning `undefined` is how the UI honestly says "unavailable on this network."
+The version we picked mattered more than we expected. We chose the release whose official contracts sit at the **same addresses on every network we support** — Ethereum Classic, its Mordor test network, and Polygon. One consistent set of addresses everywhere means far less that can go wrong, and it let us confirm each contract was really deployed by asking the chain directly rather than trusting a list. When those contracts aren't present on a network, the app honestly says the feature is unavailable. The app also carries no heavyweight Safe software library — the standard toolkit assumes the hosted server we refuse to run, and the little we actually need is stable enough to talk to directly.
 
-New vaults use the `SafeL2` singleton (it emits richer events for indexing) and deploy via `SafeProxyFactory.createProxyWithNonce(singleton, initializer, saltNonce)` — CREATE2, so the UI shows the vault's address before it exists.
+## Approving Without a Middleman
 
-Notably, there is no runtime Safe SDK in the app. `@safe-global/protocol-kit` assumes the Transaction Service we refuse to run; the ABIs we actually need are tiny and stable, so they're hand-maintained in `frontend/src/abis/` and driven through ethers v6 like every other contract in the codebase.
+A Safe can authorize a transaction two ways: owners can sign it off-chain and someone gathers the signatures, or each owner can register their approval **directly on the blockchain**. We use only the second. In plain terms:
 
-## Approvals Without Signatures: the On-Chain-Only Flow
+1. **Build** the exact transaction the group wants to make.
+2. **Fingerprint** it — reduce it to a unique hash, a short code that stands in for the full transaction and can't be forged.
+3. **Approve** — each owner sends a small on-chain transaction that says "I approve the transaction with this fingerprint." The blockchain itself becomes the record of who has approved.
+4. **Execute** — once enough approvals exist to meet the threshold, any owner triggers the transaction. The Safe checks the on-chain approvals and runs it.
 
-Safe supports two ways to authorize a transaction: off-chain ECDSA signatures collected somewhere, or **on-chain hash approvals**. We use only the second. The flow, implemented in `frontend/src/lib/custody/vaultTransaction.js`:
+No signatures are collected off-chain, and the same approval can't be counted twice. Best of all, this flow can never strand anyone: the vault's own on-chain state *is* the coordination, so if FairWins vanished, any standard Safe tool could read those same approvals and finish the job.
 
-1. **Build** the `SafeTx` at the vault's current `nonce()`.
-2. **Hash** it — an EIP-712 hash over the `SafeTx` type with domain `{chainId, verifyingContract: safe}`, proven byte-for-byte equal to the Safe's own `getTransactionHash` in our tests.
-3. **Approve**: each owner sends an on-chain `Safe.approveHash(safeTxHash)` transaction. The chain itself becomes the signature store.
-4. **Execute**: once approvals meet the threshold, any owner calls `execTransaction` with a *pre-validated* signature bundle — no ECDSA anywhere:
+## The Missing Piece: Knowing What You're Approving
 
-```js
-export function buildPrevalidatedSignatures(approverAddresses) {
-  // For each approving owner, 65 bytes: r = owner left-padded to 32 bytes,
-  // s = 32 zero bytes, v = 0x01 — concatenated in ASCENDING owner order
-  // (Safe's checkNSignatures loop requires currentOwner > lastOwner).
-  ...
-}
-```
+On-chain approvals create one real gap. When an owner is asked to approve, all the blockchain shows is the fingerprint — a meaningless-looking code that reveals nothing about where the money is going. The full details don't appear on-chain until the transaction executes, far too late to review.
 
-For `v == 1`, the Safe accepts a signature block iff `approvedHashes[owner][hash] != 0` (or the owner is `msg.sender`). Duplicate approvals can't double-count — the ascending-owner-order requirement makes a repeated block invalid on-chain, and the encoder rejects duplicates client-side first.
+The hosted server most people run exists largely to fill this gap. Our replacement is a deliberately tiny contract — think of it as a public bulletin board. When someone proposes a transaction, they post its full details there, and everyone else's app watches for proposals affecting their vault.
 
-This flow is inherently never-stranded: the vault's state *is* the coordination state. If FairWins vanishes, any generic Safe tooling can read the same `approvedHashes` and finish the job.
+The clever part is that the board holds no trust. Each co-owner's app takes the posted details, **re-computes the fingerprint itself, and refuses to approve anything whose details don't match the fingerprint being claimed**. A tampered or spoofed proposal produces a different fingerprint and dies inside the co-owner's own app; the worst a bad actor can do by posting junk is waste their own transaction fee. The board carries information, never authority.
 
-## The Missing Piece: Preimage Discovery
+And because even this contract is optional, there's a fallback: a proposer can export the full transaction as a signed file and share it as a link or QR code. The co-owner imports it, checks the same fingerprint, and approves — working even on a network where the board was never deployed.
 
-On-chain approvals create one real gap. `ApproveHash` events reveal only a 32-byte hash. A co-owner asked to approve `0x3f9a…` has no idea what it does — the full parameters (`to, value, data, operation, nonce`) don't appear on-chain until execution, which is too late to review.
+## "Operate As the Vault"
 
-The Safe Transaction Service exists largely to fill this gap. Our replacement is `contracts/custody/SafeProposalHub.sol` — an immutable, events-only broadcaster:
+A custody tab that only sends simple transfers is just a basic Safe client, not a real integration. The whole point is that a member can *become* the vault: create a wager staked from the vault's funds, or pay someone from it, with the action held until the co-owners approve. Originally the app only knew you as your personal connected wallet. Rather than teach every feature about shared vaults, every money-moving action now flows through **one shared checkpoint**:
 
-```solidity
-function propose(
-    address safe,
-    address to,
-    uint256 value,
-    bytes calldata data,
-    uint8 operation,
-    uint256 nonce,
-    bytes32 safeTxHash
-) external {
-    if (operation > 1) revert InvalidOperation();
-    if (data.length > MAX_DATA_LENGTH) revert DataTooLong();
-    emit Proposed(safe, msg.sender, safeTxHash, to, value, data, operation, nonce);
-}
-```
+- **Personal mode**: send from your own wallet, exactly as before.
+- **Vault mode**: assemble the group transaction, post it to the bulletin board, record your own approval — and return a *pending proposal*, never a completed action.
 
-That is essentially the whole contract. No state, no funds, no roles, no external calls; it cannot approve or execute anything. The proposer emits the transaction's full preimage; co-owner clients index `Proposed` for their vaults, **recompute the Safe transaction hash from the emitted parameters, and reject anything that doesn't equal the claimed `safeTxHash`** before ever calling `approveHash`. Integrity is free: a tampered or spoofed preimage produces a different hash and dies in the co-owner's own client. The worst a malicious `propose` can do is waste the proposer's gas. There's also an advisory `cancel` event — advisory because the Safe nonce, not the hub, is the real arbiter of which transaction is live.
+A persistent banner shows which identity is active, and a pending vault action shows up *only* in the vault's own queue — never as a phantom entry in your wager list or payment history until the blockchain confirms it. Implying money moved when it hasn't is exactly the dishonesty the design refuses.
 
-And because even this tiny contract is optional infrastructure, there's a fallback: the proposer can export the `SafeTx` as a signed EIP-712 typed payload and share it as a link or QR code. The co-owner imports it, verifies the same hash, and approves — working even on a chain where the hub was never deployed. The hub is recorded per network in `deployments/` (Polygon: `0x94b5b38C247CE51F7C42C83B63115998b7e970E7`), deliberately built without OpenZeppelin imports so it compiles for pre-Cancun targets like ETC and Mordor.
+One honest wrinkle surfaced along the way. Inbound movements — receiving funds, or a refund owed to the vault — need no group approval, since the contract routes that money to the recorded party no matter who asks. But *claiming a winning payout* is different: the contract insists the winner themselves claim it, so a vault that *wins* a wager must claim through the normal group-approval path. We documented that as a known exception rather than pretend a single owner could pull the payout alone.
 
-## "Operate As" — One Seam, Every Money-Moving Surface
+## A Socket for Rules
 
-A custody tab that only sends transfers is a standalone Safe client, not an integration. The point of spec 043 is that a member can *become* the vault: create a wager staked from the vault, or pay someone from it, with the action gated on co-owner approval.
-
-The frontend previously had no act-as concept — identity was always the connected wallet address. Rather than teach every flow about contract accounts, all money-moving surfaces route their final intent through one seam, `frontend/src/lib/custody/submitAsActiveAccount.js`:
-
-- **Personal mode**: send through the connected signer, exactly as before.
-- **Vault mode**: build the `SafeTx` (batching `approve` + action through `MultiSendCallOnly` when an ERC-20 allowance is needed), broadcast it via the hub, record the proposer's own `approveHash` — and return a **pending proposal**, never an executed action.
-
-`MultiSendCallOnly` rather than `MultiSend` is a deliberate restriction: the batch's inner transactions can only `CALL`, never nested-delegatecall — a smaller attack surface for the routine approve-then-act pattern. A persistent banner shows which identity is active, and a pending vault action appears *only* in the vault's queue — it never shows up as a phantom entry in My Wagers or transfer history until the chain confirms it, because implying state the chain hasn't confirmed is exactly the dishonesty the design forbids.
-
-One honest wrinkle surfaced during research. Inbound movements — receiving funds, triggering a refund owed to the vault — need no threshold, since `claimRefund` in the wager registry is caller-agnostic and routes funds to recorded parties. But `claimPayout` requires `msg.sender == winner`, and its gasless twin recovers an EOA signature via `ecrecover` with no EIP-1271 support. So a vault that *wins* a wager must claim through a threshold-approved `execTransaction`. We documented that as the FR-022c exception rather than pretending a single owner could pull the payout; fixing it properly means adding EIP-1271 verification to the registry's intent facet, which is future work, not v1.
-
-## The Guard Socket
-
-Everything above makes the vault usable; it doesn't yet make it *governable* beyond M-of-N. Safe's answer to programmable policy is the transaction guard: a contract the Safe consults via `checkTransaction(...)` before executing anything and `checkAfterExecution(...)` after. The custody family ships the scaffolding for this — `contracts/custody/ISafeGuard.sol`, a dependency-free replica of Safe v1.4.1's guard interface whose selectors (and thus its ERC-165 interface id, which `setGuard` checks) are byte-identical to the canonical one, and `contracts/custody/PolicyGuardSetup.sol`, a stateless helper delegatecalled from `Safe.setup` so a new vault is policy-governed from its very first transaction, with the initial policy committed into the vault's CREATE2 address.
-
-What those policies look like — spending rules enforced at execution time, so a quorum of compromised signers still can't violate them — is spec 049, and it's the subject of part 2.
+Everything above makes the vault usable; it doesn't yet make it *governable* beyond "enough people approved." A multisig has exactly one control — a set number of owners agree — and once that bar is cleared it will send any amount, anywhere. Safe's answer is a **transaction guard**: a contract the Safe consults before executing anything, which can veto a transaction that breaks the rules. This feature ships the wiring so a brand-new vault can be rule-governed from its very first transaction. What those rules look like — spending limits and allowlists enforced at execution time, so even a quorum of compromised signers can't break them — is the subject of part 2.
 
 ## Design Decisions
 
-- **Adopt Safe v1.4.1, don't fork it.** Years of audits and ecosystem interoperability for free; the version chosen specifically because its canonical addresses match across all three target chains.
-- **No hosted coordination.** On-chain `approveHash` + pre-validated signatures replace the Safe Transaction Service entirely. Cost: every approval is a gas-paying transaction. Benefit: the chain is the single source of truth, and the never-stranded rule holds.
-- **Events-only discovery with client-side verification.** `SafeProposalHub` carries data, never trust; the signed-payload fallback means zero required infrastructure.
-- **One `submitAsActiveAccount` seam** instead of per-surface vault logic — seven heterogeneous flows reroute through one audited chokepoint.
-- **Honest state over convenience.** Pending vault actions live only in the vault queue; the vault-won-payout exception is documented instead of papered over.
-- **References-only backup.** The encrypted app backup (spec 032) stores vault addresses and labels — never key material; the vault itself lives on-chain and reloads by address.
+- **Adopt a proven multisig, don't build one.** Years of audits and a whole ecosystem of compatible tools, for free — and we picked the version whose official addresses match across all three of our networks.
+- **No hosted coordination.** On-chain approvals replace the middleman server. Each approval is a small fee-paying transaction; in exchange, the blockchain is the single source of truth and no one can ever be locked out.
+- **A bulletin board that carries data, never trust.** Every proposal is re-verified inside each co-owner's own app, and the signed-file fallback means zero required infrastructure.
+- **Honesty over convenience.** Every money-moving flow reroutes through one well-reviewed checkpoint, pending vault actions live only in the vault queue, backups store addresses and labels but never key material, and the vault-won-payout exception is documented rather than papered over.
 
-## Sources
+## Further reading
 
-- `specs/043-safe-multisig-custody/` — spec.md, research.md (decisions 1–8), plan.md
-- `docs/developer-guide/safe-custody.md` — developer guide
-- `docs/developer-guide/treasury-security.md` — multisig-owned `TreasuryVault` pattern
-- `contracts/custody/SafeProposalHub.sol`, `contracts/custody/ISafeGuard.sol`, `contracts/custody/PolicyGuardSetup.sol`
-- `frontend/src/lib/custody/vaultTransaction.js`, `frontend/src/lib/custody/submitAsActiveAccount.js`, `frontend/src/config/safeContracts.js`
-- `deployments/polygon-chain137-v2.json` — `safeProposalHub` address
-- Safe contracts & docs — https://safe.global / https://github.com/safe-global/safe-smart-account
-- Safe deployments registry — https://github.com/safe-global/safe-deployments
-- EIP-712 (typed structured data hashing) — https://eips.ethereum.org/EIPS/eip-712
-- EIP-1271 (contract signature validation) — https://eips.ethereum.org/EIPS/eip-1271
-- ERC-165 (interface detection) — https://eips.ethereum.org/EIPS/eip-165
-- ETC Cooperative Safe wallet fork — https://github.com/etclabscore/web-core
+- Safe, the multisig wallet used here — https://safe.global
+- The EIP-712 standard for human-readable, signable transaction data — https://eips.ethereum.org/EIPS/eip-712
+- EIP-1271, how smart-contract accounts prove a signature — https://eips.ethereum.org/EIPS/eip-1271

--- a/docs/blog/posts/07-safe-multisig-custody/social.md
+++ b/docs/blog/posts/07-safe-multisig-custody/social.md
@@ -1,28 +1,28 @@
-# Social & Image — Integrating Safe as a Custody Layer, Without Running Safe's Backend
+# Social & Image — Shared Vaults Where No One Person Can Move the Money
 
 ## X (Twitter)
 
-We integrated Safe multisig custody with zero backend: on-chain approveHash + pre-validated sigs (v=1, r=owner) replace the Transaction Service, and a 66-line events-only contract handles proposal discovery. Clients verify every preimage by recomputing the hash. 🔗 <link> #Safe #multisig #web3
+A multisig is a shared wallet where several people must approve before any money moves. We built shared vaults into FairWins with zero company server: approvals live on the blockchain itself, and a tiny public bulletin board lets co-owners see what they're signing — every proposal re-verified inside their own app. 🔗 <link> #multisig #web3
 
 ## LinkedIn
 
-Most Safe integrations quietly depend on a hosted backend — the Safe Transaction Service stores proposals and signatures off-chain, and if it disappears, coordination stops. FairWins has a hard rule against app backends, so we integrated Safe v1.4.1 as our custody layer using only the chain itself.
+Most shared-treasury tools quietly depend on a hosted server in the middle — it stores proposed transactions and collects everyone's approvals, and if it disappears, coordination stops. FairWins has a hard rule against depending on a company server, so we built shared vaults using only the blockchain itself.
 
-The new post walks through the architecture:
+The new post walks through the ideas in plain terms:
 
-- The on-chain-only approval flow: each owner calls approveHash, then anyone executes with pre-validated signature bundles (v=1, r=owner address) — no off-chain ECDSA collection anywhere.
-- SafeProposalHub, a stateless, events-only contract for co-owner discovery. Clients recompute the EIP-712 Safe transaction hash from emitted parameters and reject mismatches, so the hub carries data but never trust — plus a signed-payload QR fallback so the feature works with zero infrastructure.
-- One "operate as the vault" seam routing every money-moving surface (wagers, payments, swaps) into the vault's threshold-gated queue.
-- Why Safe v1.4.1 specifically: canonical addresses are identical across Ethereum Classic, Mordor, and Polygon.
+- What a multisig is: a shared wallet where several people must approve before money moves, so no single person — or single stolen laptop — can drain it.
+- How co-owners approve directly on the blockchain, so the chain becomes the record of who agreed — no off-chain middleman anywhere.
+- A tiny public "bulletin board" contract that lets co-owners discover and read a pending transaction, while each app re-verifies every proposal itself — so the board carries information but never trust. Plus a signed-file/QR fallback so the feature works with zero infrastructure.
+- One "operate as the vault" checkpoint that routes every money-moving action (wagers, payments) into the vault's approval queue.
 
-We also cover the honest edge cases — like why a vault-won wager payout still needs threshold approval when refunds don't.
+We also cover the honest edge cases — like why a vault that *wins* a wager still needs group approval to claim, when receiving a refund doesn't.
 
 Read the full post: <link>
 
-If you've integrated Safe without the Transaction Service, what did you use for proposal discovery?
+If you've built shared-treasury tooling without a hosted backend, how did co-owners discover pending transactions?
 
-#Safe #multisig #custody #DAOtooling #smartcontracts
+#multisig #custody #DAOtooling #web3
 
 ## Image prompt (Gemini / Nano Banana)
 
-Clean modern editorial illustration, isometric style: a translucent geometric vault shaped like a faceted glass cube floating at center, sealed by three interlocking mechanical keys converging from different angles, each key held by an abstract faceless figure standing on separate floating platforms connected only by thin glowing chain-links of blockchain blocks — no wires to any central server; a small radiant beacon beside the vault emits concentric broadcast rings carrying tiny document glyphs toward the figures, symbolizing an events-only proposal broadcaster. Deep navy and teal base palette with a single warm amber accent on the beacon's rings and the keyways, soft diffused rim lighting, subtle grid horizon fading into darkness, generous negative space, precise vector-like edges, fintech-engineering brand mood, no text, no logos, no watermarks. Aspect ratio 16:9.
+Clean modern editorial illustration, isometric style: a translucent geometric vault shaped like a faceted glass cube floating at center, sealed by three interlocking mechanical keys converging from different angles, each key held by an abstract faceless figure standing on separate floating platforms connected only by thin glowing chain-links of blockchain blocks — no wires to any central server; a small radiant beacon beside the vault emits concentric broadcast rings carrying tiny document glyphs toward the figures, symbolizing a public proposal bulletin board. Deep navy and teal base palette with a single warm amber accent on the beacon's rings and the keyways, soft diffused rim lighting, subtle grid horizon fading into darkness, generous negative space, precise vector-like edges, fintech-engineering brand mood, no text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/08-multisig-policy-engine/blog.md
+++ b/docs/blog/posts/08-multisig-policy-engine/blog.md
@@ -1,130 +1,83 @@
-# Enough Signatures Is Not Enough: An On-Chain Policy Engine for Safe Multisigs
+# Enough Signatures Is Not Enough: Adding Real Rules to a Shared Vault
 
-*How a singleton transaction guard turns threshold approval into threshold approval plus policy — with no admin key and no way to brick a vault*
+*How a small guard contract turns "enough people approved" into "enough people approved, and it obeys the rules" — with no admin key and no way to lock a vault out of its own money*
 
 | | |
 |---|---|
 | **Series** | Custody & Multisig (part 2) |
 | **Part** | 8 of 34 |
-| **Audience** | Security engineers, DAO/treasury tooling builders |
-| **Tags** | `safe`, `multisig`, `policy-engine`, `transaction-guard`, `security` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Founders, product managers, and the security-curious |
+| **Tags** | `multisig`, `spending-limits`, `treasury-controls`, `security` |
+| **Reading time** | ~7 minutes |
 
 ## The transaction that had every signature it needed
 
-A three-owner treasury Safe runs a 2-of-3 threshold. One Tuesday, a proposal appears in the queue: send 180,000 USDC to an address nobody recognizes. Owner one approves it from a phone between meetings — the amount looks like the quarterly market-maker payment, and the proposal description says as much. Owner two approves an hour later for the same reason. The threshold is met. The transaction executes. The address belonged to whoever phished owner one's session and queued the proposal.
+A three-owner treasury runs a two-of-three multisig: any two owners must approve before money moves. One Tuesday a proposal appears in the queue — send 180,000 USDC to an address nobody recognizes. Owner one approves it from a phone between meetings; the amount looks like the quarterly market-maker payment, and the description says exactly that. Owner two approves an hour later for the same reason. Two approvals: threshold met. The transaction executes. The address belonged to whoever phished owner one and quietly queued the proposal.
 
-Nothing in the multisig failed. That is the uncomfortable part. A threshold multisig has exactly one control — *k* of *n* owners agree — and once that bar is cleared, the Safe will send any amount, to any destination, at any time. Every mitigation teams usually reach for is procedural: "we review destinations carefully," "we never approve on mobile," "large transfers get a call first." Procedures are policy that lives in people's heads, and people approve things between meetings.
+Nothing in the multisig failed. That's the uncomfortable part. A multisig has exactly one control — *enough* owners agree — and once that bar is cleared, it will send any amount, to any destination, at any time. Everything else teams rely on is procedure: "we review destinations carefully," "we never approve on mobile," "big transfers get a phone call first." Procedures are rules that live in people's heads, and people approve things between meetings.
 
-FairWins' custody feature (spec 043, covered in part 1 of this series) gives members shared Safe vaults with a propose/approve queue. Spec 049 adds the missing layer: a **policy engine** that constrains what an *approved* vault transaction may do — after the owners' threshold is met, before execution. The phished proposal above dies at execution against a per-transaction limit or a recipient allowlist, no matter how many signatures it collected.
+Part 1 covered FairWins' shared vaults: a group holds a multisig with a propose-and-approve queue. This post adds the missing layer — a **policy engine** that constrains what an *already-approved* transaction may do, after the threshold is met but before the money moves. The phished proposal above dies at that final step against a per-transaction limit or a recipient allowlist, no matter how many signatures it collected.
 
-The interesting engineering question is where such rules can live so that they are actually binding. Client-side checks are advisory — anyone can call the Safe directly. A backend policy service is a trusted party. The answer Safe's architecture offers is the **transaction guard**, and spec 049 builds the whole engine as one.
+The interesting question is *where* such rules can live so they're actually binding. Checks inside the app are only advisory — anyone can talk to the multisig directly. A rules service on a company server is just another party you have to trust. The place that actually works is a **transaction guard**: a contract the multisig itself consults, on-chain, before every execution.
 
-## Where a guard sits in Safe's execution path
+## Where the guard sits
 
-Safe v1.4.1 lets a Safe register a guard contract that gets a veto over every `execTransaction`. Just before executing an approved transaction, the Safe calls the guard's `checkTransaction` with the full transaction context; if the guard reverts, the transaction never executes. After execution it calls `checkAfterExecution`.
+A modern Safe multisig can register a guard contract with a veto over every transaction. Just before executing an approved transaction, the Safe hands the guard the full details; if the guard objects, the transaction never runs.
 
-FairWins keeps a dependency-free local replica of the interface in `contracts/custody/ISafeGuard.sol`, byte-identical to the canonical one (Safe's `Enum.Operation` is `uint8` in the ABI, so the selectors — and the ERC-165 interface id that `setGuard` checks as `GS300` — match exactly):
+FairWins' guard is a **single shared contract per network**: one immutable contract holds the rule settings and running totals for every vault that has opted in, filed under each vault's address. Because the multisig itself is the one asking, the guard always knows which vault's rules to apply — no setup handshake needed.
 
-```solidity
-interface ISafeGuard {
-    function checkTransaction(
-        address to,
-        uint256 value,
-        bytes calldata data,
-        uint8 operation,
-        uint256 safeTxGas,
-        uint256 baseGas,
-        uint256 gasPrice,
-        address gasToken,
-        address payable refundReceiver,
-        bytes calldata signatures,
-        address msgSender
-    ) external;
-
-    function checkAfterExecution(bytes32 txHash, bool success) external;
-}
-```
-
-The implementation, `contracts/custody/SafePolicyGuard.sol`, is a **singleton per chain**: one immutable contract holds every opted-in vault's rule configuration and live accounting, keyed by the Safe's address. Because the Safe itself is `msg.sender` when it calls the guard, the guard always knows which vault's policy to evaluate — no registration handshake needed.
-
-Two properties define the trust model. First, the guard is **restriction-only**: it can block a transaction but can never initiate, approve, or execute one, and it holds no funds (non-payable everywhere). Second, **the vault is the only authority over its own policy**: every call to `configureRules` requires `msg.sender == safe`, which is only reachable as a Safe self-transaction — meaning a policy change rides the same threshold-approved proposal queue as moving money. There is no owner, no admin role, and the contract is deliberately not upgradeable, because an upgrade key over the guard would be a backdoor over every vault's enforcement.
+Two properties define the trust model. First, the guard is **restriction-only**: it can block a transaction but never start, approve, or execute one, and it holds no money. Second, **a vault is the only authority over its own rules**: changing a vault's policy is itself a transaction that must clear that vault's normal approval threshold. There is no owner, no admin role, and the guard is deliberately *not* upgradeable — an upgrade key over it would be a master backdoor over every vault's enforcement.
 
 ## The rules
 
-Version 1 ships the classic treasury controls, each independently optional per vault:
+Version 1 ships the classic treasury controls, each independently switchable per vault:
 
-- **Per-transaction limit** — per asset (`address(0)` for the native coin, or an ERC-20 address); no single outgoing transaction may exceed it.
-- **24-hour-window limit** — per asset; the window opens at the first counted spend and resets 24 hours later.
-- **Recipient allowlist** — outgoing value may only go to approved addresses.
-- **Cooldown** — a minimum delay between fund-moving transactions.
+- **Per-transaction limit** — per asset; no single outgoing transaction may exceed it.
+- **Daily limit** — per asset, over a rolling 24-hour window.
+- **Recipient allowlist** — outgoing money may only go to pre-approved addresses.
+- **Cooldown** — a minimum wait between money-moving transactions.
 
-A transaction is *counted* — subject to limits and cooldown — when it carries native `value > 0` or calls one of three ERC-20 selectors the guard decodes: `transfer`, `transferFrom`, and `approve`. Counting `approve` is not an accident: an approval is a spending grant, and skipping it would leave an approve-then-pull bypass where the vault approves a spender within no limit and the spender drains the allowance later.
+A transaction "counts" against these limits when it moves value — sending the native coin, or one of the standard token operations the guard recognizes: transfer, transfer-on-behalf-of, and *approve*. Counting approve matters: approving a spender is a spending grant, and ignoring it would leave an obvious loophole where the vault grants an unlimited allowance and the spender quietly drains it later.
 
-The allowlist has a subtlety worth copying. For decoded token actions it gates the *beneficiary* — the `transfer`/`transferFrom` recipient or the `approve` spender — not the token contract being called. For everything else it gates the call target, so calldata the guard cannot decode still cannot reach an un-allowlisted contract. Native value riding a call additionally gates the target.
+The allowlist has a subtlety worth copying. For token movements it checks the *beneficiary* — whoever ultimately receives or can pull the tokens — not just the token contract being called. For everything else it checks the direct target, so even a transaction the guard can't fully interpret still can't reach an un-approved contract. A locked-down vault genuinely stays locked down.
 
-Calldata decoding in `_classify` slices exactly the canonical argument words (`data[4:68]` for `transfer`/`approve`, `data[4:100]` for `transferFrom`). Solidity functions ignore extra trailing calldata for static arguments, so the guard classifies a padded call exactly as the token itself would execute it — padding can neither dodge classification nor spuriously revert it.
+## Closing the escape hatches first
 
-## Hard denials: the bypasses you must close first
+Limits are worthless if a transaction can step outside the accounting entirely. So while any rule is active, the guard flatly rejects two dangerous shapes:
 
-Limits are worthless if the transaction can step outside the accounting. While any rule is active, the guard hard-rejects two shapes:
+- **Code that runs inside the vault's own context.** One transaction type lets external code execute with the vault's full authority — it could move funds without tripping any rule, or even rewrite the guard's own settings. Refused outright. (The cost is that a certain batching trick isn't available on rule-governed vaults; since these flows are single-action anyway, nothing is lost.)
+- **Gas-refund transactions.** The multisig can be told to reimburse the submitter's gas out of vault funds — an outflow the limits wouldn't otherwise see. Refused too.
 
-- **`operation == DELEGATECALL`.** Delegatecalled code runs in the Safe's own storage context — it can move funds without tripping any decode path and can literally rewrite the guard slot. The consequence is that MultiSend batching is unavailable on policy vaults; since spec 043's flows are single-call, nothing regresses.
-- **`gasPrice != 0`.** Safe's gas-refund mechanism pays `refundReceiver` out of the Safe. That is an uncounted outflow, so refund transactions are refused outright.
+Both rejections come back as clear, named errors, so the app can explain exactly why something was blocked instead of guessing at a cryptic failure.
 
-Both denials are typed errors (`DelegatecallBlocked`, `GasRefundBlocked`), like every other rejection — clients decode one canonical error format instead of parsing revert strings.
+## You can always loosen the rules
 
-## Lockout-proofing: a policy you can always loosen
+The classic failure mode of on-chain rules is locking yourself in: owners set a cooldown of a year, or turn on an allowlist whose only address is now defunct, and the vault is bricked. The fix is a simple, deliberate carve-out. Two kinds of transaction skip all the spending rules entirely: managing the vault itself (owners, threshold, the guard), and changing the vault's own policy. Both still require the vault's normal approval threshold — so the *only* thing exempt is the collective ability to change the rules.
 
-The classic failure mode of on-chain policy is self-imprisonment: owners set a cooldown of a year, or enable an allowlist with only a now-defunct address, and the vault is bricked. Spec 049's answer (FR-008) is a pair of exemptions at the top of the shared evaluation function:
+The result: a too-strict policy can always be loosened by the same group consent that set it, and no vault can ever be locked out by its own rules. This isn't just asserted — it's tested against a real multisig deployment, not a stand-in mock.
 
-```solidity
-// Lockout-proof exemptions (FR-008): vault self-management and policy
-// configuration bypass all fund rules; both still require the vault's
-// own approval threshold.
-if (to == safe) return ("", false);
-if (to == address(this)) {
-    if (value != 0) return (abi.encodeWithSelector(ValueToGuardBlocked.selector), false);
-    return ("", false);
-}
-```
+## What you see is what gets enforced
 
-Transactions targeting the Safe itself (owner, threshold, and guard management) or the guard (policy configuration, with `value == 0` enforced so the exemption cannot smuggle funds) bypass all fund rules — while still requiring the vault's threshold. A too-strict policy can therefore always be loosened by the same collective consent that created it; no vault can be locked out by its own rules. This is proven against a real Safe v1.4.1 deployment in `test/integration/policy-guard-safe.test.js`, not just against a mock.
+Owners should learn a transaction breaks policy *before* they spend approvals on it. The guard offers a read-only preview that runs the *exact same* rule check the real enforcement uses, and the app runs every proposal through it first — so what the interface warns you about can never drift from what the chain enforces. Enforcement itself is careful about ordering: the guard reads and evaluates first, then records the updated totals, and never calls out to another contract, so there's no room for the reentrancy trickery that plagues contracts that move money.
 
-## One evaluation path, shared by enforcement and preview
+## Rules from the very first transaction
 
-Owners should learn a transaction violates policy *before* they spend signatures on it. The guard exposes `previewTransaction`, a read-only twin of `checkTransaction` that runs the exact same internal `_checkPolicy` function and returns the would-be revert data. The frontend (`frontend/src/lib/custody/policy.js`) pre-flights every proposal through it, so what the UI displays can never drift from what the chain enforces — there is one rule evaluator, used verbatim by both paths.
-
-Enforcement itself follows checks-effects with no interactions at all: `_checkPolicy` is read-only, then `_commitAccounting` writes window and cooldown state. The guard makes zero external calls, so there is no reentrancy surface to reason about.
-
-## Policy from block one
-
-A vault attached to a guard after creation has a gap: transactions before attachment are unpoliced. `contracts/custody/PolicyGuardSetup.sol` closes it. It is a stateless helper delegatecalled from `Safe.setup(to, data, ...)` during vault creation: running in the new proxy's context, it writes the guard address directly into Safe's guard storage slot (`keccak256("guard_manager.guard.address")`), re-performs the ERC-165 `GS300` acceptance check that writing the slot directly would otherwise skip, emits a byte-identical `ChangedGuard` event for explorer parity, and then `call`s the guard's `configureRules` calldata — at which point `msg.sender` seen by the guard *is* the new Safe, so the creation path needs no special authority carve-out. Any revert bubbles up and aborts the whole vault creation: a half-configured vault can never deploy. And because the full initializer is hashed into the CREATE2 salt, the vault's predicted address commits to its initial policy.
-
-For existing vaults, attachment is ordered so there is no half-set gap: queue `configureRules` first (inert without the guard), then `setGuard` (activates).
+A guard attached *after* creation leaves a window where early transactions are unpoliced. So FairWins can wire the guard in during vault creation itself: the guard address and starting rules are part of the setup, baked into the vault's predicted address, and if any part of that setup fails the whole creation is aborted — a half-configured vault can never come into existence. For an existing vault, attachment is ordered so there's never a moment where the guard is half-on.
 
 ## Design decisions and accepted limits
 
-**Immutable singleton, no proxy.** Elsewhere FairWins is aggressively UUPS (`WagerRegistry`, `MembershipManager`), but the guard has no upgrade path on purpose: whoever can swap the implementation can disable every vault's enforcement. Upgrades ship as a *new* guard deployment that each vault adopts via its own threshold-approved `setGuard` — consent per vault, not fiat from a deploy key. Both contracts deploy deterministically via CREATE2 and are recorded in `deployments/` under `safePolicyGuard` / `policyGuardSetup`, rolling out Mordor (63) then Polygon (137).
+**Immutable, not upgradeable — on purpose.** Elsewhere FairWins leans on upgradeable contracts, but the guard has no upgrade path by design: whoever could swap it out could disable every vault's enforcement. Improvements ship as a *brand-new* guard that each vault chooses to adopt through its own approval — consent per vault, never a decision imposed by a single deploy key.
 
-**Fixed-reset window, not rolling.** A true rolling 24-hour window requires unbounded per-transaction history on-chain. The fixed-reset window admits up to 2× the limit across a span that straddles a reset — a bounded, disclosed weakening (research.md R3), surfaced in the UI rather than hidden.
+**Fixed daily window, not perfectly rolling.** A truly continuous rolling window would require storing unbounded transaction history on-chain. The simpler fixed-reset window can, in a worst case straddling a reset, allow up to twice the limit — a small, bounded weakening that's disclosed in the interface rather than hidden.
 
-**Unvalued calldata passes limits.** The guard values native transfers and three ERC-20 selectors; a DEX swap or arbitrary contract call passes spending limits unvalued. It still faces the allowlist on the call target, so a vault that needs full lockdown enables the allowlist and gets it.
+**Uninterpreted transactions pass the spending limits.** The guard values native transfers and the standard token operations; something exotic like a DEX swap passes the *spending* limits unmeasured. It still faces the *allowlist* on its target — so a vault that needs a hard lockdown turns on the allowlist and gets one.
 
-**Conservative accounting.** Window and cooldown state commit in `checkTransaction`, before execution. If the Safe's inner call fails without reverting the outer transaction, the spend still counts. Overcounting can only restrict, never permit — the safe direction to be wrong in.
+**Conservative accounting.** Totals are recorded before the transaction executes. If the inner action later fails quietly, the spend still counts. Overcounting can only ever restrict, never over-permit — the safe direction to err.
 
-The through-line: every rule that exists is enforced exactly, every gap that exists is named, bounded, and disclosed, and no key anywhere can waive either.
+The through-line: every rule that exists is enforced exactly, every gap that exists is named, bounded, and disclosed, and no key anywhere can quietly waive either.
 
-## Sources
+## Further reading
 
-- `specs/049-multisig-policy-engine/` — spec, plan, research, data model
-- `docs/developer-guide/multisig-policy-engine.md`
-- `contracts/custody/SafePolicyGuard.sol`
-- `contracts/custody/ISafeGuard.sol`
-- `contracts/custody/PolicyGuardSetup.sol`
-- `test/integration/policy-guard-safe.test.js`, `test/custody/SafePolicyGuard.test.js`
-- `frontend/src/lib/custody/policy.js`
-- Safe transaction guards (Safe v1.4.1 `GuardManager`): https://docs.safe.global/advanced/smart-account-guards and https://github.com/safe-global/safe-smart-account
-- ERC-165 (interface detection, the `GS300` check): https://eips.ethereum.org/EIPS/eip-165
-- ERC-20 (`transfer`/`transferFrom`/`approve` semantics): https://eips.ethereum.org/EIPS/eip-20
-- EIP-1014 (CREATE2, deterministic deployment): https://eips.ethereum.org/EIPS/eip-1014
+- Safe transaction guards, the mechanism used here — https://docs.safe.global/advanced/smart-account-guards
+- The ERC-20 token standard (transfer / approve behavior) — https://eips.ethereum.org/EIPS/eip-20
+- CREATE2, the deterministic-address technique that lets a vault commit to its rules up front — https://eips.ethereum.org/EIPS/eip-1014

--- a/docs/blog/posts/08-multisig-policy-engine/social.md
+++ b/docs/blog/posts/08-multisig-policy-engine/social.md
@@ -1,27 +1,27 @@
-# Social & Image — Enough Signatures Is Not Enough: An On-Chain Policy Engine for Safe Multisigs
+# Social & Image — Enough Signatures Is Not Enough: Adding Real Rules to a Shared Vault
 
 ## X (Twitter)
 
-Your multisig has one control: k-of-n signatures. Phish two owners and the treasury is gone. We built a Safe transaction guard enforcing spending limits, allowlists + cooldowns at execution — no admin key, no way to brick a vault. 🔗 <link> #Safe #multisig #web3security
+A multisig has one control: enough people approve. Phish two owners and the treasury is gone. We added a guard that enforces spending limits, allowlists, and cooldowns at the moment of execution — no admin key, and no way to lock a vault out of its own money. 🔗 <link> #multisig #web3security
 
 ## LinkedIn
 
-A threshold multisig has exactly one control: k of n owners agree. Once that bar is cleared, the Safe will send any amount, to any destination. Every other safeguard most teams rely on is procedural — and procedures fail quietly when someone approves a plausible-looking proposal between meetings.
+A shared multisig has exactly one control: enough owners agree. Once that bar is cleared, it will send any amount, to any destination. Every other safeguard most teams rely on is procedure — and procedures fail quietly when someone approves a plausible-looking proposal between meetings.
 
-Our latest engineering post walks through FairWins' on-chain multisig policy engine: a singleton Safe v1.4.1 transaction guard that enforces rules on approved transactions at execution time. It covers:
+Our latest post walks through FairWins' on-chain policy engine for shared vaults — a guard contract that enforces real rules on already-approved transactions, at the moment they execute. In plain terms:
 
-- How Safe's guard interface (checkTransaction / checkAfterExecution) gives a contract veto power over every execution, and why the engine is one immutable singleton per chain with no admin role and no upgrade key
-- The v1 rule set — per-transaction limits, 24-hour window limits, recipient allowlists, cooldowns — and why counting ERC-20 approve() closes the approve-then-pull bypass
-- Lockout-proofing: vault self-management and policy configuration bypass fund rules (but still require the threshold), so a too-strict policy can always be loosened and no vault can brick itself
-- Honest trade-offs: fixed-reset windows vs. rolling, unvalued calldata, conservative pre-execution accounting, and why delegatecall and gas refunds are hard-denied
+- How a "transaction guard" gives a contract veto power over every spend, and why it's one immutable, shared contract with no admin role and no upgrade key
+- The rule set — per-transaction limits, daily limits, recipient allowlists, cooldowns — and why counting token approvals closes an obvious drain-later loophole
+- Lockout-proofing: managing the vault and changing its rules skip the spending limits (but still require the group's approval), so a too-strict policy can always be loosened and no vault can brick itself
+- Honest trade-offs: a fixed daily window vs. a perfectly rolling one, uninterpreted transactions, conservative accounting, and why two dangerous transaction shapes are refused outright
 
-If you run a DAO treasury or build custody tooling, the design decisions here — especially what we chose *not* to make upgradeable — may be useful.
+If you run a shared treasury or build custody tooling, the design decisions here — especially what we chose *not* to make upgradeable — may be useful.
 
 🔗 <link>
 
 Where do you draw the line between on-chain enforcement and operational procedure for treasury controls?
 
-#Safe #multisig #DAOtreasury #smartcontracts #web3security
+#multisig #DAOtreasury #web3security #custody
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/09-intent-based-gasless-payments/blog.md
+++ b/docs/blog/posts/09-intent-based-gasless-payments/blog.md
@@ -1,6 +1,6 @@
-# One Signature, Zero Gas: Intent-Based Payments with EIP-712 and EIP-3009
+# One Signature, Zero Gas: How Gasless Payments Actually Work
 
-*How FairWins turned every user action into a signed intent — and the byte-identical struct discipline that keeps three codebases honest*
+*How FairWins turned every action into a signed "intent" — you sign what you want, and someone else pays the fee to submit it*
 
 ---
 
@@ -8,121 +8,78 @@
 |---|---|
 | **Series** | Gasless Rails (part 1 of 2) |
 | **Part** | 9 of 34 |
-| **Audience** | dApp developers, meta-transaction and relayer engineers |
-| **Tags** | `eip712`, `eip3009`, `meta-transactions`, `gasless`, `intents` |
-| **Reading time** | ~8 minutes |
+| **Audience** | Founders, product managers, and the crypto-curious |
+| **Tags** | `gasless`, `payments`, `user-experience`, `stablecoins` |
+| **Reading time** | ~7 minutes |
 
 ---
 
 ## The Stranded User
 
-A user wins a wager on FairWins. Fifty USDC sits in escrow with their address recorded as the winner. All they have to do is call `claimPayout`. One problem: their wallet holds exactly zero POL. They funded it with USDC from an exchange, they've never touched Polygon's native token, and they have no intention of learning what a gas station is. Their money is on-chain, provably theirs, and unreachable.
+A user wins a wager on FairWins. Fifty USDC sits in escrow with their address recorded as the winner. All they have to do is claim it. One problem: their wallet holds exactly zero of Polygon's native coin — the token every transaction needs to pay its network fee, its "gas." They funded their wallet with USDC from an exchange, never touched the native token, and have no intention of learning what a gas station is. Their money is on-chain, provably theirs, and completely out of reach.
 
-The pre-intent flow was worse than one stranded action — it was two transactions per money-in action. Creating a wager meant an ERC-20 `approve()` followed by the create call. Accepting one meant the same dance. Every step required native gas, and the spec for this feature (`specs/035-intent-based-payments/spec.md`) named the failure mode plainly: a user who holds only the platform stablecoin is stranded — they cannot act at all.
+The old flow was worse than one stuck action. Just creating a wager took *two* transactions: a step to authorize the platform to move your stablecoin, then the step that actually creates the wager. Accepting one meant the same dance. Every step needed native gas, and the failure mode was plain: a user who holds only the stablecoin can't act at all.
 
-The worst version of this is asymmetric: a user who scraped together gas to *stake* but can't afford gas to *claim*. Money in, no money out. Any gasless design that fixes deposits but not withdrawals has built a lobster trap.
+The cruelest version is lopsided — a user who scraped together enough gas to *place* a bet but can't afford the gas to *claim* their winnings. Money in, no money out. Any gasless design that fixes deposits but not withdrawals has built a lobster trap.
 
-Spec 035's answer is to make the entire platform operate on **signed intents**. The user signs a structured message off-chain — free — describing exactly what they want. Anyone can carry that message on-chain, but the on-chain effect is always attributed to the *signer*, never the submitter. One signature replaces approve-plus-act, and a relayer's gas wallet pays the transaction fee.
+The fix is to make the entire platform run on **signed intents**. Instead of sending a transaction and paying the fee, the user signs a message — for free, no gas — describing exactly what they want to do. Anyone can then carry that signed message onto the blockchain and pay the fee to submit it. Crucially, the on-chain effect is always credited to the person who *signed* it, never to whoever submitted it. One signature replaces the whole authorize-then-act dance, and a helper service — a "relayer" — pays the fee.
 
-## Anatomy of an Intent
+## What an Intent Actually Is
 
-An intent is an [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed struct. Every action on the platform has one — `CreateWagerIntent`, `AcceptWagerIntent`, `ClaimPayoutIntent`, `DeclareDrawIntent`, `PurchaseTierIntent`, and so on. Each struct binds three things:
+An intent is a structured, human-readable message the user signs with their wallet, built on **EIP-712** — a widely used standard for signable data a wallet can display in plain terms, so you see the actual stake, deadline, and counterparty, not a wall of hex. Every action on the platform has its own intent: create a wager, accept one, claim a payout, declare a draw, buy a membership tier, and so on.
 
-1. **The acting address** — a named field (`creator`, `taker`, `claimant`, `member`) that must equal the recovered signer.
-2. **Every action parameter** — stake amounts, deadlines, the wager ID, the metadata hash. Nothing is left for the submitter to fill in.
-3. **A replay guard and validity window** — a random 32-byte `nonce`, plus `validAfter` / `validBefore` timestamps.
+Each intent locks down three things:
 
-Here is the accept-wager struct as the contract declares it in `contracts/wagers/WagerRegistryIntents.sol`:
+1. **Who is acting** — a named field that must match whoever actually signed. You can't sign on someone else's behalf.
+2. **Every detail of the action** — stake amounts, deadlines, which wager. Nothing is left blank for the submitter to fill in later.
+3. **A replay guard and an expiry** — a random one-time code so the same intent can't be reused, plus a window so a stale intent eventually expires.
 
-```solidity
-bytes32 private constant ACCEPT_WAGER_INTENT_TYPEHASH = keccak256(
-    "AcceptWagerIntent(uint256 wagerId,address taker,bytes32 paymentNonce,"
-    "bytes32 nonce,uint256 validAfter,uint256 validBefore)"
-);
-```
+Signatures are checked under a fingerprint unique to each contract *and* each network, so a signed intent is valid on exactly one contract on exactly one blockchain — a one-time code used up on one contract can never be replayed on another. The check also accepts signatures from smart-contract wallets, so FairWins' passkey wallets can sign intents too. A failed intent never uses up its one-time code; a successful one can never run twice.
 
-Signatures are verified under a **per-contract domain**: `("FairWins WagerRegistry", "1", chainId, proxyAddress)` for wager actions, `("FairWins MembershipManager", "1", ...)` for membership actions. Chain ID and verifying contract in the domain mean a signature is valid on exactly one contract on exactly one network — a nonce consumed on one contract can never be replayed on another.
+## Paying With a Signature, Not a Gas Balance
 
-The verification machinery lives in one shared mixin, `contracts/upgradeable/SignerIntentBase.sol`. Its `_verifyIntent` checks the validity window, recovers the signer (ECDSA first, then an [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) `isValidSignature` staticcall so contract accounts — including FairWins' passkey smart wallets — can sign intents too), and burns the nonce before the action body runs any external interaction. A failed intent never consumes its nonce; a succeeded one can never run twice.
+Signing an action is the easy half. The hard half is *money-in* actions. The intent says "stake 50 USDC" — but the platform still has to pull 50 USDC out of the wallet, which normally needs a separate, gas-paying authorization first.
 
-One detail worth stealing: the nonce map lives in [ERC-7201](https://eips.ethereum.org/EIPS/eip-7201)-namespaced storage rather than sequential slots. That made `SignerIntentBase` safe to add to two *already-live* UUPS proxies (`WagerRegistry` and `MembershipManager`) without shifting a single existing storage slot or spending `__gap` reserve.
+This is what **EIP-3009** is for — a feature built into Circle's USDC that lets a holder authorize a specific payment purely by signing. The user signs an authorization naming who gets paid, how much, and a validity window; the receiving contract presents that signature to the USDC token, and the transfer happens. No standing "allowance" ever exists, and no separate transaction is needed.
 
-## The Payment Leg: EIP-3009
+So a money-in intent carries *two* signatures: the FairWins intent ("accept wager 41") and the USDC payment authorization ("pay 50 USDC"). Which raises the attack that shapes the whole design: **what stops the submitter from mixing and matching?** Could they staple your payment authorization to a different action, or pair your accept-intent with a payment meant for something else?
 
-Signature-based actions are the easy half. The hard half is money-in actions — the intent says "stake 50 USDC," but the contract still has to actually pull 50 USDC without a prior `approve()`.
+They can't, because the two signatures are cryptographically stapled together. The intent you sign references the exact payment it's meant to travel with, and the contract refuses to proceed unless the payment matches — same amount, same one-time code — the one you committed to. The USDC token adds the final lock: the payment can only land in the contract that's asking. The net result: a submitter can *refuse* to carry your intent, but can never substitute, redirect, or resize the payment.
 
-This is what [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) exists for. Circle's USDC implements `receiveWithAuthorization`: the token holder signs an authorization — under the *stablecoin's own* EIP-712 domain, not FairWins' — naming a payee, an amount, a validity window, and a random nonce. The payee contract presents that signature to the token and the transfer executes. No allowance ever exists.
+## Two Twins, Identical Rules
 
-So a money-in intent carries two signatures: the FairWins intent and the USDC authorization. Which raises the attack that defines this design: **what stops a relayer from mixing and matching?** Take Alice's payment authorization, pair it with a different action; take her accept-intent for wager 41, staple on an authorization meant for something else.
+Every gasless action is a *twin* of an ordinary one. Accepting a wager the normal way and accepting it via a signed intent run **the exact same checks against the person acting** — sanctions screening, membership gating, ownership, account freezes. The only difference is *how* the acting identity is established: from the sender on the direct path, from the recovered signature on the intent path. The submitter's own standing is never consulted, and because both twins run the same underlying action, they can't quietly drift apart.
 
-The answer is that the two legs are cryptographically stapled. Every money-in intent struct carries a `paymentNonce` field — you can see it in the typehash above — and the contract asserts that the relayer-supplied authorization is exactly the one the signer committed to:
+## Keeping Three Codebases in Perfect Sync
 
-```solidity
-function _pullWithAuthorization(
-    address token, address from, uint256 expectedValue,
-    bytes32 expectedPaymentNonce, ERC3009Auth memory auth
-) internal {
-    if (auth.value != expectedValue || auth.nonce != expectedPaymentNonce)
-        revert PaymentAuthMismatch();
-    IERC3009(token).receiveWithAuthorization(
-        from, address(this), auth.value,
-        auth.validAfter, auth.validBefore, auth.nonce,
-        auth.v, auth.r, auth.s
-    );
-}
-```
+Here's the lesson most write-ups skip. The exact shape of each intent has to be defined in *three* separate places: the smart contract that verifies it, the app that helps the user sign it, and the relayer service that handles it.
 
-The token itself enforces the third edge: `receiveWithAuthorization` requires the payee to be the calling contract, so the money can only land in the registry. The net result, stated in `docs/developer-guide/gasless-intents.md`: a relayer can *censor* an intent, but it can never substitute, redirect, or resize a payment. That is the correct trust boundary for optional infrastructure.
+These three definitions must be **byte-identical** — not just similar in spirit. The signing standard fingerprints the *entire* structure, so a single reordered field, or a field's type written slightly differently, produces a completely different fingerprint and a signature that verifies to a random, wrong address. The failure is silent when you build it and total when a real user tries: every signature rejected, every time.
 
-## The Twin Invariant
-
-Every gasless entrypoint is a *twin* of an existing self-submit function — `acceptWager` gains `acceptWagerWithAuthorization`, `claimPayout` gains `claimPayoutWithSig` — and both twins run **identical checks and effects against the acting identity**: sanctions screening, membership gating, ownership, account freeze. For self-submit that identity is `msg.sender`; for the intent path it is the recovered signer. The submitter's own entitlements are never consulted. Both facets of the wager registry inherit the same `WagerRegistryCore` action bodies, so the twins cannot drift apart behaviorally: the twin is a thin verification wrapper around the exact same internal function the direct call uses.
-
-(The registry hosts these twins on a second implementation facet reached by delegatecall, because the main implementation sits 116 bytes shy of the EVM's 24 KB code limit — a story that deserves, and gets, its own post.)
-
-## The Three-Way Struct Sync
-
-Here is the lesson most meta-transaction tutorials skip. The EIP-712 struct definitions exist in **three places**:
-
-- the Solidity typehash strings in `contracts/wagers/WagerRegistryIntents.sol` (and `MembershipManager.sol`),
-- the frontend signing definitions in `frontend/src/lib/relay/intentTypes.js`,
-- the gateway verification definitions in `services/relay-gateway/src/intent/intentTypes.js`.
-
-These must stay **byte-identical**. Not semantically equivalent — byte-identical. EIP-712 hashes the full type string, so `uint256 wagerId` versus `uint wagerId`, a reordered field, or a renamed one produces a different typehash, a different digest, and a signature that recovers to a random address. The failure is silent at build time and absolute at runtime: `InvalidIntentSignature`, every time, for every user.
-
-The discipline FairWins landed on: the deployed contract typehashes are *authoritative*; each JS file declares in its header comment which spec document it mirrors and where deviations from the spec doc were resolved in the contract's favor (the schemas doc elided fields with `…`; the deployed `AcceptWagerIntent` really does carry `paymentNonce`, so both JS files do too). The gateway file goes further and makes itself the single source its own verification, encoding, and tests all derive from — a schema change inside that service is a one-file edit. When later features added intent structs (wager pools, the callsign registry), each new struct shipped simultaneously in all three places with cross-references in comments. It is unglamorous, and it is the difference between a working gasless rail and a support queue.
+The discipline FairWins landed on treats the deployed contract as authoritative, and every other copy documents exactly where it matches. New intents ship in all three places at once, with cross-references so no one edits one and forgets the others. It's unglamorous bookkeeping, and it's the entire difference between a working gasless system and a flood of mysterious support tickets.
 
 ## Never Stranded
 
-The final rule is architectural humility: the relayer is optional infrastructure, and the design must survive its absence. Every gasless flow keeps a **self-submit fallback** — the original pay-your-own-gas path is never removed, and the frontend hook `frontend/src/lib/relay/useIntentAction.js` enforces it at wiring time: the hook *throws during development* if a call site fails to supply a `selfSubmit` function, so no screen can ship a gasless-only dead end. Relayer unset, unhealthy, rate-limiting, timing out — the hook transparently falls back, and the on-chain result is identical.
+The final rule is architectural humility: the relayer is *optional*, and the design has to survive without it. Every gasless flow keeps a **pay-your-own-gas fallback** — the original path is never removed. The app enforces this at the wiring level: a screen literally can't ship a gasless-only dead end, because the code refuses to build one. If the relayer is switched off, overloaded, rate-limiting, or timing out, the app quietly falls back to the user paying their own gas, and the on-chain result is identical.
 
-The fallback also covers chains where the payment leg simply doesn't exist. Mordor's USC stablecoin lacks EIP-3009; the frontend's `stablecoinDomain()` check throws `PaymentUnsupportedOnChain` *before* the wallet prompt ever opens, and the flow self-submits. And status is honest end to end: the UI never shows `confirmed` before a mined transaction exists — signed, pending, confirmed, expired, and failed are distinct, truthful states.
+The fallback also covers networks where the signature-based payment simply doesn't exist — one test network's stablecoin lacks it entirely, so the app detects the gap *before* opening the signing prompt and uses the normal path. And status is honest end to end: the interface never shows "confirmed" before a transaction is actually mined. Signed, pending, confirmed, expired, and failed are all distinct, truthful states.
 
 ## Design Decisions
 
-**Random nonces, not sequential.** Nonces are client-generated random 32-byte values, usable out of order — EIP-3009's own scheme, adopted for intents too. Sequential nonces serialize a user's actions and let one stuck intent block everything behind it; random nonces let a user sign three intents and have them land in any order. Cancellation is targeted: `invalidateNonce(nonce)` kills one specific unsubmitted intent, and `invalidateNonceWithSig` makes even *cancellation* gasless.
+**Random one-time codes, not a counter.** Each intent's replay guard is a random value, usable in any order. A counter would force a user's actions into strict sequence and let one stuck intent block everything behind it; random codes let someone sign three intents and have them land in any order. Cancellation is precise — a user can kill one specific unsubmitted intent, and even that can be gasless.
 
-**Sign everything, trust nothing.** Every parameter the action consumes is inside the signed struct. The alternative — signing a hash of parameters delivered out-of-band — is fewer bytes but gives wallets nothing legible to display. EIP-712 typed data means the wallet shows the user the actual stake, deadline, and counterparty they are authorizing.
+**Sign everything, trust nothing.** Every detail the action uses is inside the signed message. The alternative — signing a compact code that stands for details delivered separately — is fewer bytes but shows the user nothing legible to approve. Human-readable signed data means the wallet displays the real stake, deadline, and counterparty.
 
-**Fee netting is bounded and segregated.** An optional second EIP-3009 authorization lets the platform recover gas costs in USDC, but it is capped on-chain (`FeeExceedsCap`), settles atomically with the action, and pays a segregated `gasFeeRecipient` — never the relayer's hot key. A compromised relayer gains no fee-redirection power.
+**Fee recovery is bounded and segregated.** An optional second payment authorization lets the platform recover its gas cost in USDC, but it's capped on-chain, settles in the same transaction as the action, and pays into a segregated account — never the relayer's own wallet. A compromised relayer gains no power to skim fees.
 
-**Censorship is the accepted residual risk.** A relayer can decline to submit. It cannot forge, alter, or replay. Because self-submit always exists, censorship degrades to inconvenience — the user pays their own gas and proceeds. That trade — accept censorship, eliminate custody — is the entire design in one sentence.
+**Censorship is the accepted residual risk.** A relayer can decline to submit an intent; it cannot forge, alter, or replay one. And because the pay-your-own-gas path always exists, refusal degrades to mere inconvenience. That trade — accept the possibility of censorship, eliminate any custody of user funds — is the entire design in one sentence.
 
 ---
 
-> **Note**: FairWins wagers are peer-to-peer agreements based on publicly available information and legitimate forecasting. Gasless submission changes who pays the transaction fee, not who is accountable: every intent is attributed to its signer, who remains fully subject to applicable law and the platform's compliance screening.
+> **Note**: FairWins wagers are peer-to-peer agreements based on publicly available information and legitimate forecasting. Gasless submission changes who pays the transaction fee, not who is accountable: every intent is credited to its signer, who remains fully subject to applicable law and the platform's compliance screening.
 
-## Sources
+## Further reading
 
-- `specs/035-intent-based-payments/spec.md` — feature spec, user stories, never-stranded rule
-- `specs/035-intent-based-payments/contracts/intent-eip712-schemas.md` — intent struct schemas
-- `docs/developer-guide/gasless-intents.md` — architecture overview, twin invariant, rollout
-- `contracts/upgradeable/SignerIntentBase.sol` — shared verification mixin, nonce map, fee netting
-- `contracts/wagers/WagerRegistryIntents.sol` — the `…WithSig` / `…WithAuthorization` twins
-- `frontend/src/lib/relay/intentTypes.js` — frontend struct definitions and domain builders
-- `frontend/src/lib/relay/useIntentAction.js` — never-stranded enforcement point
-- `services/relay-gateway/src/intent/intentTypes.js` — gateway struct definitions
-- [EIP-712: Typed structured data hashing and signing](https://eips.ethereum.org/EIPS/eip-712)
-- [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009)
-- [ERC-1271: Standard Signature Validation Method for Contracts](https://eips.ethereum.org/EIPS/eip-1271)
-- [ERC-7201: Namespaced Storage Layout](https://eips.ethereum.org/EIPS/eip-7201)
+- EIP-712, the standard for human-readable signable data — https://eips.ethereum.org/EIPS/eip-712
+- EIP-3009, "transfer with authorization," the pay-by-signature feature in USDC — https://eips.ethereum.org/EIPS/eip-3009
+- ERC-1271, how smart-contract wallets prove a signature — https://eips.ethereum.org/EIPS/eip-1271

--- a/docs/blog/posts/09-intent-based-gasless-payments/social.md
+++ b/docs/blog/posts/09-intent-based-gasless-payments/social.md
@@ -1,32 +1,32 @@
-# Social & Image — One Signature, Zero Gas: Intent-Based Payments with EIP-712 and EIP-3009
+# Social & Image — One Signature, Zero Gas: How Gasless Payments Actually Work
 
 ## X (Twitter)
 
-Your user won 50 USDC on-chain. Their wallet has zero POL. Their money is provably theirs — and unreachable.
+Your user won 50 USDC on-chain. Their wallet has zero gas token. Their money is provably theirs — and unreachable.
 
-We made every action a signed EIP-712 intent, stapled to an EIP-3009 payment leg via a shared paymentNonce. Relayers can censor, never redirect.
+The fix: you sign what you want, and someone else pays the fee to submit it. The signed action and its payment are cryptographically stapled together, so a submitter can refuse but never redirect.
 
 🔗 <link>
 
-#EIP712 #gasless #web3dev
+#gasless #web3
 
 ## LinkedIn
 
-The most common way users abandon a dApp is not a bug — it is a wallet holding stablecoin but zero native gas token. They cannot approve, cannot act, and in the worst case cannot even claim funds they already won.
+The most common way users abandon a crypto app isn't a bug — it's a wallet holding stablecoin but zero gas token. They can't authorize, can't act, and in the worst case can't even claim funds they already won.
 
-Our new engineering post walks through how FairWins rebuilt every user action as an intent-based gasless flow, and the operational discipline that keeps it correct:
+Our new post walks through how FairWins rebuilt every action as a gasless flow — you sign your intent, and a helper service pays the fee to submit it — and the discipline that keeps it correct:
 
-- Every action gets a `…WithSig` twin: an EIP-712 struct binding the actor, every parameter, a random 32-byte nonce, and a validity window — verified on-chain with identical sanctions, membership, and ownership checks as the direct-call path.
-- Money-in actions staple an EIP-3009 `receiveWithAuthorization` to the intent via a shared `paymentNonce`, so a relayer can censor a payment but can never substitute, redirect, or resize one.
-- The struct definitions live in three codebases — Solidity typehashes, the frontend signer, and the relay gateway — and must stay byte-identical. One reordered field means every signature recovers to a random address.
-- The never-stranded rule: self-submit is mandatory at every call site, enforced by the frontend hook itself, so the relayer remains optional infrastructure rather than a single point of failure.
+- Every action gets a gasless twin: a signed, human-readable message binding who's acting, every parameter, a one-time replay guard, and an expiry — verified on-chain with the *identical* sanctions, membership, and ownership checks as the normal path.
+- Money-in actions staple a pay-by-signature stablecoin authorization to the intent, so a submitter can refuse to carry a payment but can never substitute, redirect, or resize it.
+- The exact shape of each intent lives in three codebases — the contract, the app, and the relayer — and must stay byte-identical. One reordered field means every signature verifies to the wrong address.
+- The never-stranded rule: a pay-your-own-gas fallback is mandatory at every screen, enforced by the app itself, so the relayer stays optional rather than a single point of failure.
 
 Full write-up: <link>
 
-How does your team keep EIP-712 structs in sync across contract, client, and backend — codegen, tests, or discipline?
+How does your team keep signed-message formats in sync across contract, client, and backend — codegen, tests, or discipline?
 
-#EIP712 #EIP3009 #MetaTransactions #Solidity #Web3Engineering
+#gasless #payments #stablecoins #web3
 
 ## Image prompt (Gemini / Nano Banana)
 
-A clean modern editorial illustration in an isometric style: a single elegant fountain pen signing a large translucent document sheet, and from the signature line a glowing continuous ribbon flows rightward through three identical crystalline gates (representing three synchronized systems) before terminating at a stylized blockchain of linked hexagonal blocks; a small paper airplane (the relayer) carries the ribbon across a gap, while a faint parallel dotted path underneath shows an alternative direct route to the same blocks, suggesting a fallback. Composition is a left-to-right horizontal flow with generous negative space, subtle grid lines in the background evoking structured typed data. Color mood: deep navy and teal base tones with a single warm amber accent tracing the signature ribbon; soft diffuse lighting with gentle rim highlights on the crystalline gates. Fintech-engineering brand feel, precise and minimal, no text, no logos, no watermarks. Aspect ratio 16:9.
+A clean modern editorial illustration in an isometric style: a single elegant fountain pen signing a large translucent document sheet, and from the signature line a glowing continuous ribbon flows rightward through three identical crystalline gates (representing three synchronized systems) before terminating at a stylized blockchain of linked hexagonal blocks; a small paper airplane (the submitter who pays the fee) carries the ribbon across a gap, while a faint parallel dotted path underneath shows an alternative direct route to the same blocks, suggesting a fallback. Composition is a left-to-right horizontal flow with generous negative space, subtle grid lines in the background evoking structured signed data. Color mood: deep navy and teal base tones with a single warm amber accent tracing the signature ribbon; soft diffuse lighting with gentle rim highlights on the crystalline gates. Fintech-engineering brand feel, precise and minimal, no text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/10-relayer-gateway-architecture/blog.md
+++ b/docs/blog/posts/10-relayer-gateway-architecture/blog.md
@@ -1,125 +1,85 @@
-# Censor, Never Steal: Splitting a Relayer into a Policy Gateway and an Execution Engine
+# Censor, Never Steal: Why the Service That Decides Is Never the Service That Signs
 
-*How FairWins runs a hot gas key in production by making sure the service that decides is never the service that signs*
+*How FairWins runs a funded gas wallet on the open internet by splitting one server into two — a bouncer that decides, and an engine that pays*
 
 | | |
 |---|---|
 | **Series** | Gasless Rails (part 2 of 2) |
 | **Part** | 10 of 34 |
-| **Audience** | Infrastructure and backend engineers |
-| **Tags** | `relayer`, `infrastructure`, `gasless`, `cloud-run`, `api-gateway` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product, founders, and the technically curious |
+| **Tags** | `gasless`, `infrastructure`, `security`, `design` |
+| **Reading time** | ~7 minutes |
 
 ---
 
 ## The button that spends someone else's money
 
-In [part 1 of this series](../09-intent-based-gasless-payments/blog.md) we covered the protocol side of gasless intents: every actor action on the FairWins wager registry has an EIP-712 `…WithSig` twin, so a user with zero gas can sign a claim or an acceptance off-chain and let someone else pay to submit it. That post ended where this one begins — with an uncomfortable word: *someone*.
+In [part 1 of this series](../09-intent-based-gasless-payments/blog.md) we covered the friendly half of gasless transactions: on FairWins, a user with no cryptocurrency for network fees can still act. They sign an instruction — "accept this wager," "claim my winnings" — with their wallet, off to the side, for free. Someone else then pays the small network fee to actually submit it. That post ended on an uncomfortable word: *someone*.
 
-Someone has to run a server. That server has to hold a funded key, accept signed blobs from the open internet, and turn them into transactions it pays for. Every failure mode you can imagine is on the menu: the key gets stolen; a bot drains the gas wallet with ten thousand valid-but-worthless intents; a sanctioned wallet routes an action through your infrastructure; a single deliberately expensive transaction burns a week of gas budget; or the whole thing goes down at 2 a.m. and users with signed intents are stranded mid-wager.
+Someone has to run a server. That server holds a funded wallet, accepts signed instructions from anyone on the internet, and turns them into paid transactions. Every bad outcome you can picture is on the table: the wallet's key gets stolen; a bot floods the server until the gas budget is gone; a sanctioned wallet slips an action through; one deliberately expensive transaction burns a week's budget in a single shot; or the whole thing falls over at 2 a.m. and people are stuck mid-wager.
 
-FairWins had an extra constraint. The platform's standing directive is *no backend* — contracts, a static SPA, and a subgraph. The relayer is the deliberate, documented exception to that rule (spec 036 FR-001/FR-004), and being the exception raised the bar: if a server must exist, its blast radius has to be provably small.
+FairWins had an extra constraint. The platform's standing rule is *no backend* — just smart contracts, a static web app, and an indexer that reads the blockchain. This gas-paying server is the one deliberate exception, and being the exception raised the bar: if a server has to exist, its potential for damage has to be small enough to describe in a sentence.
 
-The answer that shipped is a split. One service decides *whether a transaction should exist*. A different service decides *how it gets mined*. Neither can do the other's job, and the design goal is a one-liner from the architecture doc: the hosted stack can only ever **censor, never steal**.
+The design that shipped does exactly that. One service decides *whether a transaction should exist at all*. A completely different service decides *how it gets paid for and confirmed*. Neither can do the other's job. The goal, in the team's own words: the hosted system can only ever **censor, never steal**.
 
-## The split: policy in front, mechanics behind
+## The split: a bouncer in front, an engine behind
 
-The deployed footprint is a single Cloud Run service running three sidecar containers that talk over localhost:
+Picture two machines wired together.
 
-- **`relay-gateway`** (`services/relay-gateway/`) — the policy front-end, written in-house. It terminates client traffic, recovers the signer from the EIP-712/EIP-3009 signature, and runs the full validation pipeline: kill switch → parse → chain active → payment-class support → target/action allow-list → signer recovery → param/window binding → dedup on the intent's `uniquenessMarker` → fail-closed sanctions re-screen → per-signer and global quotas → bounded-queue back-pressure → per-chain gas spend cap → fee check → encode the exact `…WithSig`/`…WithAuthorization` calldata.
-- **`oz-relayer`** (`services/oz-relayer/`) — the execution engine, an unmodified [OpenZeppelin Relayer](https://docs.openzeppelin.com/relayer) built from source at a pinned tag. It owns everything the gateway deliberately doesn't: per-chain nonce lanes, gas pricing and bumping (legacy type-0 transactions on Ethereum Classic networks, EIP-1559 on Polygon), inclusion tracking, RPC failover, and the gas key itself — held in Cloud KMS on an HSM, never exportable.
-- **Redis** — ephemeral queue state for the engine. Deliberately disposable: nonce and queue state reconstructs from chain, so losing it on restart is benign.
+The first is the **bouncer**. It faces the internet, receives each signed instruction, and runs it through a checklist before letting anything through. Is the system paused by its emergency switch? Is this a supported network and action? Who actually signed this — worked out mathematically from the signature itself, never taken on the sender's word? Have we already processed this exact instruction (no double-submitting)? Does the signer pass a sanctions screen and stay under their rate limit? Would this blow the fee budget? Only an instruction that clears every gate gets packaged up and handed onward.
 
-The seam between the two is intentionally narrow. The gateway's engine client (`services/relay-gateway/src/engine/client.js`) says it plainly:
+The second is the **engine**. It is a well-known open-source piece of infrastructure, run as-is, that does one unglamorous job well: take a fully-formed transaction, pay for it, and get it confirmed on the blockchain — managing the fiddly mechanics of ordering, pricing, retries, and switching to a backup connection if one fails. Crucially, the engine holds the gas wallet's key. That key lives inside a hardware security module — a tamper-resistant vault that can *use* the key to sign but can never hand the key out.
 
-```js
-/**
- * The engine sees ONLY a built transaction ({to, value, data, speed}) — never a
- * FairWins intent or the recovered signer; all policy stays in the gateway.
- * ...
- * Written as a thin adapter interface so the engine is swappable (rrelayer/MIT
- * fallback exposes an equivalent submit + webhook surface) without touching policy.
- */
-async submitTransaction({ relayerId, to, data, speed = 'fast' }) { ... }
-```
+Between the two machines is a deliberately tiny opening. The engine receives only a finished transaction: where it's going, and how fast to push it. It never sees the original instruction, never learns who signed it, and holds no opinions. All the judgment lives in the bouncer; all the mechanics live in the engine.
 
-That narrowness buys three things. First, the engine is **swappable** — it's an off-the-shelf OSS component behind a four-field interface, so if the project ever needs to change engines, no policy code moves. Second, the engine is **auditable by configuration**: its behavior is a declarative `config.json` (`services/oz-relayer/config/config.json`) with per-chain `gas_price_cap`, `min_balance`, and — crucially — `whitelist_receivers` pinning the gas key so it can only ever pay for calls into the FairWins proxy contracts. Third, the policy is **testable without a chain**: the gateway's pipeline is dependency-injected modules under `src/policy/`, exercised by vitest with every chain and engine access mocked.
+That narrow seam buys three things. The engine is **swappable** — it's off-the-shelf, so it could be replaced without touching a line of policy logic. The engine is **auditable by its settings** rather than its code — a plain configuration file pins a spending cap per network and, most importantly, a list of the only addresses it is ever allowed to pay. Even if hijacked, it could only ever pay into FairWins' own contracts. And the policy is **testable without touching a real blockchain**, because it's cleanly separated from the machinery.
 
-Status flows back the other way, and it is deliberately honest (FR-006): the engine calls a webhook on the gateway with an HMAC-SHA256 signature over the raw body, verified timing-safe, and only after that webhook reports the transaction mined does `GET /v1/intents/:id` ever say `confirmed`. The gateway never guesses.
+Status flows back honestly: the engine tells the bouncer when a transaction is genuinely confirmed on-chain, and only then does the app report it as done. The system never guesses or reports success early.
 
 ## Fail closed where money moves
 
-The most instructive policy module is the sanctions re-screen (`services/relay-gateway/src/policy/sanctions.js`). The on-chain contracts already screen every actor through `ISanctionsGuard` — so why screen again in the gateway? Because the relayer pays gas *before* the contract gets a chance to revert, and "we paid to submit a sanctioned wallet's transaction" is a sentence nobody wants to write. The gateway therefore re-screens the *recovered* signer — not any client-asserted address — against the same on-chain guard, and the failure semantics are strict:
+The most telling item on the checklist is the sanctions screen. The smart contracts already screen everyone — so why screen again? Because the gas wallet pays the network fee *before* the contract ever gets a chance to reject the transaction, and "we paid to submit a sanctioned wallet's transaction" is a sentence nobody wants to write. So the bouncer re-checks the true signer against the same on-chain screen.
 
-```js
-} catch {
-  // Fail closed: an unreachable/erroring guard is NEVER treated as allowed (SC-005).
-  throw new GatewayError(503, 'screening_unavailable',
-    'sanctions screening could not be performed; try again or self-submit')
-}
-if (!allowed) {
-  throw new GatewayError(403, 'sanctioned_signer', 'signer failed sanctions screening')
-}
-```
+The rule when that screen can't give a clear answer is strict: if it says no, reject; if it's *unreachable*, also reject — never "assume it's fine and pay anyway." This is the instinct across the whole checklist: when money is about to move, refuse rather than guess.
 
-Guard says no → `403`. Guard unreachable → `503`, never "assume fine and submit". The on-chain screen remains authoritative; this layer just guarantees the relayer's money never moves for a wallet the chain would reject.
+## What a total compromise actually buys an attacker
 
-The rest of the pipeline follows the same instinct. Only allow-listed `(targetContract, action)` pairs are ever encoded, and the target addresses are read from the version-pinned `deployments/*-chain<ID>-v2.json` records at startup — a mismatch fails boot (FR-025). Quotas are enforced per signer and globally, an estimated-gas spend cap bounds each chain per window, and a bounded queue turns overload into `429 backpressure` instead of an unbounded memory balloon.
+Because of the split, the worst case fits in a small table:
 
-## What a total compromise buys an attacker
-
-The split makes the trust budget legible enough to fit in a table:
-
-| Component | Holds | Can do | Cannot do |
+| Part | Holds | Can do | Cannot do |
 |---|---|---|---|
-| `relay-gateway` | two shared secrets (origin lock, webhook) | refuse/accept intents, screen, rate-limit | sign, move funds, forge a signer (it is *recovered*) |
-| `oz-relayer` engine | a KMS key *handle* | sign gas transactions to allow-listed receivers | exceed the gas price cap, pay non-whitelisted addresses, spend user funds |
-| Cloud KMS (HSM) | the secp256k1 gas key | produce signatures | export the private key |
-| Gas wallet | a small gas balance | pay gas | anything else — no contract authority |
+| Bouncer | two shared passwords | accept or refuse instructions, screen, rate-limit | sign anything, move funds, fake a signer |
+| Engine | the *ability to use* the gas key | pay for transactions to approved addresses only | exceed the spending cap, pay anyone else, touch user funds |
+| Hardware vault | the actual gas key | produce signatures | ever reveal the key |
+| Gas wallet | a small balance for fees | pay network fees | anything else — it has no special authority |
 
-Compromise the entire hosted stack and you get: the gas balance, plus the ability to refuse service. No user funds are reachable — stakes sit in escrow contracts that verify every signature themselves. No admin authority is reachable — contract admin keys live on the air-gapped floppy keystore, an entirely separate custody tier. The on-chain entrypoints re-verify and re-screen everything regardless of what the gateway claims. That is what "censor, never steal" means as an engineering property rather than a slogan.
+Take over the entire hosted system and here is your whole prize: the small gas balance, plus the power to refuse service for a while. No user funds are reachable — the stakes sit in escrow contracts that independently verify every signature themselves. No administrative power is reachable — the keys that could change the contracts live offline, on physically separate storage, in an entirely different security tier. The blockchain re-checks and re-screens everything regardless of what the server claims. That's what "censor, never steal" means as an engineering property rather than a slogan.
 
-## One policy chassis, two gasless rails
+## One checklist, two gasless systems
 
-FairWins runs two gasless rails, and here is where the split pays for itself twice. The first rail is the relayed intents above. The second (spec 050) is sponsored ERC-4337 UserOperations for passkey smart accounts: a self-hosted verifying paymaster contract (`contracts/account/FairWinsVerifyingPaymaster.sol`) reimburses a bundler — pimlico's **alto**, running as its own hardened service in `services/alto-bundler/` — from a FairWins-funded EntryPoint deposit.
+FairWins actually runs two flavors of gasless transactions, and this is where the split pays off twice.
 
-A sponsored UserOp needs a per-operation authorization signature, served over [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677). Rather than standing up a second policy service, the same gateway grew a `POST /v1/paymaster` route — and it *composes the same policy modules the intent path uses*. From `services/relay-gateway/src/paymaster/policy.js`:
+The first is the one above: signed instructions submitted on a user's behalf. The second serves the platform's passkey wallets — accounts you unlock with Face ID or a fingerprint (the same WebAuthn standard your phone already uses for passwordless sign-in). For these, FairWins can sponsor the network fee directly, so the user pays nothing.
 
-> The killswitch, sanctions screen, and per-account/global quotas are the SAME modules the intent path uses (composed in the route); this module adds the two per-op ceilings that bound a single sponsored op's cost so one deliberately-expensive UserOp can't burn a large slice of the deposit.
-
-So the paymaster path is: shared killswitch → shared sanctions screen → shared quota factory (keyed by smart account) → two new per-op ceilings (`gas_ceiling_exceeded`, `cost_ceiling_exceeded`) → KMS-signed approval with a short validity window. One perimeter, one audit stream, one kill switch — two economically distinct rails. Even the health endpoint unifies them: `/healthz` reports both the gas wallet's runway in hours and the paymaster's EntryPoint deposit runway, so operators watch one number pair for both rails.
-
-The same chassis has since absorbed the platform's other gateway needs — the OpenSea collectibles proxy (specs 055/056) and the Polymarket trading proxy (spec 057) ride the same origin lock, killswitch, and quota machinery. The policy gateway turned out to be the platform's one reusable backend.
+Rather than build a second server, the same bouncer simply grew a second door. Sponsoring a fee reuses the *same* emergency switch, the *same* sanctions screen, and the *same* rate limits — plus two extra ceilings that cap what any single sponsored action can cost, so one deliberately expensive request can't drain the sponsorship fund. One perimeter, one audit trail, one emergency switch, covering two economically different systems. The same checklist has since taken on the platform's other outside connections too — the collectibles marketplace and the prediction-market trading feature. This bouncer turned out to be the platform's one reusable piece of backend.
 
 ## Optional by construction: the never-stranded rule
 
-Everything above would still be a liability if users *needed* it. They don't. Spec 036's FR-002 — the never-stranded rule — requires that every covered action completes via self-submit with an identical on-chain result when the relayer is stopped, killed, or censoring.
+All of this would still be a liability if people *needed* it. They don't. A firm rule holds throughout: every action that can go through the gas-paying server must also complete perfectly well *without* it, landing exactly the same result on the blockchain — the user just pays their own small network fee.
 
-The client enforces this mechanically. Before requesting a signature, the SPA's intent client probes the gateway's status endpoint with a bounded ~2-second timeout. Probe fails, kill switch active, chain reported down, or any relay error mid-flow → the SPA silently routes the same action through the user's own wallet as a normal user-paid transaction. Same calldata target, same on-chain result; the only difference is who paid.
+The app enforces this automatically. Before asking you to sign, it quietly checks whether the server is healthy. If that check fails, the emergency switch is on, the network looks down, or anything goes wrong mid-flow, the app silently routes the very same action through your own wallet as an ordinary paid transaction. Same destination, same result; the only difference is who covered the fee. The sponsored-passkey path behaves the same way — any problem, and the confirmation screen honestly says the user is paying.
 
-The paymaster rail has the same property in ERC-7677 terms: any error from `POST /v1/paymaster` — unsupported chain, unconfigured signer, ceiling exceeded — and the SPA rebuilds the UserOp without a paymaster and self-funds it, with the confirm UI honestly disclosing that the user pays.
-
-Optionality also shapes operations (`docs/runbooks/relayer-operations.md`). The kill switch (FR-015) is boot-configurable and toggleable at runtime via `SIGUSR2`; flipping it turns `POST /v1/intents` into `503 killswitch_active` while status polling stays up and in-flight engine transactions still track to inclusion — no accepted intent is dropped, and every new one degrades to self-submit. Because the worst case is "users pay their own gas," the kill switch is cheap to pull, which means operators will actually pull it.
+Because the worst case is merely "users pay their own fee," the emergency switch is cheap to pull — which means operators will actually pull it when they should.
 
 ## Design decisions
 
-**Build the policy, buy the engine.** Nonce management, gas bumping, and RPC failover are solved problems with sharp edges; the OpenZeppelin Relayer does them well, and FairWins runs it unmodified from a pinned tag (AGPL-safe — configured, never forked). The policy layer, by contrast, encodes FairWins-specific judgments — which contracts, which actions, whose signatures, what limits — that no off-the-shelf relayer could know. The split puts custom code exactly where the custom decisions are.
+**Build the judgment, buy the machinery.** Transaction ordering, fee pricing, and connection failover are solved problems with sharp edges; a mature open-source engine handles them well. The judgment layer — which contracts, which actions, whose signatures, what limits — encodes FairWins-specific calls no off-the-shelf tool could know. The split puts custom code exactly where the custom decisions are.
 
-**Single instance first, honestly.** Phase 1 pins Cloud Run to one instance; dedup, quotas, and spend counters are in-process. That is admitted plainly in the README rather than hidden: restart loss is benign because the on-chain `uniquenessMarker` is single-use — a replayed intent can never double-spend — and a momentarily reset rate limit is a loosening, not a breach. The policy modules are factories with narrow interfaces precisely so Phase 2 can swap in shared Redis without touching the pipeline.
+**Fail closed on money, fail soft on availability.** Screening and address-pinning fail closed — the bouncer would rather refuse than guess. Availability fails soft — every refusal degrades to self-pay. The asymmetry is the whole point: the only thing this infrastructure is ever allowed to break is its own usefulness.
 
-**Fail closed on money, fail soft on availability.** Sanctions screening and target pinning fail closed — the gateway would rather refuse than guess. Availability fails soft — every refusal degrades to self-submit. The asymmetry is the point: the only thing this infrastructure is allowed to break is its own usefulness.
+## Further reading
 
-**Document the wart.** The engine's Cloud KMS signer (v1.4.0) cannot use keyless workload identity and needs an exported service-account key — held in Secret Manager, scoped to `signerVerifier` only, flagged in the architecture doc as a tracked follow-up rather than quietly accepted. Known limitations written down are limitations that get fixed.
-
-## Sources
-
-- `specs/036-relayer-infrastructure/` — spec, plan, data model, API contracts
-- `docs/architecture/relayer-infrastructure.md` — system context, topology, trust boundaries
-- `docs/runbooks/relayer-operations.md` — kill switch, key rotation, funding
-- `docs/developer-guide/gasless-intents.md` — protocol semantics (part 1 of this series)
-- `services/relay-gateway/` — policy gateway (`src/policy/`, `src/engine/client.js`, `src/paymaster/`, `src/server.js`, `README.md`)
-- `services/oz-relayer/config/config.json` — engine policies (gas caps, receiver whitelist)
-- `services/alto-bundler/README.md` — bundler hardening for the sponsored-UserOp rail
-- `specs/050-sponsored-paymaster/` + `docs/runbooks/paymaster-operations.md` — ERC-7677 sponsorship
-- [EIP-712](https://eips.ethereum.org/EIPS/eip-712), [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009), [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337), [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677)
-- [OpenZeppelin Relayer documentation](https://docs.openzeppelin.com/relayer)
+- [WebAuthn / passkeys](https://en.wikipedia.org/wiki/WebAuthn) — the passwordless standard behind Face ID and fingerprint sign-in
+- [Account abstraction (ERC-4337)](https://eips.ethereum.org/EIPS/eip-4337) — the standard behind smart-account wallets and sponsored fees
+- [Hardware security module](https://en.wikipedia.org/wiki/Hardware_security_module) — the tamper-resistant vault that uses a key without revealing it
+- [OpenZeppelin Relayer documentation](https://docs.openzeppelin.com/relayer) — public docs for the kind of execution engine described here

--- a/docs/blog/posts/10-relayer-gateway-architecture/social.md
+++ b/docs/blog/posts/10-relayer-gateway-architecture/social.md
@@ -2,26 +2,26 @@
 
 ## X (Twitter)
 
-How do you run a hot gas key in production? Make sure the service that decides is never the service that signs. Our relayer splits policy (screening, quotas, killswitch) from execution (nonces, gas, KMS key) — worst case: censor, never steal. 🔗 <link> #web3 #infrastructure #gasless
+How do you run a funded gas wallet on the open internet safely? Make sure the service that decides is never the service that signs. FairWins splits the gasless server into a bouncer (screening, limits, emergency switch) and an engine (pays and confirms). Worst case: censor, never steal. 🔗 <link> #web3 #gasless #security
 
 ## LinkedIn
 
-Gasless transactions sound great until you're the one operating the relayer: a funded key on a server, accepting signed blobs from the open internet, paying gas for strangers.
+Gasless transactions sound great until you're the one running the server behind them: a funded wallet, accepting signed instructions from anyone on the internet, paying network fees for strangers.
 
-Part 2 of our Gasless Rails series covers how FairWins made that server safe to run — by splitting it in two. A policy gateway decides whether a transaction should exist; a separate execution engine decides how it gets mined. Neither can do the other's job.
+Part 2 of our Gasless Rails series covers how FairWins made that server safe to run — by splitting it in two. A bouncer decides whether a transaction should exist at all; a separate engine decides how it gets paid for and confirmed. Neither can do the other's job.
 
 The post walks through:
 
-- The policy/engine seam: the gateway recovers signers, screens them fail-closed against an on-chain sanctions guard, enforces quotas and spend caps — then hands the engine only `{to, data, speed}`, never the intent
-- Why the trust budget fits in a table: a full compromise of the hosted stack yields the gas balance plus the ability to refuse service — no user funds, no admin authority
-- How the same policy chassis serves two rails: relayed EIP-712 intents and an ERC-7677 verifying-paymaster endpoint for ERC-4337 UserOps, sharing one killswitch, one quota system, one audit stream
-- The never-stranded rule: every flow degrades to self-submit with an identical on-chain result, so the kill switch is cheap enough to actually pull
+- The seam between the two: the bouncer works out who really signed, screens them, enforces limits and spend caps — then hands the engine only a finished transaction, never the original instruction
+- Why the worst case fits in a small table: a full takeover of the hosted system yields the small gas balance plus the ability to refuse service — no user funds, no admin authority
+- How one checklist serves two gasless systems — user-signed instructions and sponsored fees for passkey (Face ID) wallets — sharing one emergency switch, one set of limits, one audit trail
+- The never-stranded rule: every flow falls back to self-pay with an identical on-chain result, so the emergency switch is cheap enough to actually pull
 
 Read it here: <link>
 
-If you operate relayers or paymasters: where do you draw the line between policy and execution — and what does a total compromise of your stack actually buy an attacker?
+Where would you draw the line between deciding and executing — and what would a total compromise of your setup actually buy an attacker?
 
-#web3 #ethereum #infrastructure #accountabstraction #relayer
+#web3 #gasless #infrastructure #security #fintech
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/11-uups-upgrades-storage-safety/blog.md
+++ b/docs/blog/posts/11-uups-upgrades-storage-safety/blog.md
@@ -1,128 +1,74 @@
-# UUPS Upgrades Without the Footguns: One Base Contract, One CI Gate
+# Renovating a Contract Without Changing Its Address
 
-*How FairWins ships new escrow logic to a live, funds-bearing address — and why a storage-layout check runs before every merge*
+*How FairWins ships new escrow logic to a live, funds-holding contract — and why an automated safety check runs before every change is allowed in*
 
 | | |
 |---|---|
 | **Series** | Contract Architecture (part 1) |
 | **Part** | 11 of 34 |
-| **Audience** | Solidity engineers |
-| **Tags** | `uups`, `proxy`, `upgradeable`, `storage-layout`, `solidity` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product, founders, and the technically curious |
+| **Tags** | `smart-contracts`, `upgrades`, `safety`, `design` |
+| **Reading time** | ~7 minutes |
 
-## The redeploy that strands everyone
+---
 
-Picture the escrow contract at the center of a peer-to-peer wager platform. It holds real stakes — USDC locked between counterparties — indexed by a subgraph, addressed by a frontend, referenced by every open wager. Now the roadmap calls for open-challenge wagers: a new creation path, new state, new events, on the same contract.
+## The move that strands everyone
 
-Before spec 025, FairWins had exactly one way to ship that: deploy a new contract at a new address. And a new contract starts with empty storage. Every wager, every balance, every mapping on the old address is left behind. Existing wagers become **stranded** — still holding funds, but on a contract the app no longer points at. Users get migrated or settled out-of-band on every release. The frontend and subgraph get repointed. Nobody enjoys any of it.
+Picture the escrow contract at the center of a peer-to-peer wager platform. It holds real stakes — dollars in stablecoin, locked between two people who have a bet running. A whole ecosystem points at it: the app, the blockchain indexer, every open wager. Now the roadmap calls for a new kind of wager — open challenges anyone can accept — which means new logic on that same contract.
 
-The fix is old news in principle — put a proxy in front of the logic — but the failure modes of upgradeable contracts are notorious enough that "just use UUPS" is not a plan. An uninitialized implementation can be hijacked. A constructor that silently never runs behind a proxy can start your wager IDs at zero. One reordered state variable can scramble the storage of a contract that custodies user money, and Solidity will not warn you.
+Here's the catch that makes smart contracts different from ordinary software. A normal app, you deploy the new version over the old one. A smart contract, historically, you cannot edit at all. The only way to "change" one was to deploy a brand-new contract at a brand-new address — and a brand-new contract starts completely empty. Every wager, every balance, every record on the old address gets left behind, **stranded**: still holding people's money, but at an address the app no longer points to. Users would have to be migrated or paid out by hand on every single release.
 
-So FairWins built the upgrade machinery once, made it boring, and made the dangerous part mechanically impossible to merge. Seven contracts now sit behind UUPS proxies at stable addresses — `WagerRegistry`, `MembershipManager`, `TokenFactory`, `ExternalDAORegistry`, `WagerPoolFactory`, `CallsignRegistry`, `FeeRouter` — all inheriting a single ~40-line base, all validated by the same CI gate.
+The fix, in principle, is old news: put a permanent *front door* in front of the logic. The address people use never changes; the logic behind it can be swapped. Think of it as renovating a building without changing its street address — the tenants, the mail, the lease all stay put; only the interior gets redone.
 
-## The shape: ERC-1967 proxy, UUPS logic
+But "just make it upgradeable" is not a plan, because the failure modes are genuinely nasty. Done carelessly, a fresh renovation can be hijacked by a stranger before anyone moves in. A setup step that quietly fails to run can leave the whole thing subtly broken. And — the scariest one — rearranging where the building stores its records can scramble everything already on the shelves, silently, with no warning from any tool. When those records are people's escrowed money, "silently scrambled" is a catastrophe.
 
-Each upgradeable contract is an [ERC-1967](https://eips.ethereum.org/EIPS/eip-1967) proxy in front of a swappable implementation, using the UUPS pattern ([EIP-1822](https://eips.ethereum.org/EIPS/eip-1822)): the upgrade function lives in the *implementation*, not the proxy, keeping the proxy minimal and the upgrade authorization logic upgradeable itself. The proxy address is the stable one — the address users, the frontend, and the subgraph consume. The implementation changes on every upgrade.
+So FairWins built the renovation machinery once, made it boring, and made the dangerous part *impossible to slip through*. Seven contracts now sit behind permanent front doors at stable addresses — the wager escrow, the membership system, the fee router, and others — all built on one small shared foundation, all guarded by the same automated check.
 
-`deployments/<network>-chain<id>-v2.json` records **both**: the proxy under e.g. `wagerRegistry` and the current implementation under `wagerRegistryImpl`. That dual record is not bookkeeping trivia — the storage-layout gate diffs new code against the *recorded deployed implementation*, so the file is what makes the safety check network-aware.
+## The shape: a permanent front door, swappable rooms
 
-## One base to inherit, not copy
+Each upgradeable contract is really two pieces: a thin, permanent **front door** at a fixed address that never changes, and the **current logic** behind it, which is what actually gets swapped during a renovation. FairWins keeps a written record of *both* addresses for every contract. That second address isn't just bookkeeping — the safety check compares any proposed new logic against *the exact logic currently live on that network*, so this record is what lets the check know what it's protecting.
 
-The reusable piece is `contracts/upgradeable/UUPSManaged.sol`. It contains no business logic — just the upgrade and access machinery every adopter needs, wired so the classic UUPS mistakes can't be made twice:
+## One shared foundation, not seven copies
 
-```solidity
-abstract contract UUPSManaged is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
-    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+The reusable piece is a small shared foundation — a few dozen lines — that every upgradeable contract builds on. It carries no business logic of its own, just the renovation-and-access plumbing everyone needs, wired so the classic mistakes can't be made twice. Three choices are baked in.
 
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
-        _disableInitializers();
-    }
+**A fresh renovation can never be hijacked.** The raw logic, sitting off to the side before it's wired up behind a front door, is reachable by anyone; left open, a stranger could "move in" first and cause mischief. The foundation permanently locks that side door shut the moment the logic is created. Only the real front door can ever be set up, and only once — closing the textbook attack cold.
 
-    function __UUPSManaged_init(address admin) internal onlyInitializing {
-        __UUPSUpgradeable_init();
-        __AccessControl_init();
-        _grantRole(DEFAULT_ADMIN_ROLE, admin);
-        _grantRole(UPGRADER_ROLE, admin);
-    }
+**Upgrade power is separate and can never be lost.** The authority to install new logic is its own dedicated key, kept apart from general administration, so it can later be handed to time-delayed or multi-signature governance without touching code. And because the "how to upgrade me" instructions live in the shared foundation every version inherits, no upgrade can accidentally delete the ability to do *future* upgrades. On live networks that key is held on air-gapped, offline storage — with a blunt trade-off: lose it and the contract keeps running forever but can never be renovated again.
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+**Room to grow is reserved up front.** The foundation sets aside a block of empty, reserved space so shared features can be added later without disturbing anything already in place — which brings us to the single most important rule of the whole system.
 
-    uint256[50] private __gap;
-}
-```
+## Setup runs once, and the bug everyone hits
 
-Three deliberate choices are packed in here.
+Because of how the front-door arrangement works, the normal "set things up when the contract is first created" step runs in the wrong place and gets ignored. So every contract does its initial setup through a special routine that runs exactly once, behind the real front door.
 
-**The implementation can never be initialized.** The constructor calls `_disableInitializers()`, so a bare implementation contract — the thing sitting at `wagerRegistryImpl`, reachable by anyone — can never be initialized and hijacked. Only the proxy, delegatecalling into this logic, can be initialized, and only once. This closes the textbook UUPS attack where someone initializes the raw implementation, grants themselves the upgrade role on it, and `selfdestruct`s or redirects it.
+This is where teams get burned. Any starting value set the "old" way — say, "wager numbering begins at 1" — silently never takes effect behind a front door, so wagers would start numbering at zero instead, with no compiler warning. The rule that prevents it is simple: don't set starting values inline; set every one inside that one-time routine. FairWins hit exactly this and calls it out in its developer guide. Later upgrades that need to set up *new* state get their own controlled one-time step, which can only ever run once.
 
-**Upgrades are least-privilege and non-brickable.** `UPGRADER_ROLE` is separate from `DEFAULT_ADMIN_ROLE`, so upgrade authority can later move to a timelock or multisig with no code change. And `_authorizeUpgrade` lives in the base every implementation inherits — it is never removed by an upgrade, so the ability to perform *future* upgrades is always preserved. On live networks the role is held by an air-gapped floppy-keystore admin; the runbook is blunt about the flip side: lose that key and the contract keeps working but can never be upgraded again.
+## Append-only records, and a reserve that shrinks on schedule
 
-**The base reserves its own gap.** `uint256[50] private __gap` at the base level means FairWins can add base state later without shifting every child's layout. (The OpenZeppelin `*Upgradeable` parents contribute no sequential slots — they use [ERC-7201](https://eips.ethereum.org/EIPS/eip-7201) namespaced storage.)
+Here is the rule that keeps escrowed money safe across renovations, stated plainly: **never rearrange, remove, or change the meaning of any record the contract already keeps — only ever add new ones at the end.** Think of the contract's storage as numbered shelves. Insert something in the middle and everything downstream shifts by one; now the contract reads balances off the wrong shelf. So new records only ever go on the end, drawing down from that reserved block of empty space set aside up front.
 
-## `initialize` replaces the constructor — and one bug everyone hits
+This isn't theoretical. FairWins' wager registry has been renovated twice this way — the open-challenge feature added a couple of records, a later gasless-payments upgrade added a few more — and the reserve shrank by exactly that much each time, so everything already on the shelves stayed put. The reserve getting smaller over time is the system working as intended; you can read the contract's history in that single shrinking number.
 
-Behind a proxy, a constructor runs in the implementation's context and never touches proxy storage. So adopters replace it with a one-time `initialize` guarded by OpenZeppelin's `initializer` modifier. `WagerRegistry`'s version (in `contracts/wagers/WagerRegistry.sol`) calls `__UUPSManaged_init(admin)` first, then does exactly what the old constructor did — with one line that earns its comment:
+## The gate: making the unsafe change impossible to merge
 
-```solidity
-_nextWagerId = 1; // MOVED from the inline initializer (must run behind the proxy)
-```
+Good intentions don't survive a busy Tuesday afternoon. So the append-only rule isn't left to discipline — it's enforced by an automated check that runs before any change is allowed to merge, and fails the build loudly if violated. Built on well-regarded open-source upgrade-safety tooling, it compares proposed new logic against *what is actually running on that network right now* and confirms the records line up shelf-for-shelf. Rearrange, remove, or repurpose a shelf and the check fails before the upgrade can even exist.
 
-This is the single most common conversion bug, called out in `docs/developer-guide/upgradeable-contracts.md`: an **inline state initializer** like `uint256 _nextWagerId = 1;` runs in constructor context and is silently ignored behind a proxy. Miss it and your wager IDs start at 0 — a bug no compiler flags. The rule: declare bare, assign inside `initialize`.
-
-Later upgrades that need to seed new state get a `reinitializer(N)`. When feature 024 (open challenges) landed as an in-place upgrade, the already-initialized proxy needed its EIP-712 domain set — so `initializeOpenChallenges() external reinitializer(2)` calls `__EIP712_init(...)`, invoked via `upgradeToAndCall` during the upgrade. Fresh deploys set the domain in `initialize` and can never call the reinitializer (version 2 > version 1). State that defaults to zero needs no reinitializer at all.
-
-## Append-only storage, and a gap that shrinks on schedule
-
-Proxy storage safety reduces to one rule: **never insert, reorder, remove, or retype existing state variables — only append.** Each contract ends its state with a trailing reserve, and appended state consumes it. `contracts/wagers/WagerRegistryCore.sol` — the single storage-layout definition shared by both registry facets — shows the rule living through two real upgrades:
-
-```solidity
-/// @dev Trailing storage reserve for append-only upgrades. Reduced 50 → 48 when the two
-///      open-challenge mappings were appended (feature 024), then 48 → 45 for spec 035
-///      (`feeNettingEnabled`+`gasFeeRecipient` pack into one slot, `maxGasFee`, `intentExtension`).
-///      Never insert or reorder existing state above this gap.
-uint256[45] private __gap;
-```
-
-Feature 024 appended two mappings (gap 50 → 48). Spec 035 appended a packed `bool`+`address` slot, a `uint256`, and an `address` (48 → 45). The gap shrinks by exactly the slots appended, so total layout size — and everything above the gap — never moves.
-
-## The CI gate: making the unsafe upgrade unmergeable
-
-Convention alone doesn't survive contact with a Tuesday afternoon. So the rule is enforced by `npm run check:storage-layout` (`scripts/deploy/check-storage-layout.js`), gating in CI via `.github/workflows/test.yml`. Built on OpenZeppelin's `hardhat-upgrades` validators, it runs two checks per contract in `UPGRADEABLE_CONTRACTS`:
-
-- **With a recorded deployment** (an `<key>Impl` address in `deployments/`): `upgrades.validateUpgrade(deployedImpl, Factory, { kind: "uups" })` — the new implementation must be storage-layout *compatible* with what is actually on-chain. A reordered, removed, or retyped slot fails the build before the upgrade can exist.
-- **Without one**: `upgrades.validateImplementation(...)` — the unsafe-pattern checks (missing `_disableInitializers`, stray `selfdestruct`/`delegatecall`, non-namespaced base storage).
-
-Adding a contract to the gate is one line — `{ name: "FeeRouter", deploymentsKey: "feeRouter" }` — which is how five later adopters inherited spec 025's safety net for free. The script exits non-zero on any failure; per project constitution, CI fails loudly.
-
-And the check is defense-in-depth, not the last line: the deploy tooling in `scripts/deploy/lib/upgradeable.js` runs the same validation again at execution time. `upgradeProxy({ name, proxyAddress })` calls OZ's `validateUpgrade` *before anything is sent on-chain*, deploys the new implementation, calls `upgradeToAndCall` signed by the `UPGRADER_ROLE` admin, and reports both addresses so `deployments/` records the new `…Impl`. An incompatible upgrade throws locally instead of corrupting funds remotely. `deployProxy` is only for first-time cutover — the runbook warns that re-running the deploy script mints a *new* proxy; to change logic on a live deployment you run an upgrade, never a redeploy.
-
-The pattern has been exercised for real: feature 024 shipped as an in-place upgrade of the `wagerRegistry` proxy, and spec 026's voucher redemption as the first in-place upgrade of the `membershipManager` proxy — same address, all state preserved, ABI grows.
+Adding a new contract to this protection is a one-line change, which is how five later contracts inherited the original safety net for free. And it's belt-and-suspenders: the deployment tooling runs the same validation *again* at the moment of upgrade, before anything is sent to the blockchain — so an incompatible change fails harmlessly on a developer's machine instead of corrupting funds on a live network. To change a live contract you renovate it in place; re-running the *initial* deploy would mint a whole new front door at a new address, so you never do that.
 
 ## Design decisions
 
-**UUPS over Transparent proxy.** The upgrade function in the implementation keeps the proxy minimal and lets the authorization policy itself evolve. The cost — an implementation that forgets `_authorizeUpgrade` bricks upgrades — is neutralized by putting the gate in the inherited base, where no upgrade can drop it.
+**A shared foundation instead of per-contract copies.** Copy-pasted plumbing drifts, and drifted plumbing is exactly where a locked side door quietly gets left open. One shared foundation centralizes all the dangerous parts, so adopting it is nearly mechanical: build on the foundation, move setup into the one-time routine, reserve some growing room, register with the tooling.
 
-**A shared base instead of per-contract wiring.** Copy-pasted proxy plumbing drifts; drifted plumbing is where initializer lockouts get forgotten. `UUPSManaged` centralizes `_disableInitializers`, the role grants, and the upgrade gate, so an adopter's diff is just: inherit, convert constructor to `initialize`, add a `__gap`, register with the tooling.
+**Coexistence instead of a risky mass migration.** The old, non-upgradeable registry couldn't be retrofitted, and moving live escrow en masse was judged too dangerous. So old wagers stay settle-only at the old address while every new wager lands on the new front door, and the app shows both honestly until the old side drains naturally.
 
-**Coexistence over migration at cutover.** The legacy non-upgradeable registry couldn't be retro-wrapped, and on-chain state migration of live escrow was judged unsafe for v1. Spec 025 chose coexistence: legacy wagers stay settle-only on the old address while all new wagers land on the proxy, and the app surfaces both honestly until the legacy side drains.
+**Roll forward, never back.** There's no automatic undo. A bad renovation is fixed by renovating *again* to a corrected version — and because the ability to do future upgrades can never be lost, that path is always open.
 
-**No downgrades — roll forward.** There is no automatic rollback. A bad upgrade is corrected by upgrading again to a fixed implementation; the non-brickable gate guarantees that path always exists, and prior implementation addresses live in the deployments file's git history if re-pointing to a known-good build is the fastest fix.
+**Honest limits.** Upgradeability is a trust statement, not a free lunch: whoever holds the upgrade key can replace the code that holds user stakes. FairWins mitigates that with separated keys, offline signing, and a documented path to time-delayed or multi-signature governance — but "upgradeable" and "immutable" are opposite promises, and the platform makes that choice deliberately, per contract. Some, like a bearer collectible meant to be permanent, are intentionally left *un*-upgradeable.
 
-**Honest limits.** Upgradeability is a trust statement, not a free lunch: whoever holds `UPGRADER_ROLE` can replace the code that custodies user stakes. FairWins mitigates with least-privilege role separation, an air-gapped signing key, and a documented path to a timelock/multisig — but "upgradeable" and "immutable" are opposite promises, and the platform makes that choice per contract deliberately (the `MembershipVoucher` bearer NFT, for instance, is intentionally *not* upgradeable).
+## Further reading
 
-## Sources
-
-- `specs/025-upgradeable-registry/spec.md` — motivation, coexistence cutover, upgrade-safety clarifications
-- `specs/027-upgradeable-membership/` — second adopter (MembershipManager)
-- `contracts/upgradeable/UUPSManaged.sol` — shared base (role gate, initializer lockout, base `__gap`)
-- `contracts/wagers/WagerRegistry.sol` / `contracts/wagers/WagerRegistryCore.sol` — `initialize`, `reinitializer(2)`, append-only storage history
-- `scripts/deploy/check-storage-layout.js` + `.github/workflows/test.yml` — the CI gate
-- `scripts/deploy/lib/upgradeable.js` — `deployProxy` / `upgradeProxy` / `getImplementation`
-- `docs/developer-guide/upgradeable-contracts.md` — adopter guide, inline-initializer bug
-- `docs/runbooks/contract-upgrades.md` — pre-flight, in-place upgrade, rollback, failure modes
-- `deployments/mordor-chain63-v2.json` — proxy + implementation records
-- EIP-1822 (UUPS): https://eips.ethereum.org/EIPS/eip-1822
-- ERC-1967 (proxy storage slots): https://eips.ethereum.org/EIPS/eip-1967
-- ERC-7201 (namespaced storage): https://eips.ethereum.org/EIPS/eip-7201
-- OpenZeppelin UUPS & Upgrades Plugins docs: https://docs.openzeppelin.com/contracts/5.x/api/proxy#UUPSUpgradeable, https://docs.openzeppelin.com/upgrades-plugins/
+- [Upgradeable smart contracts — OpenZeppelin docs](https://docs.openzeppelin.com/upgrades-plugins/) — the public tooling and patterns this design builds on
+- [Proxy pattern (upgradeable contracts) — overview](https://blog.openzeppelin.com/proxy-patterns) — plain-language introduction to the front-door approach
+- [The Spurious Dragon hardfork](https://en.wikipedia.org/wiki/Ethereum) — background on why contracts have hard limits at all
+- For FairWins-specific details, see the FairWins developer documentation.

--- a/docs/blog/posts/11-uups-upgrades-storage-safety/social.md
+++ b/docs/blog/posts/11-uups-upgrades-storage-safety/social.md
@@ -2,26 +2,26 @@
 
 ## X (Twitter)
 
-Shipping new logic to a live escrow contract without stranding a wager: 7 UUPS proxies, one ~40-line shared base, and a CI gate that diffs storage layouts against the deployed impl before merge. The `__gap` shrank 50→48→45 — on purpose. 🔗 <link> #Solidity #UUPS #web3
+How do you ship new logic to a live escrow contract without stranding people's money? Renovate the building without changing its address: a permanent front door, swappable logic behind it, and an automated check that refuses any change that would scramble the records. 🔗 <link> #web3 #smartcontracts #security
 
 ## LinkedIn
 
-Every Solidity team eventually faces the same problem: the contract holding user funds needs new logic, but a fresh deployment starts with empty storage — stranding every balance and mapping at the old address.
+Every smart-contract team eventually faces the same problem: the contract holding user funds needs new logic — but historically, "changing" a contract meant deploying a fresh one at a new address, stranding every balance at the old one.
 
-Our latest engineering post walks through how FairWins made in-place upgrades boring (in the best way) across seven UUPS proxies, from the wager escrow to the fee router:
+Our latest post walks through how FairWins made in-place upgrades boring (in the best way), using an analogy: renovating a building without changing its street address. The tenants, mail, and lease stay put; only the interior gets redone.
 
-- A single shared base, `UUPSManaged`, that locks out implementation hijacking (`_disableInitializers`), separates `UPGRADER_ROLE` from admin, and keeps the upgrade path non-brickable by construction
-- Constructor-to-`initialize` conversion, including the silent bug everyone hits: inline state initializers that never run behind a proxy
-- Append-only storage with a trailing `__gap` that shrinks by exactly the slots each upgrade appends — with the real history from two shipped upgrades
-- A CI-gated storage-layout check that validates new code against the *recorded deployed implementation*, so a state-corrupting upgrade fails the build instead of corrupting funds
+- A single shared foundation that locks the door on hijacking a fresh renovation, keeps upgrade power separate, and makes it impossible to lose the ability to upgrade again later
+- The silent bug everyone hits: setting starting values the "old" way, which quietly never takes effect behind a permanent front door
+- Append-only records — think numbered shelves you only ever add to — so an upgrade can never scramble what's already stored
+- An automated check that compares proposed new logic against what's actually running live, and fails the build before a fund-corrupting change can ship
 
-We also cover the honest trade-off: upgradeability is a trust statement, and some contracts (like bearer-asset NFTs) deliberately stay immutable.
+We also cover the honest trade-off: upgradeability is a trust statement, and some contracts (like a permanent bearer collectible) deliberately stay immutable.
 
 Read the full post: <link>
 
-How does your team gate storage-layout compatibility — CI, deploy-time validation, or both?
+How does your team keep upgrades from corrupting live state — automated checks, deploy-time validation, or both?
 
-#Solidity #SmartContracts #UUPS #DevOps #Ethereum
+#web3 #smartcontracts #security #fintech #engineering
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/12-two-facet-proxy-24kb/blog.md
+++ b/docs/blog/posts/12-two-facet-proxy-24kb/blog.md
@@ -1,146 +1,80 @@
-# The Two-Facet Proxy: Beating the 24 KB Contract-Size Limit
+# One Contract, Two Halves: Beating a Hard Size Limit Without Moving House
 
-*How FairWins added sixteen gasless entrypoints to a contract with 116 bytes of headroom — without adopting a Diamond*
+*How FairWins added sixteen new gasless features to a contract that had almost no room left — without changing the address everyone already relies on*
 
 | | |
 |---|---|
 | **Series** | Contract Architecture (part 2) |
-| **Part** | 2 of 3 |
-| **Audience** | Solidity engineers hitting the EIP-170 size ceiling |
-| **Tags** | `eip170`, `proxy`, `delegatecall`, `facets`, `solidity`, `diamond-adjacent` |
-| **Reading time** | ~9 minutes |
+| **Part** | 12 of 34 |
+| **Audience** | Product, founders, and the technically curious |
+| **Tags** | `smart-contracts`, `architecture`, `gasless`, `design` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-## 116 bytes of headroom
+## A strict page limit, almost reached
 
-Every ambitious protocol eventually meets the same compiler output:
+Ethereum-style blockchains impose a rule that surprises people the first time they hit it: a deployed smart contract cannot exceed a fixed size — roughly 24 kilobytes of compiled code. It's a hard ceiling baked into the network for a good reason (it stops one contract from forcing every computer on the network to load an unboundedly large program), and it isn't going away. Think of it as a strict page limit on a document that must fit in a single binder.
 
-```
-Warning: Contract code size is 24460 bytes and exceeds 24576 bytes (a limit
-introduced in Spurious Dragon). This contract may not be deployable on Mainnet.
-```
+FairWins' central wager contract had almost filled that binder. When the team set out to add platform-wide *gasless* features — acting without paying network fees yourself — the contract had already compiled to within a hair of the limit: about 116 bytes of headroom left. Not 116 kilobytes — 116 *bytes*, roughly the length of this sentence.
 
-Except in our case it wasn't a warning yet. When FairWins started spec 035 — platform-wide gasless intents — the `WagerRegistry` implementation compiled to **24,460 of 24,576 bytes**. That's 116 bytes of headroom. The feature called for roughly sixteen new signer-attributed entrypoints: a `…WithSig` or `…WithAuthorization` twin for every core action (create, accept, claim, refund, draw, decline, declare-winner, and the open-challenge variants), each carrying EIP-712 verification, replay-nonce bookkeeping, and for the money-in paths an atomic EIP-3009 stake pull plus optional fee netting.
+The new work needed far more than that. It called for roughly sixteen new entry points: for every core action — create a wager, accept one, claim winnings, request a refund — a companion version that lets someone act by signing an instruction instead of paying fees directly, each carrying its own signature-checking and anti-replay bookkeeping. Sixteen of those do not fit in 116 bytes. They don't fit in a hundred times that.
 
-Sixteen entrypoints do not fit in 116 bytes. They don't fit in 2 KB. And the usual escape hatches all had problems. Cranking optimizer runs down shrinks bytecode but taxes every user's gas forever. External libraries move code out, but retrofitting `DELEGATECALL`-linked libraries across a live, audited escrow contract is invasive surgery. Deploying the intent surface as a *separate contract* at a *separate address* breaks the thing that matters most: the registry is a UUPS proxy at a **stable address** — one ABI, one event stream for the subgraph, one EIP-712 domain that thousands of already-signed intents verify against.
+The usual escape hatches all had problems. Packing the code more tightly makes every transaction cost users more, forever. Moving logic into separate helper modules is invasive surgery on a live, audited, money-holding contract. And you can't just deploy the new features as a *separate* contract at a *separate* address, because the whole point is that this contract lives at one **stable address** — one identity that the app, the blockchain indexer, and thousands of already-signed instructions all depend on. Move house and you break all of them.
 
-The limit itself is [EIP-170](https://eips.ethereum.org/EIPS/eip-170): since the Spurious Dragon hardfork, deployed runtime code is capped at `0x6000` (24,576) bytes, so that a `CALL` can never force a node to load unboundedly large code from disk. It is not going away, and Polygon — FairWins' flagship network — enforces it like mainnet does.
+What shipped instead was a neat trick: keep one address, one identity, one public face — but split the contract internally into **two cooperating halves** that share a single set of records.
 
-What shipped instead is a pattern we'd describe as *diamond-adjacent*: **one proxy, two implementations, one storage definition**.
+## One front door, two halves behind it
 
-## One proxy, two facets
+Here's the arrangement. The contract still presents a single front door at a single address. Behind it sit two halves:
 
-The registry today is three contracts in `contracts/wagers/`:
+- The **main half** holds everything that was already there — creating wagers, accepting them, claiming payouts — plus a small piece of "receptionist" logic for anything it doesn't recognize.
+- The **extension half** holds all the new gasless companions, plus a few rarely-used, non-urgent functions that were moved over simply to free up space in the main half.
 
-| Contract | Role |
-|---|---|
-| `WagerRegistryCore.sol` | Abstract base: **the** storage layout plus every internal action body. Both facets inherit it. |
-| `WagerRegistry.sol` | The main facet — the actual UUPS implementation. Every pre-existing external function, plus a `fallback()`. |
-| `WagerRegistryIntents.sol` | The extension facet — the `…WithSig`/`…WithAuthorization` twins, fee-netting admin/getters, and relocated cold paths. |
+When a request comes in for something the main half knows how to do, it handles it directly, exactly as before — no slowdown, no extra cost. When a request comes in for something the main half *doesn't* recognize, that receptionist logic quietly forwards it to the extension half, which does the work and answers as if it had been the front desk all along.
 
-The proxy (a standard ERC-1967/UUPS proxy from spec 025) points at `WagerRegistry`. A call to a known selector — `createWager`, `acceptWager`, `claimPayout` — dispatches normally inside the main facet, exactly as before the split. A call to a selector the main facet *doesn't* define lands in its fallback, which forwards the raw calldata to the second implementation:
+The crucial detail is *how* it forwards. The extension half doesn't run off on its own; it runs *as if it were part of the main contract*, using the same records, address, and identity. To anyone outside — a user, the app, the indexer — there is simply one contract that happens to know how to do everything, with no visible seam. This matters enormously for signed instructions: a signature is bound to a specific contract identity, and because both halves share the exact same identity, an instruction verifies correctly no matter which half carries it out.
 
-```solidity
-/// @custom:oz-upgrades-unsafe-allow delegatecall
-fallback() external {
-    address ext = intentExtension;
-    if (ext == address(0)) revert UnknownFunction();
-    assembly {
-        calldatacopy(0, 0, calldatasize())
-        let ok := delegatecall(gas(), ext, 0, calldatasize(), 0, 0)
-        returndatacopy(0, 0, returndatasize())
-        switch ok
-        case 0 { revert(0, returndatasize()) }
-        default { return(0, returndatasize()) }
-    }
-}
-```
+Which functions went where was a deliberate sort by *temperature*. The new gasless companions went to the extension. So did **cold** functions — housekeeping tasks with no impatient user waiting, like batch-expiring stale wagers or pulling in an outcome from an external data source — relocated purely to reclaim room. The **hot** paths people use constantly stayed in the main half, paying zero extra cost. Only gasless and housekeeping calls take the small detour.
 
-Because this is a `delegatecall` from code *already executing in the proxy's context*, the extension facet runs against the proxy's storage, emits events attributed to the proxy's address, and — critically for signed intents — sees `address(this)` as the proxy. The EIP-712 domain (`"FairWins WagerRegistry"`, version `"1"`, chainId, verifying contract) is therefore identical whether a function lives in facet one or facet two. Callers see a single contract.
+## The discipline that makes it safe
 
-Which functions went where was a deliberate sort. The intent twins obviously live in `WagerRegistryIntents`. But the split also bought headroom by relocating **cold paths** out of the main facet: `batchExpireOpen`, `autoResolveFromPolymarket`, and `autoResolveFromOracle` are keeper-style functions with no latency-sensitive callers, so they moved behind the fallback with byte-identical behavior. Even three view getters (`feeNettingEnabled`, `gasFeeRecipient`, `maxGasFee`) sit in the extension purely for main-facet code-size headroom. Hot user paths stay in the main facet and pay zero extra dispatch cost; only relayed intents and keeper calls pay the one extra `DELEGATECALL` hop.
+Two halves sharing one set of records is exactly the setup that, done wrong, corrupts everything. If the two halves disagree by even a little about how those records are organized, one of them will read balances off the wrong shelf. So the defense is structural, not a matter of care: **the record layout is defined in exactly one place** — a shared base that *both* halves are built on. There is no second copy to drift out of sync. Both halves inherit the same shelf plan by construction.
 
-## The storage discipline that makes it safe
+That shared base holds something else: the single authoritative version of *what each action actually does*. Rather than writing "accept a wager" twice — once for the pay-your-own-fee path, once for the gasless path — the real logic lives once and simply takes "who is acting" as an input. The direct path passes in the sender; the gasless companion passes in whoever signed the instruction. One body of logic, two ways to reach it — so the two versions of an action *cannot* drift apart in their rules any more than the records can.
 
-Two implementations executing against one storage layout is exactly the failure mode that bricks proxies. The defense is structural, not procedural: **the layout is defined once**, in `WagerRegistryCore`, and both facets inherit it. From the base contract's own header:
+And because discipline you can't verify is just hope, the same automated safety check from part 1 of this series was extended to police the two halves. Before any change can merge, it treats the extension half as if it were a proposed upgrade of the main half and confirms their record layouts still line up perfectly. Any drift fails the build before it can ship.
 
-> BOTH facets execute against the SAME proxy storage, so both MUST inherit this exact contract — the storage layout is defined once, here, and can never drift between facets.
+## Turning the whole thing off is a feature
 
-`WagerRegistryCore` also holds every internal action body (`_createWager`, `_acceptWager`, `_claimPayout`, …), each taking the acting identity as an explicit parameter instead of reading `msg.sender`. The self-submit externals in the main facet pass `msg.sender`; the intent twins pass the recovered signer. One body, two attributions — the "twin invariant" — so checks and effects can't drift between the gasless and self-submit paths any more than storage can.
+Pointing the front door's receptionist at the extension half is a powerful act — that half runs with full access to the shared records — so the authority to change where it points is the same high-privilege, offline-held key that authorizes upgrades in general. Nobody else can repoint it.
 
-The usual UUPS rules still apply on top: storage is append-only above a trailing `uint256[45] private __gap` (it shrank 48 → 45 when spec 035 appended the packed fee-netting scalars and the `intentExtension` slot). The intent replay-nonce map deliberately lives elsewhere — in `contracts/upgradeable/SignerIntentBase.sol`, which uses **ERC-7201 namespaced storage** at a fixed keccak-derived slot, costing zero gap slots and making the mixin safe to add to an already-live proxy.
+That same pointer doubles as an off switch. Set it to "nowhere" and the entire gasless surface goes dark in one move — the receptionist simply reports "I don't know that function" for every gasless request. That sounds drastic, but it's safe by design, because every gasless action has a pay-your-own-fee twin. Flipping the switch degrades the product to "users pay their own network fees," never to "users are stranded mid-wager." It's a kill switch you can actually afford to use.
 
-Discipline you can't verify is hope. So `npm run check:storage-layout` — the CI-gating script from part 1 of this series — grew a facet-pair mode in `scripts/deploy/check-storage-layout.js`:
+## One contract, as far as anyone can tell
 
-```javascript
-// Facet pairs sharing ONE proxy's storage (spec 035): the extension facet is
-// delegatecalled from the main facet's fallback, so its storage layout MUST be
-// compatible with the main implementation's.
-const FACET_PAIRS = [
-  { main: "WagerRegistry", facet: "WagerRegistryIntents" },
-];
-```
-
-It runs OpenZeppelin's `upgrades.validateUpgrade(MainFactory, FacetFactory, { kind: "uups" })` — treating the facet as if it were an upgrade of the main implementation, so any sequential-slot drift fails CI before it can ship. The check is intentionally one-directional: the extension additionally carries `SignerIntentBase`'s ERC-7201 namespace, which the main facet legitimately does not declare, and a namespaced slot can never collide with sequential or gap slots.
-
-Two smaller honesty notes baked into the code. The extension facet is annotated `@custom:oz-upgrades-unsafe-allow missing-initializer` — by design it is *never* initialized; the proxy is initialized exactly once through the main facet, and `UUPSManaged`'s constructor disables initializers on the bare implementations. And the fallback's `delegatecall` carries `@custom:oz-upgrades-unsafe-allow delegatecall`, an explicit acknowledgment rather than a suppression of a surprise.
-
-## Governance: routing is upgrading
-
-Pointing the fallback at new code is equivalent in authority to replacing the implementation — the extension runs with full access to the proxy's storage. So the wiring function is gated accordingly:
-
-```solidity
-function setIntentExtension(address extension) external onlyRole(UPGRADER_ROLE) {
-    intentExtension = extension;
-    emit IntentExtensionUpdated(extension);
-}
-```
-
-`UPGRADER_ROLE` — the same role that authorizes UUPS upgrades, held by the air-gapped floppy-keystore admin — controls the extension pointer. Setting it to zero disables the entire intent surface (the fallback reverts with `UnknownFunction`), which doubles as a kill switch: because every gasless flow keeps a self-submit twin, turning the facet off degrades the product to "users pay their own gas," never to "users are stranded."
-
-## Developer experience: one ABI at one address
-
-Tooling sees one contract. The test helper `test/helpers/proxy.js` exports `deployWagerRegistry`, which deploys the main implementation behind an `ERC1967Proxy`, deploys `WagerRegistryIntents`, wires `setIntentExtension` as the admin, and returns an ethers `Contract` bound to the proxy address with a **merged ABI** — `mergeAbis(Impl.interface, IntentsImpl.interface)`, deduplicating fragments and dropping constructors and fallbacks. Tests and integrators call `registry.acceptWagerWithAuthorization(...)` and `registry.acceptWager(...)` on the same object without knowing a facet boundary exists. The subgraph needs no changes at all: every event still originates from the proxy address.
-
-## Why not a full Diamond?
-
-[EIP-2535](https://eips.ethereum.org/EIPS/eip-2535) (Diamonds) is the canonical answer to "my contract won't fit," and it deserves an honest comparison rather than a strawman.
-
-A Diamond gives you a generic selector-to-facet mapping, `diamondCut` for per-selector upgrades, loupe functions for on-chain introspection, and effectively unlimited facets. If we expected the registry to keep growing indefinitely across many independently-upgraded modules, that machinery would earn its cost.
-
-We chose against it for four concrete reasons:
-
-1. **We already had a proxy standard.** The registry was a shipped UUPS proxy at a stable address (spec 025), with deploy tooling, an upgrade runbook, and CI validation built around `hardhat-upgrades`. Migrating to a Diamond proxy would have meant replacing working, audited infrastructure to solve a code-size problem — maximum blast radius for the actual requirement.
-2. **Tooling and verification.** OpenZeppelin's upgrade-safety validators understand UUPS; they don't validate diamonds. Our facet-pair check reuses `validateUpgrade` unchanged. Block-explorer verification and ABI handling for diamonds remain rougher than "one implementation plus one extension."
-3. **Hot paths stay on normal dispatch.** A Diamond routes *every* call through the fallback and a selector-mapping `SLOAD`. In the two-facet design, `createWager` and `claimPayout` dispatch directly in the main facet exactly as before; only the relayed and keeper paths pay the extra hop.
-4. **Audit surface.** A Diamond's cut logic, selector registry, and loupe are their own attack surface with their own history of subtle bugs. Our routing layer is twelve lines of assembly plus one role-gated setter.
-
-The trade-offs cut the other way too, and it's worth being plain about them. The two-facet pattern has **no on-chain introspection** — nothing enumerates which selectors the extension serves; the merged ABI is an off-chain convention. Selector precedence is implicit: if both facets defined the same function, the main facet would silently win, because the fallback only fires for selectors the main facet lacks (the shared `WagerRegistryCore` base and interface definitions make an accidental collision a compile-time conflict in practice, but the proxy itself doesn't check). Facet upgrades are all-or-nothing per facet, not per selector. And the pattern scales awkwardly past two or three facets — a chain of fallbacks is a worse Diamond, not a better one. If the extension facet itself ever approaches 24 KB, the right move is probably a real Diamond, and we'd rather make that call then than pre-pay for it now.
-
-For one contract, one overflow, and a hard requirement to preserve a live address, ABI, event stream, and EIP-712 domain: two facets, one storage core, and a CI gate was the smallest design that is actually safe.
+For everyone building on top, the seam is invisible. The tooling presents both halves as a single contract with one combined menu of functions; developers call a direct action and its gasless twin on the same object without knowing a boundary exists. The blockchain indexer needs no changes at all, because every event still comes from the one shared address. The split is an internal detail that never surfaces.
 
 *FairWins wagers settle from public-information outcomes via external oracles; participants remain subject to applicable law and compliance obligations in their jurisdictions.*
 
-## Design decisions
+## Why not the fully general solution?
 
-- **Split by temperature, not just by feature.** The extension facet took the new intent twins *and* relocated cold paths (`batchExpireOpen`, `autoResolveFrom*`) and even three view getters, maximizing main-facet headroom while keeping user-facing hot paths on direct dispatch.
-- **One storage definition, enforced twice.** Both facets inherit `WagerRegistryCore` (structural guarantee); `check:storage-layout` validates the pair with `validateUpgrade` in CI (mechanical guarantee). Neither alone is sufficient — inheritance can't catch a facet compiled from a stale branch; a script can't stop someone declaring state in a facet unless the convention exists.
-- **New cross-cutting state goes in ERC-7201 namespaces.** `SignerIntentBase`'s nonce map costs zero gap slots and is safe to add to live proxies — the same trick `EIP712Upgradeable` uses.
-- **Routing authority equals upgrade authority.** `setIntentExtension` is `UPGRADER_ROLE`-gated because a delegatecall target with full storage access *is* an implementation, whatever you call it.
-- **Zero-address as kill switch, backed by the never-stranded rule.** Disabling the facet degrades gracefully because every gasless entrypoint has a self-submit twin.
+There's a well-known, more elaborate pattern for exactly this problem — the "Diamond" standard — that lets a single contract fan out to unlimited independently-upgradeable pieces, with on-chain machinery to track which piece handles what. It's the canonical answer to "my contract won't fit," and it deserves an honest comparison rather than a strawman.
 
-## Sources
+If FairWins expected this contract to keep growing indefinitely across many separately-managed modules, that machinery would earn its cost. The team chose the simpler two-half approach for four concrete reasons:
 
-- `contracts/wagers/WagerRegistry.sol` — main facet, fallback delegatecall, `setIntentExtension`
-- `contracts/wagers/WagerRegistryIntents.sol` — extension facet: intent twins, relocated cold paths, fee-netting admin
-- `contracts/wagers/WagerRegistryCore.sol` — shared storage layout + actor-threaded internal action bodies, `__gap` history
-- `contracts/upgradeable/SignerIntentBase.sol` — ERC-7201 namespaced replay-nonce mixin
-- `scripts/deploy/check-storage-layout.js` — `FACET_PAIRS` validation (`npm run check:storage-layout`)
-- `test/helpers/proxy.js` — `deployWagerRegistry` + `mergeAbis` merged-ABI helper
-- `docs/developer-guide/gasless-intents.md` — facet-split architecture table, pre-split size (24,460 / 24,576 bytes)
-- `specs/035-intent-based-payments/` — spec, plan, research for the gasless-intent feature
-- [EIP-170: Contract code size limit](https://eips.ethereum.org/EIPS/eip-170)
-- [EIP-2535: Diamonds, Multi-Facet Proxy](https://eips.ethereum.org/EIPS/eip-2535)
-- [ERC-7201: Namespaced Storage Layout](https://eips.ethereum.org/EIPS/eip-7201)
-- [OpenZeppelin Upgrades plugin](https://docs.openzeppelin.com/upgrades-plugins/) — `validateUpgrade` used for facet-pair checking
+1. **It already had a working upgrade standard.** Switching frameworks would have meant replacing live, audited infrastructure just to solve a size problem — maximum risk for a narrow need.
+2. **Tooling and verification are simpler.** The existing safety tooling understands the two-half arrangement out of the box; the general framework is rougher to validate and to verify on block explorers.
+3. **Hot paths stay fast.** The general framework routes *every* call through an extra lookup step. Here, common actions dispatch directly at no added cost; only gasless and housekeeping calls take the detour.
+4. **Smaller attack surface.** The general framework's routing machinery is its own body of code with a history of subtle bugs. The two-half routing is a dozen lines plus one gated switch.
+
+The trade-offs cut both ways. The two-half design has no on-chain catalog of what the extension can do, and it doesn't gracefully scale past two or three halves — a chain of forwarders would just be a worse version of the general framework. If the extension half ever approaches the size limit itself, the right move is probably to adopt the full framework then, rather than pre-pay for it now.
+
+For one contract, one overflow, and a hard requirement to preserve a live address, a stable public face, an unbroken event stream, and a signing identity that thousands of instructions already trust: two cooperating halves, one shared record layout, and an automated gate was the smallest design that is genuinely safe.
+
+## Further reading
+
+- [EIP-170: contract code size limit](https://eips.ethereum.org/EIPS/eip-170) — the origin of the ~24 KB ceiling
+- [EIP-2535: the Diamond standard](https://eips.ethereum.org/EIPS/eip-2535) — the general multi-piece pattern discussed above
+- [Upgradeable contracts — OpenZeppelin docs](https://docs.openzeppelin.com/upgrades-plugins/) — the safety tooling this design reuses
+- For FairWins-specific details, see the FairWins developer documentation.

--- a/docs/blog/posts/12-two-facet-proxy-24kb/social.md
+++ b/docs/blog/posts/12-two-facet-proxy-24kb/social.md
@@ -2,32 +2,26 @@
 
 ## X (Twitter)
 
-Our contract compiled to 24,460 of 24,576 bytes — 116 bytes of headroom — and the next feature needed 16 new entrypoints.
-
-We didn't reach for a Diamond. One proxy, two implementations, one shared storage base, and a CI gate that validates the pair.
-
-🔗 <link>
-
-#Solidity #EVM #SmartContracts
+Our central contract had ~116 bytes of room left — and the next feature needed 16 new entrypoints. Smart contracts have a hard size limit, like a strict page limit for one binder. Our fix: split one contract into two cooperating halves that share one set of records, at one unchanged address. 🔗 <link> #web3 #smartcontracts
 
 ## LinkedIn
 
-Every serious Solidity team eventually hits EIP-170: deployed bytecode is capped at 24,576 bytes, and no optimizer setting saves you once a live, audited contract needs a large new feature. Our wager registry sat at 24,460 bytes when a gasless-transactions spec called for roughly sixteen new EIP-712 entrypoints.
+Ethereum-style blockchains cap how big a single smart contract can be — roughly 24 KB, a hard ceiling you can't optimize your way past. Think of it as a strict page limit for a document that must fit in one binder. Our central wager contract had almost filled its binder when a big new gasless-features effort needed sixteen more entrypoints.
 
-The obvious answer is an EIP-2535 Diamond. We shipped something smaller instead — and the new post walks through exactly how and why:
+The elaborate industry answer is the "Diamond" pattern. We shipped something smaller — and the new post walks through how and why:
 
-- One UUPS proxy, two implementation facets: unknown selectors delegatecall from the main contract's fallback to an extension facet, so callers still see one address, one ABI, one event stream, and one EIP-712 domain.
-- A single abstract base contract defines the storage layout and all internal action bodies; both facets inherit it, so layouts structurally cannot drift.
-- A CI gate runs OpenZeppelin's validateUpgrade on the facet pair, treating the extension as an upgrade of the main implementation — drift fails the build.
-- An honest comparison with Diamonds: what we gave up (introspection, per-selector upgrades) and what we kept (direct dispatch on hot paths, existing tooling, a twelve-line routing layer).
+- One address, one public face, but two cooperating halves behind it: the main half handles what it knows; anything it doesn't recognize gets quietly forwarded to an extension half — which runs as if it were the same contract, sharing the same records and identity.
+- The record layout is defined in exactly one shared place both halves are built on, so they structurally cannot disagree about where things are stored.
+- An automated gate checks the two halves line up before any change can merge.
+- An honest comparison with the Diamond pattern: what we gave up, and what we kept (fast common paths, existing tooling, a tiny routing layer).
 
-If your contract is creeping toward the ceiling, this is a shipped, testable pattern you can borrow before committing to a full facet framework.
+If your contract is creeping toward the ceiling, this is a shipped, testable pattern worth knowing before you reach for a heavier framework.
 
 🔗 <link>
 
-Where do you draw the line between "split the contract" and "adopt a Diamond"?
+Where would you draw the line between "split the contract" and "adopt a heavier framework"?
 
-#Solidity #EVM #SmartContracts #Web3 #ProtocolEngineering
+#web3 #smartcontracts #architecture #engineering #fintech
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/13-deterministic-singleton-deployment/blog.md
+++ b/docs/blog/posts/13-deterministic-singleton-deployment/blog.md
@@ -1,140 +1,74 @@
-# One Salt, Three Chains: What Deterministic Deployment Actually Buys You
+# One Address, Everywhere: Why Deterministic Deployment Matters
 
-*How FairWins uses the Safe Singleton Factory for stable addresses across Mordor, Polygon, and Amoy — and why a per-chain resolver is still non-negotiable*
+*How FairWins keeps the same smart contract at the same address across three blockchains — and why a single source of truth for those addresses is the part that really prevents outages*
 
 | | |
 |---|---|
 | **Series** | Contract Architecture, part 3 |
-| **Audience** | Protocol engineers, DevOps |
-| **Tags** | `create2`, `deterministic-deployment`, `multi-chain`, `devops` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product managers, founders, and the crypto-curious |
+| **Tags** | `multi-chain`, `reliability`, `behind-the-scenes` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-## The Bug That Ships Silently
+## The bug that ships silently
 
-Picture the failure mode every multi-chain team eventually hits. You redeploy a contract to a testnet — maybe a compiler bump, maybe a constructor tweak. The deploy script prints a fresh address. Someone updates the frontend config. Nobody updates the subgraph manifest. The relay gateway keeps the old address in an environment variable that was set three months ago in a dashboard nobody remembers.
+Picture the failure mode every team that runs on more than one blockchain eventually hits. You redeploy a smart contract to a test network — maybe a small tweak, maybe a routine update. The deploy tool prints out a fresh address for the contract. Someone updates the app to point at it. But the search-and-indexing service still points at the old address. And a background service — the one that pays transaction fees on users' behalf — was configured months ago and nobody remembers to change it.
 
-Nothing crashes. The frontend talks to the new contract, the indexer indexes the old one, and the gateway relays transactions into a contract that no longer matches the ABI it was policy-checked against. Users see wagers that "exist" but never index, or gasless transactions that revert with no obvious cause. The bug isn't in any one system — it's in the *drift between them*.
+Nothing crashes. The app talks to the new contract, the indexer watches the old one, and the background service tries to help users interact with a contract that no longer matches what it expects. Users see wagers that seem to "exist" but never show up in listings, or transactions that mysteriously fail. The bug isn't in any single system. It's in the drift between them.
 
-FairWins runs its escrow, membership, and oracle stack on three live EVM networks — Mordor (Ethereum Classic's testnet, chain 63), Polygon Amoy (80002), and Polygon mainnet (137) — with three independent consumers of every contract address: a React frontend, a Graph subgraph, and a relay gateway that sponsors gasless transactions. That's nine opportunities per contract for address drift.
+FairWins runs its escrow, membership, and settlement machinery on three live blockchains at once — a couple of test networks and one production network. Three separate systems consume every contract's address: the web app, an indexing service that makes data searchable, and a background service that sponsors fees for users. That's a lot of places for a single address to fall out of sync.
 
-The defense has two layers, and it's worth being precise about what each one does. Deterministic deployment makes addresses *reproducible* — the same deploy script produces the same address, every run, and often the same address on every chain. A single-source-of-truth resolver makes addresses *consistent* — every consumer reads from one record per chain, mechanically. The first layer is the popular one. The second is the one that actually prevents the bug.
+The defense has two layers, and it's worth being precise about what each one does. Deterministic deployment makes addresses reproducible — running the same deploy produces the same address every time, and often the same address on every chain. A single source of truth makes addresses consistent — every system reads from one authoritative record per chain. The first layer gets all the attention. The second is the one that actually prevents the outage.
 
-## Layer 1: CREATE2 via the Safe Singleton Factory
+## Layer one: the same address by design
 
-Ordinary contract creation (`CREATE`) derives the new address from the deployer's address and nonce. Nonces are history: run the same script twice, or on a chain where the deployer has sent one extra transaction, and you get a different address. [EIP-1014](https://eips.ethereum.org/EIPS/eip-1014) added `CREATE2`, which removes history from the equation:
+A smart contract lives at an address, the way a house sits at a street address. Normally, that address is derived partly from how many transactions the deploying account has ever sent — its history. Run the same deploy twice, or run it on a chain where the account happened to send one extra transaction, and you get a different address. History leaks in.
 
-```
-address = keccak256(0xff ++ deployer ++ salt ++ keccak256(init_code))[12:]
-```
+There is a well-established alternative that removes history from the equation. Instead of depending on transaction count, the address is computed purely from three ingredients: who is doing the deploying, a chosen label (often called a "salt"), and the exact contents of the contract. Same three ingredients, same address — on any chain.
 
-Deployer, salt, init code. Nothing else. If those three inputs are identical on two chains, the address is identical on two chains.
+The "who is deploying" part is the subtle one. If each chain used its own one-off deployment helper, those helpers would sit at different addresses and the whole scheme would collapse. The fix is a shared, industry-standard deployment helper that already exists at the same address on every major chain — the same open infrastructure the Safe wallet ecosystem relies on. Because that shared helper is the "who," every chain computes the same result.
 
-The catch is the `deployer` term. If each chain's deployment EOA calls `CREATE2` through its own throwaway factory, the factory addresses differ and determinism collapses. The standard fix is a *shared* factory that already exists at the same address everywhere. FairWins uses the [Safe Singleton Factory](https://github.com/safe-global/safe-singleton-factory), pinned in `scripts/deploy/lib/constants.js`:
+Two nice properties fall out of this. First, before spending anything, the deploy process can calculate where a contract will land and check whether it's already there. If it is, the deploy reuses what exists. So a half-finished deploy can be re-run safely: whatever landed stays put, whatever didn't gets finished. Re-running is a no-op, not a duplicate. Second, the salt is a plain, versioned label. Bump the version and you get a clean, parallel set of addresses for a new generation of contracts, while the old ones stay untouched and reachable.
 
-```javascript
-/**
- * Safe Singleton Factory address - same on all EVM networks
- * Used for deterministic CREATE2 deployments
- */
-const SINGLETON_FACTORY_ADDRESS = "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7";
-```
+## Where sameness holds, and where it honestly doesn't
 
-The factory itself was placed at that address on each network via a presigned deployment transaction (the same family of techniques as [EIP-2470](https://eips.ethereum.org/EIPS/eip-2470)'s keyless deployment). Calling it is trivially simple: send a transaction whose data is `salt ++ init_code`, and it executes `CREATE2` on your behalf. Because the factory is the `deployer` term in the address formula, every chain computes the same result.
+Here is the part most explanations skip. "Same address on every chain" only holds when all three ingredients match — and the contract's contents include its start-up settings. Change a setting per chain and the contents change, so the address changes. That is not a bug; it is the system working correctly.
 
-The workhorse is `deployDeterministic` in `scripts/deploy/lib/helpers.js`. Before spending any gas, it computes where the contract *will* land and checks whether it's already there:
+A few honest examples from FairWins:
 
-```javascript
-// Compute deterministic address
-const initCodeHash = ethers.keccak256(deploymentData);
-const deterministicAddress = ethers.getCreate2Address(
-  SINGLETON_FACTORY_ADDRESS,
-  salt,
-  initCodeHash
-);
+- A contract that manages account keys takes no start-up settings, so it sits at the exact same address on all three chains. Full sameness.
+- A sanctions-screening contract needs to know which watchlist to consult. On the test networks it points at a stand-in list; on production, a real commercial sanctions feed. Different setting, different contents, different address — exactly as intended.
+- The upgradeable contracts — the wager registry, the membership manager, the wager-pool factory — don't use this trick at all. Each is deployed once per chain and then never redeployed. When the logic needs to change, it's swapped in place at the same address, with an automated safety check making sure the swap can't scramble the data already stored there. Stability by policy rather than by math.
 
-// Check if contract is already deployed
-const existingCode = await ethers.provider.getCode(deterministicAddress);
-if (existingCode !== "0x") {
-  return {
-    address: deterministicAddress,
-    contract: ContractFactory.attach(deterministicAddress),
-    alreadyDeployed: true
-  };
-}
-```
+The honest summary: the "same address everywhere" trick applies only to simple, unchanging, setting-free contracts. Everything else gets per-chain address stability instead — which turns out to be exactly what the rest of the system needs.
 
-That `getCode` check is the quiet superpower: **idempotency**. Re-running `scripts/deploy/deploy.js` against a network where everything is already deployed is a no-op that attaches to existing contracts instead of minting duplicates. A partially failed deploy can simply be re-run; whatever landed stays put, whatever didn't gets deployed. The helper also enforces the [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860) 49,152-byte initcode limit and warns past the [EIP-170](https://eips.ethereum.org/EIPS/eip-170) 24,576-byte runtime limit before it wastes a transaction finding out on-chain.
+## Layer two: one record per chain, one lookup everywhere
 
-Salts are human-readable, versioned strings, hashed via `generateSalt` (`ethers.id`, i.e. `keccak256` of the UTF-8 string). The active deployment uses the prefix recorded in every `deployments/*-v2.json` file:
+Because addresses can legitimately differ per chain, no part of the system is allowed to assume they don't. Every deploy writes its results to a per-chain record: which network, which addresses, which settings, which starting point for indexing. The team treats those records as the single source of truth, and three systems read from them.
 
-```
-salt = keccak256("FairWins-P2P-v2.0-KeyRegistry")
-```
+The web app never has addresses typed in by hand. A sync step reads the record and regenerates the app's address list automatically. At runtime, one lookup answers "what's the address of this contract on this chain?" It's chain-aware and honest about absence: the test networks have no connection to certain external prediction markets, so those entries simply don't exist there, and the app quietly hides that capability rather than pointing at a wrong address. Even the "live on these networks" list on the marketing site is derived from the same records.
 
-Bump the version prefix and you get a clean, parallel address space for a v3 — old deployments stay untouched and reachable.
+The indexing service reads the same addresses and starting points, so it watches the right contracts from the right block.
 
-One more ergonomic detail: local Hardhat networks obviously don't ship with the factory pre-installed. `ensureSingletonFactory` detects a local chain, funds the factory's one-shot signer address, and replays the presigned deployment transaction from the `@safe-global/safe-singleton-factory` package — so `localhost` and CI exercise the *same* deployment path as production instead of a mock shortcut.
+The fee-sponsoring background service is the strictest reader of all. It loads the records at startup and refuses to boot if any chain it serves is missing its core addresses. The reasoning is simple: a service that pays real gas for users' transactions must never act on a contract it can't positively identify. A loud crash at startup is infinitely cheaper than quietly doing the wrong thing in production.
 
-## Where Determinism Actually Holds — and Where It Honestly Doesn't
+Same information, three ways of consuming it — regenerated config for the app, watch-lists for the indexer, a boot-time safety check for the background service — all flowing from one record per chain.
 
-Here's the part most write-ups skip. "Same address on every chain" has three preconditions — same factory, same salt, same init code — and *init code includes the ABI-encoded constructor arguments*. Look at the recorded deployments and the pattern is textbook:
+## Why we built it this way
 
-- **`KeyRegistry`** takes no constructor arguments. It sits at `0xcEFdeBba8E040c035c690ca9057cF22E73247c24` on Mordor, Amoy, *and* Polygon. Full determinism.
-- **`SanctionsGuard`** takes an admin and an oracle address. Mordor and Amoy both point at a mock sanctions oracle, so they share `0xdF41355dD5E47FCA4eE2F2205af4C70Dab8C13B3`. Polygon points at the real Chainalysis sanctions oracle (`0x40C579…C8fb`) — different constructor arg, different init code, different address. Working exactly as designed.
-- **UUPS proxies** — `wagerRegistry`, `membershipManager`, `wagerPoolFactory` — are *not* CREATE2-deployed at all. A comment in `scripts/deploy/deploy.js` says it plainly: *"unlike the prior CREATE2 deploy this is NOT idempotent — re-running mints a new proxy."* Their address stability comes from a different mechanism entirely: the proxy is deployed once per chain and then never redeployed. Logic changes ship as in-place upgrades through `scripts/deploy/lib/upgradeable.js`, gated by `npm run check:storage-layout` in CI. Stable address, swappable implementation — determinism by *policy*, not by opcode.
+**Standard infrastructure over a homegrown deployer.** Rolling our own deployment helper would mean guarding an extra key on every chain and taking on a new thing to audit. The shared, battle-tested helper already exists at one address across the chains we target, so we lean on it.
 
-This is the honest taxonomy: CREATE2 gives cross-chain address equality only to immutable, argument-free singletons. Everything else gets *per-chain* address stability — which turns out to be what the consumers actually need.
+**Re-runnable deploys over fragile ceremonies.** Because a deploy checks whether a contract already exists before doing anything, "deploy it" and "confirm it's deployed" are the same command — no separate resume procedure to maintain.
 
-## Layer 2: One Record Per Chain, One Resolver Everywhere
+**Recorded addresses over computed ones.** A tempting shortcut is to have every system recompute addresses on the fly. We deliberately don't. The upgradeable contracts don't follow the math, settings vary by chain, and a computed address only tells you where a contract would be — not that the right thing is actually there.
 
-Because addresses can legitimately differ per chain, no consumer is allowed to assume they don't. Every deploy run writes its results to `deployments/<network>-chain<id>-v2.json` — network, deployer, per-contract addresses, constructor args, salt prefix, deploy blocks. The repo treats these files as the source of truth for on-chain addresses, and three consumers hang off them:
+**Always look it up per chain.** Even for the contract that happens to share one address everywhere today, the code still looks it up per chain. Hardcoding "it's the same everywhere" bakes today's coincidence into tomorrow's outage.
 
-**The frontend** never hand-edits addresses. `npm run sync:frontend-contracts` (see `scripts/utils/sync-frontend-contracts.js`) reads the deployment record and rewrites the per-network address maps in `frontend/src/config/contracts.js`, scoped to the right network block. It also re-emits plain-JSON ABIs from the hand-maintained JS ABI modules so downstream consumers read generated artifacts, not hand-copied ones. At runtime, exactly one function resolves addresses:
+The trade-offs are real. The shared deployment helper is a dependency we don't own; if a future chain lacks it, someone has to install it first. Byte-for-byte identical contract contents requires build discipline. And the "same address everywhere" trick doesn't extend to upgradeable contracts, which carry their own upgrade-governance burden instead. Deterministic deployment is a tool, not a doctrine. The single source of truth is the doctrine.
 
-```javascript
-export function getContractAddressForChain(contractName, chainId) {
-  if (chainId == null) return getContractAddress(contractName)
-  const chainContracts = NETWORK_CONTRACTS[chainId]
-  return chainContracts ? chainContracts[contractName] : undefined
-}
-```
+## Further reading
 
-Chain-aware, and honest about absence: Mordor has no Polymarket, Chainlink, or UMA, so those adapter keys simply don't exist in its map and the resolver returns `undefined` — the UI degrades the capability rather than pointing at a wrong address. The landing page's "deployed on" list is even derived from the same maps (`getDeployedNetworks` filters for networks carrying a live `wagerRegistry`), so shipping a new chain updates the marketing surface with zero UI edits.
-
-**The subgraph** keys its manifests off `subgraph/networks.json`, which carries the same per-network addresses and start blocks as the deployment records.
-
-**The relay gateway** is the strictest consumer. `services/relay-gateway/src/config/index.js` reads the `deployments/*-chain<ID>-v2.json` files directly at boot, and refuses to start if any enabled chain is missing a record with `wagerRegistry`, `membershipManager`, and `sanctionsGuard` addresses. The comment in the file states the policy: *fail loudly — never run against a stale/unknown target*. A gateway that sponsors gas for user transactions must never relay into a contract it can't identify; a crash at boot is infinitely cheaper than a policy check against the wrong bytecode.
-
-Same information, three consumption styles — regenerated config for the frontend, manifest data for the indexer, boot-time validation for the gateway — but a single upstream artifact per chain.
-
-## Design Decisions
-
-**Safe Singleton Factory over a bespoke deployer.** Rolling a custom CREATE2 factory means custody of a deployer key per chain and a new audit surface. The Safe factory already exists at one address across the EVM networks FairWins targets (including Mordor — a useful test, since niche chains are where presigned-deployment schemes usually break), and it's the same infrastructure Safe itself relies on.
-
-**Idempotent scripts over deployment ceremony.** The `getCode`-then-attach pattern means "deploy" and "verify the deployment exists" are the same command. There is no separate resume path to maintain, and CI can run the real deploy script against a fresh Hardhat chain on every push.
-
-**Recorded addresses over computed addresses.** A tempting shortcut is to have consumers *compute* CREATE2 addresses instead of reading a record. FairWins deliberately doesn't: proxies aren't CREATE2, constructor args vary by chain, and a computed address tells you where a contract *would* be, not that the right bytecode is actually there. The `deployments/` records capture what was verifiably deployed; the resolver distributes that fact.
-
-**Per-chain resolution as a hard rule.** Even for `KeyRegistry` — genuinely identical on all three chains today — code goes through `getContractAddressForChain`. Hardcoding "it's the same everywhere" bakes today's coincidence into tomorrow's outage the first time a chain needs a divergent deploy.
-
-The trade-offs are real: the singleton factory is a dependency you don't control (if a future chain lacks it, someone must fund and replay the presigned deployment first); byte-identical init code requires compiler and metadata discipline; and CREATE2 determinism simply doesn't extend to upgradeable proxies, which carry their own upgrade-governance burden instead. Deterministic deployment is a tool, not a doctrine — the resolver is the doctrine.
-
-## Sources
-
-- `scripts/deploy/lib/helpers.js` — `deployDeterministic`, `generateSalt`, `ensureSingletonFactory`
-- `scripts/deploy/lib/constants.js` — `SINGLETON_FACTORY_ADDRESS`, per-network token/oracle addresses
-- `scripts/deploy/deploy.js` — v2 deployment orchestration, salt prefix `FairWins-P2P-v2.0-`, proxy non-idempotency notes
-- `scripts/deploy/lib/upgradeable.js` + `scripts/deploy/check-storage-layout.js` — in-place UUPS upgrades
-- `scripts/utils/sync-frontend-contracts.js` — deployment-record → frontend config/ABI sync
-- `deployments/mordor-chain63-v2.json`, `deployments/amoy-chain80002-v2.json`, `deployments/polygon-chain137-v2.json` — recorded addresses compared above
-- `frontend/src/config/contracts.js` — `getContractAddressForChain`, `getDeployedNetworks`, per-network maps
-- `services/relay-gateway/src/config/index.js` — boot-time deployment-record validation
-- `subgraph/networks.json` — per-network subgraph addresses
-- `docs/developer-guide/singleton-deployment-patterns.md` — pattern research and alternatives survey
-- [EIP-1014: Skinny CREATE2](https://eips.ethereum.org/EIPS/eip-1014)
-- [EIP-2470: Singleton Factory](https://eips.ethereum.org/EIPS/eip-2470)
-- [EIP-170: Contract code size limit](https://eips.ethereum.org/EIPS/eip-170), [EIP-3860: Limit and meter initcode](https://eips.ethereum.org/EIPS/eip-3860)
-- [Safe Singleton Factory](https://github.com/safe-global/safe-singleton-factory)
-- [OpenZeppelin proxy documentation](https://docs.openzeppelin.com/contracts/5.x/api/proxy) (UUPS / ERC-1967)
+- [EIP-1014: the CREATE2 address scheme](https://eips.ethereum.org/EIPS/eip-1014) — the standard behind reproducible contract addresses
+- [The Safe Singleton Factory](https://github.com/safe-global/safe-singleton-factory) — the shared, same-address-everywhere deployment helper
+- [OpenZeppelin's guide to upgradeable contracts](https://docs.openzeppelin.com/contracts/5.x/api/proxy) — how a contract keeps one address while its logic changes

--- a/docs/blog/posts/13-deterministic-singleton-deployment/social.md
+++ b/docs/blog/posts/13-deterministic-singleton-deployment/social.md
@@ -1,25 +1,25 @@
-# Social & Image — One Salt, Three Chains: What Deterministic Deployment Actually Buys You
+# Social & Image — One Address, Everywhere: Why Deterministic Deployment Matters
 
 ## X (Twitter)
 
-CREATE2 gives you the same address on every chain — until a constructor arg differs. How FairWins deploys via the Safe Singleton Factory, why the deploy script is idempotent, and why a per-chain resolver still does the real work. 🔗 <link> #Solidity #DevOps
+The same smart contract can live at the same address on every blockchain — until one setting differs. How FairWins keeps addresses reproducible across three chains, why re-running a deploy is a safe no-op, and why one source of truth for addresses does the real work. 🔗 <link> #Blockchain #Reliability
 
 ## LinkedIn
 
-The worst multi-chain bug ships silently: a redeploy mints a fresh address, the frontend gets updated, the subgraph doesn't, and the relay gateway keeps an address from a three-month-old env var. Nothing crashes — the systems just quietly drift apart.
+The worst multi-chain bug ships silently: a contract gets redeployed to a new address, the app is updated, the search index isn't, and a background service keeps an address from a config nobody remembers. Nothing crashes — the systems just quietly drift apart, and users see wagers that "exist" but never show up.
 
-Our latest FairWins engineering post walks through the two-layer defense we run across Mordor, Amoy, and Polygon:
+Our latest FairWins engineering post walks through the two-layer defense we run across three blockchains:
 
-- CREATE2 via the Safe Singleton Factory: same salt + same init code = same address, with human-readable versioned salts and idempotent deploy scripts (re-running is a safe no-op)
-- Where determinism honestly breaks: per-chain constructor args change the init code, and UUPS proxies aren't CREATE2 at all — their stability comes from in-place upgrades, not opcodes
-- One recorded deployment file per chain as the single source of truth, consumed three ways: regenerated frontend config, subgraph manifests, and a relay gateway that refuses to boot against an unknown target
-- Why "resolve per chain, every time" is the rule even for contracts that happen to share an address today
+- Reproducible addresses: with the right approach, the same contract lands at the same address on every chain, using human-readable versioned labels and deploys you can safely re-run
+- Where sameness honestly breaks: a per-chain setting changes the contract's contents and therefore its address, and our upgradeable contracts get their stability a different way entirely
+- One recorded file per chain as the single source of truth, consumed three ways: regenerated app config, search-index watch-lists, and a fee-sponsoring service that refuses to start against an unknown target
+- Why "look it up per chain, every time" is the rule even for contracts that happen to share an address today
 
 Read the full post: <link>
 
-How does your team keep contract addresses in sync across frontends, indexers, and off-chain services — computed, recorded, or something else?
+How does your team keep contract addresses in sync across apps, indexers, and background services — computed, recorded, or something else?
 
-#Solidity #DevOps #SmartContracts #Ethereum #web3
+#Blockchain #Reliability #SmartContracts #Web3
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/14-wager-lifecycle-contract/blog.md
+++ b/docs/blog/posts/14-wager-lifecycle-contract/blog.md
@@ -1,130 +1,87 @@
-# The Wager Lifecycle Contract: Anatomy of a Peer-to-Peer Escrow State Machine
+# The Wager Lifecycle: How a Handshake Bet Becomes a Payout Nobody Can Strand
 
-*How FairWins' `WagerRegistry` turns a handshake bet into seven explicit states, two hard deadlines, and a payout nobody can strand*
+*How FairWins turns an informal bet into a small set of clear states, two hard deadlines, and a payout that always has a way out*
 
 ---
 
 | | |
 |---|---|
 | **Series** | Prediction Markets — Part 1 |
-| **Audience** | Smart-contract developers |
-| **Tags** | `escrow`, `state-machine`, `solidity`, `prediction-markets`, `p2p` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product managers, founders, and the crypto-curious |
+| **Tags** | `escrow`, `prediction-markets`, `how-it-works`, `p2p` |
+| **Reading time** | ~7 minutes |
 
-> **Responsible-use note.** FairWins wagers are peer-to-peer forecasts on publicly available information. Nothing here is a mechanism for trading on material non-public information or circumventing regulation; all participants remain fully subject to applicable law and compliance obligations in their jurisdiction.
+> **Responsible-use note.** FairWins wagers are peer-to-peer forecasts on publicly available information. This is skill-based forecasting, not a mechanism for trading on material non-public information or circumventing regulation. All participants remain fully subject to applicable law and compliance obligations in their jurisdiction.
 
 ---
 
 ## The bet that never pays out
 
-Two engineers bet 200 USDC on whether a protocol upgrade ships before the end of the quarter. Both are good for it. Neither wants to hand the money to the other in advance, neither wants a third party holding it, and both have seen how this ends without structure: the outcome lands, the loser goes quiet, and the "bet" becomes an awkward memory.
+Two colleagues bet 200 USDC on whether a software project ships before the end of the quarter. Both are good for it. Neither wants to hand the money over in advance, and neither wants a third party sitting on it. Both have seen how this ends without structure: the outcome lands, the loser goes quiet, and the "bet" becomes an awkward memory.
 
-The failure modes of an informal wager are surprisingly enumerable. The counterparty never actually commits their stake. The event resolves but nobody has authority to say who won. The event *doesn't* resolve — the upgrade is cancelled — and there's no agreed path to unwind. Or the money is committed somewhere and a bug, a dispute, or a disappearing party leaves it stuck forever.
+The ways an informal wager falls apart are surprisingly countable. The other person never actually puts their money in. The event happens but nobody has the authority to say who won. The event doesn't happen at all — the project is cancelled — and there's no agreed way to unwind. Or the money is locked up and a bug, a dispute, or a person who vanishes leaves it stuck forever.
 
-An escrow contract worth deploying has to close every one of those holes explicitly. That is what FairWins' `WagerRegistry` (`contracts/wagers/WagerRegistry.sol`) does: it is less a "betting contract" than a state machine over other people's money, where every state has a defined set of exits and no state is a dead end. This post walks its anatomy — the states, the deadlines, the resolution paths, and the checks-effects-interactions discipline that holds it together.
+An escrow system worth building closes every one of those holes on purpose. That is what the FairWins wager engine does. It's less a "betting contract" than a careful set of rules over other people's money, where every situation has a defined set of exits and no situation is a dead end. This post walks through that anatomy: the states a bet can be in, the deadlines that keep it honest, the ways a winner gets decided, and the discipline that makes it safe.
 
-## Seven states, no dead ends
+## A handful of states, no dead ends
 
-Every wager is a `Wager` struct in proxy storage, and its position in the lifecycle is a single enum (`contracts/interfaces/IWagerRegistryTypes.sol`):
+Think of every wager as moving through a small number of clearly defined states, like stops on a track.
 
-```solidity
-enum Status { None, Open, Active, Resolved, Cancelled, Refunded, Draw }
+The happy path is short. Someone creates a wager, and their stake is escrowed — locked in the contract, held by code rather than by either person. The wager is now open. The named opponent accepts, their stake is pulled in too, and the wager becomes active. Once the outcome is known, it's marked resolved with a recorded winner, and the winner claims both stakes in a single payout.
 
-enum ResolutionType {
-    Either, Creator, Opponent, ThirdParty,
-    Polymarket, ChainlinkDataFeed, ChainlinkFunctions, UMA
-}
-```
+The interesting design is in the unhappy paths, because every state that holds money has an exit that needs no cooperation from the other side:
 
-The happy path is short. `createWager` escrows the creator's stake and writes the wager as `Open`, emitting `WagerCreated`. The named opponent calls `acceptWager`, their stake is pulled in, the status flips to `Active`, and `WagerAccepted` fires. Once the outcome is known, the wager becomes `Resolved` with a recorded `winner`, and the winner calls `claimPayout` to receive both stakes in one transfer (`PayoutClaimed`).
+- **The opponent never shows up.** While the wager is still open, the creator can cancel and get their stake back, the opponent can formally decline, or — once the deadline to accept has passed — anyone at all can trigger a refund to the creator.
+- **The outcome never lands.** If a wager is active but the deadline to resolve passes with no result, either side can trigger a refund that returns each person's own stake.
+- **The event genuinely ties.** Both participants can agree to a draw (or an appointed arbitrator can declare one), and each stake goes home.
 
-The interesting design is in the unhappy paths, because each live state has an exit that requires no cooperation from the other side:
+One subtlety: cancelling an offer that was never accepted erases the wager entirely and returns the creator's money, because no counterparty history exists yet. Once two people are in, refunds and draws keep the record and simply mark it settled. Either way, the money finds its way back.
 
-- **`Open`, opponent never shows.** The creator can `cancelOpen` (emits `WagerCancelled`), the opponent can `declineWager` — both refund the creator immediately — or anyone can call `claimRefund` after the accept deadline passes, emitting `WagerRefunded`.
-- **`Active`, outcome never lands.** After the resolve deadline, `claimRefund` returns each side's own stake and marks the wager `Refunded`.
-- **`Active`, the event genuinely ties.** Both participants consent to a draw (or the arbitrator declares one), each stake goes home, and `WagerDrawn` fires.
+## Two hard deadlines
 
-One subtlety for anyone reading the source: the pre-acceptance exits (`cancelOpen`, `declineWager`) don't set `Status.Cancelled` — they refund the creator and `delete` the wager record entirely, reclaiming storage. The enum value exists for ABI stability, but a cancelled offer simply ceases to be. Post-acceptance exits, by contrast, keep the record and mark it `Refunded` or `Draw`, because two parties' history now hangs off it.
+Every wager carries two fixed calendar deadlines set the moment it's created: a deadline to accept and a deadline to resolve. They are specific dates, not vague durations. The accept deadline must be in the future, the resolve deadline must come after it, and both are capped — an offer goes stale within a month, and even a fully active wager has a guaranteed exit within roughly half a year.
 
-## Two absolute deadlines
+That ordering rule means a wager can never become active with its resolution window already closed. The caps mean no wager can hold money hostage forever. Deadlines are the "something always eventually happens" half of the design: the states guarantee which moves are legal, and the deadlines guarantee some move is always eventually available to a single person acting alone.
 
-Every wager carries two Unix timestamps set at creation: `acceptDeadline` and `resolveDeadline`. They are absolute, not durations, and the contract validates their shape in one shared check (`contracts/wagers/WagerRegistryCore.sol`):
+Notice also who's allowed to trigger the deadline paths. The refund path deliberately pays the original participants no matter who sets it in motion — so a neutral bystander, or an automated helper sweeping up expired wagers, can clean things up without being able to redirect a single cent.
 
-```solidity
-uint64 public constant MAX_ACCEPT_WINDOW = 30 days;
-uint64 public constant MAX_RESOLVE_WINDOW = 180 days;
+## Deciding a winner
 
-function _checkDeadlines(uint64 acceptDeadline, uint64 resolveDeadline) internal view {
-    if (acceptDeadline <= block.timestamp) revert BadDeadlines();
-    if (resolveDeadline <= acceptDeadline) revert BadDeadlines();
-    if (acceptDeadline > block.timestamp + MAX_ACCEPT_WINDOW) revert BadDeadlines();
-    if (resolveDeadline > block.timestamp + MAX_RESOLVE_WINDOW) revert BadDeadlines();
-}
-```
+How a wager gets settled is chosen when it's created and locked in for its whole life. There are two broad families.
 
-The ordering constraint (`accept < resolve`) means the machine can never enter `Active` with its resolution window already closed. The caps mean no wager can hold funds hostage indefinitely: an offer goes stale within 30 days, and even a fully active wager has a guaranteed exit within 180. Deadlines are the liveness half of the design — the state machine guarantees *which* transitions are legal, and the deadlines guarantee that *some* transition is always eventually available to a single, unilateral caller.
+The human paths put the decision in named hands:
 
-Notice also who may trigger the timeout path. `claimRefund` deliberately pays the original participants regardless of who calls it, so a neutral third party — or an automated keeper via `batchExpireOpen` — can sweep expired wagers without being able to redirect a cent.
+- **Either side may declare.** Mutual-trust settlement, only allowed when both people staked the same amount. On a lopsided bet, the side risking less could simply declare itself the winner and grab the bigger pot — so uneven bets must name a single settler, an arbitrator, or an outside referee instead.
+- **One named party declares** — either the creator or the opponent, agreed up front.
+- **A neutral arbitrator declares.** Named at creation, required to be neither participant, and the sole decider.
 
-## Eight ways to decide a winner
+The other family hands the decision to an oracle — the trusted referee that tells the contract who won, an outside source of truth like a market or a data feed that the contract can read. For these wagers, no human declares the result by hand; instead, anyone can trigger an automatic settlement that reads the outcome from the linked source and pays the right side. The system refuses to even create an oracle-settled wager if the referee isn't wired up, or if the question has already been decided — because a bet on a known answer isn't a bet.
 
-`ResolutionType` is fixed per wager at creation and determines exactly one authority that can settle it. The first four are human paths, checked in `_declareWinner`:
+Draws follow the same split. For human-settled wagers, a draw needs consent: the first person proposes it, the second confirms, and either can back out before the other agrees, so a one-sided proposal never freezes anything. An arbitrator can call a draw alone. Oracle-settled wagers can't be drawn by hand — a tie there only arises when the referee itself reports a tie.
 
-- **`Either`** — either participant may declare. This is mutual-trust settlement, and the contract restricts it to equal-stakes wagers (`EitherRequiresEqualStakes`): on an asymmetric wager, the side risking less could self-declare and seize the larger stake, so leveraged offers must name a single settler, an arbitrator, or an oracle.
-- **`Creator` / `Opponent`** — exactly one named party declares.
-- **`ThirdParty`** — an arbitrator, named at creation and required to be neither participant, declares alone.
+## Safe by construction: checks before money moves
 
-The remaining four are oracle paths — `Polymarket`, `ChainlinkDataFeed`, `ChainlinkFunctions`, `UMA` — where `declareWinner` reverts outright and anyone may instead call the auto-resolve entrypoints, which read the linked condition through an `IOracleAdapter` (`contracts/oracles/IOracleAdapter.sol`) and map the boolean outcome to a winner via the `creatorIsYes` flag recorded at creation. Creation-time validation (`_checkOracleLinkage`) refuses an oracle wager whose condition is missing, whose adapter is unwired, or whose condition has *already resolved* — a stale-condition bet is a bet on a known answer.
+The system only ever escrows a short, admin-approved list of stablecoins and similar tokens. Every action that moves money follows the same disciplined order, and the payout is the clearest example.
 
-Draws follow the same authority split. For the participant types, `declareDraw` accumulates consent in a two-bit mask — the first call emits `DrawProposed`, the second settles — and either side can `revokeDraw` before the other agrees, so a one-sided proposal never locks anything. An arbitrator settles a draw solo. Oracle types can't be drawn manually at all; a draw there arises only from the oracle reporting a tie.
+First it checks: is the wager actually resolved, is the caller actually the winner, and has it not already been paid? Only then does it mark the wager as paid — before sending anything — and only then does it transfer the money. Marking "paid" before the transfer is the whole trick: it closes a classic attack where a malicious token tries to re-enter mid-transfer and claim twice. By the time any outside code runs, the wager is already stamped paid. The same "check, record, then move money" order repeats everywhere funds change hands.
 
-## Checks-effects-interactions, everywhere it counts
+The checks stage is also where the compliance layer lives. Before a single token moves, both the sanctions screen and the membership check run against the people involved.
 
-The registry escrows allowlisted ERC-20 stakes — USDC and WMATIC in practice, with amounts as `uint128` and the allowlist admin-controlled via `setTokenAllowed`. Every function that moves tokens follows the same shape, and the payout path is the cleanest illustration:
+## Why we built it this way
 
-```solidity
-function _claimPayout(address actor, uint256 wagerId) internal {
-    Wager storage w = _wagers[wagerId];
-    if (w.status != Status.Resolved) revert NotResolved();
-    if (actor != w.winner) revert NotWinner();
-    if (w.paid) revert AlreadyPaid();
+**Exits stay open even when the system is paused.** An emergency pause can stop new wagers from being created or accepted — but it deliberately does not block declaring a winner, settling a draw, or claiming a payout or refund. An emergency brake must never become a way to trap people's escrowed money. Only a targeted, explicitly moderated freeze on a specific account can block that account's exits.
 
-    w.paid = true;
-    // Compute as uint256 to avoid uint128 overflow on sum
-    uint256 payout = uint256(w.creatorStake) + uint256(w.opponentStake);
-    IERC20(w.token).safeTransfer(w.winner, payout);
+**Fixed dates over countdowns.** Storing real calendar deadlines makes every timeout a simple "are we past this date?" check and lets the app and automated helpers agree on when a wager expires without reconstructing anything.
 
-    emit PayoutClaimed(wagerId, w.winner, payout);
-}
-```
+**One decider per wager, chosen up front.** There's no fallback chain from oracle to arbitrator to participant. Who settles is a commitment both sides accepted at creation. Ambiguity about who gets to call it is exactly the failure mode of the handshake bet, so the system refuses to reintroduce it.
 
-Checks first (right state, right caller, not yet paid), then the effect (`w.paid = true`), then the interaction (the transfer). Even with OpenZeppelin's `ReentrancyGuard` wrapping every external entrypoint, the ordering stands on its own: a reentrant or misbehaving token sees the wager already marked paid. The same pattern repeats in `_settleDraw` and `_claimRefund`, where status flips and consent state is cleared before any `safeTransfer` runs.
+**A stable home that can still improve.** The wager engine lives at a permanent address while its logic can be upgraded in place, with an automated safety check ensuring an upgrade can add to the machine but never scramble the wagers already inside it.
 
-The checks phase is also where the compliance and membership layers live, uniformly across create and accept: a sanctions screen (`ISanctionsGuard.checkBlocked`) on the acting parties, then a membership gate (`IMembershipManager.checkCanCreate`) — all evaluated before a single token moves.
+The result is an escrow system you can reason about like a map: a handful of states, a hard clock on every step that holds money, and no place to get stuck. That shape — not any single clever line of code — is what makes it safe to lock 400 USDC between two people who trust the outcome more than they trust each other.
 
-## Design decisions
+## Further reading
 
-**Exits stay open when the machine is paused.** A `GUARDIAN_ROLE` pause halts *new* activity — `createWager` and `acceptWager` carry `whenNotPaused` — but `declareWinner`, `declareDraw`, `claimPayout`, and `claimRefund` deliberately do not. An emergency stop must never become a mechanism for stranding escrowed funds; only per-account freezes (an explicitly moderated state) block an individual's exits.
-
-**Absolute timestamps over durations.** Storing `acceptDeadline`/`resolveDeadline` as absolute `uint64` values makes every timeout check a single comparison against `block.timestamp`, makes deadlines legible off-chain without reconstruction, and lets the frontend, subgraph, and keepers all agree on expiry without knowing creation time.
-
-**One authority per wager, chosen up front.** There is no fallback chain from oracle to arbitrator to participant. A wager's resolution path is a creation-time commitment both sides accepted; ambiguity about who settles is precisely the failure mode of the handshake bet, so the contract refuses to reintroduce it.
-
-**Events as the integration surface.** `WagerCreated`, `WagerAccepted`, `WagerResolved`, `PayoutClaimed`, `WagerRefunded`, `WagerCancelled`, and `WagerDrawn` mirror every transition, and an append-only per-user index (`getUserWagers`) gives O(user) lookups without log scans. The subgraph and frontend never need to reconstruct state transitions from storage diffs.
-
-**A state machine at a stable address.** Since spec 025 (`specs/025-upgradeable-registry/`), the registry is a UUPS proxy: wager state lives at a permanent address while logic ships as in-place upgrades, gated by a storage-layout compatibility check so an upgrade can extend the machine but never scramble the wagers already inside it. The behavior in this post — every state, every exit — survives an upgrade because the upgrade process is not allowed to touch the storage that encodes it.
-
-The result is an escrow contract you can audit as a graph: seven states, a bounded clock on every edge that holds money, and no node without an exit. That shape — not any single clever line — is what makes it safe to lock 400 USDC between two people who trust the outcome more than they trust each other.
-
-## Sources
-
-- `contracts/wagers/WagerRegistry.sol` — external entrypoints, admin surface, pause/freeze semantics
-- `contracts/wagers/WagerRegistryCore.sol` — shared state, `_checkDeadlines`, `_createWager`, `_declareWinner`, `_declareDraw`, `_claimPayout`, `_claimRefund`
-- `contracts/interfaces/IWagerRegistryTypes.sol` — `Status` / `ResolutionType` enums, `Wager` struct, event definitions
-- `contracts/oracles/IOracleAdapter.sol` — oracle resolution interface
-- `docs/developer-guide/smart-contracts.md` — state-machine diagram, resolution-type table, deployed addresses
-- `specs/025-upgradeable-registry/spec.md` — UUPS migration rationale and storage-layout guarantees
-- `test/WagerRegistry.test.js`, `test/WagerRegistry.draw.test.js` — lifecycle, deadline, refund, and draw-consent behavior
-- OpenZeppelin Contracts: ReentrancyGuard, SafeERC20, AccessControl, UUPS — https://docs.openzeppelin.com/contracts
-- EIP-712 (typed structured data signing, used by the open-challenge accept path) — https://eips.ethereum.org/EIPS/eip-712
-- ERC-1822 / UUPS proxiable standard — https://eips.ethereum.org/EIPS/eip-1822
+- [ERC-20](https://eips.ethereum.org/EIPS/eip-20) — the token standard behind the stablecoins used as stakes
+- [Reentrancy and the "checks-effects-interactions" pattern](https://en.wikipedia.org/wiki/Reentrancy_(computing)) — the class of attack the payout ordering defends against
+- [EIP-712 typed-data signing](https://eips.ethereum.org/EIPS/eip-712) — the standard behind accepting an open challenge with a signature
+- [OpenZeppelin Contracts](https://docs.openzeppelin.com/contracts) — the audited building blocks used for access control and safe token transfers

--- a/docs/blog/posts/14-wager-lifecycle-contract/social.md
+++ b/docs/blog/posts/14-wager-lifecycle-contract/social.md
@@ -1,27 +1,27 @@
-# Social & Image — The Wager Lifecycle Contract
+# Social & Image — The Wager Lifecycle
 
 ## X (Twitter)
 
-A P2P escrow contract is really a state machine over other people's money. FairWins' WagerRegistry: 7 states, 2 hard deadlines (30d accept / 180d resolve), 8 resolution authorities — and no state without a unilateral exit. Anatomy inside. 🔗 <link> #Solidity #SmartContracts #web3
+A peer-to-peer escrow is really a careful set of rules over other people's money. FairWins wagers: a handful of clear states, two hard deadlines (accept within a month, resolve within ~6 months), several ways to decide a winner — and no state without a one-sided exit. Anatomy inside. 🔗 <link> #PredictionMarkets #Web3
 
 ## LinkedIn
 
-Informal bets fail in predictable ways: the counterparty never commits their stake, nobody has authority to declare the winner, the event never resolves, or the money gets stuck. Building an on-chain escrow that closes every one of those holes is a design exercise in state machines, not just token transfers.
+Informal bets fail in predictable ways: the other person never puts their money in, nobody has authority to declare the winner, the event never happens, or the money gets stuck. Building an escrow that closes every one of those holes is a design exercise in clear states and guaranteed exits, not just moving tokens around.
 
-Part 1 of our Prediction Markets series dissects FairWins' `WagerRegistry` — the peer-to-peer wager escrow contract — as a lifecycle:
+Part 1 of our Prediction Markets series walks through the FairWins wager lifecycle in plain terms:
 
-- Seven explicit states (Open → Active → Resolved/Refunded/Draw) where every state that holds funds has an exit requiring no cooperation from the other party
-- Two absolute deadlines per wager (acceptDeadline, resolveDeadline) with hard caps of 30 and 180 days, so escrow can never be stranded indefinitely
-- Eight resolution types — participant-declared, arbitrator, and oracle-driven (Polymarket, Chainlink, UMA) — each fixing exactly one settlement authority at creation
-- Checks-effects-interactions discipline on every token movement, and why exit paths deliberately stay open even when the contract is paused
+- A handful of clear states (open → active → resolved / refunded / draw) where every state that holds funds has an exit needing no cooperation from the other person
+- Two hard deadlines per wager — one to accept, one to resolve — capped so escrow can never be stranded indefinitely
+- Several ways to decide a winner — named parties, a neutral arbitrator, or an oracle (the trusted referee that tells the contract who won) — each fixed at creation
+- "Check, record, then move money" discipline on every payout, and why exits deliberately stay open even when the system is paused
 
-If you're building anything that escrows funds between untrusting parties, the lifecycle framing here generalizes well beyond wagers.
+These are skill-based forecasts on publicly available information; participants remain subject to applicable law. If you're building anything that escrows funds between parties who don't fully trust each other, the lifecycle framing here generalizes well beyond wagers.
 
 Read the full post: <link>
 
-What's your approach to guaranteeing liveness in escrow contracts — timeouts, keepers, or something else?
+What's your approach to guaranteeing that escrowed funds always have a way out — timeouts, automated helpers, or something else?
 
-#Solidity #SmartContracts #Ethereum #DeFi #Engineering
+#PredictionMarkets #SmartContracts #Fintech #Web3 #Engineering
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/15-oracle-adapter-abstraction/blog.md
+++ b/docs/blog/posts/15-oracle-adapter-abstraction/blog.md
@@ -1,150 +1,90 @@
-# Three Kinds of Truth, One Interface: The Oracle Adapter Layer
+# Three Kinds of Truth, One Referee Slot: How FairWins Settles a Bet
 
-*How a single `IOracleAdapter` contract interface absorbs push feeds, request/callback oracles, optimistic dispute, and Polymarket's resolved markets — without the escrow contract knowing the difference*
+*How four very different sources of truth — live price feeds, on-demand data lookups, human-judgment disputes, and resolved prediction markets — all plug into the same slot, so the escrow never has to know the difference*
 
 | | |
 |---|---|
 | **Series** | Prediction Markets (part 2) |
 | **Part** | 15 of 34 |
-| **Audience** | Oracle integrators, smart-contract engineers |
-| **Tags** | `oracles`, `chainlink`, `uma`, `polymarket`, `adapter-pattern` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product managers, founders, and the crypto-curious |
+| **Tags** | `oracles`, `prediction-markets`, `how-it-works` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-> **Important Note**: This article describes prediction markets based on publicly available information and legitimate forecasting. Oracle-settled wagers are not a mechanism for trading on material non-public information or circumventing securities regulations. All participants remain fully subject to applicable laws and compliance requirements.
+> **Responsible-use note.** This article describes prediction markets based on publicly available information and legitimate, skill-based forecasting. Oracle-settled wagers are not a mechanism for trading on material non-public information or circumventing securities regulations. All participants remain fully subject to applicable law and compliance obligations in their jurisdiction.
 
 ---
 
-## Three wagers, three truths
+## Three wagers, three kinds of truth
 
 Consider three wagers a member might create on FairWins:
 
-1. *"ETH closes above $4,000 on September 30."* The truth is a number that a Chainlink price feed already publishes on-chain, continuously, whether anyone asks or not.
-2. *"The city's open-data API reports more than 40mm of rainfall for October."* The truth lives behind an HTTPS endpoint. Nothing on-chain knows it until someone goes and fetches it.
-3. *"The Meridian–Vantage merger closes before Q3."* The truth is a human judgment about a messy real-world event. No feed publishes it; no API is authoritative. Someone has to assert it, and someone else has to be able to dispute them.
+1. *"ETH closes above $4,000 on September 30."* The truth is a number that a well-known price feed already publishes on the blockchain, continuously, whether anyone asks or not.
+2. *"The city's open-data service reports more than 40mm of rainfall for October."* The truth lives behind a web address. Nothing on the blockchain knows it until someone goes and fetches it.
+3. *"The Meridian–Vantage merger closes before the third quarter."* The truth is a human judgment about a messy real-world event. No feed publishes it and no service is authoritative. Someone has to assert it, and someone else has to be able to dispute them.
 
-Each of these needs a fundamentally different oracle. The first is a **push feed**: data arrives on-chain on the oracle's schedule and you read the latest value. The second is **request/callback**: you send a request, a decentralized network executes it off-chain, and the answer comes back in an asynchronous callback. The third is **optimistic dispute**: anyone may assert the answer with a bond; the assertion stands unless challenged within a liveness window, and challenges escalate to a voting-based resolution.
+Each needs a fundamentally different referee — an oracle, meaning the trusted outside source that tells the contract who won. The first is a live feed: data arrives on the blockchain on its own schedule and you read the latest value. The second is an on-demand lookup: you ask a question, a network fetches the answer off the blockchain, and it comes back a moment later. The third is a dispute process: anyone may assert the answer by putting up a deposit, and the assertion stands unless someone challenges it within a set window.
 
-FairWins' escrow contract — the `WagerRegistry` covered in part 1 — should not care about any of this. It holds two stakes and needs exactly one bit: did YES win? The engineering problem is designing the seam so that four very different resolution machines (the three above, plus reading Polymarket's already-resolved markets) all collapse to that one bit, with the same failure semantics, behind the same interface.
+Here's the key idea. The FairWins escrow — the wager engine from part 1 — should not care about any of this. It holds two stakes and needs exactly one fact: did the "yes" side win? The engineering challenge is designing a single slot so that four wildly different referees all reduce to that one yes-or-no answer, with the same behavior when the answer isn't available yet.
 
-## The interface: one bit, one sentinel
+## The slot: one yes-or-no, one "not yet"
 
-The seam is `contracts/oracles/IOracleAdapter.sol`. Every adapter — Polymarket, Chainlink Data Feeds, Chainlink Functions, UMA Optimistic Oracle V3 — implements it. The heart of the interface is two functions:
+Every referee, no matter how it works inside, plugs into the same standard slot and answers two questions: has this been decided yet, and if so, who won? The answer to "who won" is deliberately just a single yes-or-no. FairWins wagers are binary — the creator takes one side, the opponent the other — so every referee's richer internal output (numbers, arrays, verdicts) gets boiled down to one bit right at the boundary, keeping the escrow's settlement logic to a single shape of answer.
 
-```solidity
-function isConditionResolved(bytes32 conditionId)
-    external view returns (bool resolved);
+One more convention does a surprising amount of work: asking a referee is always safe and never errors out. If the answer isn't ready, it simply reports "not resolved yet." That lets the app, the escrow, and automated helpers all check in cheaply and often — and, as we'll see, it lets an undecidable outcome route to a refund instead of a wrong payout. Each referee also advertises whether it's available on a given network, so the app can hide a settlement option that isn't wired up rather than let a member start a wager that would dead-end.
 
-function getOutcome(bytes32 conditionId) external view returns (
-    bool outcome,      // true if the "YES" or "PASS" side won
-    uint256 confidence, // basis points, 10000 = 100%
-    uint256 resolvedAt  // timestamp; 0 = not resolved
-);
-```
+## How the escrow stays referee-agnostic
 
-Three conventions do the real work:
+The escrow keeps a small directory: for each kind of oracle settlement, which referee to consult. Wiring one up is an admin action; leaving one unset disables that option on that network. The referee is consulted at exactly two moments.
 
-**`bytes32 conditionId` is the universal key.** Each adapter defines what a condition id *means* — a Polymarket CTF condition hash, an admin-registered feed-threshold config, a Functions request template, an UMA claim — but to the registry it is an opaque 32-byte handle stored on the wager.
+At creation, the escrow checks that an oracle-settled wager names a valid question, that a referee for its type is configured, and — importantly — that the question hasn't already been decided. You can't open a wager on an outcome the referee has already called.
 
-**The outcome is a `bool`, deliberately.** FairWins wagers are binary: creator takes one side, opponent takes the other. Collapsing every oracle's richer output (payout numerator arrays, `int256` feed answers, DON byte responses, assertion verdicts) down to a single bool at the adapter boundary means the registry's settlement code has exactly one shape.
+At settlement, anyone may trigger resolution. This is permissionless on purpose: the outcome is a pure fact of public record, so there's no reason to restrict who pushes the button. The escrow looks up the right referee, asks who won, and pays out — or, if the answer is "not yet," waits. That's the entire connection; the escrow contains no referee-specific code at all.
 
-**`resolvedAt == 0` is the unresolved sentinel.** `getOutcome` is a view; it never reverts on "not yet." A zero timestamp tells the caller there is nothing to act on. This one convention carries surprising weight, as we'll see with Polymarket ties.
+## Referee one: reading a resolved prediction market
 
-The interface also carries operational surface: `oracleType()` (a human-readable tag like `"Polymarket"` or `"UMA-OOv3"`), `isAvailable()` (is the underlying oracle actually deployed and responsive on this network?), `isConditionSupported`, and `getConditionMetadata`.
+The simplest referee doesn't run an oracle at all — it reads the output of one. Large public prediction markets already resolve their questions and publish the result on the blockchain. This referee looks up that published result and maps it to a plain yes-or-no. It costs almost nothing to operate — no deposits, no subscriptions, no data to curate — which is why it's the model FairWins offers first.
 
-## The consumer: how `WagerRegistry` stays oracle-agnostic
+The subtle case is a tie. These markets occasionally resolve 50/50 — an "invalid" or disputed outcome. That's not a decidable yes-or-no, and paying either side would be wrong. So the referee reports "not resolved" even though the market technically settled, and the escrow reads that as "resolved tie" and settles the wager as an immediate draw: both stakes returned. The failure mode of an undecidable question is a refund, never a coin flip.
 
-The registry (`contracts/wagers/WagerRegistryCore.sol`) holds a dedicated `IOracleAdapter public polymarketAdapter` slot — kept for ABI compatibility with the original Polymarket-only design — plus a generic registry for everything after it:
+The trade-offs: you can only wager on questions the market already lists, and the timing is out of your hands. In exchange, it's nearly free to run.
 
-```solidity
-mapping(ResolutionType => IOracleAdapter) public oracleAdapters;
-```
+## Referee two: a threshold on a live price feed
 
-`ResolutionType` (in `contracts/interfaces/IWagerRegistryTypes.sol`) enumerates `Polymarket`, `ChainlinkDataFeed`, `ChainlinkFunctions`, and `UMA` alongside the human-arbitrated types. Admins wire adapters with `setPolymarketAdapter` / `setOracleAdapter`; an unset adapter simply disables that resolution type on that network.
+The second referee turns a continuously-updated price feed into a yes-or-no. An admin registers a condition like "is this feed above this number after this date?" Once the date passes, anyone can trigger the evaluation: it reads the feed, insists the reading is fresh enough (rejecting stale data), compares it to the threshold, and locks in the answer.
 
-The adapter is consulted at exactly two moments in a wager's life:
+The trade-offs: this only answers questions that boil down to "a number versus a threshold at or after a time." But for those it's the cheapest and lowest-trust of the four, because the data is already on the blockchain and anyone can trigger the check. The honest caveat: the reading is the latest value at the moment someone evaluates, not the exact value at the deadline instant — though the freshness requirement bounds this.
 
-**At creation**, `_checkOracleLinkage` enforces that an oracle-typed wager carries a non-zero condition id, that the adapter for its type is configured, and — the stale-condition mitigation — that the condition is *not already resolved*. You cannot open a wager on an outcome the oracle has already decided.
+## Referee three: an on-demand lookup for arbitrary data
 
-**At settlement**, anyone may call `autoResolveFromPolymarket(wagerId)` or the generic `autoResolveFromOracle(wagerId)` (both live in the `WagerRegistryIntents` facet; part 1 covered why the registry is two facets behind one proxy). The path is permissionless by design — settlement is a pure function of public oracle state, so there is no reason to gate who triggers it. The generic path is four lines of essence: look up the adapter for `w.resolutionType`, call `getOutcome`, revert `ConditionNotResolved` if `resolvedAt == 0`, otherwise settle the win.
+The third referee handles truths that live behind a web service. It registers a small, pinned script describing exactly what to fetch, then anyone can request resolution: a decentralized network runs the script off the blockchain and delivers the answer back a moment later, which gets locked in.
 
-That's the whole coupling. The registry never imports a Chainlink or UMA interface.
+Because the answer comes back asynchronously, two safeguards matter. A second request is blocked while one is in flight, and a failed fetch leaves the question unresolved — so a flaky data source means "try again," never "wrong answer locked in forever."
 
-## Adapter one: Polymarket, reading someone else's settled truth
+The trade-offs: maximum flexibility — any public data a script can reach — paid for in trust and upkeep. You're trusting the registered script and the service it queries. There's a funded subscription to maintain, and the round trip means settlement takes two steps.
 
-`contracts/oracles/PolymarketOracleAdapter.sol` doesn't run an oracle at all — it reads the output of one. Polymarket markets settle on the Gnosis Conditional Token Framework (CTF), where a condition id is `keccak256(oracle, questionId, outcomeSlotCount)` and resolution is a pair of payout numerators: `[1,0]` means YES, `[0,1]` means NO. The adapter fetches `getPayoutNumerators` from the CTF contract (Polygon only — Polymarket runs nowhere else), caches the result, and maps `payouts[0] > payouts[1]` to `outcome = true`.
+## Referee four: truth by unchallenged assertion
 
-The subtle case is a tie. Polymarket markets occasionally resolve 50/50 — an "invalid" or UMA-disputed market. Equal numerators are not a decidable YES/NO, and paying either side would be wrong. The adapter's answer is the sentinel:
+The fourth referee handles the merger question — outcomes that need human judgment. Someone asserts the answer and puts up a deposit. If nobody disputes it within a set window, the assertion is accepted as truth. If someone does dispute it, the question escalates to a broader token-holder vote, and the verdict comes back the same way. The referee doesn't care whether the answer arrived quietly or after a fight — it just records it.
 
-```solidity
-// A tie (equal payout numerators — e.g. a 50/50 split or an
-// "invalid"/UMA-disputed Polymarket resolution) is not a decidable
-// YES/NO outcome. Return the unresolved sentinel (resolvedAt=0) so
-// WagerRegistry leaves the wager unsettled and the deadline-based
-// refund path returns both stakes, rather than paying a fixed side.
-if (cached.passNumerator == cached.failNumerator) {
-    return (false, 0, 0);
-}
-```
+The trade-offs: this is the only one of the four that can answer genuinely arbitrary questions — at the cost of capital (someone must post a deposit), time (the challenge window is a floor on resolution), and an economic assumption: an unchallenged false assertion wins, so the deposit has to make it worthwhile for honest people to watch.
 
-On the registry side, `autoResolveFromPolymarket` disambiguates: `resolvedAt == 0` *plus* `isConditionResolved() == true` means "resolved tie," and the wager settles as an immediate draw — both stakes back. A genuinely unresolved market reverts and the deadline-based refund path remains the backstop. The failure mode of an undecidable question is a refund, never a coin-flip payout.
+## The shared discipline
 
-**Trade-offs:** you can only wager on questions Polymarket already lists; resolution timing is entirely external; and you inherit Polymarket's own resolution stack (which is itself UMA underneath). In exchange, the adapter is nearly free to operate — no bonds, no subscriptions, no feed curation — which is why it's the model FairWins exposes first.
+The four referees agree on more than the slot. Each remembers its answer after the first resolution, so future checks are cheap. Each makes triggering settlement open to anyone while keeping the setup of questions restricted to admins — curation is trusted, settlement is not. And here's the quiet payoff: FairWins currently exposes only the resolved-prediction-market option to members, keeping the other three behind a configuration switch, while the underlying system fully supports all four. Narrowing the product to one option required zero changes to the escrow, because the slot was already there.
 
-## Adapter two: Chainlink Data Feeds, a threshold on a push feed
+## Why we built it this way
 
-`contracts/oracles/ChainlinkDataFeedOracleAdapter.sol` turns a continuously-updated price feed into a binary outcome. An admin registers a condition as `(feed, threshold, comparison, deadline)` — the comparison being one of `GT/GTE/LT/LTE/EQ` — against an allowlisted `AggregatorV3Interface` feed. After the deadline, *anyone* calls `evaluate(conditionId)`: it reads `latestRoundData()`, requires `updatedAt >= deadline` (rejecting stale data with `StaleFeedData`), compares the answer to the threshold, and caches the boolean forever.
+- **A yes-or-no answer, not a rich payout.** Binary wagers need one bit; funneling every referee's output through that single shape keeps settlement singular. The cost is that multi-outcome markets need a different design.
+- **Fail toward a refund.** Undecidable market outcomes settle as draws; failed lookups stay unresolved; stale feeds are rejected. No path ever guesses a winner.
+- **Referees are optional add-ons.** The escrow works with zero referees configured; each degrades gracefully to "this settlement type isn't available here," and the app reflects that per network.
 
-**Trade-offs:** this model only answers questions that reduce to *number vs. threshold at/after time T* — but for those it is the cheapest and lowest-trust of the four, because the data is already on-chain and the evaluation is a pure function anyone can trigger. The honest caveat: `latestRoundData()` is the latest answer *at evaluation time*, not the answer at the deadline instant. The staleness check bounds this (the round must postdate the deadline), and the first caller after the deadline fixes the reading — an incentive to evaluate promptly if the number is drifting your way.
+Four referees, three ways of working, one slot — and an escrow that never learned the difference.
 
-## Adapter three: Chainlink Functions, request/callback for arbitrary APIs
+## Further reading
 
-`contracts/oracles/ChainlinkFunctionsOracleAdapter.sol` handles truths that live behind an API. A condition registers an encoded Chainlink Functions request (the JavaScript source is pinned by a `sourceHash`), a subscription id, gas limit, and DON id. `requestResolution(conditionId)` — again permissionless — sends the request to the Decentralized Oracle Network; the answer arrives asynchronously in the inherited `fulfillRequest` callback, which decodes the DON script's single `uint8` return (0 = NO, 1 = YES) and caches it.
-
-Asynchrony forces two guards the synchronous adapters don't need: a `conditionToPendingRequest` mapping rejects a second request while one is in flight, and a DON-reported error emits `RequestFailed` and leaves the condition unresolved — so a flaky API means "try again," never "wrong answer cached forever."
-
-**Trade-offs:** maximum expressiveness — any public API a script can query — paid for in trust and operations. You are trusting the registered script and the API it queries; the source hash makes the script auditable but not less trusted. There's a funded subscription to maintain, and the request/callback round trip means resolution is a two-transaction affair.
-
-## Adapter four: UMA Optimistic Oracle V3, truth by unchallenged assertion
-
-`contracts/oracles/UMAOptimisticOracleV3Adapter.sol` handles the merger question — outcomes that need human judgment. A condition registers a human-readable `claim`, a bond currency and amount, and a liveness window. `assertResolution(conditionId, asserter)` pulls the bond from the caller and posts the claim to UMA's Optimistic Oracle V3 via `assertTruth`. If the liveness window passes undisputed, OOv3 calls back `assertionResolvedCallback(assertionId, assertedTruthfully)` and the adapter caches the verdict. If disputed, the question escalates to UMA's Data Verification Mechanism (a token-holder vote) and resolves through the same callback — the adapter doesn't distinguish a quiet settlement from a fought one.
-
-One implementation detail worth stealing: the adapter reserves `conditionToAssertion[conditionId]` with a sentinel value *before* the external `assertTruth` call, so a reentrant call sees "assertion already pending" and reverts — checks-effects-interactions preserved without a post-call write to that mapping (the real `assertionId → conditionId` link lives in a separate mapping written after the call). The regression suite for this lives in `test/oracles/UMAOptimisticOracleV3Adapter.test.js`.
-
-**Trade-offs:** the only model of the four that can answer *arbitrary* questions — at the cost of capital (someone must post the bond), latency (the liveness window is a floor on resolution time), and an economic-security assumption: an unchallenged false assertion wins, so the bond must make watching worthwhile.
-
-## Shared discipline across all four
-
-The adapters converge on more than the interface. All cache resolutions in an identical `CachedResolution` struct, making `getOutcome` a cheap view after the first resolution. All make the resolution *trigger* permissionless while keeping condition *registration* owner-only — curation is trusted, settlement is not. And all take an explicit `admin` constructor argument rather than `Ownable(msg.sender)`: FairWins deploys adapters deterministically via CREATE2 through the Safe Singleton Factory, and `msg.sender` in that context is the factory, not the operator. `test/oracles/AdapterDeterministicOwnership.test.js` is the regression test for the day that bug shipped.
-
-`isAvailable()` earns its keep off-chain: spec 023 (`specs/023-oracle-graph-gating/`) gates the frontend's oracle-wager entry point per network, so a user on a chain with no adapters never starts a flow that dead-ends. And spec 003 (`specs/003-polymarket-only-oracle-ui/`) is the abstraction's quiet payoff: the frontend currently exposes *only* the Polymarket model, hiding Chainlink and UMA behind a configuration switch — while the contracts keep all four fully supported. Narrowing the product surface required zero contract changes, because the seam was already there.
-
-## Design decisions
-
-- **A `bool` outcome, not a payout vector.** Binary wagers need one bit; forcing every oracle's output through that funnel at the adapter boundary keeps settlement code singular. The cost is that multi-outcome markets need a different design (wager pools solve this differently — spec 034).
-- **Sentinel over revert for "unresolved."** `getOutcome` as a non-reverting view lets the registry, the frontend, and keepers poll cheaply, and lets "resolved tie" and "not resolved" share a wire format while the registry disambiguates with one extra call.
-- **Fail toward refund.** Undecidable Polymarket outcomes settle as draws; failed Functions requests stay unresolved; stale feeds revert. No path guesses a winner.
-- **`confidence` is honest.** Every adapter today returns 10,000 basis points (or 0 with the sentinel). The field exists so a future probabilistic adapter can report less than certainty without an interface break — it is headroom, not a claim.
-- **Adapters are peripherals, not dependencies.** The registry works with zero adapters configured; each adapter degrades to "this resolution type unavailable here," and the UI reflects that per network.
-
-Four resolution machines, three interaction models, one interface — and an escrow contract that never learned the difference.
-
-## Sources
-
-- `contracts/oracles/IOracleAdapter.sol` — the shared interface
-- `contracts/oracles/PolymarketOracleAdapter.sol` — CTF resolved-market reads, tie sentinel
-- `contracts/oracles/ChainlinkDataFeedOracleAdapter.sol` — push-feed threshold evaluation
-- `contracts/oracles/ChainlinkFunctionsOracleAdapter.sol` — request/callback via DON
-- `contracts/oracles/UMAOptimisticOracleV3Adapter.sol` — optimistic assertion + dispute callback
-- `contracts/wagers/WagerRegistryCore.sol`, `contracts/wagers/WagerRegistryIntents.sol` — `_checkOracleLinkage`, `autoResolveFromPolymarket`, `autoResolveFromOracle`
-- `contracts/interfaces/IWagerRegistryTypes.sol` — `ResolutionType` enum
-- `specs/003-polymarket-only-oracle-ui/spec.md` — Polymarket-only frontend exposure
-- `specs/023-oracle-graph-gating/spec.md` — per-network oracle availability gating
-- `test/oracles/` — adapter unit tests incl. `AdapterDeterministicOwnership.test.js`
-- `docs/developer-guide/oracle-open-challenges.md` — oracle-settled open challenges
-- Chainlink Data Feeds: https://docs.chain.link/data-feeds
-- Chainlink Functions: https://docs.chain.link/chainlink-functions
-- UMA Optimistic Oracle V3: https://docs.uma.xyz/developers/optimistic-oracle-v3
-- Polymarket documentation: https://docs.polymarket.com
-- Gnosis Conditional Token Framework: https://docs.gnosis.io/conditionaltokens/
+- [Chainlink Data Feeds](https://docs.chain.link/data-feeds) — live on-chain price feeds
+- [Chainlink Functions](https://docs.chain.link/chainlink-functions) — on-demand off-chain data lookups
+- [UMA Optimistic Oracle](https://docs.uma.xyz/developers/optimistic-oracle-v3) — truth by unchallenged assertion with a dispute window
+- [Polymarket](https://docs.polymarket.com) and the [Gnosis Conditional Token Framework](https://docs.gnosis.io/conditionaltokens/) — how public prediction markets record their resolved outcomes

--- a/docs/blog/posts/15-oracle-adapter-abstraction/social.md
+++ b/docs/blog/posts/15-oracle-adapter-abstraction/social.md
@@ -1,27 +1,27 @@
-# Social & Image — Three Kinds of Truth, One Interface: The Oracle Adapter Layer
+# Social & Image — Three Kinds of Truth, One Referee Slot
 
 ## X (Twitter)
 
-One escrow contract, four oracles: Polymarket resolved markets, Chainlink push feeds, request/callback Functions, UMA optimistic assertions. All collapse to one bool behind IOracleAdapter — and an undecidable tie becomes a refund, never a coin flip. 🔗 <link> #Solidity #Oracles
+One escrow, four referees: resolved prediction markets, live price feeds, on-demand data lookups, and human-judgment disputes. All plug into one slot and answer a single yes-or-no — and an undecidable tie becomes a refund, never a coin flip. 🔗 <link> #PredictionMarkets #Oracles
 
 ## LinkedIn
 
-An escrow contract that settles forecasting wagers needs exactly one bit from the outside world: did YES win? But the truth behind that bit can live in very different places — a price feed that publishes on-chain continuously, an HTTPS API nothing on-chain knows about, or a messy real-world event that needs a human assertion with a dispute window.
+An escrow that settles forecasting wagers needs exactly one fact from the outside world: did the "yes" side win? But the truth behind that fact can live in very different places — a price feed that publishes on-chain continuously, a web service nothing on-chain knows about, or a messy real-world event that needs a human assertion with a dispute window.
 
-Our latest FairWins engineering post covers how one Solidity interface absorbs all of them:
+Our latest FairWins engineering post covers how one standard slot absorbs all of them — an oracle being the trusted referee that tells the contract who won:
 
-- The `IOracleAdapter` seam: an opaque `bytes32` condition id, a single `bool` outcome, and a `resolvedAt == 0` sentinel for "nothing to act on yet"
-- Four adapters, three interaction models: Polymarket resolved-market reads, Chainlink Data Feed thresholds, Chainlink Functions request/callback, and UMA Optimistic Oracle V3 assertions
+- One slot, one yes-or-no answer, and a "not resolved yet" signal for "nothing to act on"
+- Four referees, three ways of working: resolved prediction markets, live price-feed thresholds, on-demand data lookups, and unchallenged-assertion disputes
 - Failure semantics that never guess: a 50/50 or invalid market settles as a draw with both stakes returned — no path invents a winner
-- Why the escrow registry never imports a Chainlink or UMA interface, and how that let the product narrow to Polymarket-only with zero contract changes
+- Why the escrow never contains any referee-specific code, and how that let the product narrow to a single option with zero changes to the escrow
 
-These are skill-based forecasts on publicly available information, and the design goal is honest settlement — including when the honest answer is "nobody won."
+These are skill-based forecasts on publicly available information, and participants remain subject to applicable law. The design goal is honest settlement — including when the honest answer is "nobody won."
 
 Read the full post: <link>
 
-If you've integrated multiple oracle providers behind one interface, what convention did you standardize on for "not resolved yet"?
+If you've plugged multiple data sources behind one interface, what convention did you standardize on for "not resolved yet"?
 
-#Solidity #Oracles #SmartContracts #Chainlink #web3
+#PredictionMarkets #Oracles #SmartContracts #Web3
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/16-draw-resolution-open-challenges/blog.md
+++ b/docs/blog/posts/16-draw-resolution-open-challenges/blog.md
@@ -1,14 +1,14 @@
-# When Nobody Wins and Anyone Can Play: Draw Resolution and Open-Challenge Wagers
+# When Nobody Wins and Anyone Can Play: Draws and Open Challenges
 
-*The two edge cases that make a peer-to-peer betting protocol feel finished: settling a wager that has no fair winner, and posting a wager that has no opponent yet*
+*The two edge cases that make a peer-to-peer betting app feel finished: settling a wager that has no fair winner, and posting a wager that has no opponent yet*
 
 | | |
 |---|---|
 | **Series** | Prediction Markets, part 3 |
 | **Part** | 16 of 34 |
-| **Audience** | Smart-contract developers |
-| **Tags** | `prediction-markets`, `escrow`, `edge-cases`, `solidity` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product-minded builders, founders, and the crypto-curious |
+| **Tags** | `prediction-markets`, `escrow`, `edge-cases`, `product-design` |
+| **Reading time** | ~7 minutes |
 
 ---
 
@@ -16,147 +16,72 @@
 
 ---
 
-## Two Wagers That the Happy Path Can't Handle
+## Two wagers the happy path can't handle
 
-Dana and Priya have 200 USDC each escrowed on whether a cup final ends in a home win. Mid-week, the match is abandoned — rescheduled outside the window their wager described. Neither of them should win. Under the original `WagerRegistry`, their only exit was to do nothing: wait for the `resolveDeadline` to pass, then call `claimRefund`, which returns both stakes on a timed-out Active wager. It works, but it is slow, and on-chain it is indistinguishable from two people who simply forgot about their bet. An indexer, a history view, or a dispute reviewer cannot tell a deliberate "we agree this is void" from abandonment.
+Dana and Priya each put 200 USDC into escrow on whether a cup final ends in a home win. Mid-week the match is abandoned and rescheduled outside the window their wager described. Neither of them should win.
 
-The second gap is at the other end of the lifecycle. Marcus wants to post a wager to his group chat: 50 USDC on a Polymarket market, first taker wins the other side. But `createWager` binds a named `opponent` at creation, and only that exact address can accept. There is no way to say "whoever wants this, take it" — let alone to do so without broadcasting the private terms to every mempool scanner watching for fresh escrow.
+In the earliest version of FairWins, their only exit was to do nothing: wait for the resolution deadline to pass, then claim a refund, which returns both stakes on a timed-out wager. That works, but it is slow — and on the public ledger it looks identical to two people who simply forgot about their bet. Anyone reading the history later, including a dispute reviewer, could not tell a deliberate "we agree this is void" from plain abandonment.
 
-These are the edge cases that separate a demo from a protocol. FairWins closed them with two features: **draw resolution** (spec 004) — a deliberate, distinctly-recorded "both stakes back" outcome — and **open-challenge wagers** (specs 024 and 041) — counterparty-less wagers gated by a four-word claim code. Both live in the same contracts: `contracts/wagers/WagerRegistry.sol` and the shared storage/logic base `contracts/wagers/WagerRegistryCore.sol`.
+The second gap sits at the other end of the story. Marcus wants to drop a wager into his group chat: 50 USDC on a public prediction market, first taker gets the other side. But a normal wager names one specific opponent at creation, and only that exact wallet can accept. There was no way to say "whoever wants this, take it" — let alone to do it without broadcasting the private terms to every automated bot watching for fresh escrow.
 
-## A Seventh Terminal State
+These are the edge cases that separate a demo from a product. FairWins closed them with two features: **draw resolution** — a deliberate, distinctly recorded "both stakes back" outcome — and **open-challenge wagers** — counterparty-less wagers protected by a four-word claim code.
 
-The wager state machine gained one enum member and one event:
+## A distinct "draw" outcome
 
-```solidity
-enum Status { None, Open, Active, Resolved, Cancelled, Refunded, Draw }
+The first fix was to give the system a real, named outcome for a draw, separate from a refund. That distinction is the whole point. A timed-out refund and a mutually agreed draw return the same money, but they mean different things, and now the app and its public history can show "settled as a draw" differently from "timed out."
 
-event WagerDrawn(uint256 indexed wagerId, address indexed creator,
-                 address indexed opponent, address by);
-```
+Settlement itself is deliberately boring: each party gets back exactly their own stake. Stakes need not be equal, and no value moves between participants — it is a clean unwind, not a payout. Under the hood it reuses the same safe transfer pattern the refund path already relied on, updating the wager's status before any money moves.
 
-(`contracts/interfaces/IWagerRegistryTypes.sol`.) `Draw` is terminal and distinct from `Refunded`, which is the whole point: the subgraph and the app can render "settled as a draw" differently from "timed out." Settlement itself is deliberately boring — it reuses the proven refund shape, checks-effects-interactions throughout:
+The interesting design question was authority: who is allowed to say "draw"? A unilateral draw would be an attack. The losing side of a live wager would declare a draw the instant the outcome turned against them. So the right to call a draw depends on how the wager resolves in the first place:
 
-```solidity
-function _settleDraw(uint256 wagerId, Wager storage w, address by) internal {
-    w.status = Status.Draw;
-    delete _drawConsent[wagerId];
-    membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
-    membershipManager.recordClose(w.opponent, WAGER_PARTICIPANT_ROLE);
+- **Wagers the two parties settle between themselves** require *both* of them to agree. The first person to declare a draw simply records a proposal; the second person's confirmation completes it. A pending proposal never freezes the wager — either side can still declare a winner or fall back to the timeout refund, and the proposer can withdraw the offer. "Declining" a draw takes no action at all: just don't confirm.
+- **Wagers settled by a named arbitrator** let that arbitrator call a draw alone, consistent with their existing power to name a winner.
+- **Wagers settled by an outside data source** (a public prediction market, a price feed) allow *no* human to force a draw — not a participant, not an arbitrator, not an admin. On these, a draw can only come from the data source itself.
 
-    IERC20 token = IERC20(w.token);
-    token.safeTransfer(w.creator, w.creatorStake);
-    token.safeTransfer(w.opponent, w.opponentStake);
+Manual draws are also blocked once the resolution deadline passes, because past that point the timeout refund already returns both stakes; a late manual draw would only muddy the record.
 
-    emit WagerDrawn(wagerId, w.creator, w.opponent, by);
-}
-```
+## When the market itself ties
 
-Each party gets back exactly their own stake — stakes need not be equal, and no value moves between participants. Status flips and consent state clears before any token transfer, and both parties' concurrency slots on the `MembershipManager` are released.
+Public prediction markets can resolve indecisively — a 50/50 split, or an "invalid" ruling after a dispute. FairWins reads that tie directly from the market and settles the wager as a draw the moment anyone triggers resolution, refunding both sides rather than inventing a winner. A market that resolves cleanly still produces a winner; one that hasn't resolved yet still waits. The system is careful to tell "resolved as a tie" apart from "not resolved yet."
 
-## Who Gets to Say "Draw"?
+## A wager with no opponent
 
-The interesting design question was authority. A unilateral draw is an attack: the losing side of an `Either`-resolved wager would declare a draw the moment the outcome went against them. Spec 004 splits authority three ways by resolution type, implemented in `_declareDraw`:
+Open challenges attack the second gap. The creator posts a wager with no named opponent, escrows their own stake as usual, and ties the wager to one clever thing: a **four-word claim code**, drawn from the standard BIP-39 word list that crypto wallets use for recovery phrases. Four words out of 2,048 gives roughly seventeen trillion combinations. The code is generated on the creator's own device and never sent to any server.
 
-- **Participant-resolved wagers** (`Either`, `Creator`, `Opponent`) require *both* parties. The contract keeps a per-wager consent bitmask — `bit0` for the creator, `bit1` for the opponent — outside the `Wager` struct so `getWager`'s ABI is untouched:
+The trick is that the code *is* a key. Run the four words through a fixed recipe and you get a cryptographic keypair, plus a separate key that unlocks the wager's encrypted terms. That one shareable secret does three jobs at once:
 
-```solidity
-uint8 consent = _drawConsent[wagerId];
-if ((consent & bit) == 0) {
-    consent |= bit;
-    _drawConsent[wagerId] = consent;
-    emit DrawProposed(wagerId, actor);
-}
-if (consent == _CONSENT_BOTH) {
-    _settleDraw(wagerId, w, actor);
-}
-```
+1. **Discovery.** The code points to the single live wager it belongs to. Without it, an open challenge is one anonymous entry among many.
+2. **Authorization to accept.** To take the wager, you prove you hold the code by signing a short, structured message with the code's key. Crucially, that signature is bound to the taker's own wallet address — so a bot that copies a pending "accept" transaction out of the network's waiting area cannot reuse the signature for itself. Re-signing requires the code.
+3. **Readability.** The same secret decrypts the private terms — which is what makes an open challenge possible at all, since you cannot encrypt terms to a specific recipient when you don't yet know who the recipient is.
 
-  The first `declareDraw` records a proposal; the second party's call completes it. Crucially, a pending proposal never locks the wager — `declareWinner` and the timeout refund remain fully available, and the proposer can back out via `revokeDraw` (emitting `DrawRevoked`). "Declining" a draw needs no action at all: just don't confirm.
+The first valid acceptance locks in the taker as the opponent, flips the wager to active, and frees the code's fingerprint for reuse. Uniqueness only has to hold among challenges that are open right now, so nothing piles up in storage forever.
 
-- **`ThirdParty` wagers**: the named arbitrator settles a draw alone, consistent with their existing authority to declare a winner.
+## Guardrails for an unknown counterparty
 
-- **Oracle-resolved wagers** (Polymarket, Chainlink, UMA): no human — participant, arbitrator, or admin — can force a draw. `_declareDraw` reverts with `DrawNotApplicable()`. A draw on these wagers can only come from the oracle itself.
+An unknown taker changes the threat model, so open challenges carry extra rules:
 
-Manual draws are also rejected after the `resolveDeadline` (`ResolveExpired`) — past that point the timeout refund already returns both stakes, so a manual draw would only muddy the record.
+- **No self-resolution.** A lone unknown party can never be the sole judge of the outcome. Open challenges must resolve by an outside data source, by mutual agreement, or by a named arbitrator.
+- **Equal stakes only.** Both sides post the same amount. A publicly shared code with lopsided odds would invite people to snipe only the favorable side; equal stakes make it a race about *who* takes the bet, not an economic edge.
+- **Higher tier to create, any active member to take.** Posting a code-gated wager is a Silver-and-above privilege, while accepting runs the same checks as any named opponent — sanctions screening of both parties, active membership, concurrency limits — with no membership backdoor.
+- **No decline, one clean cancel.** There is no "decline" on an open challenge; the creator canceling an unaccepted challenge is the only way to release it early.
+- **Party separation.** The creator can't take their own challenge, and a named arbitrator can't take it either — a check that has to run at accept time, because the opponent was unknown when the wager was posted.
 
-## The Oracle Tie
+Layer the market-settled version on top and the platform's most trustless combination falls out for free: a challenge anyone with the code can take, settled automatically by a public market, timeline derived from the market's own end date, and refunding both sides if that market resolves invalid.
 
-Polymarket markets can resolve indecisively: a 50/50 split, or an "invalid" resolution after a UMA dispute. The `PolymarketOracleAdapter` (`contracts/oracles/PolymarketOracleAdapter.sol`) detects this as equal payout numerators from the Conditional Tokens Framework and returns its unresolved sentinel (`resolvedAt == 0`) rather than inventing a winner. That sentinel is ambiguous, though — it also means "not resolved yet." The resolve path disambiguates in `contracts/wagers/WagerRegistryIntents.sol`:
+## Design decisions
 
-```solidity
-(bool outcome, , uint256 resolvedAt) = polymarketAdapter.getOutcome(w.polymarketConditionId);
-if (resolvedAt == 0) {
-    if (polymarketAdapter.isConditionResolved(w.polymarketConditionId)) {
-        _settleDraw(wagerId, w, msg.sender);   // resolved tie -> immediate draw
-        return;
-    }
-    revert ConditionNotResolved();             // genuinely unresolved -> unchanged
-}
-_settleOracleWin(wagerId, w, outcome);
-```
+**A draw is a new outcome, not a new kind of judge.** The list of who can resolve a wager is untouched. A draw is simply a new thing that can *happen*, permitted or forbidden depending on the resolution type. That kept every ordinary wager's path exactly as it was.
 
-A resolved tie settles as a draw the moment anyone calls `autoResolveFromPolymarket` — no waiting out the deadline. A decisive market still produces a winner; an unresolved one still reverts.
+**Mutual consent over unilateral mercy.** Requiring both sides to agree on a participant-settled draw costs a second confirmation, but it removes the "losing side declares a draw" grief entirely — and because an unconfirmed proposal never locks anything, the worst a stalling counterparty can do is nothing.
 
-## A Wager With No Opponent
+**No admin override for stuck data sources.** A market that never resolves falls back to the deadline refund, which already returns both stakes. Adding a human override there would have created exactly the trusted party the whole design works to avoid.
 
-Open challenges (spec 024) attack the second gap. `createOpenWager` creates a wager with `w.opponent` left as `address(0)`, escrows the creator's stake as usual, and binds one new thing: a `claimAuthority` address. That address is the on-chain face of a **four-word claim code** — four words from the BIP-39 English wordlist (2048⁴ = 2⁴⁴ combinations), generated client-side and never sent to any server.
+**A fast code recipe, honestly scoped.** Turning the four words into a key is deliberately cheap. Because the code's public fingerprint sits on-chain, a determined attacker with dedicated hardware could in principle grind through the seventeen-trillion space. FairWins accepts that residual risk openly, scopes the guarantee to casual guessing, and asks the interface to say so for meaningful stakes. The recipe is versioned, leaving room to swap in a slower, harder-to-crack method later without breaking existing wagers.
 
-The trick is that the code *is* a keypair. `frontend/src/utils/claimCode/deriveFromCode.js` derives, from the normalized four words, a secp256k1 private key (`keccak256("FairWins/claim/v1" || code)`) whose address becomes the on-chain `claimAuthority`, plus an independent domain-separated symmetric key that seals the private terms envelope. One shareable secret does triple duty:
+Edge cases are where escrow apps earn trust. A wager that can end with nobody winning, and begin with nobody on the other side, is a wager system that has met its users.
 
-1. **Discovery** — `openWagerIdForClaim(authority)` maps the derived address to the single live wager. Without the code, an open challenge is one indistinguishable entry among many.
-2. **Accept authorization** — the taker proves knowledge of the code by presenting an EIP-712 signature *from the code-derived key*:
+## Further reading
 
-```solidity
-bytes32 digest = _hashTypedDataV4(
-    keccak256(abi.encode(OPEN_ACCEPT_TYPEHASH, wagerId, taker)));
-if (digest.recover(signature) != authority) revert BadClaimSignature();
-```
-
-   The typed struct is `OpenAccept(uint256 wagerId, address taker)`. Binding `taker` into the signed digest is the front-running defense: a mempool observer who copies a pending `acceptOpenWager` transaction cannot replay the signature for their own address — re-signing requires the code.
-3. **Readability** — the symmetric key opens the encrypted terms, replacing the usual recipient-key encryption that is impossible when the recipient is unknown at creation.
-
-The first valid acceptance binds the taker as opponent, flips the wager to `Active`, and calls `_clearClaim`, which frees the commitment for reuse — uniqueness is enforced only among *currently open* challenges (`ClaimAuthorityInUse` on collision), so no unbounded state accumulates.
-
-## Guardrails for an Unknown Counterparty
-
-An unknown taker changes the threat model, and `createOpenWager` encodes the responses directly:
-
-- **No self-resolution.** `Creator` and `Opponent` resolution types revert with `OpenResolutionTypeNotAllowed` — a lone unknown party must never be the sole resolver. Open challenges are restricted to oracle types, `Either`, and `ThirdParty`.
-- **Equal stakes only.** One `stake` parameter sets both sides. A publicly shared code with asymmetric odds would invite adverse-selection sniping of the favorable side; symmetric stakes make the race merely about *who* takes the bet, not an economic edge.
-- **Silver-and-above to create, any active tier to take.** Per `docs/system-overview/roles-and-tiers.md`, posting a code-gated wager is a higher-tier privilege (`getActiveTier(...) >= Silver`, else `InsufficientMembershipTier`), while accepting runs the same gauntlet as any named opponent — sanctions screening of both parties, active membership, concurrency limits — with no tier floor and no membership backdoor.
-- **No decline.** `declineWager` on an open challenge reverts with `DeclineNotAllowedForOpenChallenge`; the creator's `cancelOpen` is the sole release for an unaccepted open challenge.
-- **Party separation.** The creator cannot take their own challenge (`SelfWager`), and a taker who is the named arbitrator is refused (`ArbitratorCannotTake`) — a check that must run at accept because the opponent was unknown at creation.
-
-Spec 041 then layered on oracle-settled open challenges: the creator picks a Polymarket market and the *event* defines the timeline — `frontend/src/lib/openChallenge/oracleTimeline.js` derives `acceptDeadline` from the market's end date and `resolveDeadline` from end-plus-settlement-buffer, both capped. Combined with the tie-handling above, the platform's most trustless combination falls out for free: a challenge anyone with the code can take, settled automatically by a public market, and refunding both sides if that market resolves invalid.
-
-## Design Decisions
-
-**Draw is a new outcome, not a new resolution type.** The eight resolution types (who resolves) are untouched; a draw is a ninth thing that can *happen*, gated per-type. That kept the accept, escrow, and payout paths byte-identical for every wager that never draws.
-
-**Mutual consent over unilateral mercy.** Requiring both signatures on participant-resolved draws costs a second transaction, but removes the "losing side declares a draw" grief entirely — and because an unconfirmed proposal never locks anything, the worst a stalling counterparty can do is nothing.
-
-**No admin override for stuck oracles.** A permanently unresolved oracle falls back to the deadline refund, which already returns both stakes. Adding a human draw override for oracle wagers would have created a trusted party where the whole point was not having one.
-
-**A fast KDF, honestly scoped.** The v1 code derivation is two keccak passes — deliberately cheap. With the commitment public on-chain, a determined attacker with dedicated hardware could brute-force 2⁴⁴; spec 024 accepts this residual risk explicitly, scopes the guarantee to casual/indiscriminate guessing, and requires the UI to say so for meaningful stakes. The `v1` domain tags (`FairWins/claim/v1`, `FairWins/terms/v1`) leave room to swap in a memory-hard KDF without breaking existing wagers.
-
-**Code-derived readability, forever.** Even after acceptance, the opponent reads terms via the code — there is no re-keying to their registered encryption key. Losing the code means "terms unavailable," never lost funds or blocked resolution.
-
-Edge cases are where escrow protocols earn trust. A wager that can end with nobody winning, and begin with nobody on the other side, is a wager system that has met its users.
-
-## Sources
-
-- `specs/004-draw-resolution/spec.md` — draw resolution requirements and authority model
-- `specs/024-open-challenge-wagers/spec.md` — claim-code open challenges, entropy floor, tier gating
-- `specs/041-oracle-open-challenges/spec.md` — oracle-settled open challenges, event-derived timelines
-- `contracts/wagers/WagerRegistry.sol` — `createOpenWager`, `acceptOpenWager`, `declareDraw`, `revokeDraw`
-- `contracts/wagers/WagerRegistryCore.sol` — `_declareDraw`, `_settleDraw`, `_acceptOpenWager`, draw-consent bitmask
-- `contracts/wagers/WagerRegistryIntents.sol` — `autoResolveFromPolymarket` tie disambiguation
-- `contracts/oracles/PolymarketOracleAdapter.sol` — equal-payout-numerator tie detection
-- `contracts/interfaces/IWagerRegistryTypes.sol` — `Status` enum, `WagerDrawn` / `DrawProposed` / `DrawRevoked` events
-- `frontend/src/utils/claimCode/deriveFromCode.js`, `frontend/src/utils/claimCode/wordlist.js` — code→keypair derivation, BIP-39 wordlist
-- `frontend/src/lib/openChallenge/oracleTimeline.js` — event-derived deadlines
-- `docs/system-overview/roles-and-tiers.md` — Silver+ creation gate, tier limits
-- EIP-712: Typed structured data hashing and signing — https://eips.ethereum.org/EIPS/eip-712
-- BIP-39: Mnemonic code for generating deterministic keys — https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
-- Polymarket / Conditional Tokens documentation — https://docs.polymarket.com
+- [EIP-712: Typed structured data hashing and signing](https://eips.ethereum.org/EIPS/eip-712) — the standard behind the signed "accept" message
+- [BIP-39: Mnemonic code word list](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) — the word list the four-word claim code draws from
+- [Polymarket documentation](https://docs.polymarket.com) — how public prediction markets resolve, including ties and invalid outcomes

--- a/docs/blog/posts/16-draw-resolution-open-challenges/social.md
+++ b/docs/blog/posts/16-draw-resolution-open-challenges/social.md
@@ -2,26 +2,26 @@
 
 ## X (Twitter)
 
-How does an escrow contract settle a forecast nobody should win? FairWins added a distinct Draw state (mutual consent, per-resolution-type authority) and open challenges gated by a 4-word claim code that is secretly a keypair. 🔗 <link> #Solidity #SmartContracts
+How does an escrow app settle a forecast nobody should win? FairWins added a distinct "draw" outcome (mutual consent, authority set by how the wager resolves) plus open challenges protected by a 4-word claim code that is secretly a key. 🔗 <link> #PredictionMarkets #Web3
 
 ## LinkedIn
 
-Two edge cases separate a demo escrow contract from a finished protocol. First: a forecast between two parties is voided by events — the match is abandoned, the question becomes moot. Neither side should win, but "wait for the deadline and refund" is indistinguishable on-chain from two people forgetting about it. Second: someone wants to post a challenge with no named counterparty — first qualified taker joins — without broadcasting the terms to every mempool observer.
+Two edge cases separate a demo escrow app from a finished product. First: a forecast between two parties is voided by events — the match is abandoned, the question becomes moot. Neither side should win, but "wait for the deadline and refund" looks identical on the public ledger to two people forgetting about it. Second: someone wants to post a challenge with no named counterparty — first qualified taker joins — without broadcasting the terms to every bot watching for new escrow.
 
-Our latest FairWins engineering post walks through how both were closed:
+Our latest FairWins post walks through how both were closed:
 
-- A distinct `Draw` terminal state that returns each party exactly their own stake, with authority split by resolution type: mutual consent for participant-resolved wagers, arbitrator-only for third-party, and no human override at all for oracle-settled ones
-- Tie handling: an invalid or 50/50 oracle resolution settles as an immediate draw — the protocol refunds rather than inventing a winner
-- Open challenges gated by a four-word claim code that doubles as a keypair: discovery, EIP-712 accept authorization bound to the taker's address (front-running defense), and terms decryption from one shareable secret
+- A distinct "draw" outcome that returns each party exactly their own stake, with authority set by how the wager resolves: mutual consent when the two parties settle it, arbitrator-only for a named judge, and no human override at all when an outside market settles it
+- Tie handling: an invalid or 50/50 market resolution settles as an immediate draw — the platform refunds rather than inventing a winner
+- Open challenges protected by a four-word claim code that doubles as a key: it points to the wager, authorizes acceptance (bound to the taker's own address, so a copied transaction can't be replayed), and decrypts the private terms — all from one shareable secret
 - The guardrails an unknown counterparty demands: no self-resolution, equal stakes only, tier gating, sanctions screening
 
 These are skill-based forecasts on public information between consenting, screened participants — and the design bias throughout is refund over guesswork.
 
 Read the full post: <link>
 
-Where do you draw the line between admin override and pure protocol rules when a contract outcome becomes undecidable?
+Where do you draw the line between admin override and pure rules when an outcome becomes undecidable?
 
-#Solidity #SmartContracts #Ethereum #ProtocolDesign
+#PredictionMarkets #Web3 #ProductDesign #Ethereum
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/17-wager-pools-erc1167/blog.md
+++ b/docs/blog/posts/17-wager-pools-erc1167/blog.md
@@ -1,97 +1,63 @@
-# Wager Pools: ERC-1167 Clones and Address-Keyed Payouts
+# Wager Pools: Group Escrow Where the Winner's Address Is the Claim Code
 
-*Why FairWins gave group wagers their own factory of immutable minimal-proxy clones — and why the winner's address is the claim code*
+*Why FairWins gave group wagers their own factory of cheap, tamper-proof clones — and why nobody has to hold a secret to collect*
 
 | | |
 |---|---|
 | **Series** | Prediction Markets (part 4) |
 | **Part** | 17 of 34 |
-| **Audience** | Smart-contract developers |
-| **Tags** | `erc1167`, `minimal-proxy`, `clones`, `factory`, `governance` |
-| **Reading time** | ~8 minutes |
+| **Audience** | Product-minded builders, founders, and the crypto-curious |
+| **Tags** | `prediction-markets`, `group-escrow`, `governance`, `product-design` |
+| **Reading time** | ~7 minutes |
 
-> **Important note**: This article describes wagering based on publicly available information and legitimate forecasting among consenting participants. Wager pools are not a mechanism for trading on material non-public information or circumventing applicable regulation. All participants remain fully subject to applicable laws and compliance requirements — the platform screens every creator and joiner against sanctions and membership gates before funds move.
+> **Responsible-use note**: This article describes wagering based on publicly available information and legitimate forecasting among consenting participants. Wager pools are not a mechanism for trading on material non-public information or circumventing applicable regulation. All participants remain fully subject to applicable laws and compliance requirements — the platform screens every creator and joiner against sanctions and membership gates before funds move.
 
-## Twelve people, one bracket, one escrow
+## Twelve people, one bracket, one pot
 
-The FairWins `WagerRegistry` is built for a specific shape of agreement: two sides, an oracle or counterparty resolution, one payout. It handles that shape well. But the request that kept coming back from testers was a different shape entirely: *twelve of us ran a season-long fantasy league; first place gets 60%, second gets 30%, third gets 10%. Hold the money so nobody has to chase anyone in March.*
+FairWins' core escrow is built for a specific shape of agreement: two sides, a resolution from an outside data source or an arbitrator, one payout. It handles that shape well. But the request that kept coming back from testers was a different shape entirely: *twelve of us ran a season-long fantasy league; first place gets 60%, second gets 30%, third gets 10%. Hold the money so nobody has to chase anyone in March.*
 
-You cannot express that as a 1v1 wager without contortions — sixty-six pairwise wagers, or a designated stakeholder wallet everyone has to trust. What the group actually needs is one escrow that N people pay into, and a resolution mechanism that doesn't depend on any external oracle, because "who won our league" is not a Polymarket condition. The group *is* the oracle.
+You cannot express that as a one-on-one wager without contortions — sixty-six separate pairwise bets, or a designated wallet everyone has to trust. What the group actually needs is one pot that everyone pays into, and a way to settle it that doesn't depend on any outside market, because "who won our league" is not something a public market can answer. The group *is* the referee.
 
-This is spec 034, and it shipped as **Wager Pools**: a `WagerPoolFactory` that stamps out one isolated `WagerPool` contract per group. It is a deliberately parallel system — a documented exception to the platform rule that all wager escrow routes through `wagerRegistry` — and it made two architectural choices that run opposite to the registry's: the pools are **immutable ERC-1167 clones** rather than logic behind an upgradeable proxy, and resolution is a **creator-proposed payout matrix keyed by public wallet addresses**, approved by the members themselves.
+That is what **Wager Pools** delivers: a factory that stamps out one isolated escrow contract per group. It is a deliberately parallel system — a documented exception to the platform's usual rule that all wager escrow flows through the core registry — and it makes two choices that run opposite to that registry: each pool is a cheap, **tamper-proof clone** rather than upgradeable logic behind a proxy, and settlement is a **creator-proposed payout list keyed to public wallet addresses**, approved by the members themselves.
 
-That second choice has a story. The spec directory is still called `specs/034-zk-wager-pools/` because the original design used Semaphore V4: anonymous membership commitments, zero-knowledge approval votes, payouts keyed by claim nullifiers. It worked — real Groth16 proofs verified on-chain in integration tests. Testers killed it anyway. The private "claim code" (a nullifier the winner had to reveal to the creator, not derivable from any public data) was the failure point: it turned "collect your winnings" into a secret-handling exercise. The round-7 addendum in `specs/034-zk-wager-pools/spec.md` records the pivot: Semaphore removed entirely, `ZKWagerPool → WagerPool`, membership, voting, and claims by public wallet address. When your users are a friend group who already know each other, anonymity was cost without benefit — and dropping the BN254 pairing requirement had a side effect: pools became deployable to Ethereum Classic's Mordor testnet, which is the launch target ahead of Polygon.
+That second choice has a story. The original design leaned on zero-knowledge cryptography: anonymous membership, private approval votes, payouts unlocked by a secret only the winner knew. It worked — the anonymity proofs verified on-chain in testing. Testers killed it anyway. That private claim secret — a code the winner had to reveal to collect, derivable from nothing public — turned "collect your winnings" into a nerve-wracking secret-handling exercise. So the team pulled the anonymity out entirely and made membership, voting, and claims work by plain public wallet address. When your users are a friend group who already know each other, anonymity was cost without benefit. Dropping the heavy cryptography had a bonus: the pools became light enough to launch first on Ethereum Classic's Mordor test network, ahead of Polygon.
 
-## One upgradeable factory, N immutable pools
+## One upgradeable factory, many frozen pools
 
-The system has exactly one state-bearing, upgradeable contract: `contracts/pools/WagerPoolFactory.sol`, a UUPS proxy inheriting the platform's shared `contracts/upgradeable/UUPSManaged.sol` base, with append-only storage and a trailing `__gap`. Everything else is a clone:
+The system has exactly one long-lived, upgradeable piece: the factory. Everything else is a clone.
 
-```solidity
-poolId = ++poolCount;
-pool = Clones.clone(poolImpl);
+The factory uses a well-known technique called the **minimal proxy** (the ERC-1167 standard). A minimal proxy is a tiny contract — about 45 bytes — whose entire job is to forward every call to one shared implementation. Each pool is one of these clones: it costs a fraction of a full deployment, gets its own address and its own isolated pot of money, and shares its logic with every other pool.
 
-WagerPool(pool).initialize(
-    p.token, creator, p.buyIn, p.maxMembers,
-    p.thresholdBips, p.acceptDeadline, p.resolveDeadline
-);
-```
+The crucial property is what clones *don't* have: an upgrade path. Once a pool is created, its rules are frozen for its life. The factory admin can point *future* pools at new logic, but no one — not the admin, not a vote — can change the rules governing money already sitting in an existing pool. Compare the core registry, which is deliberately upgradeable so a single long-lived contract can evolve in place. A pool is the opposite kind of object: short-lived (capped at a resolve deadline of at most 180 days), fully specified at birth, holding funds for a closed group. For that object, "the rules cannot change under you" is worth more than the ability to patch it later.
 
-`Clones.clone` is OpenZeppelin's implementation of [ERC-1167](https://eips.ethereum.org/EIPS/eip-1167), the minimal proxy standard: a 45-byte contract whose entire runtime code is "delegatecall everything to a hard-coded implementation address." Each pool costs a fraction of a full deployment, gets its own address and its own isolated storage, and shares bytecode with every other pool.
-
-The crucial property is what clones *don't* have: an upgrade path. The implementation address is baked into the clone's bytecode. Once a pool is created, its rules are frozen for its life. The factory admin can call `setTemplate` to point *future* pools at a new `poolImpl`, but no one — not the admin, not an upgrade vote — can change the logic governing money already escrowed. Compare the registry side of the platform, where `WagerRegistry` is a UUPS proxy precisely so a long-lived singleton can evolve in place. A pool is the opposite kind of object: short-lived (bounded by a resolve deadline of at most 180 days), fully parameterized at birth, holding funds for a closed group. For that object, "the rules cannot change under you" is worth more than patchability. The master implementation calls `_disableInitializers()` in its constructor; each clone is initialized exactly once, by the factory, in the same transaction that creates it.
-
-Before cloning anything, `_createPool` screens the creator's real wallet through the same shared singletons the registry uses — `ISanctionsGuard.checkBlocked` and `IMembershipManager.checkCanCreate` under a dedicated `POOL_PARTICIPANT_ROLE` — and validates deadlines with `_checkDeadlines`, which mirrors `WagerRegistry` exactly: `acceptDeadline` in the future and within 30 days, `resolveDeadline` strictly after it and within 180 days. Pools and 1v1 wagers deliberately share the same temporal feel. The pool calls back into the factory (`screen` / `requireMembership`) to apply the same checks to every joiner. On value-bearing networks `screeningRequired` is set, both guards must be configured, and the buy-in token must be on an admin-curated allowlist — `escrowTotal` is derived arithmetically as `memberCount * buyIn`, which only holds for well-behaved tokens, so fee-on-transfer and rebasing tokens are excluded at the door.
+Before creating anything, the factory screens the creator's real wallet through the same sanctions and membership checks the core system uses, and validates the deadlines the same way: joining must close within 30 days, settlement within 180, in that order. Pools and one-on-one wagers deliberately share the same sense of timing. On networks where real money is at stake, the buy-in token must be on an approved allowlist — the total pot is just headcount times buy-in, which only holds for well-behaved tokens, so exotic tokens that shift balances on transfer are excluded at the door.
 
 ## The address is the claim code
 
-Resolution is where the address-based redesign earns its keep. After joining closes — creator's call, auto-close when full, or anyone poking `pokeDeadline` past the accept deadline — the denominator freezes and the creator proposes a full payout matrix:
+Settlement is where the address-based redesign earns its keep. After joining closes — the creator's call, an automatic close when the pool is full, or anyone nudging it past the deadline — the member count freezes and the creator proposes a full payout list: who gets what.
 
-```solidity
-struct PayoutEntry {
-    address winner;
-    uint256 amount;
-}
+The contract validates that list before anyone can vote on it: it can't be empty, can't pay a nonexistent address, and the amounts must sum to the exact pot, to the penny. The proposal and its entire breakdown are recorded on-chain, so every member sees the precise split from public data before approving. Nothing about the outcome lives in a side channel.
 
-function proposeOutcome(PayoutEntry[] calldata entries) external;
-```
+Members approve with a plain transaction. Revising the list starts a fresh tally rather than carrying over old votes. The pool settles when approvals reach a set fraction of the members who joined — with one hard floor: in any multi-member pool, at least two approvals are required. That means no single member — including the creator, who might also be a player — can unilaterally lock in a self-dealing payout. The creator *proposes*; only the group *disposes*. And if the group never reaches the threshold, the deadline flips the pool into refund-only mode and everyone recovers exactly their buy-in. Funds can't be stranded by a stalemate.
 
-`proposeOutcome` validates the matrix on-chain before it can ever be voted on: non-empty, no zero-address winner, and `sum(amounts) == escrowTotal` — the exact escrow, to the wei. The `proposalId` is `keccak256(abi.encode(entries))`, and the `OutcomeProposed` event inlines the entire matrix, so every member reads the precise split from chain data before approving. Nothing about the outcome lives off-chain.
+Claiming is where "the address is the claim code" becomes literal. A winner submits the agreed payout list and points to their row; the contract confirms the list matches the one the group locked in, confirms that row belongs to the caller, and pays out to any address the winner names. There is no secret to exchange, nothing to reveal to the creator, nothing to lose. Every member can work out every claim from the public roster. Claims are tracked per *row* rather than per person, so a list that names the same winner twice (say, first *and* third place) is fully claimable, row by row.
 
-Members approve with a plain transaction. Approvals are counted per `(proposalId, member)` — revising the matrix produces a new id and restarts the tally with no storage reset. The pool resolves when approvals reach a fraction-of-joined threshold:
+## Gasless collection, baked in from day one
 
-```solidity
-/// Approvals required = ceil(frozenDenominator * thresholdBips / 10000).
-uint256 req = (num + 9999) / 10000;
-if (req == 0) req = 1;
-if (frozenDenominator >= 2 && req < 2) req = 2;
-```
+Because a pool can never be upgraded, whatever convenience features it will ever have must be in the template on day one. So every member action ships with a signed, "gasless" twin: instead of paying network fees yourself, you sign an intent and a helper service submits it for you. That includes the money-in path — a member with zero native gas can still buy in using a signed token authorization — and, most importantly, the money-out path. A winner with an empty gas tank can sign a claim that a helper submits, and because the signed claim is bound to a specific row and payout address, that helper can never redirect the winnings.
 
-That last line is a governance floor: in any multi-member pool, at least two approvals are required, so no single member — including the creator, who may also be a joined member — can unilaterally lock a self-dealing payout. The creator *proposes*; only the group *disposes*. And if the group never reaches threshold, the `resolveDeadline` converts the pool to refund-only: every member recovers exactly their buy-in. Funds cannot be stranded by a deadlock.
-
-Claiming is where the "address is the claim code" phrase becomes literal. A winner calls `claim(entries, index, recipient)`; the contract checks that the supplied matrix hashes to `lockedOutcome`, that `entries[index].winner == msg.sender`, and pays `entries[index].amount` to any `recipient` the winner chooses. There is no secret to exchange, nothing to reveal to the creator, nothing to lose. Every party can derive every claim from the public roster. Claims are tracked per **row index** rather than per winner address — `mapping(uint256 => bool) claimedIndex` — a small but deliberate detail: a matrix that lists the same winner in multiple rows (say, first *and* third place) is fully claimable row by row, and never strands escrow. `claim`, `refund`, and `cancel` are the only paths by which value leaves the contract, all behind reentrancy guards and checks-effects-interactions.
-
-## Gasless twins baked into immutable bytecode
-
-Immutability forced one design constraint you don't face with proxies: whatever relayer support a pool will ever have must be in the template on day one. So every actor-attributed action carries an [EIP-712](https://eips.ethereum.org/EIPS/eip-712) `…WithSig` twin — `approveWithSig`, `claimWithSig`, `proposeOutcomeWithSig`, `closeJoiningWithSig`, `cancelWithSig`, `refundWithSig` — via the shared `contracts/upgradeable/SignerIntentBase.sol` mixin, which authorizes the recovered signer instead of `msg.sender` under a per-clone EIP-712 domain (`"FairWins WagerPool"`, version `"1"`) with single-use nonces. The money-in path gets its own relayable form: `joinWithAuthorization` moves USDC via [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) `receiveWithAuthorization`, so a member with zero native gas can still buy in. The strongest case is the winner with an empty gas tank: `claimWithSig` binds the signed intent to `index` and `recipient`, so a relayer can submit the claim but can never redirect the payout.
-
-Clones create one operational wrinkle for relaying: their addresses are dynamic, so a relayer engine cannot pre-whitelist them. The factory answers with pass-through forwarders (`approveWithSigFor`, `claimWithSigFor`, and friends) that let the relayer target only the stable factory address, while an on-chain provenance check — `poolAddressToId[pool] != 0` — guarantees the forwarded call can only reach a pool this factory actually minted. The forwarders add no trust; each clone still verifies the member's signature against its own domain. Self-submit remains the primary path throughout: gasless is a convenience layer, never a dependency.
+Clones create one wrinkle here: each pool has a fresh, unpredictable address, so a helper service can't pre-approve them one by one. The factory solves this by acting as a stable front door — the helper only ever targets the factory, and an on-chain check guarantees a forwarded call can only reach a pool this factory actually created, with each pool still verifying the member's own signature. And self-submitting your own transaction always remains the primary path — gasless is a convenience layer, never a dependency.
 
 ## Design decisions
 
-- **A parallel system, on purpose.** Pools do not route through `wagerRegistry`, its oracle adapters, or its draw logic — group self-resolution is a genuinely different trust model, and grafting an N-party matrix vote onto a 24 KB-constrained two-facet proxy would have compromised both. The exception is documented platform-wide; the systems share compliance interfaces (`ISanctionsGuard`, `IMembershipManager`) and identical deadline semantics so they can converge later.
-- **Immutable clones over upgradeable pools.** Per-pool proxies would allow post-deploy fixes but would also mean an admin key can rewrite the rules of live escrow. For bounded-lifetime group funds, FairWins chose the stronger promise. The cost is real: a template bug affects every existing pool with no patch path, which is why the template requires a formal security review before going live on any value-bearing network.
-- **Public addresses over zero-knowledge.** The Semaphore design was cryptographically sound and empirically working; it lost to a usability finding. The lesson generalizes: privacy machinery whose secret-handling burden lands on the *winner at claim time* fails exactly when the stakes are highest. Two-word nicknames survive as pure client-side display, derived from the wallet address, never on-chain.
-- **On-chain matrix validation over commit-and-reveal.** Requiring the full matrix at propose time (validated to sum to escrow, emitted in the event) costs calldata but buys the invariant that a locked outcome is always fully claimable — members never approve a hash they cannot verify from chain data alone.
+- **A parallel system, on purpose.** Pools don't route through the core wager registry or its outside-data resolution. Group self-settlement is a genuinely different trust model, and bolting a many-party approval vote onto the tightly space-constrained core contract would have compromised both. The two systems share the same compliance checks and identical deadline behavior, so they can converge later.
+- **Frozen clones over upgradeable pools.** Upgradeable pools would allow post-launch fixes but would also mean an admin key could rewrite the rules of live escrow. For bounded-lifetime group funds, FairWins chose the stronger promise. The cost is real: a template bug affects every existing pool with no patch path, which is why the template gets a formal security review before going live anywhere real money moves.
+- **Public addresses over zero-knowledge.** The anonymous design was cryptographically sound and empirically working; it lost to a usability finding. The lesson generalizes: privacy machinery whose secret-handling burden lands on the *winner at claim time* fails exactly when the stakes are highest. Friendly two-word nicknames survive as pure display, derived from the wallet address on the user's own device, never stored on-chain.
+- **Validate the full payout list up front.** Requiring the complete breakdown at proposal time — checked to sum to the exact pot, and published in full — costs a little more data but buys a guarantee members care about: a locked outcome is always fully claimable, and nobody ever approves a split they can't see.
 
-## Sources
+## Further reading
 
-- `specs/034-zk-wager-pools/spec.md` — including the round-7 redesign addendum (Semaphore removed, address-based pivot)
-- `specs/034-zk-wager-pools/implementation-notes.md` — tester rounds, gas figures, ETC/Mordor enablement
-- `contracts/pools/WagerPool.sol`, `contracts/pools/WagerPoolFactory.sol`
-- `contracts/pools/interfaces/IWagerPool.sol`, `contracts/pools/interfaces/IWagerPoolFactory.sol`
-- `contracts/upgradeable/SignerIntentBase.sol`, `contracts/upgradeable/UUPSManaged.sol`
-- `docs/developer-guide/zk-wager-pools.md` (documents the pre-pivot Semaphore architecture; historical context)
-- [ERC-1167: Minimal Proxy Contract](https://eips.ethereum.org/EIPS/eip-1167)
-- [EIP-712: Typed structured data hashing and signing](https://eips.ethereum.org/EIPS/eip-712)
-- [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009)
-- [OpenZeppelin Clones library](https://docs.openzeppelin.com/contracts/5.x/api/proxy#Clones)
+- [ERC-1167: Minimal Proxy Contract](https://eips.ethereum.org/EIPS/eip-1167) — the tiny-clone standard behind every pool
+- [OpenZeppelin Clones library](https://docs.openzeppelin.com/contracts/5.x/api/proxy#Clones) — a widely used implementation of that standard
+- [EIP-712: Typed structured data hashing and signing](https://eips.ethereum.org/EIPS/eip-712) — the format behind the signed, gasless action twins
+- [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009) — how a member with no gas can still fund a buy-in

--- a/docs/blog/posts/17-wager-pools-erc1167/social.md
+++ b/docs/blog/posts/17-wager-pools-erc1167/social.md
@@ -2,24 +2,24 @@
 
 ## X (Twitter)
 
-Group wager pools as immutable ERC-1167 clones: one UUPS factory, 45-byte proxies, and a payout matrix where the winner's address IS the claim code. We built the ZK version first — testers killed it. 🔗 <link> #Solidity #SmartContracts #ERC1167
+Group wager pools as tamper-proof ERC-1167 clones: one upgradeable factory, tiny 45-byte proxies, and a payout list where the winner's public address IS the claim code. We built the zero-knowledge version first — testers killed it. 🔗 <link> #PredictionMarkets #Web3
 
 ## LinkedIn
 
-How do twelve people escrow a season-long fantasy league on-chain when no oracle can answer "who won our league"? Our 1v1 wager registry couldn't express it — so FairWins built wager pools as a deliberately parallel system, and made two choices that run opposite to the registry's architecture.
+How do twelve people escrow a season-long fantasy league on-chain when no outside market can answer "who won our league"? Our one-on-one wager escrow couldn't express it — so FairWins built wager pools as a deliberately parallel system, and made two choices that run opposite to the core design.
 
 The new post covers:
 
-- Why each pool is an immutable ERC-1167 minimal-proxy clone (45 bytes of runtime code) stamped out by a single UUPS factory — and why "the rules cannot change under your escrow" beat upgradeability for bounded-lifetime group funds
-- The address-keyed payout matrix: creator proposes, the contract validates sum == escrow on-chain, members approve to a fraction-of-joined threshold (minimum two approvals, so no self-dealing lock), and the winner's public address is the claim code — no secrets to exchange
-- Baking EIP-712 gasless twins and EIP-3009 joins into immutable bytecode, plus factory forwarders that let a relayer whitelist one stable address while on-chain provenance checks constrain reachable targets
-- The honest part: we built and empirically verified the Semaphore/Groth16 anonymous version first. Testers rejected the private claim code, and the spec directory name is the fossil record.
+- Why each pool is a tamper-proof minimal-proxy clone (about 45 bytes) stamped out by a single upgradeable factory — and why "the rules cannot change under your escrow" beat upgradeability for bounded-lifetime group funds
+- The address-keyed payout list: the creator proposes, the contract checks the amounts sum to the exact pot on-chain, members approve to a fraction-of-joined threshold (minimum two approvals, so no self-dealing lock), and the winner's public address is the claim code — no secrets to exchange
+- Gasless collection baked into every pool from day one, plus a stable factory front door that lets a helper service submit on behalf of members while on-chain checks constrain what it can reach
+- The honest part: we built and verified the anonymous zero-knowledge version first. Testers rejected the private claim code, so we swapped it for plain public addresses.
 
 Full write-up: <link>
 
-When have you chosen immutability over upgradeability for value-bearing contracts — and did it hold up?
+When have you chosen "the rules can't change" over upgradeability for value-bearing contracts — and did it hold up?
 
-#Solidity #SmartContracts #Ethereum #Web3 #ProtocolEngineering
+#PredictionMarkets #Web3 #ProductDesign #Ethereum
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/18-envelope-encryption/blog.md
+++ b/docs/blog/posts/18-envelope-encryption/blog.md
@@ -6,8 +6,8 @@
 |---|---|
 | **Series** | Privacy Architecture |
 | **Part** | 1 (published) |
-| **Audience** | Applied cryptographers, fintech engineers |
-| **Tags** | `encryption`, `envelope-encryption`, `privacy`, `prediction-markets` |
+| **Audience** | Product-minded builders, founders, and the crypto-curious |
+| **Tags** | `encryption`, `privacy`, `prediction-markets` |
 | **Reading time** | ~14 minutes |
 
 > **This post is already published.** Read it here:
@@ -17,16 +17,19 @@
 with real money — without broadcasting their firms' positioning to a public
 order book. The published post walks their wager through the five stages of a
 binding contract (creation, offer, consideration, acceptance, execution), and
-shows how envelope encryption makes it work: terms encrypted once with a random
-key, that key wrapped per participant using wallet-derived X-Wing keypairs
-(X25519 + ML-KEM-768 hybrid, ChaCha20-Poly1305 payloads), the envelope stored
-on IPFS with only a 60-byte CID on-chain, and USDC escrow plus oracle-pegged
-resolution making settlement automatic. It closes with honest limitations —
-privacy protects competitive intelligence, not illegal activity; participants
-remain subject to applicable law.
+shows how *envelope encryption* makes it work: the terms are encrypted once with
+a single random key, and that key is then re-wrapped separately for each
+participant, using keypairs derived from their own wallets so no central service
+ever holds a master key. The encrypted envelope lives off-chain, with only a
+tiny reference stored on the blockchain, while escrow and automatic,
+market-pegged settlement handle the money. The wrapping uses a post-quantum
+hybrid scheme (pairing today's proven encryption with a quantum-resistant one)
+to defend against "harvest now, decrypt later" attacks. It closes with honest
+limitations — privacy protects competitive intelligence, not illegal activity;
+participants remain subject to applicable law.
 
-## Sources
+## Further reading
 
-- `docs/developer-guide/envelope-encryption-spec.md`
-- `docs/developer-guide/encryption-architecture.md`
-- `specs/002-e2e-encryption-lifecycle/`
+- The full published article, linked above, is the primary reference.
+- For deeper background, see the FairWins developer documentation on the
+  platform's encryption approach.

--- a/docs/blog/posts/18-envelope-encryption/social.md
+++ b/docs/blog/posts/18-envelope-encryption/social.md
@@ -2,7 +2,7 @@
 
 ## X (Twitter)
 
-A private bet with public enforceability: wager terms encrypted once, the key wrapped per participant with wallet-derived X-Wing keypairs (X25519 + ML-KEM-768), envelope on IPFS, 60-byte CID on-chain. Escrow + oracle pegging settle it automatically. 🔗 <link> #web3 #privacy
+A private bet with public enforceability: wager terms encrypted once, then the key re-wrapped for each participant using keys derived from their own wallets. The envelope lives off-chain; only a tiny reference goes on-chain. Escrow and market pegging settle it automatically. 🔗 <link> #web3 #privacy
 
 ## LinkedIn
 
@@ -11,9 +11,9 @@ Public prediction markets have a problem for professionals: your position is the
 Our engineering post on FairWins' private prediction markets shows how envelope encryption resolves this tension. It covers:
 
 - The five-stage contract lifecycle — creation, offer, consideration, acceptance, execution — mapped onto smart-contract escrow and automatic settlement
-- Envelope encryption in practice: terms encrypted once with a random key, then that key wrapped per participant using keypairs derived deterministically from each wallet's signature — no central key custody
-- Post-quantum protection via X-Wing (hybrid X25519 + ML-KEM-768) with ChaCha20-Poly1305, defending against harvest-now-decrypt-later attacks
-- Off-chain/on-chain separation: the encrypted envelope lives on IPFS while the chain stores only a CID, addresses, stakes, and outcome — so larger post-quantum ciphertexts cost no extra gas
+- Envelope encryption in practice: terms encrypted once with a random key, then that key re-wrapped for each participant using keys derived from their own wallet — so no central service ever holds a master key
+- Post-quantum protection via a hybrid scheme that pairs today's proven encryption with a quantum-resistant one, defending against "harvest now, decrypt later" attacks
+- Off-chain/on-chain separation: the encrypted envelope lives off-chain while the blockchain stores only a tiny reference, the addresses, stakes, and outcome — so larger ciphertexts cost no extra gas
 
 One thing we're explicit about: this privacy protects competitive intelligence and trading strategies, not illegal activity. Participants remain fully subject to applicable law and professional obligations.
 

--- a/docs/blog/posts/19-multi-recipient-encryption/blog.md
+++ b/docs/blog/posts/19-multi-recipient-encryption/blog.md
@@ -1,144 +1,83 @@
-# One Ciphertext, N Wrapped Keys: Multi-Recipient Encryption for Private Wagers
+# One Locked Box, Several Keyholders: How a Private Wager Can Add a Referee
 
-*How FairWins lets two participants and a neutral arbitrator each decrypt the same payload — without re-encrypting it for anyone*
+*How FairWins lets two players and a neutral referee each open the same encrypted agreement — without making a second copy for anyone*
 
 | | |
 |---|---|
 | **Series** | Privacy Architecture (part 2 of 4) |
 | **Part** | Follows [Envelope encryption for private prediction markets](../../private-prediction-markets-envelope-encryption.md) |
-| **Audience** | Applied cryptography engineers |
-| **Tags** | `encryption`, `key-wrapping`, `privacy`, `cryptography` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product, founders, and the crypto-curious |
+| **Tags** | `encryption`, `privacy`, `plain-english` |
+| **Reading time** | ~7 minutes |
 
-> **Important note**: As in part 1, the private wagers described here are based on publicly available information and legitimate forecasting. Encryption protects competitive intelligence and trading strategies — not illegal activity. All participants remain fully subject to applicable laws and compliance obligations.
+> **Important note**: As in part 1, the private wagers described here are based on publicly available information and legitimate forecasting. Encryption protects competitive intelligence and trading strategy — not illegal activity. All participants remain fully subject to applicable laws and compliance obligations.
 
-## The Third Reader Problem
+## The third-reader problem
 
-In part 1 of this series, Sarah and Marcus made a 50,000 USDC private wager on a pharmaceutical merger. Their terms lived encrypted on IPFS; the chain held only a reference. Exactly two people on Earth could read the plaintext, and the smart contract guaranteed settlement anyway.
+In part 1, Sarah and Marcus made a 50,000 USDC private wager on a pharmaceutical merger. Their terms lived encrypted in public storage; the blockchain held only a reference. Exactly two people on Earth could read the agreement, and the smart contract guaranteed the money would settle correctly anyway.
 
-That design had a quiet casualty: arbitration. Some wagers can't be resolved by an oracle — "the merger closes before Q3" maps cleanly to a Polymarket condition, but "our redesign ships before yours" does not. For those, FairWins supports a `ThirdParty` resolution type where a neutral human declares the winner. And here the two-reader envelope broke down completely. The arbitrator could be *named* on-chain and *authorized* to call `declareWinner` — but they could not read the terms they were supposed to rule on, and they couldn't even enumerate the wagers naming them. The feature was disabled in the app: a resolver who can't see the agreement is worse than no resolver.
+That design had a quiet casualty: refereeing. Some bets settle themselves — "the merger closes before Q3" can be checked against a public prediction market. But "our team's redesign ships before yours" cannot. Those bets need a neutral human to read the terms and declare a winner. And here the two-reader setup fell apart. The referee could be named on the blockchain and given authority to call the result — but they couldn't read the agreement they were supposed to judge, or even find the wagers that named them. So the feature sat disabled. A referee who can't see the contract is worse than no referee.
 
-The naive fixes are all bad. Re-encrypt the whole payload once per reader, and storage grows linearly while the copies can silently diverge — three ciphertexts that may not decrypt to the same terms is a dispute generator, not a dispute resolver. Share one symmetric key among all readers out-of-band, and you've reinvented the key-distribution problem the system exists to avoid. Give the platform a master key so it can grant access, and you've abandoned end-to-end encryption entirely.
+The obvious fixes are all bad. Make a fresh encrypted copy for each reader, and you now have several copies that can quietly drift apart — a recipe for disputes, not a way to settle them. Share one password by email or chat, and you've reinvented the exact problem the system exists to avoid. Give the platform a master key, and you've thrown away the whole promise that no one but the players can read the bet.
 
-The actual fix — FairWins spec 005 — required zero changes to the cryptography. The envelope format was multi-recipient from day one. What changed is *who gets counted as a recipient*, plus a one-line contract change so arbitrators can find their wagers. This post walks the mechanism that made that a config change instead of a redesign.
+The real fix needed no new cryptography. The design was already built to have multiple keyholders — it just wasn't using that capability. What changed was *who counts as a keyholder*, plus a tiny bookkeeping tweak so referees can find their cases. This post walks the mechanism that turned a redesign into a settings change.
 
-## One DEK, a Wrapped Key per Reader
+## One locked box, one key per person
 
-The envelope scheme (implemented in `frontend/src/utils/crypto/envelopeEncryption.js`, entirely client-side) separates *content encryption* from *access grants*:
+Think of the system as a locked box. Instead of scrambling the agreement separately for each person, it does something cleverer:
 
-1. Generate a random 32-byte **data encryption key (DEK)**.
-2. Encrypt the wager terms **once** with the DEK using ChaCha20-Poly1305 (RFC 8439) — an AEAD, so tampering fails authentication rather than yielding garbage plaintext.
-3. For each recipient, **wrap the DEK**: run X25519 ECDH between a fresh ephemeral keypair and the recipient's registered public key, derive a key-encryption key (KEK) with HKDF-SHA256, and encrypt the DEK under that KEK.
+1. It picks a fresh, random key and locks the agreement **once**. This is the only copy of the content, sealed with modern authenticated encryption — the kind where tampering makes the box refuse to open rather than spilling out garbage.
+2. Then, for each person allowed in, it locks *that key itself* inside a small personal envelope only that person's wallet can open.
 
-Here is the wrap loop, verbatim from `encryptEnvelope`:
+The result is a single sealed box plus a bundle of personal envelopes — one per reader, each labeled with that reader's wallet address — all built on well-known, independently audited cryptography.
 
-```javascript
-const wrappedKeys = recipients.map(recipient => {
-  const ephemeralKeyPair = generateEphemeralKeyPair()
+This is what makes multiple readers practical. The expensive part — locking the agreement — happens once no matter how many people you add; each extra reader costs one tiny envelope. And because everyone opens the *same* box, there's no question about which copy is the "real" one for a referee to argue over.
 
-  // ECDH to derive shared secret
-  const sharedSecret = x25519.getSharedSecret(
-    ephemeralKeyPair.privateKey,
-    recipient.publicKey
-  )
+Opening it runs in reverse: find the envelope with your address on it, your wallet opens it to recover the shared key, and the key opens the box. Each person's path is independent — if one player's wallet is compromised, the attacker gets that player's envelope, not anyone else's.
 
-  // Derive key encryption key from shared secret
-  const kek = hkdf(sha256, sharedSecret, new Uint8Array(0), ENVELOPE_INFO, 32)
+## Where the personal envelopes come from
 
-  // Encrypt DEK with KEK
-  const keyNonce = randomBytes(12)
-  const keyCipher = chacha20poly1305(kek, keyNonce)
-  const wrappedDek = keyCipher.encrypt(dek)
-  ...
-})
-```
+To lock the key for someone, you need their public "lockbox address" — the thing anyone can use to seal a message only they can open. But the person creating the wager may never have met the referee. So FairWins keeps a small public directory on the blockchain mapping each wallet to its current encryption key. Anyone can look up anyone's key; only you can set your own.
 
-The resulting JSON envelope has a single `content` block (nonce + ciphertext) and a `keys[]` array with one entry per reader, keyed by lowercase Ethereum address. Everything uses the audited Noble libraries (`@noble/curves`, `@noble/ciphers`, `@noble/hashes`).
+Users never manage these keys by hand. A regular wallet produces its encryption key by signing one fixed message and turning that signature into a key — same wallet, same key, every device. Passkey accounts (the same Face ID / fingerprint sign-in standard, WebAuthn, your phone already uses) derive the same kind of key from their own secure seed. Either way: nothing to write down, no key server to trust. The directory allows a range of key sizes, leaving room for a future-proof key type (below) without ever changing the contract.
 
-The cost model is what makes multi-recipient practical. Content encryption is O(1) in the reader count; each additional reader costs one ephemeral keypair, one ECDH, one HKDF call, and ~60 bytes of wrapped-key entry. A 5 KB terms document shared with three readers is stored once, not three times — and every reader provably decrypts the *same* ciphertext, so there is no "which copy is canonical" question for an arbitrator to litigate.
+## Making the referee a real reader
 
-Decryption is the mirror image: find your entry in `keys[]`, recompute the shared secret against the stored ephemeral public key, derive the KEK, unwrap the DEK, decrypt the content. Each reader's path is fully independent — compromise of one reader's wallet exposes their wrapped key, not the wrapping of anyone else's.
+With multiple keyholders and a public key directory already in place, "let the referee read the wager" came down to one thing: add a third person to the list of keyholders when a wager names a referee. Two people for a normal bet, three with a referee — who then opens the agreement exactly like a player.
 
-## Where Public Keys Come From
+Three surrounding decisions carry the real design weight:
 
-Wrapping a DEK for someone requires their encryption public key, and the creator may never have communicated with the arbitrator directly. That directory is on-chain: `contracts/privacy/KeyRegistry.sol`, a deliberately minimal contract.
+**Refuse to create a bet the referee can't read.** A wager can only be locked for someone whose encryption key is already in the directory. If the named referee has never registered a key, creation is *blocked* right away, naming who's missing. The alternative — quietly minting a wager whose own referee can never open it, discovered months later at settlement — is far worse than a little friction up front.
 
-```solidity
-contract KeyRegistry {
-    uint256 private constant MIN_KEY_LENGTH = 32;
-    uint256 private constant MAX_KEY_LENGTH = 2048;
+**Finding your cases is public bookkeeping, not guesswork.** Being able to open an agreement is useless if you don't know it exists. So when a wager names a referee, the blockchain quietly adds it to the referee's personal index, alongside the two players. Referees browse their caseload the same way players already do — one extra line in a ledger, no new machinery.
 
-    mapping(address => bytes) private _keys;
+**The blockchain vouches for the sealed box.** The blockchain stores a fingerprint of the sealed agreement. Before trusting anything it fetches, a reader re-checks that fingerprint, so a swapped or corrupted box is *detected*, not shown as real. And if storage is temporarily unreachable, the app says so — the money never waits on the text being available.
 
-    event KeyRegistered(address indexed user, bytes key, uint64 timestamp);
+One honesty point mirrors the platform's approach to fees: when a referee is a reader, the interface says so. Players should never believe a bet is strictly two-party-private when a third keyholder exists.
 
-    function registerKey(bytes calldata publicKey) external { ... }
-    function getPublicKey(address user) external view returns (bytes memory);
-    function hasKey(address user) external view returns (bool);
-}
-```
+## Growing and shrinking the guest list
 
-Keys are opaque bytes bounded to 32–2048 bytes, which is not an accident: it accommodates both a 32-byte X25519 key and a 1216-byte X-Wing hybrid post-quantum key (more below) without a contract change. Re-registering overwrites — the wallet is the identity, the key is just its current encryption endpoint.
+Because access is granted through those little envelopes, changing the guest list never touches the sealed agreement. Any existing reader — not just the creator — can open the shared key and seal a new envelope for a newcomer, with no blockchain transaction at all.
 
-Users never manage these keys. An EOA derives its keypair deterministically from an EIP-191 `personal_sign` of a fixed message; the signature is hashed with Keccak-256 into the private key or seed. Passkey smart accounts (which have no EOA to sign with) derive the same shape of keypair via HKDF from their WebAuthn PRF master seed. Same wallet, same key, every device — nothing to back up, no key server to trust.
+Removal is where the design is honest about its limits. You can strike someone's envelope from the bundle, but that doesn't un-tell them a key they already saw and might have saved. True revocation means re-locking under a brand-new key. FairWins documents this plainly rather than pretending removing a name equals taking back access. Locks grant access; they can't reach into someone's memory.
 
-## Making the Arbitrator a First-Class Reader
+## The future-proof variant
 
-With N-recipient wrapping and an on-chain key directory already in place, spec 005 (`specs/005-multi-recipient-encryption/`) reduced "let the arbitrator read the wager" to recipient assembly at creation time:
+Everything above also runs in a second mode built to resist a future threat: an attacker who records encrypted data today, hoping to crack it years from now once quantum computers mature ("harvest now, decrypt later"). This variant seals each envelope with a hybrid approach (an emerging standard called X-Wing) combining today's proven encryption with a new quantum-resistant method — if *either* holds, your data stays sealed. The envelopes get bigger; the sealed agreement and blockchain footprint don't change, and old and new bets coexist.
 
-```
-recipients = [
-  { address: creator,    publicKey: lookupPublicKey(creator) },
-  { address: opponent,   publicKey: lookupPublicKey(opponent) },
-  // only for ThirdParty wagers with an assigned arbitrator:
-  { address: arbitrator, publicKey: lookupPublicKey(arbitrator) },
-]
-envelope = encryptEnvelope(termsPlaintext, recipients)
-```
+## Why it was built this way
 
-Two without an arbitrator, three with. The arbitrator decrypts exactly like a participant — the decryption hooks already key off `keys[].address` and needed no changes. But three surrounding decisions carry the real design weight:
+- **Reuse the multiple-keyholder capability instead of inventing an "observer" role.** The referee simply *is* a third keyholder who also declares the winner — one more entry in a list that always supported many.
+- **Block creation on a missing key rather than patch it later.** Failing loudly at creation beats failing silently at settlement, at the cost of a little friction: a referee registers a key before being named.
+- **No pretend revocation.** Removing a reader without re-locking is documented as *not* true revocation. Correct-but-limited, stated openly, beats a guarantee the math can't back.
 
-**Fail closed on missing keys (FR-007).** A wager can only be encrypted for a reader whose key is registered. If the named arbitrator has never called `registerKey`, creation is *blocked* with a message naming the missing party — the alternative is silently minting a wager its own resolver can never read, discovered months later at resolution time. The reader set is fixed when the bundle is prepared; late-binding a reader after creation is explicitly out of scope for v1.
+The through-line so far: part 1 encrypted one agreement for two rival readers; part 2 shows the same locked box stretching to whatever readers a wager's life requires. Part 3 turns the same machinery inward — syncing your own private data across your own devices.
 
-**Discovery is on-chain, not cryptographic.** Being able to decrypt a wager is useless if you don't know it exists. The one contract change in spec 005 extends the existing per-user index in `WagerRegistry.createWager`: alongside the creator and opponent, `_userWagerIds[w.arbitrator].add(wagerId)` when an arbitrator is set. Arbitrators enumerate their caseload through the same `getUserWagerIds` reads participants already use — one extra `SSTORE`, no new events or storage variables.
+## Further reading
 
-**Integrity binds off-chain to on-chain.** The envelope lives on IPFS; the wager stores `metadataHash = keccak256("encrypted:ipfs://<CID>")` on-chain. A reader recomputes the hash before trusting a fetched bundle, so a substituted or corrupted envelope is *detected*, never displayed as valid. And if IPFS is unreachable, the terms degrade to an honest "unavailable" state — funds and resolution never block on plaintext availability.
-
-One honest-disclosure point mirrors the platform's fee doctrine: when an arbitrator is a reader, the UI says so. Participants should never believe a wager is two-party-private when a third key entry exists.
-
-## Growing and Shrinking the Reader Set
-
-Because access is granted per wrapped key, membership changes don't touch the content ciphertext. `addRecipient` lets *any existing reader* — not only the creator — unwrap the DEK with their own key and wrap it for a newcomer, appending one entry to `keys[]`. Since the envelope lives off-chain, this needs no transaction.
-
-Removal is where the abstraction is honest about its limits. `removeRecipient` filters an entry out of `keys[]`, and its docstring says the quiet part loud: *"This doesn't re-encrypt — they may still have the DEK cached. For true revocation, create a new envelope with new DEK."* Multi-recipient encryption grants access; it cannot un-know a key someone already held. FairWins documents this rather than pretending deletion equals revocation.
-
-## The Post-Quantum Variant
-
-Everything above runs identically under the v2.0 envelope, which swaps the per-recipient X25519 exchange for **X-Wing** — the IETF hybrid KEM combining X25519 with ML-KEM-768. `encryptEnvelopeXWing` calls `xwingEncapsulate` per recipient (a 1120-byte KEM ciphertext replaces the 32-byte ephemeral key) and derives the KEK from the combined shared secret via the spec's SHA3-256 combiner. If *either* component algorithm holds, the wrap holds — protection against harvest-now-decrypt-later adversaries. The wrapping layer absorbed the ~35× ciphertext growth with no change to content encryption or the on-chain footprint: the chain still stores a ~60-byte reference regardless of how heavy the envelope gets. `decryptEnvelopeUnified` dispatches on the envelope's `algorithm` field, so v1.0 and v2.0 bundles coexist.
-
-## Design Decisions
-
-- **Reuse the N-recipient API instead of adding an "observer" role.** The original request asked for participants plus an observer; the spec resolved the observer *as* the arbitrator, who reads and resolves. No new cryptosystem, no new role machinery — a third entry in an array that always supported N.
-- **Block creation on missing keys rather than late-bind.** Fail loudly at creation beats failing silently at resolution. The trade-off is friction — an arbitrator must register a key before being named — accepted for v1.
-- **Discovery via the registry index, not encrypted scanning.** Trial-decrypting every envelope on IPFS would be private but unusable; an on-chain index write is cheap and reuses existing reads. The trade-off: who arbitrates what is public metadata.
-- **Accept visible recipient addresses.** `keys[].address` is plaintext, so the reader set of any bundle is enumerable. Hiding it would break the "find my entry" decryption step; the design accepts this as consistent with blockchain transparency.
-- **No backward secrecy by design.** Removal without DEK rotation is documented as non-revocation. Correct-but-limited, stated plainly, beats an implied guarantee the math doesn't back.
-
-The through-line of the series so far: part 1 encrypted one agreement for two adversarial readers; part 2 shows the same envelope stretching to any reader set the wager's lifecycle demands. Part 3 turns the same machinery inward — syncing a user's own encrypted data across their devices.
-
-## Sources
-
-- `specs/005-multi-recipient-encryption/spec.md` — requirements, edge cases, decisions
-- `specs/005-multi-recipient-encryption/contracts/encryption-bundle-contract.md` — bundle invariants, recipient assembly
-- `specs/005-multi-recipient-encryption/contracts/wager-registry-arbitrator-index.md` — the arbitrator discovery index
-- `docs/developer-guide/envelope-encryption-spec.md` — primitives, envelope formats, security considerations
-- `docs/developer-guide/encryption-architecture.md` — end-to-end flow and key registry integration
-- `contracts/privacy/KeyRegistry.sol` — on-chain public-key directory
-- `frontend/src/utils/crypto/envelopeEncryption.js` — envelope encryption implementation (v1.0 X25519, v2.0 X-Wing)
-- `docs/blog/private-prediction-markets-envelope-encryption.md` — series anchor (part 1)
-- [RFC 7748 — X25519](https://datatracker.ietf.org/doc/html/rfc7748)
-- [RFC 8439 — ChaCha20-Poly1305](https://datatracker.ietf.org/doc/html/rfc8439)
-- [RFC 5869 — HKDF](https://datatracker.ietf.org/doc/html/rfc5869)
-- [EIP-191 — Signed Data Standard](https://eips.ethereum.org/EIPS/eip-191)
-- [IETF X-Wing hybrid KEM draft](https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/)
-- [Noble cryptography libraries](https://paulmillr.com/noble/)
+- [ChaCha20-Poly1305 authenticated encryption (RFC 8439)](https://datatracker.ietf.org/doc/html/rfc8439) — the "tampering makes it refuse to open" property
+- [X25519 key exchange (RFC 7748)](https://datatracker.ietf.org/doc/html/rfc7748) — how two parties agree on a shared key
+- [HKDF key derivation (RFC 5869)](https://datatracker.ietf.org/doc/html/rfc5869)
+- [WebAuthn / passkeys](https://www.w3.org/TR/webauthn-2/) — the Face ID / fingerprint sign-in standard
+- [The X-Wing hybrid post-quantum scheme](https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/)
+- [The Noble cryptography libraries](https://paulmillr.com/noble/) — the audited building blocks used here

--- a/docs/blog/posts/19-multi-recipient-encryption/social.md
+++ b/docs/blog/posts/19-multi-recipient-encryption/social.md
@@ -1,25 +1,25 @@
-# Social & Image — One Ciphertext, N Wrapped Keys: Multi-Recipient Encryption for Private Wagers
+# Social & Image — One Locked Box, Several Keyholders: How a Private Wager Can Add a Referee
 
 ## X (Twitter)
 
-Encrypt once, wrap the key N times: FairWins private wagers keep one ChaCha20-Poly1305 ciphertext plus an X25519-wrapped DEK per reader. Adding a neutral arbitrator was a third array entry — not a redesign. 🔗 <link> #encryption #privacy #web3
+Lock the agreement once, hand out a personal key-envelope per reader. That's how a two-person private wager on FairWins adds a neutral referee — a third keyholder, not a redesign, and everyone opens the exact same box. 🔗 <link> #encryption #privacy #web3
 
 ## LinkedIn
 
-A resolver who can't read the agreement they're supposed to rule on is worse than no resolver. That was the state of FairWins' third-party arbitration: the arbitrator was named and authorized on-chain, but the wager terms were end-to-end encrypted for exactly two participants. Re-encrypting per reader, sharing keys out-of-band, or holding a platform master key were all non-starters.
+A referee who can't read the agreement they're supposed to judge is worse than no referee. That was the state of FairWins' private wagers: the referee was named and authorized on-chain, but the terms were end-to-end encrypted for exactly two players. Making a fresh copy per reader, sharing a password by chat, or handing the platform a master key were all non-starters.
 
-The fix required zero new cryptography — the envelope format was multi-recipient from day one. The new post walks the mechanism:
+The fix required zero new cryptography — the design already supported multiple keyholders. The new post walks it in plain terms:
 
-- One DEK encrypts the terms once (ChaCha20-Poly1305 AEAD); each reader gets an X25519 + HKDF wrapped copy of the DEK — ~60 bytes per reader, and everyone provably decrypts the same ciphertext.
-- An on-chain `KeyRegistry` supplies encryption public keys, sized to fit both X25519 and X-Wing hybrid post-quantum keys without a contract change.
-- Fail-closed creation: no registered key for a named arbitrator, no wager — never a wager its own resolver can't read.
-- Honest limits: removing a reader from the envelope is not revocation, and the design says so plainly.
+- One sealed box holds the agreement; each reader gets a tiny personal envelope holding the key to it — everyone opens the same box, no drifting copies.
+- A small public directory on-chain supplies each person's encryption key, with room for a future quantum-resistant key type built in.
+- Refuse-to-create: no registered key for a named referee, no wager — never a bet its own referee can't read.
+- Honest limits: striking someone from the guest list isn't the same as taking back a key they already saw, and the design says so plainly.
 
 Full write-up: 🔗 <link>
 
-Where do you draw the line between access-grant machinery and true revocation in E2EE systems?
+Where do you draw the line between granting access and truly revoking it in end-to-end encrypted systems?
 
-#encryption #cryptography #privacy #web3 #ethereum
+#encryption #privacy #web3 #ethereum
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/20-encrypted-data-sync/blog.md
+++ b/docs/blog/posts/20-encrypted-data-sync/blog.md
@@ -1,120 +1,77 @@
-# Client-Side Encrypted Data Sync: Moving Your Data Between Devices Without a Server That Can Read It
+# Moving Your Data Between Devices — Without a Server That Can Read It
 
-*How FairWins backs up a member's address book and preferences to public storage — encrypted with a key only their wallet can reproduce, located by a 40-line contract*
+*How FairWins backs up your address book and settings to public storage, locked with a key only your own wallet can reproduce*
 
 | | |
 |---|---|
 | **Series** | Privacy Architecture (part 3) |
-| **Audience** | Privacy-focused app engineers |
-| **Tags** | `e2ee`, `data-sync`, `privacy`, `client-side-encryption` |
-| **Reading time** | ~8 minutes |
+| **Audience** | Product, founders, and the privacy-curious |
+| **Tags** | `privacy`, `backup`, `plain-english` |
+| **Reading time** | ~7 minutes |
 
 ## The data that lives in one browser
 
-A member has been using FairWins on their laptop for six months. They have a curated address book — contacts with nicknames, notes, and saved addresses across Polygon and Mordor. They have tuned preferences: favorite markets, default slippage, saved searches. Then they open the app on their phone. Everything is empty.
+A member has used FairWins on their laptop for six months. They've built up a curated address book — contacts with nicknames and notes — and tuned their settings: favorite markets, saved searches. Then they open the app on their phone. Everything is empty.
 
-This isn't a bug. FairWins deliberately has no application backend — the footprint is client, IPFS, and chain. There is no user database to sync from, which is exactly why the platform can promise it never reads your data: it never holds it. But the flip side is that user-authored state lives in one browser's `localStorage`, scoped to the connected wallet. A second device can't see it, and clearing the browser destroys it permanently.
+This isn't a bug. FairWins deliberately has no backend of its own — the whole system is your browser, public file storage, and the blockchain. There is no company database to sync from, which is exactly why the platform can promise it never reads your data: it never holds it. The flip side is that everything you personally created lives inside one browser, tied to your wallet. A second device can't see it, and clearing your browser wipes it for good.
 
-The conventional fix is a sync server. The server stores each user's data, devices pull it down, everyone is happy — except now there's a database of every member's contact list, and a party that can read, lose, or be compelled to hand over all of it. That trade was never on the table here.
+The usual fix is a sync server. The company stores each member's data, devices pull it down — except now there's a database of every member's contact list, and a company that can read it, lose it, or be forced to hand it over. That trade was never on the table.
 
-Spec 032's answer keeps the no-backend constraint intact: the client bundles the data, encrypts it with a key **only the member's wallet can reproduce**, pins the ciphertext to IPFS, and records a pointer to it in a tiny on-chain registry. Any device that controls the same wallet can walk that chain backwards — read the pointer, fetch the blob, re-derive the key, decrypt. The "server" in this sync system is public infrastructure that stores only ciphertext and a content hash. Let's walk each stage.
+The answer keeps the no-backend promise intact. Your device gathers your data, locks it with a key **only your wallet can reproduce**, uploads the locked file to public storage, and writes a tiny pointer to it on the blockchain. Any device holding the same wallet can walk that trail backwards — read the pointer, fetch the file, re-create the key, unlock. The "server" here is public infrastructure that only ever holds a scrambled file and a fingerprint of it. Let's walk each stage.
 
-## Keys that travel with the user
+## A key that travels with you, stored nowhere
 
-The hard problem in client-side encrypted sync isn't the encryption — it's key distribution. If the key is stored on device A, device B can't decrypt. If the key is stored on a server, you've rebuilt the thing you were avoiding. If the user must transcribe a recovery code, they'll lose it.
+The hard part of this kind of backup isn't the locking — it's the key. If the key lives on your laptop, your phone can't unlock anything. If it lives on a server, you've rebuilt the thing you were trying to avoid. If you have to write down a recovery code, you'll lose it.
 
-FairWins sidesteps storage entirely: the key is *derived*, deterministically, from something the member already carries — their wallet. `frontend/src/lib/backup/backupCrypto.js` asks the wallet to sign a fixed domain message and hashes the signature into a 32-byte symmetric key:
+FairWins sidesteps storage entirely: the key is *re-created on demand* from something you already carry — your wallet. Your wallet signs one fixed message, and that signature is turned into the lock's key.
 
-```javascript
-export const DATA_BACKUP_MESSAGE_V1 = 'FairWins Data Backup v1'
+This works because of a well-established property of standard wallets: signing the same message with the same wallet produces the exact same signature every time, on any device. Sign it on your laptop to lock your data; sign it on your phone and you hold the identical key. Nothing is stored, sent, or handed to anyone. It's the same idea part 1 used for wager keys — but the message is deliberately different, so your backup key can never accidentally match any other key your wallet produces.
 
-/** Derive the 32-byte symmetric key from a signature string. Pure + deterministic. */
-export function deriveKeyFromSignature(signature) {
-  return getBytes(keccak256(toUtf8Bytes(signature)))
-}
-
-export async function deriveKey(signer) {
-  const signature = await signer.signMessage(DATA_BACKUP_MESSAGE_V1)
-  return deriveKeyFromSignature(signature)
-}
-```
-
-This works because standard wallets implement RFC 6979 deterministic ECDSA: the same key signing the same message produces the same signature every time, on every device. Sign once on the laptop to encrypt; sign the same message on the phone and you hold the same key. Nothing is stored, transmitted, or escrowed. This is the same pattern part 1 of this series used for wager-content keys — but the domain message is deliberately distinct (`"FairWins Data Backup v1"` vs. the wager and address-book messages), so the backup key can never coincide with any other key the wallet derives.
-
-Passkey accounts (spec 041) don't have an ECDSA signer to prompt, so the same file ships a login-method-agnostic twin: `deriveKeyFromSeed(seed)` hashes the account's PRF-derived master seed together with the same domain message. Both paths are deterministic per account, so a backup made under a wallet session restores under a passkey session for the same account, and vice versa. The determinism assumption is guarded, not assumed silently: spec 032's FR-001a requires that a wallet which cannot reproduce its signature fails *honestly* — a wrong key can only ever produce an AEAD authentication failure, surfaced as "no usable backup," never a garbage restore.
+Passkey accounts (the Face ID / fingerprint sign-in standard) don't sign messages the same way, so a matching path produces the same key from the account's own secure seed. Either way the key comes out the same for a given account, so a backup made in a wallet session restores fine in a passkey session, and vice versa. And it fails *honestly*: a wallet that can't reproduce its own key gets a clean "no usable backup" message — never a garbled, half-decrypted mess presented as your real data.
 
 ## The bundle: one file, every network
 
-What actually gets encrypted is a single unified bundle per wallet, assembled by `frontend/src/lib/backup/backupBundle.js` from an explicit registry of synced objects (`frontend/src/lib/backup/syncedObjects.js`). Each entry declares how to load itself, how to merge on restore, and — critically — whether it is **network-scoped**. Today the registry holds five objects:
+What actually gets locked is a single bundle per wallet, assembled from a short, explicit list of things worth syncing. Each item declares how to load itself, how to combine on restore, and — importantly — whether it belongs to a specific network. Today the list holds five kinds of data:
 
-- **Address book** — additive merge keyed on `(address, chainId)`; every saved address carries its chain id.
-- **Preferences** — global scalars and lists (favorite markets, default slippage); last-writer-wins.
-- **Vault references** (spec 043) — custody vault pointers, identity `(chainId, address)`.
-- **Activity ledger** (spec 051) — client-only records that can't be re-derived from chain; both merge and replace modes union by `entryId`, because a "replace" that deleted audit history would violate the ledger's append-only guarantee.
-- **Open-challenge recovery codes** — stored in the bundle as an *opaque, already-encrypted envelope*; the codes never enter the backup channel in cleartext, and restore only writes it when the device has no local vault.
+- **Address book** — merged additively, so restoring never deletes contacts; every saved address remembers its network.
+- **Preferences** — your global settings; newest wins.
+- **Vault references** — pointers to your custody vaults.
+- **Activity ledger** — a private, on-device record of things that can't be rebuilt from the blockchain; restores always add rather than delete, since quietly erasing your own history would break its whole purpose.
+- **Recovery codes for open challenges** — carried through as an already-sealed blob that never travels in readable form, written back only if the new device has none of its own.
 
-The network tagging matters more than it looks. A backup made while connected to Mordor must restore Polygon contacts to Polygon. Rather than fragmenting backups per network, every network-specific element carries its chain id inside the one bundle, and `parseBundle` rejects any network-scoped element missing its tag — a malformed bundle throws before it can touch local data. Data that re-derives from chain (balances, tier caches, on-chain history) is deliberately excluded: sync user-authored state, not caches.
+The network tagging matters more than it looks. A backup made while connected to one network has to restore each contact to the *right* network. So every network-specific item carries its network label inside the one bundle — and a bundle missing a required label is rejected before it can touch your device. Data that can simply be rebuilt from the blockchain (balances, caches, transaction history) is deliberately left out: back up what *you* authored, not what the chain can regenerate. Adding a future kind of data later is one more entry on that list — no rebuilding the machinery.
 
-Adding a future object — tokens, DAOs — is one registry entry declaring its merge rule and scope truthfully. No redesign of the machinery (FR-016).
+## Lock, upload, point
 
-## Encrypt, pin, point
+The backup flow has four steps: gather the bundle, re-create the key, lock the bundle, then save it in two places — once to public file storage, once to the blockchain. The locking uses the same authenticated encryption as elsewhere in the series, with the format version bound in so a file can never be silently reinterpreted as a different format.
 
-The backup path in `frontend/src/hooks/useDataBackup.js` is four steps: build the bundle, derive the key, encrypt, then persist twice — once to IPFS, once to chain. Encryption is ChaCha20-Poly1305 (via the audited `@noble/ciphers`, in `frontend/src/utils/crypto/primitives.js`) with a random 96-bit nonce and the format/version string bound as AEAD associated data, so an envelope can't be silently reinterpreted under a different format version.
+Uploading the locked file returns a content address — a fingerprint that doubles as its retrieval handle. But a fingerprint alone recreates the original problem: your phone doesn't know it. So the final step writes that handle to a tiny, almost aggressively boring contract on one canonical network. It holds no money, has no special roles, and lets only a wallet set its own pointer. Writing an empty value clears it — that's how "delete my backup" works: the trail is cut, and the stored file is left to expire.
 
-The ciphertext is pinned to IPFS, which returns a CID. But a CID on its own recreates the recovery-code problem — the phone doesn't know it. So the last step is a transaction to `contracts/privacy/BackupPointerRegistry.sol` on a single canonical network (Polygon mainnet, chain 137), and the contract is almost aggressively boring:
-
-```solidity
-contract BackupPointerRegistry {
-    uint256 private constant MAX_CID_LENGTH = 256;
-    mapping(address => string) private _pointer;
-
-    event BackupPointerSet(address indexed owner, string cid, uint64 timestamp);
-
-    /// @notice Set, overwrite, or clear (with "") the caller's backup pointer.
-    function setPointer(string calldata cid) external {
-        if (bytes(cid).length > MAX_CID_LENGTH) revert CidTooLong();
-        _pointer[msg.sender] = cid;
-        emit BackupPointerSet(msg.sender, cid, uint64(block.timestamp));
-    }
-
-    function getPointer(address owner) external view returns (string memory) { ... }
-}
-```
-
-Value-free, no roles, no external calls, keyed purely on `msg.sender` — only a wallet can set its own pointer. It uses no OpenZeppelin imports so it also compiles on pre-Cancun targets like ETC/Mordor. Writing `""` clears the pointer, which is how "remove my backup" works: the locator is severed and the pin can lapse.
-
-Restore inverts the pipeline with no transaction at all: read `getPointer` through a read-only provider (free, and it works whatever network the member is connected to), fetch the envelope by CID, re-derive the key, decrypt, validate, then apply. Before anything is written, the member chooses **merge** (additive, the default) or **replace** (confirmed, destructive) — a restore that silently overwrote a newer local address book would cause the very loss the feature exists to prevent.
+Restoring runs the pipeline in reverse, with no transaction and no fee: read the pointer (a free lookup that works whatever network you're connected to), fetch the locked file, re-create the key, unlock, check it, and apply it. Before anything is written, you choose **merge** (add to what's here, the default) or **replace** (a confirmed, destructive overwrite). A restore that silently clobbered a newer address book would cause the very loss the feature exists to prevent.
 
 ## Honest state, everywhere
 
-A sync feature earns trust through its failure modes. The implementation is strict about three distinctions:
+A backup feature earns trust through how it behaves when things go wrong. This one is strict about three distinctions:
 
-- **"No backup" vs. "couldn't check."** `readPointer` in `frontend/src/lib/backup/backupRegistry.js` returns `""` for a genuinely empty pointer but `null` for an unreachable RPC — the UI says "nothing to restore" for one and "try again later" for the other, and never presents empty-as-truth.
-- **"Backed up" means both writes confirmed.** Success is shown only after the IPFS pin *and* the pointer transaction confirm. No optimistic checkmarks.
-- **Undecryptable means untouched.** A wrong key, tampered envelope, or foreign format fails AEAD authentication or bundle validation and is reported as "no usable backup"; local data — which remains the working source of truth throughout — is never overwritten with garbage.
+- **"No backup" versus "couldn't check."** An empty pointer means there's genuinely nothing to restore; an unreachable network means we don't know yet. The app says "nothing to restore" for one and "try again later" for the other — never dressing up "couldn't reach it" as "you have nothing."
+- **"Backed up" means both saves confirmed.** Success shows only after the file upload *and* the pointer transaction both go through — no optimistic checkmarks.
+- **Can't unlock means don't touch.** A wrong key, tampered file, or foreign format fails its integrity check and is reported as "no usable backup." Your local data — the working source of truth the whole time — is never overwritten with garbage.
 
 ## Trade-offs
 
-**The pointer is public by design.** Anyone can see that a wallet has a backup, its CID, and when it changed (spec 032, FR-005b). That metadata is the accepted price of trustless retrieval — the alternative locators all reintroduce something worse. IPNS was rejected for resolution reliability; a member-held recovery code is loss-prone; a platform lookup service breaks the no-backend rule. The *content* stays ciphertext, so the metadata never discloses personal data.
+**The pointer is public by design.** Anyone can see that a wallet has a backup, where it points, and when it last changed. That metadata is the accepted price of retrieving your data without trusting anyone — every alternative was worse: a self-resolving name was too unreliable, a member-held recovery code is easy to lose, a company lookup service would break the no-backend rule. The *contents* stay locked, so the metadata never reveals anything personal.
 
-**Manual, not automatic.** This is explicit backup/restore, not background sync. Automatic sync would mean gas per change, always-on discovery, and data leaving the device without a deliberate act — spec 032 makes opt-in-by-action a hard requirement (FR-010): nothing leaves the device until the member triggers it, and they're told about the on-chain cost before signing. Background sync remains a possible later evolution, on this same substrate.
+**Manual, not automatic.** This is deliberate backup and restore, not silent background sync — which would mean a fee on every little change, always-on tracking, and your data leaving the device without a decision from you. Nothing leaves until you trigger it, and you're told the small on-chain cost before you approve. Background sync could come later, on this same foundation.
 
-**Lose the wallet, lose the backup.** There is no recovery path without the key material, by design. A general social-recovery scheme is explicitly out of scope; the encrypted export/import file from spec 021 remains as a zero-infrastructure offline fallback for members who prefer not to transact.
+**Lose the wallet, lose the backup.** There's no recovery path without your key material, by design. A broad social-recovery scheme is out of scope for now; a plain encrypted export file remains as an offline fallback for members who'd rather not transact at all.
 
-**One canonical network.** Backups cost cents of gas on Polygon and require switching to it; restore reads are free from anywhere. A soft ~1 MB size cap warns — but never blocks — oversized bundles.
+**One canonical network.** Backups cost a few cents of network fees and require switching to that network; restore reads are free from anywhere.
 
-The sum is a sync system where every storage layer is public — IPFS blobs anyone can fetch, a registry anyone can read — and none of it is readable by anyone but the wallet holder. The key never exists at rest; it exists wherever the member is.
+The sum is a sync system where every storage layer is public — files anyone can fetch, a pointer anyone can read — yet none of it is readable by anyone but you. The key exists nowhere at rest; it exists wherever you are.
 
-## Sources
+## Further reading
 
-- `specs/032-encrypted-data-sync/spec.md`, `plan.md` — feature spec and canonical-network decision
-- `contracts/privacy/BackupPointerRegistry.sol` — the on-chain locator
-- `frontend/src/lib/backup/backupCrypto.js`, `backupBundle.js`, `syncedObjects.js`, `backupRegistry.js` — key derivation, bundle, object registry, pointer client
-- `frontend/src/hooks/useDataBackup.js` — backup/restore orchestration
-- `frontend/src/utils/crypto/primitives.js` — ChaCha20-Poly1305 AEAD via `@noble/ciphers`
-- `frontend/src/abis/backupPointerRegistry.js` — ABI + canonical chain id (Polygon, 137)
-- `specs/002-e2e-encryption-lifecycle/`, `docs/developer-guide/encryption-architecture.md` — the wallet-signature key-derivation pattern this feature reuses
-- RFC 6979 — Deterministic ECDSA: https://datatracker.ietf.org/doc/html/rfc6979
-- RFC 8439 — ChaCha20-Poly1305 AEAD: https://datatracker.ietf.org/doc/html/rfc8439
-- EIP-191 — Signed data standard (`personal_sign`): https://eips.ethereum.org/EIPS/eip-191
-- IPFS CIDs: https://docs.ipfs.tech/concepts/content-addressing/
+- [Deterministic ECDSA signatures (RFC 6979)](https://datatracker.ietf.org/doc/html/rfc6979) — why the same wallet re-creates the same key every time
+- [ChaCha20-Poly1305 authenticated encryption (RFC 8439)](https://datatracker.ietf.org/doc/html/rfc8439)
+- [WebAuthn / passkeys](https://www.w3.org/TR/webauthn-2/) — the Face ID / fingerprint sign-in standard
+- [Content addressing on IPFS](https://docs.ipfs.tech/concepts/content-addressing/) — how the "fingerprint that doubles as a retrieval handle" works

--- a/docs/blog/posts/20-encrypted-data-sync/social.md
+++ b/docs/blog/posts/20-encrypted-data-sync/social.md
@@ -1,26 +1,26 @@
-# Social & Image — Client-Side Encrypted Data Sync: Moving Your Data Between Devices Without a Server That Can Read It
+# Social & Image — Moving Your Data Between Devices Without a Server That Can Read It
 
 ## X (Twitter)
 
-Cross-device sync with zero backend: FairWins derives the backup key from a deterministic wallet signature (RFC 6979), encrypts client-side, pins ciphertext to IPFS, and a tiny value-free contract stores the pointer. 🔗 <link> #e2ee #privacy #web3
+Cross-device sync with no backend: FairWins re-creates your backup key from a wallet signature (same wallet, same key, every device), locks your data on your own device, uploads the scrambled file to public storage, and writes a tiny pointer on-chain. 🔗 <link> #privacy #web3
 
 ## LinkedIn
 
-Your app has no backend — that's the privacy promise. But it also means a member's address book and preferences live in one browser's localStorage. Open the app on a second device: empty. The conventional fix is a sync server, which recreates exactly the database of user data the architecture exists to avoid.
+Your app has no backend — that's the privacy promise. But it also means a member's address book and settings live in one browser. Open the app on a second device: empty. The usual fix is a sync server, which recreates exactly the database of user data the whole design exists to avoid.
 
-FairWins' answer keeps the no-backend constraint intact, and the new post walks each stage:
+FairWins' answer keeps the no-backend promise intact, and the new post walks each stage in plain terms:
 
-- Key derivation with no storage: the wallet signs a fixed domain message, and RFC 6979 deterministic ECDSA means the same wallet reproduces the same 32-byte key on every device. Nothing is stored, transmitted, or escrowed.
-- One unified bundle per wallet — address book, preferences, vault references, activity ledger — with per-object merge rules and network-scoped tagging so Polygon contacts restore to Polygon.
-- ChaCha20-Poly1305 ciphertext pinned to IPFS, located by a value-free on-chain pointer registry keyed purely on `msg.sender`.
-- Honest failure modes: "no backup" vs. "couldn't check" are distinct states, and a wrong key can only fail AEAD authentication — never produce a garbage restore.
+- A key stored nowhere: your wallet signs one fixed message, and a standard wallet reproduces the same signature — and the same key — on every device. Nothing is stored, sent, or escrowed.
+- One bundle per wallet — address book, preferences, vault references, activity ledger — with per-item merge rules and network labels so each contact restores to the right network.
+- The locked file goes to public storage; a tiny, money-free on-chain pointer says where — and only your wallet can set it.
+- Honest failure modes: "no backup" and "couldn't check" are different states, and a wrong key can only ever fail its integrity check — never produce a garbled restore.
 
 Full write-up: 🔗 <link>
 
-Would you trust derived-not-stored keys for user data sync, or is a recovery-code escape hatch non-negotiable?
+Would you trust a key that's re-created on demand rather than stored, or is a recovery-code escape hatch non-negotiable?
 
-#e2ee #privacy #web3 #ipfs #encryption
+#privacy #web3 #encryption #ipfs
 
 ## Image prompt (Gemini / Nano Banana)
 
-Clean modern abstract-geometric editorial illustration: a laptop and a smartphone rendered as minimal translucent glass silhouettes at opposite sides of the frame, linked not directly but through a high arc of small encrypted cubes flowing up into a stylized distributed-storage constellation — faceted nodes joined by thin luminous lines — with a tiny, solitary beacon marker beneath the arc representing the on-chain pointer. The cubes are visibly sealed and opaque-cored, suggesting ciphertext in transit through public space. Deep navy base with layered teal gradients and a faint isometric grid; one warm amber accent lights the single key glyph hovering beside both devices, identical on each side. Soft diffuse lighting, subtle glow on connection lines, precise fintech-engineering minimalism, ample negative space. No text, no logos, no watermarks. Aspect ratio 16:9.
+Clean modern abstract-geometric editorial illustration: a laptop and a smartphone rendered as minimal translucent glass silhouettes at opposite sides of the frame, linked not directly but through a high arc of small encrypted cubes flowing up into a stylized distributed-storage constellation — faceted nodes joined by thin luminous lines — with a tiny, solitary beacon marker beneath the arc representing the on-chain pointer. The cubes are visibly sealed and opaque-cored, suggesting scrambled data in transit through public space. Deep navy base with layered teal gradients and a faint isometric grid; one warm amber accent lights the single key glyph hovering beside both devices, identical on each side. Soft diffuse lighting, subtle glow on connection lines, precise fintech-engineering minimalism, ample negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/21-nullifier-system/blog.md
+++ b/docs/blog/posts/21-nullifier-system/blog.md
@@ -1,238 +1,75 @@
-# The Nullifier System: A Privacy-Preserving Blocklist That Never Shipped
+# The Blocklist That Never Shipped: Voiding Bad Markets Without Publishing a Wall of Shame
 
-*What FairWins built when it needed to revoke bad markets without publishing a
-blacklist — and why the word "nullifier" means something different here than it
-does in Tornado Cash*
+*A design-history piece: what FairWins built to revoke bad markets without posting a public blacklist — a compact cryptographic membership check — and the honest reasons it was shelved*
 
 | | |
 |---|---|
 | **Series** | Privacy Architecture (part 4) |
-| **Audience** | ZK and privacy engineers |
-| **Tags** | `nullifiers`, `zk`, `privacy`, `rsa-accumulator`, `moderation` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product, founders, and the crypto-curious |
+| **Tags** | `privacy`, `moderation`, `design-history`, `plain-english` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-> This post describes a peer-to-peer wager platform built around forecasting on
-> publicly available information. Nothing here is a mechanism for evading law or
-> sanctions screening; the "nullifier" below is a moderation primitive, and it is
-> archived. Participants on any live FairWins surface remain subject to applicable
-> law and to the platform's on-chain sanctions guard.
+> This post describes a design that was explored and then shelved. It is a moderation idea, not a way to evade law or sanctions screening. Everything live on FairWins today runs the platform's real compliance checks, and all participants remain subject to applicable law.
 
 ## A word with two meanings
 
-If you come from the zero-knowledge world, "nullifier" has a precise meaning. In
-Tornado Cash, a nullifier is a value you reveal when you withdraw a note so that
-the same note cannot be withdrawn twice. In Semaphore, a nullifier hash binds a
-signal to an identity and an external topic so a member can prove "I am in this
-group and I have not spoken on this topic before" without revealing which member
-they are. The nullifier is the anti-double-spend, anti-replay half of an
-otherwise anonymous action. You never learn *who*; you only learn *again* — and
-you reject the "again."
+"Nullifier" is a loaded term. In privacy tech — coin mixers and anonymous-signaling systems — a nullifier is a one-time value you reveal to prove you haven't already spent something or already voted, all without revealing *who* you are. It's the anti-double-use safeguard behind an otherwise anonymous action. You never learn *who*; you only learn *again* — and you reject the "again."
 
-FairWins has a "nullifier system" too, documented in `docs/NULLIFIER_SYSTEM.md`
-and `docs/developer-guide/nullifier-system.md`. It is worth being blunt up front:
-it is **not** that. The FairWins nullifier does not prevent replay of a
-privacy-preserving action. It uses "nullify" in the older sense — *to make null,
-to void* — and it is a moderation tool: a way for a platform admin to revoke a
-malicious market or a bad-actor address so the frontend stops displaying it and,
-optionally, contracts stop transacting with it.
+The FairWins design explored here borrowed that word for a different, older meaning: *to nullify* as in *to void, to cancel*. It was a moderation tool — a way for a platform admin to void a scam market or block a repeat bad actor, so the app would stop showing it and, optionally, the smart contracts would refuse to deal with it. Worth being blunt: it is not the anonymous-spend kind of nullifier, and it never reached a live network. This is a design-history piece.
 
-What makes it interesting to a ZK engineer is the *shape* of the problem, which
-turns out to be the same shape as a nullifier set. A blocklist is a set. You want
-to answer one question against that set — "is this thing revoked?" — and its dual,
-"prove this thing is *not* revoked." The FairWins design reached for the same
-cryptographic primitive the ZK-mixer literature reaches for when it wants compact,
-privacy-preserving set membership: an **RSA accumulator**. This post walks that
-design, and is honest about the fact that it never reached a live network.
+What makes it interesting anyway is the *shape* of the problem. A blocklist is a set of things. You want to answer one question about that set — "is this thing blocked?" — and its harder twin, "prove this thing is *not* blocked." That second question is exactly what a certain family of cryptography is unusually good at — the same family the privacy-tech world reaches for. So the design reached for it too.
 
 ## The problem: revoking without publishing
 
-Consider the moderation problem for a permissionless-feeling market venue. An
-admin discovers a market crafted to defraud participants, or an address that keeps
-seeding abusive markets. They want it gone from the interface, and for
-high-value paths they want the contract itself to refuse to interact with it.
+Picture moderating an open, permissionless-feeling marketplace. An admin finds a market built to defraud people, or an address that keeps spinning up abusive markets. They want it gone from the interface — and for high-value actions, they want the contract itself to refuse to touch it.
 
-The naive implementation is an on-chain mapping — `mapping(address => bool)
-blocked` — and that is genuinely fine for small sets. But it has two properties
-the designers disliked. First, the blocklist is fully public and fully
-enumerable: anyone can read every entry, which turns a moderation list into a
-published "wall of shame" and leaks the platform's threat model. Second, storage
-and gas grow with the list. The `docs/NULLIFIER_SYSTEM.md` table lays out the
-trade study explicitly: an on-chain mapping is O(n) storage with a public list; a
-Merkle tree gives O(log n) proofs and partial privacy; an RSA accumulator gives
-O(1) storage, O(1) on-chain footprint, and — the headline property — the ability
-to prove that something is **not** in the set without revealing the set.
+The obvious way to do this is a simple on/off list stored on the blockchain: this address is blocked, that one isn't. For small lists, that's genuinely fine. But it has two properties the designers disliked. First, a blocklist on a public blockchain is fully readable — anyone can pull up every entry, turning a moderation list into a published "wall of shame" that broadcasts the platform's threat model. Second, its storage and cost grow with every entry.
 
-That last property is exactly what a ZK nullifier set needs, approached from the
-opposite direction. A mixer proves *membership* of a commitment and *non-membership*
-of a nullifier. Here the platform wants to prove *non-membership* in a blocklist:
-"this market is clean, and here is a 256-byte witness that says so, and the witness
-tells you nothing about what else is blocked."
+So the design set a more ambitious goal: check whether something is blocked, and even *prove* that something is *not* blocked, without ever publishing the list itself.
 
-## The design: prime mapping plus an RSA accumulator
+## The idea: shrink the whole list into one small value
 
-The archived contract lives at
-`contracts-archive/security/NullifierRegistry.sol`, with its cryptography in
-`contracts-archive/libraries/RSAAccumulator.sol` and
-`contracts-archive/libraries/PrimeMapping.sol`. It is `AccessControl`,
-`ReentrancyGuard`, `Pausable`, and it supports two modes that share one storage
-layout.
+Here's the everyday-analogy version. Imagine every blocked item gets its own unique padlock, and you build a single master seal by threading all those padlocks together into one compact object. That one object stands in for the entire blocklist — whether the list has one entry or a million, the object on the blockchain stays the same tiny size.
 
-**Simple mode** is the boring, working half — plain mappings with an audit trail:
+The clever part is what you can do with that seal. Given it, someone can produce a short "certificate of innocence" for a specific market — a small proof that this market's padlock was *never* threaded into the seal. And critically, that certificate reveals nothing about what *else* is on the list. You learn "this one is clean," and nothing more.
 
-```solidity
-mapping(bytes32 => bool) public nullifiedMarkets;
-mapping(address => bool) public nullifiedAddresses;
-mapping(bytes32 => uint256) public marketNullifiedAt;
-mapping(bytes32 => address) public marketNullifiedBy;
-```
+That's the mirror image of the privacy-tech nullifier. Here the platform proves: "this market is *not* in the blocklist, here's a compact proof, and the proof tells you nothing about the rest of the list."
 
-An admin holding `NULLIFIER_ADMIN_ROLE` calls `nullifyMarket` or `nullifyAddress`
-with a human-readable reason; the mapping flips, a timestamp and the admin address
-are recorded, and an event carries the reason off-chain for indexing. Batch
-variants exist, capped at `MAX_BATCH_SIZE = 50` to bound gas and prevent a
-DoS-by-huge-array. Reads are trivial:
+Under the hood this used a well-known cryptographic accumulator — a construction from the academic literature designed for exactly this "compress a set into one value, then prove membership or non-membership" job. The app could carry a cached copy of the seal and check a market on the spot, and a sensitive on-chain action could demand a proof instead of trusting a simple list lookup.
 
-```solidity
-function isAddressNullified(address addr) external view returns (bool) {
-    return nullifiedAddresses[addr];
-}
-```
+## Two modes, one design
 
-**Accumulator mode** is where the ZK-adjacent machinery appears. Every element —
-a market hash or an address hash — is deterministically mapped to a prime. The
-mapping starts from the keccak hash, forces it odd, and walks upward by twos until
-a Miller-Rabin test passes:
+The design actually offered two ways to run, sharing one structure.
 
-```solidity
-function hashToPrimeUint(bytes32 hash) internal pure returns (uint256 prime) {
-    uint256 candidate = uint256(hash) | 1;   // ensure odd
-    uint256 iterations = 0;
-    while (!isPrime(candidate) && iterations < 1000) {
-        candidate += 2;                        // only test odd numbers
-        iterations++;
-    }
-    require(iterations < 1000, "Prime search exceeded limit");
-    return candidate;
-}
-```
+**The simple mode** was the boring, working half: a plain on/off list with an audit trail. An admin marks a market or address as void with a human-readable reason; the change is timestamped, the admin recorded, the reason logged. Batch versions were capped at a fixed size so nobody could jam the system with an enormous request. This mode ships zero fancy cryptography and gives you an obvious paper trail — but the list is public, exactly the downside above.
 
-Deterministic hash-to-prime is the same trick the RSA-accumulator literature uses
-so that the accumulator value is a single group element representing the product
-of all members' primes: `A = g^(p1 * p2 * ... * pn) mod n`. Adding an element is a
-single modular exponentiation, `A_new = A^p mod n`. The whole revoked set — one
-entry or a million — collapses to one 256-byte value stored on-chain.
+**The compact mode** was the privacy upgrade: the single-seal, prove-it's-not-blocked machinery just described, layered on the same structure. The guidance was to use simple mode for small lists and reach for the compact one only when the list got large or hiding it actually mattered.
 
-Non-membership is the payoff. To prove an element `x` is *not* in the set, an
-off-chain prover computes a Bezout witness `(d, b)` such that the accumulator and
-generator satisfy the identity `A^d · g^b ≡ g (mod n)` — which can only hold if
-`gcd(prime(x), product_of_members) = 1`, i.e. `x` was never accumulated. The
-contract verifies it:
+## The catch: enforcement, and a ceremony that never happened
 
-```solidity
-function verifyNonMembership(
-    bytes32 elementHash,
-    bytes calldata witnessD,
-    bytes calldata witnessB,
-    bool dNegative
-) external view returns (bool valid);
-```
+Two parts of the platform were wired to *enforce* a block on-chain: a legacy market-creation path that could refuse a blocked address, and a treasury component that could refuse to pay out to a blocked recipient. But both hid that enforcement behind a switch that defaulted to **off**. Left alone, the system degraded to "the app hides bad markets, the contracts don't care." That was a safety choice — a bug or a stolen admin key couldn't freeze trading unless someone had flipped the switch — but it also meant "voided" meant nothing on-chain until someone did.
 
-The frontend can carry a cached accumulator and check a market client-side, and a
-critical on-chain path can demand a proof rather than trusting a mapping read. The
-JavaScript side of this lives in `frontend/src/utils/rsaAccumulator.js` and
-`frontend/src/utils/primeMapping.js`, wired through the React hooks
-`useNullifierContracts` and `useMarketNullification` and surfaced in the admin
-`NullifierTab`.
+The bigger catch was the compact mode's foundation. That scheme depends on a **trusted setup**: some secret numbers must be generated to bootstrap the system and then *destroyed*. If anyone keeps them, they can forge proofs in both directions — mark a real scam market as clean, or frame a legitimate one as blocked. This is a well-known caveat for this family of cryptography, the same class of setup risk many privacy systems carry. The design called for a careful, verifiable ceremony to generate and destroy those secrets safely. That ceremony was never run.
 
-## The integration points — and the trust model
+## Why it was shelved
 
-Two consumers were designed to enforce revocation on-chain. The legacy
-`FriendGroupMarketFactory` imports the registry, holds an `enforceNullification`
-flag, and checks `isAddressNullified` before letting an address create, accept, or
-be added to a market — reverting with `AddressNullified()` if blocked. A
-`TreasuryVault` could refuse withdrawals to a nullified recipient. Both gate the
-check behind an owner-set enforcement toggle that defaults **off**, so the system
-degrades to "frontend filters, chain does not care" unless an operator explicitly
-opts in.
+Search the live codebase and there's no blocklist system in it. No live network runs one. The whole thing sits in a reference-only archive — kept for study, never deployed. The app hooks that once talked to it now simply do nothing when no such system answers.
 
-The security of accumulator mode rests entirely on a **trusted setup**: the RSA
-modulus `n` must be the product of two secret safe primes that are destroyed after
-generation. If anyone knows the factorization, they can forge both membership and
-non-membership proofs — add a market to the blocklist that verifies as clean, or
-clear a real one. That is the classic RSA-accumulator caveat, and it is the same
-class of ceremony risk that ZK systems carry for their structured reference
-strings. The docs call for a verifiable ceremony or MPC; nothing in the repo
-performs one.
+The honest read is that FairWins pivoted. Instead of an admin-run market blocklist with its own bespoke cryptography and an unperformed ceremony, the platform shipped compliance checks that are actually wired into the money path: a shared sanctions check run against real wallet addresses across wagers and pools, plus role-based gating of who can participate. Those solve the real "keep bad actors out" problem without the ceremony risk and without a custom accumulator to maintain.
 
-## Design decisions and trade-offs
+## What's worth keeping from it
 
-- **Accumulator over Merkle tree.** A Merkle blocklist gives non-membership too,
-  but requires sorted leaves and O(log n) proofs that grow with the set, and it
-  still tends to leak neighbors. The accumulator's constant on-chain footprint and
-  set-hiding property were the deciding factors — at the cost of a trusted setup a
-  Merkle tree does not need.
-- **Two modes, one contract.** Simple mode is deployable today with zero ceremony
-  and an obvious audit trail; accumulator mode is the privacy upgrade layered on
-  the same storage. The `docs/developer-guide/nullifier-system.md` guidance is to
-  use simple mode below ~1,000 entries and only reach for the accumulator when the
-  set is large or the privacy of the list itself matters.
-- **Enforcement off by default.** Making on-chain checks opt-in keeps gas and
-  liveness risk out of the common path — a bug or a compromised admin key cannot
-  freeze trading unless an operator turned enforcement on. The flip side is that
-  "revoked" means nothing on-chain until someone flips that switch.
-- **Admin, not governance.** Revocation is a single role, `NULLIFIER_ADMIN_ROLE`,
-  granted by the default admin. The docs themselves flag this as the weak point and
-  list multisig/timelock and a future governance-based path as the mitigation. It
-  is centralized moderation wearing a cryptographic coat.
+So if you came looking for a mixer-style anonymous-spend nullifier, the accurate answer is: this was a *nullification* registry — a voiding tool — not a nullifier in the privacy-tech sense, and it was shelved before launch.
 
-## Why it is archived — and what a real nullifier looks like here
+What survives is a clean case study in a genuinely useful idea: you can compress an entire blocklist into a single small value and then prove a specific item *isn't* on it, without ever revealing the rest. That's a real capability with real trade-offs — a trusted-setup ceremony you have to actually perform, enforcement that's meaningless until switched on, and moderation that ultimately rested on a single admin role rather than governance. The value of studying it is precisely that the cryptography is real and the limits are printed on the label.
 
-Grep the active tree and there is no nullifier: `contracts/` has no
-`NullifierRegistry`, no live network in `deployments/` configures one (only a
-`localhost` chain-1337 registries file references a `nullifierRegistry` address),
-and the testnet address that appears in the old dev guide points at Polygon Amoy,
-a network FairWins has since moved off. The whole system sits in
-`contracts-archive/`, which the project guide marks reference-only: never import,
-never deploy. The frontend hooks still exist but soft-fail to a no-op when no
-registry answers.
+The lesson for builders is familiar: reach for exotic cryptography only when the problem truly needs it. A plain list was simpler, honest, and — for the sizes that actually mattered — good enough. When FairWins needed real enforcement, it chose primitives already proven on the value path over a beautiful mechanism that still owed the world a ceremony.
 
-The honest read is that FairWins pivoted away from an admin-run market blocklist
-toward compliance primitives that are actually wired into the value path — a shared
-`ISanctionsGuard` checked on real wallet addresses across wagers and pools, and
-role-gated participation via `MembershipManager`. Those solve the "keep bad actors
-out" problem without a bespoke accumulator and its ceremony risk.
+## Further reading
 
-So if you came looking for a Semaphore-style spend-nullifier preventing replay of
-an anonymous action, the accurate answer is: FairWins designed a *nullification*
-registry, not a *nullifier* in the mixer sense, and then shelved it. What survives
-is a clean, self-contained study in applying an RSA accumulator to a set-membership
-problem — the exact primitive the ZK world uses, pointed at moderation instead of
-anonymity. That is a genuinely useful thing to have read in full, even as reference
-code, precisely because the cryptography is real and the honest limits are on the
-label.
-
-## Sources
-
-- `docs/NULLIFIER_SYSTEM.md` — full RSA-accumulator design, trade study, and
-  security model
-- `docs/developer-guide/nullifier-system.md` — simple vs. accumulator mode, admin
-  workflow, historical deployment notes
-- `contracts-archive/security/NullifierRegistry.sol` — the registry contract
-  (archived, reference-only)
-- `contracts-archive/libraries/RSAAccumulator.sol`,
-  `contracts-archive/libraries/PrimeMapping.sol` — accumulator math and
-  deterministic hash-to-prime
-- `contracts-archive/markets/FriendGroupMarketFactory.sol` — legacy on-chain
-  enforcement integration
-- `frontend/src/hooks/useNullifierContracts.js`,
-  `frontend/src/hooks/useMarketNullification.js`,
-  `frontend/src/utils/rsaAccumulator.js` — client-side filtering and proof
-  verification
-- `deployments/localhost-chain1337-registries-deployment.json` — the only
-  deployment record that references a `nullifierRegistry`
-- Background: Semaphore protocol (semaphore.pse.dev) and Tornado Cash on ZK
-  nullifiers; Camenisch–Lysyanskaya, *Dynamic Accumulators* (2002) and Boneh–Bünz–Fisch,
-  *Batching Techniques for Accumulators* (2018) on RSA accumulators; RFC-style RSA
-  parameter guidance at eips.ethereum.org for on-chain `modExp` (EIP-198)
+- [The Semaphore protocol](https://semaphore.pse.dev/) — the anonymous-signaling sense of "nullifier"
+- [Camenisch & Lysyanskaya, *Dynamic Accumulators* (2002)](https://link.springer.com/chapter/10.1007/3-540-45708-9_5) — the foundational paper on cryptographic accumulators
+- [Boneh, Bünz & Fisch, *Batching Techniques for Accumulators* (2018)](https://eprint.iacr.org/2018/1188) — modern non-membership proofs
+- [Trusted setup ceremonies, explained](https://en.wikipedia.org/wiki/Trusted_setup) — why generating-and-destroying secrets is the recurring risk

--- a/docs/blog/posts/21-nullifier-system/social.md
+++ b/docs/blog/posts/21-nullifier-system/social.md
@@ -1,30 +1,29 @@
-# Social & Image — The Nullifier System: A Privacy-Preserving Blocklist That Never Shipped
+# Social & Image — The Blocklist That Never Shipped: Voiding Bad Markets Without Publishing a Wall of Shame
 
 ## X (Twitter)
 
-"Nullifier" in Tornado = anti-double-spend. FairWins' "nullifier" = something else entirely: an RSA-accumulator blocklist that voids bad markets and proves a market is NOT revoked in ~256 bytes — no public blacklist. It's archived, and we explain honestly why. 🔗 <link>
+"Nullifier" in a coin mixer = anti-double-spend. FairWins explored something else entirely: a way to void bad markets and prove a market is NOT blocked in a tiny proof — with no public blacklist. It was shelved, and the new post explains honestly why. 🔗 <link>
 
-#ZK #privacy #cryptography
+#privacy #cryptography #moderation
 
 ## LinkedIn
 
-Moderating a permissionless market venue has an awkward requirement: you sometimes need to revoke a malicious market or a bad-actor address — but publishing a plaintext, fully-enumerable blocklist on-chain leaks your threat model and grows gas with every entry.
+Moderating an open marketplace has an awkward requirement: you sometimes need to revoke a scam market or a repeat bad actor — but posting a plaintext, fully-readable blocklist on a public blockchain broadcasts your threat model and grows in cost with every entry.
 
-FairWins' archived "nullifier system" reached for the same primitive the ZK-mixer world uses for its nullifier sets — an RSA accumulator — and pointed it at moderation instead of anonymity. The latest engineering post walks the design and is candid about the fact that it never reached a live network:
+FairWins explored a design that borrowed a trick from privacy tech — compress the entire blocklist into one small value, then prove a specific market is *not* on it without revealing the rest. The new design-history post walks it in plain terms and is candid that it never reached a live network:
 
-- Why "nullifier" here means *void*, not the Tornado/Semaphore anti-replay value — and where the two ideas genuinely overlap
-- Deterministic hash-to-prime + `A = g^(product of primes) mod n`: the whole revoked set collapses to one 256-byte value
-- Non-membership proofs via a Bezout witness — prove a market is clean without revealing the blocklist
-- The honest limits: a trusted-setup ceremony that was never run, enforcement off by default, and why FairWins shipped a sanctions guard instead
+- Why "nullifier" here means *void*, not the coin-mixer anti-double-spend value — and where the two ideas genuinely overlap
+- The everyday-analogy version: many blocked items threaded into a single compact seal, plus a short "certificate of innocence" for anything that's clean
+- The honest limits: a trusted-setup ceremony that was never performed, enforcement switched off by default, and why FairWins shipped a real sanctions check instead
 
-A clean case study in applying real accumulator cryptography to a set-membership problem — with the trade-offs on the label.
+A clean case study in reaching for exotic cryptography only when the problem truly needs it — trade-offs printed on the label.
 
 🔗 <link>
 
-When does a compact cryptographic accumulator actually beat a plain on-chain mapping for your use case — and is the trusted setup worth it?
+When does a compact cryptographic membership check actually beat a plain on/off list — and is the setup ceremony worth it?
 
-#ZeroKnowledge #Cryptography #Blockchain #SmartContracts #Privacy
+#Cryptography #Privacy #Blockchain #Moderation
 
 ## Image prompt (Gemini / Nano Banana)
 
-A clean modern editorial illustration in isometric style for a fintech-engineering blog banner. Central subject metaphor: a single glowing sealed vault-node or lockbox that many faint, ghostly geometric tokens flow toward, but instead of being listed on a public ledger they are absorbed and compressed into one small luminous cube — visualizing many blocked items collapsing into a single compact cryptographic value. Around it, a scattering of prime-number motifs and thin mathematical filament lines (modular-arithmetic curves) drift as translucent overlays. Composition: off-center focal cube on the right third, negative space on the left, subtle depth with layered planes. Color mood: deep navy and teal base with a single warm amber accent used only on the compressed cube and one proof-witness beam. Lighting: soft volumetric glow from the cube, cool ambient fill, gentle rim light on the geometric shapes. Slightly muted, precise, engineering-grade aesthetic — not flashy, not neon. No text, no logos, no watermarks. Aspect ratio 16:9.
+A clean modern editorial illustration in isometric style for a fintech-engineering blog banner. Central subject metaphor: a single glowing sealed vault-node or lockbox that many faint, ghostly geometric tokens flow toward, but instead of being listed on a public ledger they are absorbed and compressed into one small luminous cube — visualizing many blocked items collapsing into a single compact cryptographic value. Around it, a scattering of abstract number motifs and thin mathematical filament lines drift as translucent overlays. Composition: off-center focal cube on the right third, negative space on the left, subtle depth with layered planes. Color mood: deep navy and teal base with a single warm amber accent used only on the compressed cube and one thin proof beam. Lighting: soft volumetric glow from the cube, cool ambient fill, gentle rim light on the geometric shapes. Slightly muted, precise, engineering-grade aesthetic — not flashy, not neon. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/22-fee-router/blog.md
+++ b/docs/blog/posts/22-fee-router/blog.md
@@ -1,116 +1,75 @@
-# The FeeRouter: One Source of Truth for Platform Fees
+# One Place for Every Fee: How FairWins Keeps Its Pricing Honest
 
-*How FairWins centralized every configurable fee into a single capped, disclosed, on-chain registry — without centralizing trust*
+*How FairWins moved every platform fee into a single, capped, on-chain price list — so the number you see is always the number you pay*
 
 | | |
 |---|---|
 | **Series** | Finance Surfaces (part 1) |
 | **Part** | 22 of 34 |
-| **Audience** | Protocol and product engineers |
-| **Tags** | `fees`, `fee-router`, `solidity`, `uups`, `product` |
-| **Reading time** | ~8 minutes |
+| **Audience** | Product managers, founders, and the crypto-curious |
+| **Tags** | `fees`, `pricing`, `transparency`, `product` |
+| **Reading time** | ~6 minutes |
 
-## Three fee systems walk into a codebase
+## Three fee systems, three chances to get it wrong
 
-By mid-2026, FairWins had shipped three integrations that touched revenue, and each had grown its own fee plumbing. The OpenSea referral (Collect) cost members nothing and paid FairWins out of OpenSea's economics. The Polymarket builder fee (Predict) was a real, disclosed taker cost, configured through gateway environment variables. And Earn — Morpho lending vaults behind an ERC-4626 interface — had no native revenue-share program at all, which meant FairWins earned nothing on it.
+By mid-2026, FairWins had shipped three features that touched money, and each had grown its own way of handling fees. One feature, a marketplace connection, cost members nothing — the partner paid FairWins out of its own economics. Another, prediction-market trading, carried a small, disclosed trading fee that lived in the server's settings. And a third, a savings-style feature that earned yield on idle funds, had no way to make money at all.
 
-The plan was to charge a small platform fee on Earn deposits. The obvious implementation was also the wrong one: hardcode 50 bps in the deposit path, add another env var to the gateway, put a matching constant in the frontend so the confirm screen shows the right number. That's three copies of one number, owned by three deploy pipelines. The failure mode writes itself: an operator changes the gateway env var, forgets the frontend constant, and a member confirms a screen that says 0.50% while the backend charges 0.60%. For a platform whose entire fee doctrine is *the member always sees the real cost before signing*, a stale disclosure isn't a display bug — it's a broken promise.
+The plan was to add a small platform fee to that savings feature. The obvious way to build it was also the wrong way: write the fee into the deposit code, add a copy to the server's settings, and put a matching number in the app so the confirmation screen shows the right percentage. That's three copies of one number, each owned by a different release process. Someone updates one, forgets another, and a member approves a screen that says 0.50% while the system actually charges 0.60%. For a company whose whole pricing philosophy is *you always see the real cost before you approve anything*, a stale number on a screen isn't a cosmetic bug. It's a broken promise.
 
-There's a second failure mode that no amount of config discipline fixes: the race. A member reviews a deposit at 50 bps, an admin raises the rate to 75 bps, and the member's transaction lands after the change. Whatever the UI said, the chain charges the live rate. If the fee logic lives in scattered constants, there is nowhere to even express "charge me at most what I was shown."
+There's a second problem that no amount of careful configuration solves: timing. Suppose a member is reviewing a deposit at 0.50%, an administrator raises the rate to 0.75%, and the member's transaction happens to go through just after the change. Whatever the screen said, the system charges the current rate. When the fee logic is scattered across three places, there's nowhere to even express the idea "never charge me more than what I was just shown."
 
-Spec 060's answer was to make fees a first-class on-chain subsystem: one contract, the `FeeRouter` (`contracts/fees/FeeRouter.sol`, a UUPS proxy recorded under the `feeRouter` / `feeRouterImpl` deployment keys), that is the *only* place a fee rate lives — and to make the charge path enforce the disclosure.
+FairWins' answer was to make fees a first-class part of the system with a single home: one on-chain price list that is the *only* place any fee rate lives — and to make the payment step itself enforce the promise on the screen.
 
-## A registry keyed by keccak
+## A single, tamper-evident price list
 
-Every configurable fee is a service entry keyed by `bytes32 serviceId = keccak256("<label>")` — `earn.lend`, `polymarket.taker`, `polymarket.maker`. The entry itself is small:
+Think of it as one shared, public price list living on the blockchain. Every fee the platform can charge is one entry on that list, labeled by what it's for — the savings fee, the trading fee, and so on. Each entry holds just two things that matter to a member: the current rate, and a hard ceiling that rate can never exceed.
 
-```solidity
-enum ServiceKind {
-    Unregistered,
-    Wrapped,    // chargeable through the router (e.g. earn.lend)
-    ConfigOnly  // read-only rate for off-chain enforcement (e.g. polymarket.taker)
-}
+That ceiling is the key idea. When a fee is first added to the list, its maximum is fixed forever. An administrator can move the current rate up and down beneath that ceiling, but no one — not even an admin — can raise the ceiling itself. For fees that FairWins charges directly, there's also an absolute company-wide limit of 2.5%, so no single entry can ever be set higher than that.
 
-struct Service {
-    uint16 capBps; // hard ceiling for feeBps; 0 => unregistered
-    uint16 feeBps; // live rate, 0..capBps
-    ServiceKind kind;
-}
-```
+Some entries on the list are charged directly by the platform. Others are just a published number that a separate part of the system reads and applies elsewhere — the prediction-market trading fee works this way, where the price list simply holds the agreed-upon number everyone references. One list, two uses, no duplicate copies of the number floating around.
 
-The `kind` split is what lets one registry cover very different fee mechanics. **Wrapped** services are charged by the router itself, on-chain, atomically. **ConfigOnly** services store a rate that an off-chain enforcer reads — the Polymarket builder bps, which the relay gateway attaches to CLOB orders per spec 057. The router never touches ConfigOnly money; it just holds the number everyone agrees on.
+Every rate change is recorded permanently and publicly on the blockchain, including who made it. That record *is* the audit history — the admin screen that shows fee changes just reads it back rather than keeping its own separate log that could drift out of sync.
 
-Caps are fixed at registration and can never be edited afterward. `registerService` is one-shot per id, rejects a zero cap, and for wrapped services bounds the cap by an absolute constant:
+## Charging the fee and delivering the value, all at once
 
-```solidity
-/// @notice Absolute ceiling for any Wrapped service's cap (2.5%).
-uint16 public constant MAX_WRAPPED_FEE_BPS = 250;
-```
+For fees FairWins charges directly, the platform does the whole thing in a single, all-or-nothing transaction. When a member deposits into the savings feature, one step pulls in their money, sends the small fee to the company treasury, and puts the remainder to work on the member's behalf — together, indivisibly.
 
-`setFeeBps` — gated by `FEE_ADMIN_ROLE` — enforces `newBps <= capBps`, and the charge path re-checks the cap as defense in depth. The emergency lever is deliberately `setFeeBps(id, 0)`, not a cap change: an operator can always zero a misbehaving fee immediately, but nobody, including admins, can quietly raise the ceiling members were told about. Every change emits `FeeBpsChanged(serviceId, oldBps, newBps, actor)`, and that event stream *is* the audit history — the AdminPanel Fees tab renders it directly rather than keeping a parallel log.
+The "all-or-nothing" part matters. If any piece fails, the entire transaction is undone. The treasury can never end up holding a fee for a deposit that didn't actually happen. And there's a further safeguard: if the member's money would somehow buy them nothing in return, the whole thing reverts rather than letting their principal vanish. The fee is only ever payment for value actually delivered.
 
-## Atomic charging: fee-for-value or nothing
+Two small design choices show the safety-first mindset. Rounding always favors the member — a fee small enough to round down to nothing is simply charged as zero. And if a particular network was never fully set up with a treasury to receive fees, the system skips the fee entirely and completes the deposit anyway. A setup mistake on FairWins' side can cost FairWins some revenue, but it can never strand a member's money.
 
-For wrapped services, the router is also the settlement path. Earn deposits don't call the vault; they call the router:
+## The confirmation screen becomes a promise the system keeps
 
-```solidity
-function depositToVaultWithFee(
-    bytes32 serviceId,
-    address vault,
-    uint256 assets,
-    address receiver,
-    uint16 maxFeeBps
-) external nonReentrant returns (uint256 shares);
-```
+Here's the piece that closes the timing gap. Before a member ever signs anything, the app reads the live rate straight from the price list and shows it. Then, when the member approves, that exact rate they saw travels along with the transaction as a ceiling.
 
-In one transaction the router pulls the member's principal, transfers `floor(assets · bps / 10 000)` to the treasury, approves the ERC-4626 vault for the remainder, and deposits it for the member. Any failing leg reverts the whole action, so the treasury can never keep a fee for a deposit that didn't happen. The router holds no balances outside a transaction — there is nothing to drain between calls. And if the vault returns zero shares for a nonzero net deposit, the router reverts `ZeroShares()` rather than letting a vault swallow principal: the fee is only ever payment for value actually delivered.
+The result: if an administrator raises the rate while a member's transaction is in flight, the member either pays no more than what the confirmation screen showed, or the transaction simply stops and they get to review again. The confirmation screen is no longer a courtesy or a best guess. It's a limit the system itself enforces. The one rule everyone building on this must follow is a matter of honesty, not code: never send along a ceiling you didn't actually show the member.
 
-Two edge cases show the fail-safe posture. Fee math floors, in the member's favor — a fee that rounds to zero in the asset's smallest unit is charged as zero. And if a network's treasury was never configured (`treasury == address(0)`), the router *skips* the fee entirely and emits `FeeSkippedNoTreasury` instead of reverting or parking funds. An ops misconfiguration must never strand a member's deposit; it can only cost FairWins revenue.
+## Honest disclosure, made mechanical
 
-## `maxFeeBps`: the disclosure becomes enforceable
+FairWins had this fee philosophy before the price list existed: fees are shown before you approve, as a clearly named line with the real percentage and the real dollar amount — never hidden, never buried inside a spread, never called "free" when it isn't. The price list turns that philosophy into a system with exactly three possible outcomes, and every feature must handle all three:
 
-The last parameter of `depositToVaultWithFee` is the interesting one. The frontend quotes the live rate before any signature (`frontend/src/lib/fees/feeQuote.js` reads `getService` straight from the router) and passes that *quoted* rate back as `maxFeeBps`. On-chain:
+- **No fee applies here** (this network has no price list, or the fee was never turned on): the feature proceeds with no fee and no fee line at all — behaving exactly as it did before fees existed. A zero fee is invisible, as it should be.
+- **A live rate is available**: show it plainly, and carry it along as the enforced ceiling.
+- **The rate couldn't be read** on a network that should have one: stop and don't proceed. The one thing a feature may never do is guess low and possibly undercharge in a way that misleads. The deposit flow pauses until the rate can be confirmed — fail safe, not fail open. (Withdrawals are never affected.)
 
-```solidity
-uint16 liveBps = svc.feeBps;
-if (liveBps > svc.capBps) revert CapExceeded(); // defense in depth
-if (liveBps > maxFeeBps) revert FeeAboveQuoted();
-```
+The server side follows the same discipline. It reads published rates from the price list, keeps a short-lived cached copy, and falls back to a labeled default only during an outage — always honestly marked as a fallback. Crucially, the server keeps no fee settings of its own. There's no second place to change a number. An admin edits the one on-chain list, and everything else follows.
 
-This closes the race permanently. If an admin raises the rate while a member's transaction is in flight, the member either pays at most what the confirm screen showed or the transaction reverts and they re-review. The confirm screen is no longer a courtesy; it's a signed ceiling the contract enforces. The one rule integrators must honor is behavioral, not technical: never call the router with a `maxFeeBps` you did not actually display.
+## Why build it this way
 
-## The honest-disclosure doctrine, mechanized
+**One list instead of per-feature fee code.** The old approach — each feature owning its own fee logic — is exactly how the tangle of duplicate numbers happened in the first place. Now a new integration simply *registers an entry* on the list: pick a label, set a ceiling, and reuse the standard show-it-then-charge-it flow. The rate starts at zero, so nothing is charged until someone deliberately turns it on.
 
-FairWins' fee doctrine predates the router: fees are disclosed before signature, as a named line with the live percentage and absolute amount — never hidden, never folded into a spread, never labeled "free" when they aren't. The router turns that doctrine into code paths with exactly three outcomes, and `fetchFeeQuote` makes integrators handle all of them:
+**Central configuration is not central trust.** Administrators got one convenient screen, but members got stronger guarantees than before: a permanent ceiling on every fee, an absolute company-wide cap, a rate you can't be charged above once you've seen it, and a public, permanent history of every change. The admin's power is fenced in by limits anyone can verify for themselves.
 
-- **No router on this chain** (or service unregistered): `{ available: false, bps: 0 }` — proceed with no fee and no fee line, byte-identical to pre-060 behavior. Zero fee means the feature behaves as if the fee system never existed.
-- **Live rate obtained**: disclose it and pass it as `maxFeeBps`.
-- **Read failed on a network that has a router**: *block the action.* The one thing a surface may never do is proceed on a possibly understated rate. Earn's deposit flow pauses (withdrawals are unaffected) until the read succeeds — fail-safe, not fail-open.
+**You're charged on the way in, never on the way out.** Fees apply when you put money in; withdrawals are always free. It keeps the mental model simple — you saw the cost when you deposited — and keeps the exit path completely independent of any fee lookup.
 
-The relay gateway follows the same discipline from the other side. `services/relay-gateway/src/fees/onchain.js` reads the Polymarket bps from the router via a cached `eth_call` (30-second TTL), clamps to the spec-057 caps before serving — a clamp firing is logged as a should-be-impossible warning, since the contract enforces the caps too — serves a stale value for at most 10× the TTL during an RPC outage, and then drops to env-configured fallback bps, honestly labeled `source: "env-fallback"` in the API response. Crucially, the gateway stays *stateless*: no admin API, no persistence, no second fee-config store. An admin edits on-chain; every reader follows.
+**Rounding favors you.** On tiny amounts the fee rounds down to zero, and that's charged as zero. A deliberate small bias in the member's favor.
 
-## Design decisions
+**Honest limits.** The system assumes ordinary, well-behaved digital dollars like USDC; exotic tokens that change their own balances aren't supported. And because a fee's ceiling is permanent, a mistaken ceiling can't be edited — only abandoned in favor of a fresh entry. That rigidity is the price of a ceiling members can rely on. The price list itself can be improved over time to support new kinds of fees, always keeping the same guarantees: show the rate, respect the ceiling, record the change.
 
-**One registry instead of per-feature fee logic.** The alternative — each integration owning its fee — is how the pre-060 sprawl happened. Now a new integration (Lido, Polygon liquid staking, Uniswap are the named candidates) *registers a service* rather than building a fee path: pick a label, `registerService(ethers.id('stake.lido'), capBps, Wrapped)`, wire the standard quote-and-disclose flow. The rate starts at 0; nothing is charged until an operator acts.
+The result is a fee system whose most important property is one members never have to think about: there is no path on which the number they were shown and the number they're charged can ever drift apart.
 
-**Centralized config is not centralized trust.** Admins got one screen, but members got harder guarantees than before: an immutable per-service cap, an absolute 250 bps ceiling on wrapped services, a contract-enforced consent ceiling, and a public `FeeBpsChanged` history. The admin's power is bounded by constants members can read on-chain.
+## Further reading
 
-**Entry-only fees.** Wrapped fees apply to principal at entry; withdrawals are never charged. This keeps the mental model simple ("you saw the cost when you put money in") and keeps the exit path free of any fee-read dependency.
-
-**Floor rounding, member's favor.** A deliberate bias: on tiny principals the fee rounds to zero and is charged as zero — the router still emits a `FeeCharged` event with `feeAmount = 0` so reconciliation counts exactly one router event per deposit. The monthly reconciliation invariant is exact: every `FeeCharged.feeAmount` equals one same-transaction ERC-20 transfer to the treasury (`docs/runbooks/fee-operations.md` treats any divergence as a security incident).
-
-**Known limits.** Fee-on-transfer and rebasing tokens are unsupported — the router assumes the pulled amount equals the requested amount, true for the curated vault assets like USDC. One-shot registration means a mistaken cap can't be fixed, only abandoned for a new service id; that rigidity is the price of caps members can rely on. And the router is a UUPS proxy (`UUPSManaged`, append-only storage with a trailing `__gap`, CI-gated `check:storage-layout`), so new wrapped entrypoints for differently shaped actions — staking, swaps — can ship as in-place upgrades, provided they keep the same accounting, events, cap re-check, and `maxFeeBps` ceiling.
-
-The result is a fee system whose most important property is the one members never see: there is no code path on which the number they were shown and the number they are charged can diverge.
-
-## Sources
-
-- `specs/060-platform-fee-wrapper/spec.md` — feature spec, user stories, acceptance scenarios
-- `contracts/fees/FeeRouter.sol` — router implementation (registry, caps, atomic charging)
-- `contracts/fees/IFeeRouter.sol` — interface, `Service` struct, events, errors
-- `docs/developer-guide/platform-fees.md` — architecture, disclosure rules, service registration
-- `docs/runbooks/fee-operations.md` — rate changes, emergency-zero, treasury reconciliation
-- `services/relay-gateway/src/fees/onchain.js` — stateless cached on-chain rate reader
-- `frontend/src/lib/fees/feeQuote.js` — quote path and the three integrator outcomes
-- [ERC-4626: Tokenized Vaults](https://eips.ethereum.org/EIPS/eip-4626) — the vault interface behind `depositToVaultWithFee`
-- [ERC-1822 / UUPS](https://eips.ethereum.org/EIPS/eip-1822) and [OpenZeppelin upgradeable contracts](https://docs.openzeppelin.com/contracts/5.x/api/proxy) — the proxy pattern the router builds on
+- [ERC-4626: Tokenized Vaults](https://eips.ethereum.org/EIPS/eip-4626) — the shared standard for the yield-earning pools the savings fee wraps
+- [ERC-1822 / UUPS proxies](https://eips.ethereum.org/EIPS/eip-1822) and [OpenZeppelin's upgradeable-contract docs](https://docs.openzeppelin.com/contracts/5.x/api/proxy) — the widely used pattern that lets an on-chain system be improved over time without losing its data
+- For deeper implementation details, see the FairWins developer documentation.

--- a/docs/blog/posts/22-fee-router/social.md
+++ b/docs/blog/posts/22-fee-router/social.md
@@ -1,26 +1,26 @@
-# Social & Image — The FeeRouter: One Source of Truth for Platform Fees
+# Social & Image — One Place for Every Fee
 
 ## X (Twitter)
 
-One source of truth for every fee: FairWins' FeeRouter keeps each rate under an immutable per-service cap (wrapped ≤ 250 bps), and the quoted rate rides along as maxFeeBps — charge above what the member saw and the tx reverts. 🔗 <link> #solidity #defi #fintech
+FairWins now keeps every platform fee on a single, public price list — each rate under a permanent ceiling no one can raise. Better still: the rate you see at approval rides along as a hard limit, so you can never be charged more than the number on your screen. 🔗 <link> #fintech #transparency #web3
 
 ## LinkedIn
 
-Three integrations, three fee systems: env vars in the gateway, constants in the frontend, nothing on-chain. The failure mode writes itself — an operator updates one copy of the number, a member confirms a screen showing 0.50% while the backend charges 0.60%. For a platform whose fee doctrine is "the member always sees the real cost before signing," a stale disclosure isn't a display bug; it's a broken promise.
+Three features, three different ways of handling fees: a number in the server, a copy in the app, nothing shared. The failure mode writes itself — someone updates one copy, a member approves a screen showing 0.50% while the system charges 0.60%. For a company whose whole pricing philosophy is "you always see the real cost before you approve," a stale number isn't a display bug. It's a broken promise.
 
-FairWins' spec 060 made fees a first-class on-chain subsystem, and the new post walks the design:
+FairWins fixed it by making fees a first-class part of the system with a single home. The new post walks through the design:
 
-- One `FeeRouter` contract holds every configurable rate as a `bytes32` service id — no fee constant lives anywhere else, and the gateway only reads it.
-- Caps are immutable at registration, with an absolute 250 bps ceiling on wrapped services. Admins can zero a fee instantly; nobody can quietly raise a ceiling.
-- `maxFeeBps` turns the confirm screen into an enforceable contract: if the live rate exceeds what the member was shown, the transaction reverts.
-- Atomic fee-for-value charging via `depositToVaultWithFee` — the treasury can never keep a fee for a deposit that didn't happen.
+- One public, on-chain price list holds every fee — no copy of the number lives anywhere else.
+- Every fee has a permanent ceiling it can never exceed, plus an absolute 2.5% cap on fees FairWins charges directly. Admins can zero a fee instantly; no one can quietly raise a ceiling.
+- The rate you see at approval becomes an enforced limit — if the live rate is higher, the transaction simply stops.
+- Charging is all-or-nothing: the treasury can never keep a fee for a deposit that didn't happen.
 
 Full write-up: 🔗 <link>
 
-Should fee disclosure be contract-enforced everywhere, or is UI-level disclosure enough for your users?
+Should fee disclosure be enforced by the system itself, or is showing it in the app enough for your users?
 
-#solidity #defi #fintech #web3 #smartcontracts
+#fintech #transparency #web3 #pricing #product
 
 ## Image prompt (Gemini / Nano Banana)
 
-Clean modern isometric editorial illustration: a single transparent routing hub — a faceted glass prism or junction box — at the center of the frame, with several thin conduits entering from the left carrying streams of small geometric tokens; inside the hub each stream visibly splits into a large continuing flow and one small measured sliver diverted to a compact vault, the split governed by a fixed physical gate rendered as a solid immovable bar (the hard cap). Above the hub floats a minimal open ledger panel with abstract bar marks, implying the rate is displayed before anything moves. Deep navy background with teal gradients and a fine engineering grid; a single warm amber accent illuminates the small diverted sliver and the gate, making the fee path the brightest, most visible element in the scene — nothing hidden. Soft precise studio lighting, crisp edges, minimalist fintech-engineering aesthetic, generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.
+Clean modern isometric editorial illustration: a single transparent routing hub — a faceted glass prism or junction box — at the center of the frame, with several thin conduits entering from the left carrying streams of small geometric tokens; inside the hub each stream visibly splits into a large continuing flow and one small measured sliver diverted to a compact vault, the split governed by a fixed physical gate rendered as a solid immovable bar (the hard ceiling). Above the hub floats a minimal open ledger panel with abstract bar marks, implying the rate is displayed before anything moves. Deep navy background with teal gradients and a fine engineering grid; a single warm amber accent illuminates the small diverted sliver and the gate, making the fee path the brightest, most visible element in the scene — nothing hidden. Soft precise studio lighting, crisp edges, minimalist fintech-engineering aesthetic, generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/23-earn-erc4626-vaults/blog.md
+++ b/docs/blog/posts/23-earn-erc4626-vaults/blog.md
@@ -1,120 +1,82 @@
-# Earn Without Custody Surprises: Wrapping ERC-4626 Vaults With a Disclosed, Atomic Fee
+# Earn Without Surprises: Putting Idle Funds to Work, With a Fee You Can See
 
-*How FairWins routes lending deposits into external Morpho vaults, charges its platform fee in the same transaction, and shows the member the exact rate before they sign*
+*How FairWins lets members earn yield on idle stablecoins without ever handing over custody — and charges its fee in the open, in the same transaction*
 
 - **Series:** Finance Surfaces (part 2)
 - **Part:** 23 of 34
-- **Audience:** DeFi integrators; protocol and product engineers
-- **Tags:** `erc4626`, `defi`, `lending`, `yield`, `fees`
-- **Reading time:** ~8 minutes
+- **Audience:** Product managers, founders, and the crypto-curious
+- **Tags:** `yield`, `savings`, `non-custodial`, `fees`, `transparency`
+- **Reading time:** ~7 minutes
 
 ---
 
-## The idle-balance problem, and the two bad answers
+## The idle-money problem, and two tempting shortcuts
 
-FairWins members hold stablecoins in their connected accounts between wagers. Between the moment a payout lands and the moment the next wager is created, that USDC sits idle. Members asked the obvious question — can it earn something in the meantime? — and the team faced the two answers most consumer crypto apps reach for.
+FairWins members hold stablecoins — digital dollars like USDC — in their accounts between wagers. In the stretch between one payout landing and the next wager being created, that money just sits there. Members asked the obvious question: can it earn something in the meantime? And the team ran straight into the two answers most consumer crypto apps reach for.
 
-The first bad answer is custody: run your own yield product, pool member deposits, and manage the strategy in-house. That turns a wager-escrow platform into an asset manager, with everything that implies — a new value-bearing contract surface, discretionary control over member funds, and a trust model the rest of the platform deliberately avoids.
+The first tempting shortcut is to take custody: build your own savings product, pool everyone's deposits, and manage the strategy in-house. That quietly turns a wager-escrow platform into an asset manager — holding member money and taking on exactly the kind of trust obligations the rest of FairWins is deliberately designed to avoid.
 
-The second bad answer is the hidden spread: route deposits into someone else's protocol, quietly keep a slice of the yield or the principal, and let the member discover the difference in their statement. Plenty of "earn" features work this way. It's also exactly the kind of quiet skim that FairWins' constitution forbids — every fee on the platform is disclosed before signature, or it doesn't exist.
+The second tempting shortcut is the hidden skim: route deposits into someone else's yield product, quietly keep a slice of the return, and let members discover the difference only if they go looking. Plenty of "earn" features work this way. It's also precisely the kind of quiet markup FairWins' own standards forbid — every fee is shown before you approve it, or it doesn't exist.
 
-The Earn section (spec `050-earn-lending-rewards`) is the answer that avoids both: deposits go **directly from the member's account into third-party ERC-4626 vaults** — curated Morpho lending vaults on Ethereum mainnet and Polygon PoS — with FairWins never taking custody, and the platform fee, when one is configured, charged **atomically in the same transaction** by an on-chain router that refuses to charge more than the rate the member was shown. This post walks through both layers: the non-custodial vault integration, and the fee wrapper that monetizes it honestly.
+The Earn feature avoids both traps. Deposits go **straight from the member's own account into established, third-party yield pools** — curated lending vaults run by Morpho, a well-known protocol, on Ethereum and Polygon — with FairWins never holding the money. And the platform fee, when one is turned on, is charged **in the very same transaction**, by an on-chain price list that refuses to charge a penny more than the rate the member was shown.
 
-## Layer one: direct ERC-4626 deposits, no FairWins contracts
+## A "vault," in plain terms
 
-[ERC-4626](https://eips.ethereum.org/EIPS/eip-4626) is the tokenized-vault standard: `deposit(assets, receiver)` mints shares, `convertToAssets(shares)` values a position, `maxDeposit`/`maxWithdraw` report honest limits, `withdraw`/`redeem` exit. Because Morpho's Vault V1 (MetaMorpho) implements the full surface, the base Earn integration shipped as a **frontend-only** feature — no FairWins contracts, no backend. The client discovers vaults through Morpho's public GraphQL API (`listed: true`, the same curation the Morpho app itself uses), reads positions authoritatively on-chain, and claims protocol rewards through Merkl's distributor.
+Before going further, one piece of vocabulary. In this world, a **vault** is just a shared pool that earns yield. Many people deposit the same kind of digital dollar into one pool; the pool lends those dollars out and earns interest; and each depositor owns a proportional slice, which grows as the interest accrues. When you want out, you redeem your slice for your share of the pool.
 
-One curation detail matters for anyone wrapping vaults: only Morpho **Vault V1** is surfaced. Vault V2 returns `0` from `maxDeposit`/`maxWithdraw` by design, which makes honest limit display impossible — and honest limits are load-bearing in this UI, not decoration.
+There's a widely adopted standard for how these pools behave, called ERC-4626. Because it's a standard, any app can deposit into, check, and withdraw from any compliant pool in a consistent way — the same reason a standard electrical outlet lets any appliance plug in. Morpho's vaults follow it fully, which is what let FairWins connect to them cleanly.
 
-The write path (`frontend/src/lib/earn/vaultActions.js`) applies safety rails before any wallet prompt:
+## Half one: deposits that never touch a FairWins wallet
 
-- pure validators reject zero, over-balance, and over-cap amounts with member-facing reasons;
-- approvals are for the **exact amount** — no unlimited allowances;
-- spendable deposits are dry-run with `staticCall` from the member's address, so vault-side rejections (cap reached, paused) surface before anything is signed;
-- withdrawals are bounded by `maxWithdraw`, and full exits use `redeem(shares)` so share dust never strands.
+Because these vaults follow a common standard, the basic Earn experience needed **no FairWins smart contracts and no FairWins server** in the money path at all. The app finds available vaults through Morpho's public directory (the same curated list the Morpho app itself uses), reads each member's balance directly from the blockchain, and lets members claim earned rewards through the standard distributor.
 
-Writes are expressed as `{ target, data, value }` batches through the app's unified `sendCalls` rail: a passkey smart account authorizes the whole approve-plus-deposit batch with one WebAuthn ceremony via a UserOp; a classic wallet signs the legs sequentially. Custody never changes hands — the vault's `deposit` names the member as `receiver`, and shares sit in the member's own account.
+One curation detail is worth mentioning because it protects members: FairWins only surfaces vaults that can honestly report their own deposit and withdrawal limits. A newer vault design that hides those limits is deliberately left out — because showing members accurate limits is load-bearing here, not decoration.
 
-Notably, spec 050 shipped with **no platform fee at all**. Morpho has no referral or transaction-source fee parameter (nothing like Aave's referral code), so there was no way to monetize attribution natively — and rather than bolt on a rushed fee mechanism, FR-013 made fee-free operation an explicit, documented decision, with treasury revenue deferred to a future spec.
+Before any deposit, the app runs several safety checks: it rejects amounts that are zero, more than the member has, or over the vault's cap; it approves only the **exact amount** — never an open-ended, unlimited permission; it does a dry run first, so a vault-side rejection surfaces *before* the member signs; and on a full exit it redeems the member's entire slice, so no tiny remnant gets stranded.
 
-## Layer two: the FeeRouter, and why the fee is a contract concern
+Members using a passkey wallet — the same face-or-fingerprint login standard (WebAuthn) your phone uses — can approve the whole thing with a single tap. Throughout, custody never changes hands: the vault deposits directly in the member's name, and the resulting slice sits in the member's own account, not FairWins'.
 
-That future spec is `060-platform-fee-wrapper`, and its core decision is that a platform fee on someone else's protocol must be **atomic** — fee and deposit in one transaction, or neither. The naive alternative, two transfers ("send us the fee, then deposit the rest"), can strand a member mid-flow: fee paid, deposit failed, treasury holding money for a service that never happened.
+Notably, Earn first shipped with **no platform fee at all**. Morpho has no built-in way to reward an app for sending it deposits, so there was no clean way to earn revenue on the connection — and rather than bolt on a rushed fee, FairWins made fee-free operation an explicit, documented decision and deferred the revenue question to later.
 
-The `FeeRouter` (`contracts/fees/FeeRouter.sol`, a UUPS proxy) is the single on-chain source of truth for every configurable platform fee. Each fee is a `bytes32 serviceId = keccak256("<label>")` — Earn's is `earn.lend` — with a `Service { capBps, feeBps, kind }` entry. `Wrapped` services are charged by the router itself; `ConfigOnly` entries (the Polymarket builder rates) just store rates that off-chain enforcers read. Wrapped caps are fixed at registration and bounded by `MAX_WRAPPED_FEE_BPS = 250` (2.5%); `earn.lend` registers at that cap with a live rate of **zero** until a `FEE_ADMIN_ROLE` holder deliberately sets one.
+## Half two: the fee, and why it belongs on-chain
 
-The member-facing entrypoint is the wrapper deposit:
+"Later" is this feature's second half. The key decision: a platform fee charged on top of someone else's yield product must be **all-or-nothing** — the fee and the deposit happen together in one transaction, or neither happens. The naive alternative, two separate steps ("send us the fee, then deposit the rest"), can leave a member stranded halfway: fee paid, deposit failed, treasury holding money for a service that never happened.
 
-```solidity
-function depositToVaultWithFee(
-    bytes32 serviceId,
-    address vault,
-    uint256 assets,
-    address receiver,
-    uint16 maxFeeBps
-) external nonReentrant returns (uint256 shares) {
-    // ...service lookup and zero checks elided...
-    uint16 liveBps = svc.feeBps;
-    if (liveBps > svc.capBps) revert CapExceeded(); // defense in depth
-    if (liveBps > maxFeeBps) revert FeeAboveQuoted();
-    // ...fee math elided...
-    asset.safeTransferFrom(msg.sender, address(this), assets);
-    // ...fee transfer + FeeCharged event elided...
-    uint256 netAmount = assets - feeAmount;
-    asset.forceApprove(vault, netAmount);
-    shares = IERC4626(vault).deposit(netAmount, receiver);
-    if (shares == 0) revert ZeroShares();
-    asset.forceApprove(vault, 0);
-}
-```
+FairWins solves this with its single on-chain price list — the one and only home for every platform fee. Each fee is one labeled entry with a current rate and a permanent ceiling it can never exceed. The Earn fee registers at a ceiling of 2.5%, with a live rate of **zero** until an administrator deliberately sets one.
 
-One call pulls the member's gross principal, sends `floor(assets · bps / 10 000)` to the treasury, and deposits the remainder into the ERC-4626 vault with the member as `receiver`. Any failing leg reverts everything — the treasury can never keep a fee for a deposit that did not happen. The router holds no balance outside a transaction.
+When a fee is active, a single transaction does the whole job: it pulls in the member's money, sends the small fee to the treasury, and deposits the remainder into the vault with the member as the owner. If any step fails, the entire thing is undone — the treasury can never keep a fee for a deposit that didn't go through. Three safeguards carry most of the design's weight:
 
-Three details in that function carry most of the design's weight:
+**The rate you saw is a hard ceiling.** The app sends back the exact rate it displayed. If an administrator raises the rate while a member's transaction is in flight, the transaction stops rather than charging the higher number. A member can never pay more than what was on the confirmation screen — enforced by the system, not by good manners.
 
-**`maxFeeBps` is a consent ceiling.** The frontend passes back the exact rate it displayed. If an admin raises `feeBps` while the member's transaction is in flight, the call reverts with `FeeAboveQuoted()` instead of charging the higher rate. A member can never pay more than the number they saw on the confirm screen — enforced by the contract, not by UI politeness.
+**A missing treasury skips the fee; it never loses funds.** If some network was never set up with a treasury to receive fees, the system simply deposits the full amount, fee-free. A setup mistake costs FairWins revenue; it never strands a member's principal.
 
-**A missing treasury skips the fee, never loses funds.** If `treasury` is `address(0)` on some network, the router deposits the full amount and emits `FeeSkippedNoTreasury`. An ops misconfiguration costs FairWins revenue; it never strands a member's principal.
+**No value, no charge.** If the member's money would somehow buy them nothing in the vault, the whole transaction reverts rather than taking a fee for nothing.
 
-**Zero shares reverts.** The router pulled principal and possibly took a fee; if the vault would mint nothing in return, `ZeroShares()` unwinds the whole action rather than breaking the fee-for-value guarantee.
+Rounding always favors the member — a fee small enough to round to nothing is charged as zero — and the system deliberately supports only ordinary, well-behaved digital dollars like USDC.
 
-The math floors in the member's favor — a fee that rounds to zero in the asset's smallest unit is charged as zero — and fee-on-transfer or rebasing tokens are explicitly unsupported, which is fine for the curated vault assets (plain ERC-20s like USDC).
+## The disclosure promise: three outcomes, no fourth
 
-## The disclosure contract: three outcomes, no fourth
+Before the deposit screen ever shows a confirm button, the app reads the live rate and lands in exactly one of three states:
 
-The client half lives in `frontend/src/lib/fees/feeQuote.js`. Before the deposit sheet ever shows a confirm button, `fetchFeeQuote({ serviceId, chainId, provider })` reads the live rate from the router and resolves to exactly one of three states:
+1. **No fee applies** (this network has no price list, or the Earn fee was never turned on): the flow proceeds fee-free, behaving *exactly* as it did before fees existed. No fee line appears — because implying a fee that isn't charged is as dishonest as hiding one that is.
+2. **A live rate is available**: the deposit screen shows a clearly named "FairWins platform fee" line — the percentage, the dollar amount, and the net amount reaching the vault — before any signature. The rate the member saw is pinned to the transaction as its ceiling.
+3. **The rate couldn't be read** on a network that should have one: the screen **blocks the deposit** with an honest "we couldn't confirm the fee right now" message. Proceeding on a possibly-understated rate isn't an option, and neither is silently assuming zero.
 
-1. **No router on this chain** (or the service isn't registered): `{ available: false, bps: 0 }`. The flow proceeds fee-free — and `buildDepositCalls` emits a batch **byte-identical** to the pre-fee behavior: approve the vault, `deposit(amount, account)`. No fee line appears, because implying a fee that isn't charged is as dishonest as hiding one that is.
-2. **Live rate obtained**: the `VaultSheet` (`frontend/src/components/earn/VaultSheet.jsx`) renders a named "FairWins platform fee" line — rate as a percent, absolute amount, and the net amount reaching the vault — with an info bubble, before any signature. The deposit reroutes through the router: approve the **router** for the gross amount, then `depositToVaultWithFee(earn.lend, vault, amount, account, quotedBps)`, pinning the transaction to the disclosed rate.
-3. **The read failed on a chain that has a router**: the quote throws, and the sheet **blocks deposits** with an honest "the platform fee rate could not be confirmed right now" message. Proceeding on a possibly understated rate is not an option; neither is silently assuming zero.
+There is deliberately no fourth outcome. Every rate change, meanwhile, is public and permanent, forming the audit history the admin panel reads back — and each charge is a matching public record, so the fee taken always equals the transfer to the treasury in the same transaction.
 
-There is deliberately no fourth state. The quote helper mirrors the contract's `quoteFee` math exactly — including the treasury-unset skip, so the UI never displays a fee the router would not actually charge.
+## Why build it this way
 
-Every rate change is public history: `FeeBpsChanged(serviceId, oldBps, newBps, actor)` events are the audit log the AdminPanel Fees tab renders, and `FeeCharged` is the reconciliation record — its `feeAmount` equals the ERC-20 transfer to the treasury in the same transaction.
+**A fee on the way in, not a cut of your yield.** FairWins takes a small percentage of the principal at deposit and touches nothing afterward. A performance fee — a cut of the returns — would require FairWins to sit inside the yield path and effectively hold member deposits, which is exactly the custody the platform refuses. An entry fee keeps positions purely member-owned.
 
-## Design decisions
+**One price list, not a fee per feature.** The next yield integration just registers a new labeled entry — a configuration change, not new code — reusing the same charge-and-deposit path, ceiling, consent limit, and public record. The alternative, every feature inventing its own fee handling, is how platforms end up with rates hardcoded in three places and no audit trail.
 
-**Entry-only fee, not a performance fee.** The router skims basis points of the principal at deposit time and touches nothing afterward. A performance or management fee would require FairWins to sit in the yield path — Morpho's documented "distributor revenue" pattern of a treasury-owned wrapper vault does exactly that, and was considered and deferred precisely because it is a new value-bearing contract that would custody member deposits. An entry fee keeps the router stateless between transactions and keeps positions purely member-owned.
+**Honest failure over a smooth guess.** Much of the design's care goes into refusing to guess: a rate that can't be read blocks the action rather than defaulting to zero; an unconfigured fee is treated as no fee rather than an unknown fee; a missing treasury skips rather than reverts. The rule underneath all of it: the member either sees the true number, or the action doesn't happen.
 
-**One router, not per-integration fee logic.** The next wrapped integration (Lido, Polygon liquid staking, Uniswap) registers a `serviceId` — config, not code. Anything ERC-4626-shaped reuses `depositToVaultWithFee` as-is; differently shaped actions add a purpose-built entrypoint to the same router with the same cap re-check, consent ceiling, and event discipline. The alternative — each feature inventing its own fee store — is how platforms end up with rates hardcoded in three clients and no audit trail.
+Worth naming honestly: the fee only touches deposits, so withdrawals are always free — the system can't hold an exit hostage. And the yield itself is entirely Morpho's. FairWins doesn't guarantee any particular return, and the vaults carry their own risk as third-party software — which the Earn screen states plainly, right under a required "Powered by Morpho" credit.
 
-**Caps are immovable.** A wrapped service's `capBps` is fixed at registration, bounded at 250 bps, and re-checked on the charge path (defense in depth against a corrupted rate). The emergency lever is `setFeeBps(id, 0)`, not cap surgery. Members and integrators get a hard, on-chain upper bound on what the fee can ever become.
+## Further reading
 
-**Honest failure over graceful degradation.** Most of the fee system's complexity is in refusing to guess: a failed rate read blocks the action rather than defaulting to zero; an unregistered service is fee-free rather than fee-unknown; a missing treasury skips rather than reverts. The rule generalizing all of it: the member either sees the true number or the action doesn't happen.
-
-The honest limits of the design are worth naming too. The fee only wraps deposits — withdrawals go straight to the vault, so the router can't ransom an exit, but also can't meter one. And the yield itself remains entirely Morpho's: FairWins guarantees neither APY nor the third-party vault's smart-contract risk, and the Earn UI says so under a mandated "Powered by Morpho" attribution.
-
-## Sources
-
-- `specs/050-earn-lending-rewards/spec.md` — Earn section requirements, custody model, FR-013 fee decision
-- `specs/060-platform-fee-wrapper/spec.md` — fee wrapper requirements, caps, disclosure rules
-- `docs/developer-guide/earn-integration.md` — Earn architecture, vault curation, safety rails
-- `docs/developer-guide/platform-fees.md` — FeeRouter architecture, disclosure rules, service registration
-- `contracts/fees/FeeRouter.sol`, `contracts/fees/IFeeRouter.sol` — router implementation and interface
-- `frontend/src/lib/earn/vaultActions.js` — deposit/withdraw batch construction, fee routing
-- `frontend/src/lib/fees/feeQuote.js` — live-rate quoting and the three-outcome contract
-- `frontend/src/components/earn/VaultSheet.jsx` — fee-line disclosure and blocked-state UI
-- `scripts/deploy/lib/feeServices.js` — `earn.lend` registration (cap 250 bps, Wrapped)
-- ERC-4626 Tokenized Vaults: https://eips.ethereum.org/EIPS/eip-4626
-- OpenZeppelin ERC-4626 / SafeERC20 / UUPS docs: https://docs.openzeppelin.com/contracts
-- Morpho distributor revenue concepts: https://docs.morpho.org/build/earn/concepts/generate-revenue/
+- [ERC-4626: Tokenized Vaults](https://eips.ethereum.org/EIPS/eip-4626) — the shared standard behind the yield pools this feature connects to
+- [Morpho documentation](https://docs.morpho.org/) — the third-party lending protocol whose vaults power Earn
+- [OpenZeppelin contract libraries](https://docs.openzeppelin.com/contracts) — the widely used building blocks for safe token handling and upgradeable on-chain systems
+- For deeper implementation details, see the FairWins developer documentation.

--- a/docs/blog/posts/23-earn-erc4626-vaults/social.md
+++ b/docs/blog/posts/23-earn-erc4626-vaults/social.md
@@ -1,27 +1,27 @@
-# Social & Image — Earn Without Custody Surprises
+# Social & Image — Earn Without Surprises
 
 ## X (Twitter)
 
-Idle USDC between wagers should earn — without custody and without a hidden skim. FairWins deposits straight into Morpho ERC-4626 vaults, and charges its platform fee atomically via a FeeRouter that reverts if the live rate ever exceeds the bps you saw at signing. 🔗 <link>
+Idle stablecoins between wagers should earn — without custody and without a hidden skim. FairWins deposits straight into Morpho's shared yield pools, and charges its platform fee openly in the same transaction, refusing to charge more than the rate you saw at approval. 🔗 <link>
 
-#DeFi #ERC4626 #SmartContracts
+#DeFi #yield #transparency
 
 ## LinkedIn
 
-Every consumer crypto "earn" feature faces two tempting shortcuts: take custody and become an asset manager, or route into someone else's protocol and quietly keep a slice of the yield. FairWins refused both.
+Every consumer crypto "earn" feature faces two tempting shortcuts: take custody and become an asset manager, or route into someone else's yield product and quietly keep a slice of the return. FairWins refused both.
 
-Our new Earn section (spec 050 + 060) deposits idle stablecoins directly from the member's account into curated Morpho ERC-4626 vaults — FairWins never holds funds — and monetizes it with a single honest fee. The post walks through both layers:
+Our new Earn feature deposits idle stablecoins directly from the member's own account into curated, third-party yield pools run by Morpho — FairWins never holds the funds — and monetizes it with a single honest fee. The post walks through both halves:
 
-- Non-custodial ERC-4626 integration: exact-amount approvals, staticCall dry-runs, `redeem` on full exits so share dust never strands.
-- The `FeeRouter`: one on-chain source of truth, each fee a `bytes32 serviceId` with an immovable hard cap (250 bps max on wrapped services).
-- Atomic charging: `depositToVaultWithFee` takes the fee and deposits the remainder in one transaction — any failing leg reverts everything.
-- Honest disclosure: `maxFeeBps` is a consent ceiling; a member can never pay more than the rate shown on the confirm screen, and a failed rate read blocks the deposit rather than guessing zero.
+- No custody: exact-amount approvals, a dry run before you sign, and a clean full-exit so no leftover dust gets stranded.
+- One on-chain price list: every fee has a permanent ceiling it can never exceed (2.5% max on fees FairWins charges directly).
+- All-or-nothing charging: the fee and the deposit happen in one transaction — any failing step reverts everything.
+- Honest disclosure: the rate you see at approval is a hard limit; you can never pay more, and if the rate can't be confirmed the deposit is blocked rather than guessed.
 
-The rule that generalizes all of it: the member either sees the true number, or the action doesn't happen.
+The rule that generalizes all of it: the member either sees the true number, or the action doesn't happen. 🔗 <link>
 
-How does your team handle fee disclosure when integrating third-party DeFi protocols? 🔗 <link>
+How does your team handle fee disclosure when building on top of third-party protocols?
 
-#DeFi #ERC4626 #SmartContracts #Solidity #FinTech
+#DeFi #yield #transparency #fintech #noncustodial
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/24-predict-polymarket-builder-codes/blog.md
+++ b/docs/blog/posts/24-predict-polymarket-builder-codes/blog.md
@@ -1,6 +1,6 @@
-# Predict: Monetizing Polymarket Order Flow Without Ever Touching an Order
+# Predict: Earning From Prediction-Market Trades Without Ever Touching One
 
-*How FairWins added prediction-market trading with zero contract changes, zero custody, and one honestly disclosed fee line*
+*How FairWins added prediction-market trading with no custody, no contract changes, and one honestly disclosed fee*
 
 ---
 
@@ -8,111 +8,81 @@
 |---|---|
 | **Series** | Finance Surfaces (part 3) |
 | **Part** | 24 of 34 |
-| **Audience** | DeFi / trading integrators |
-| **Tags** | `polymarket`, `clob`, `trading`, `builder-codes`, `non-custodial` |
-| **Reading time** | ~8 minutes |
+| **Audience** | Product managers, founders, and the crypto-curious |
+| **Tags** | `prediction-markets`, `polymarket`, `non-custodial`, `transparency` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-> **Important Note**: This article describes trading on prediction markets based on publicly available information and legitimate forecasting. Nothing here is a mechanism for trading on material non-public information or circumventing securities regulations. All participants remain fully subject to applicable laws, compliance requirements, and Polymarket's own regional restrictions, which FairWins surfaces and never bypasses.
+> **A note on responsible use:** This article describes trading on prediction markets using publicly available information and ordinary, skill-based forecasting. Nothing here is a way to trade on secret, non-public information or to sidestep the rules that govern these markets. Everyone who participates remains fully subject to applicable law and to Polymarket's own regional restrictions — which FairWins surfaces to members and never tries to bypass.
 
 ---
 
-## The 401 That Redesigned the Feature
+## The error message that redesigned the feature
 
-The first design for Predict looked like every other relayer pattern in the FairWins codebase: the member builds an order, the relay gateway holds one shared operator credential, and the gateway submits the order to Polymarket's central limit order book (CLOB) on the member's behalf. Clean, familiar, one secret to manage.
+The first design for Predict looked like every other pattern FairWins had built: the member creates an order, a FairWins server holds one shared credential, and the server submits the order to Polymarket on the member's behalf. Clean, familiar, one secret to manage.
 
-It failed against the live API with a 401: `Invalid api key`.
+It failed against the live system with a single blunt error: *invalid API key*.
 
-The reason is a deliberate property of Polymarket's CLOB V2: **every order is bound to its signer**. An API credential is registered under a specific wallet address, and the exchange rejects any order whose signer doesn't match the address that credential was derived for. A single shared key cannot submit trades for other people's wallets — which is exactly the property you want from a non-custodial exchange, and exactly the property that kills the "gateway submits for you" architecture.
+The reason is a deliberate feature of how Polymarket works, not a bug. On Polymarket, **every order is cryptographically tied to the wallet that signed it**. A credential is registered to one specific wallet, and the exchange rejects any order whose signer doesn't match. A single shared key simply cannot place trades for other people's wallets — which is exactly the property you want from a non-custodial exchange, and exactly the property that kills the "our server trades for you" approach.
 
-That rejection forced the design that shipped, and it turned out to be the better one: the member's own wallet is the only order signer, orders go from the browser straight to `clob.polymarket.com`, and FairWins earns revenue not by intermediating the trade but by *attributing* it — a `bytes32` builder code attached to every order via signed headers. This post walks through how that works, and why the resulting fee had to be disclosed differently from every other integration in the app.
+That rejection forced a different design, and it turned out to be the better one: the member's own wallet is the only thing that ever signs an order, orders go from the member's browser straight to Polymarket, and FairWins earns money not by sitting in the middle of the trade but by *attributing* it — attaching a small referral tag to each order. This post walks through how that works, and why the resulting fee had to be disclosed differently from any other feature in the app.
 
-## What Predict Is (and Is Not)
+## What Predict is (and isn't)
 
-Predict (spec 057) is a frontend section plus a thin relay-gateway proxy, structured exactly like the Collect (OpenSea) feature that preceded it: **no smart-contract changes, no custody, nothing routed through `wagerRegistry`**. There is no FairWins contract in the trade path at all. The pieces:
+Predict is a section of the app plus a thin, read-only helper on the server side. There are **no smart-contract changes and no custody** — FairWins never holds a member's funds or touches their trade. The pieces are simple:
 
-- **Browse** goes through the gateway proxy (`services/relay-gateway/src/polymarket/`), which fronts Polymarket's Gamma API for market discovery and the Data API for a wallet's positions — both public, read-only, cached, and rate-limited.
-- **Trading** is client-direct. The browser talks to the CLOB itself using credentials only the member holds.
-- **Revenue** is Polymarket's builder-code program: attributed volume earns a builder fee plus a share of the weekly USDC rewards pool.
+- **Browsing** markets and positions goes through a lightweight server proxy that fronts Polymarket's public, read-only data — cached and rate-limited, nothing more.
+- **Trading** is direct: the member's browser talks to Polymarket itself, using credentials only the member holds.
+- **Revenue** comes from Polymarket's official referral program for apps, called **builder codes**: trades FairWins helps generate earn a small referral fee plus a share of a weekly rewards pool.
 
-It is also **Polygon-only**, because Polymarket runs nowhere else. The capability is a one-line set in `frontend/src/config/networks.js`:
+Predict is also **Polygon-only**, because that's the only network Polymarket runs on. On any other network the Predict tab simply doesn't appear — no greyed-out button, no "coming soon," just absent.
 
-```js
-// Predict (spec 057): Polymarket prediction-market trading is available ONLY on
-// Polygon (137) — Polymarket runs nowhere else. Everywhere else the capability
-// is false and the Predict tab hides entirely (FR-018 soft-fail).
-const PREDICT_CHAIN_IDS = new Set([137])
-```
+## Each member trades with their own keys
 
-On any other chain the Predict tab doesn't render at all. No greyed-out button, no "coming soon" — the surface simply isn't there.
+Because every order is tied to its signer, each member derives their own trading credentials. This costs one signature — a wallet prompt, not an actual transaction and no gas — and the app remembers it for the session, so a member signs at most once. Those credentials are **never sent to a FairWins server**; the browser talks to Polymarket directly.
 
-## Per-User Credentials, Client-Direct Orders
+The order itself — its exact structure, rounding, and signature — is handled entirely by Polymarket's own official trading library, so FairWins never hand-builds an order and risks getting it subtly wrong. And here's a detail that shapes everything downstream: the referral tag is *not* part of the signed order at all. The signed order has no slot for it. Attribution rides alongside the order, on the request itself.
 
-Since the CLOB binds orders to their signer, each member derives their own API credentials. `frontend/src/lib/predict/clobSession.js` wraps the official `@polymarket/clob-client`: `createOrDeriveApiKey()` is deterministic per wallet and costs one gasless L1 EIP-712 signature — a wallet prompt, no transaction. The resulting `{ key, secret, passphrase }` is cached in `sessionStorage` per address, so the member signs at most once per session, and the credentials are **never sent to a FairWins server**. The CLOB serves `Access-Control-Allow-Origin: *`, so the SPA calls it directly; the member's L2 credentials never transit the gateway.
+## The attribution seam: crediting the trade without shipping secrets
 
-The order itself — the EIP-712 struct, amount rounding, salt, signature, submission — is owned entirely by the SDK. An early attempt to hand-roll the struct produced subtly wrong orders: the real CTF Exchange order is 12 fields under domain `"Polymarket CTF Exchange"` version `"1"`, and notably it contains **no builder field**. Attribution is not part of the signed order at all. It rides on request headers.
+FairWins' builder code is a public identifier — think of it as a referral tag. Crediting a trade to FairWins means attaching a few extra pieces of signed information to each order submission. Producing that signature requires a genuine shared secret (FairWins' own builder credentials), so that secret lives **only on the server**, never in the browser.
 
-## The Attribution Seam: Signing Headers Without Shipping Secrets
+The bridge between "trade happens in the browser" and "secret lives on the server" is a small, narrow request: when the member is about to submit an order, the browser asks the server to produce just the attribution signature — nothing else. The server signs and returns those few values, which get stacked onto the member's own order. Two properties matter here:
 
-FairWins' builder code is a public `bytes32` (`0x6e0316783960e149b53466f0f2c5fdbaf5ce11ba15669491de980f6dedc493a3`). Attribution works by attaching four `POLY_BUILDER_*` headers — key, passphrase, signature, timestamp — to each order submission, HMAC-signed with FairWins' registered builder credentials. Those credentials *are* a shared secret, so they live only in the gateway's environment (`POLYMARKET_API_KEY` / secret / passphrase — server-side configuration, never exposed to the browser).
+First, the server signs **attribution only** — it never sees the order, the member's credentials, or their positions. Second, attribution is **best-effort**: if the server is down or unconfigured, the order goes through *unattributed* rather than being blocked. FairWins losing a referral fee is never a reason a member can't trade. This mirrors a rule that runs through the whole platform: a member is never stranded for the sake of FairWins' revenue.
 
-The bridge between "SDK in the browser" and "secret on the server" is a duck-typed remote signer in `clobSession.js`. The CLOB client only ever calls `isValid()` and `generateBuilderHeaders(method, path, body)`, so `makeBuilderConfig` returns a shim that forwards those three values to the gateway's `POST /v1/polymarket/:chainId/builder-sign` endpoint (`services/relay-gateway/src/polymarket/routes.js`). The gateway — Polygon-gated, origin-locked, killswitched, and write-quota'd like every other write route — computes the HMAC with `@polymarket/builder-signing-sdk` and returns the four headers, which the SDK stacks on top of the member's own L2 auth headers.
+## Fees, honestly
 
-Two properties matter here. First, the gateway signs *attribution headers only* — it never sees an order, a credential, or a position. Second, attribution is **best-effort**: if the gateway is down, unconfigured, or the fetch fails, the shim returns `undefined` and the SDK posts the order *unattributed* rather than blocking it. The never-stranded rule (FR-015) applies to revenue too — FairWins losing a fee is never a reason a member can't trade.
+This is where Predict differs from FairWins' marketplace feature, and the difference is the most instructive part of the design.
 
-## Fees, Honestly
+That other feature's referral reward comes out of the *partner's* own fee — it costs the member nothing — so it's credited silently, with no fee line. Polymarket's builder fee is different: it's **additive**. It stacks on top of Polymarket's own trading fee and is a real cost to the trader. Because it's a genuine, additional cost, honesty demands it be shown — not credited silently.
 
-This is where Predict diverges from Collect, and the divergence is the most instructive part of the design. OpenSea's affiliate reward comes out of OpenSea's own fee — zero user cost — so Collect attributes silently. Polymarket's builder fee is **additive**: it stacks on top of Polymarket's own platform taker fee and is a real cost to the taker. The single source for that distinction is `services/relay-gateway/src/polymarket/builderCode.js`:
+So the confirmation screen treats it exactly the way FairWins' disclosure philosophy requires: the builder fee appears as its own clearly labeled "FairWins builder fee" line — never folded into a total, never described as free. Polymarket's *own* fee is a separate matter: it's calculated by Polymarket's engine at the moment a trade executes and varies with price and size, so rather than invent a dollar figure FairWins can't guarantee, the screen discloses it as a separate note. The rule is "what you see is what you're charged" for the one fee FairWins controls, and honest uncertainty about the one it doesn't. (Traders who post orders that others fill, rather than taking existing ones, pay no builder fee at all.)
 
-```js
-/**
- * KEY DIFFERENCE from the OpenSea `attachReferral` seam: OpenSea's referral
- * reward comes out of OpenSea's own fee (no user cost), so that seam is a
- * silent no-op. Polymarket's builder fee is ADDITIVE — it stacks on top of
- * the platform taker fee and is a REAL cost to the taker — so the fee bps
- * returned here feed a VISIBLE fee line in the client's cost breakdown.
- */
-export function attachBuilderCode(config, { chainId, isMaker = false }) { /* … */ }
-```
+The rate is a setting, not buried in code: by default half a percent (50 basis points) for takers and zero for makers, hard-capped at Polymarket's program limits. That cap is enforced the moment the server starts up: if someone misconfigures the fee above the allowed limit, the server refuses to start rather than quietly overcharging. A fat-fingered rate becomes an outage you notice in seconds, not a fee incident you discover in a support ticket weeks later.
 
-So the confirm UI treats the fee the way the platform's honest-disclosure doctrine demands: `computeCost` in `frontend/src/lib/predict/clobOrder.js` computes the notional and the builder fee in floored bigint math (no float drift) and emits `"FairWins builder fee"` as its own labelled line — never folded into a total, never described as free. Polymarket's *own* taker fee is a curve over price and size computed by their engine at execution; rather than fabricate a dollar estimate FairWins can't guarantee, the confirm UI discloses it as a separate note. The rule is "shown == charged" for the one fee FairWins controls, and honest uncertainty for the one it doesn't. Makers pay no builder fee at all.
+For context, a taker's total cost lands around Polymarket's own fee (which varies by market category) plus FairWins' half-percent — comparable to other regulated prediction platforms and mid-pack among Polymarket-connected apps.
 
-The rates are configuration, not code: default **50 bps taker / 0 maker**, hard-capped at Polymarket's program limits of 100/50. The cap is enforced at the gateway's boot, loudly:
+## The region gate
 
-```js
-// services/relay-gateway/src/config/index.js
-const bps = int(env, 'POLYMARKET_BUILDER_TAKER_FEE_BPS', 50)
-if (bps > 100) throw new Error(
-  `[relay-gateway] POLYMARKET_BUILDER_TAKER_FEE_BPS=${bps} exceeds the 100 bps cap`)
-```
+Polymarket blocks trading from certain regions as a matter of its own policy. FairWins checks a member's eligibility before showing fees and again before submitting. A blocked member gets an honest region notice and a link to Polymarket itself — FairWins never bypasses the block, and never shows a trade button that's guaranteed to fail. The same "degrade honestly" pattern covers every failure: if a fee can't be confirmed, signing is blocked rather than guessed; during an outage, the member gets a clear message and a link out.
 
-A misconfigured fee doesn't silently clamp or quietly overcharge — the gateway refuses to start. For context, total taker cost lands around Polymarket's curved platform fee (~0.75%–1.8% by category) plus the 0.5% builder fee: comparable to Kalshi and mid-pack among third-party Polymarket builders (see `specs/057-predict-polymarket/research.md`, D2–D4).
+## Why build it this way
 
-## The Region Gate
+**Attribution over intermediation.** Even setting aside the signer rule that made a middleman impossible, crediting trades is simply the better trade-off: FairWins earns on volume without ever holding a member's credentials, orders, or funds — no custody, no broker posture, and the smallest possible secret to protect.
 
-Polymarket blocks order placement from restricted regions as a matter of its own policy. `frontend/src/lib/predict/geoblock.js` checks `polymarket.com/api/geoblock` before fee load and before submit. A blocked member gets an honest region notice and a "Trade on Polymarket ↗" link-out — FairWins never bypasses the block, and never renders a trade button that's going to fail. The same degrade-honestly pattern covers every failure mode: fees unconfirmable ⇒ signing is blocked rather than guessed; killswitch or outage ⇒ message plus a Polymarket link; passkey wallets ⇒ an honest "not available yet" (`PASSKEY_PREDICT_ENABLED = false` until ERC-1271 order binding is verified end-to-end).
+**Direct trading, server-side reads only.** Splitting the two paths means the trust-sensitive part — the signed order — has no FairWins hop at all, while the cacheable part — browsing markets — gets sensible limits and a kill switch. The server can go down and members can still trade.
 
-## Design Decisions
+**A fee that's a setting, with a hard cap at startup.** Keeping the rate in configuration rather than code, and refusing to start if it's set too high, turns a potential fee scandal into a boring, immediate, self-correcting failure.
 
-**Attribution over intermediation.** The CLOB's signer binding made a submitting relayer impossible, but even without that constraint, header-based attribution is the better trade: FairWins earns on volume without holding credentials, orders, or funds — no custody, no broker posture, and the smallest possible secret surface (one builder credential set, used only for HMACs).
+**Disclose what you control, admit what you don't.** The additive builder fee gets its own exact, labeled line. Polymarket's execution-time fee gets an honest note rather than a made-up estimate. The tidier alternative — one blended "total" — would be less truthful, so FairWins didn't ship it.
 
-**Client-direct trading, gateway reads.** Splitting the paths means the latency- and trust-sensitive leg (signed orders) has no FairWins hop, while the cacheable leg (market browse, positions) gets quotas and a killswitch. The gateway can die and members can still trade.
+The honest open trade-off: passkey wallets can't trade on Predict yet. Ordinary wallets work today, and support for passkey-based signatures is coming once it can be verified end to end — the honest, working answer shipped ahead of the complete one.
 
-**Fee as config with a boot-time cap.** Rates in environment config keep bps out of client code; the boot failure turns a fat-fingered `500` into an outage you notice in seconds instead of a fee incident you discover in a support ticket.
+## Further reading
 
-**Disclose what you control, admit what you don't.** The additive builder fee gets an exact labelled line; Polymarket's execution-time fee gets an honest note instead of a made-up estimate. The alternative — one blended "total" — would be tidier and less truthful.
-
-The open trade-off is the deferred passkey path: EOA wallets trade today, smart-account signatures wait for verified ERC-1271 support, and the honest answer shipped ahead of the complete one.
-
-## Sources
-
-- `specs/057-predict-polymarket/` — spec, plan, and research (D2–D4 fee benchmarking, D9 builder seam)
-- `docs/developer-guide/predict-polymarket.md` — architecture and operations overview
-- `services/relay-gateway/src/polymarket/` — `builderCode.js`, `routes.js` (builder-sign endpoint), `client.js`, `normalize.js`
-- `services/relay-gateway/src/config/index.js` — fee caps and boot-time validation
-- `frontend/src/lib/predict/` — `clobSession.js`, `clobOrder.js`, `builderFee.js`, `geoblock.js`, `tradeSigner.js`
-- `frontend/src/config/networks.js` — `PREDICT_CHAIN_IDS` Polygon-only capability
-- Polymarket CLOB documentation — https://docs.polymarket.com/
-- `@polymarket/clob-client` — https://www.npmjs.com/package/@polymarket/clob-client
-- EIP-712: Typed structured data hashing and signing — https://eips.ethereum.org/EIPS/eip-712
+- [Polymarket documentation](https://docs.polymarket.com/) — the prediction-market exchange behind Predict, including its builder-code referral program
+- [EIP-712: typed structured data signing](https://eips.ethereum.org/EIPS/eip-712) — the widely used standard for the human-readable signatures that authorize orders
+- [Prediction market (overview)](https://en.wikipedia.org/wiki/Prediction_market) — background on how these markets work
+- For deeper implementation details, see the FairWins developer documentation.

--- a/docs/blog/posts/24-predict-polymarket-builder-codes/social.md
+++ b/docs/blog/posts/24-predict-polymarket-builder-codes/social.md
@@ -1,27 +1,27 @@
-# Social & Image — Predict: Monetizing Polymarket Order Flow Without Ever Touching an Order
+# Social & Image — Predict: Earning From Prediction-Market Trades Without Ever Touching One
 
 ## X (Twitter)
 
-A 401 redesigned our whole feature: Polymarket's CLOB binds every order to its signer, so a shared relayer can't submit for you. FairWins earns by *attributing* trades — a bytes32 builder code in signed headers — and discloses the additive builder fee as its own line, never "free." 🔗 <link>
+One error message redesigned our whole feature: Polymarket ties every order to the wallet that signed it, so a shared server can't trade for you. FairWins earns by *crediting* trades — a small referral tag on each order — and shows the builder fee as its own line, never "free." 🔗 <link>
 
-#PredictionMarkets #Polymarket #Web3
+#PredictionMarkets #Polymarket #transparency
 
 ## LinkedIn
 
-The first design for Predict — FairWins' prediction-market trading surface built on publicly available information and skill-based forecasting — looked like every relayer pattern we had: a shared gateway credential submits orders on the member's behalf. It failed against the live API with a 401.
+The first design for Predict — FairWins' prediction-market trading feature, built on publicly available information and skill-based forecasting — looked like every server pattern we had: one shared credential submits orders for the member. It failed against the live system with an "invalid API key" error.
 
-Polymarket's CLOB binds every order to its signer by design. That killed the intermediating-relayer architecture and forced a better one. The post covers:
+Polymarket ties every order to the wallet that signed it, by design. That killed the middleman approach and forced a better one. The post covers:
 
-- Client-direct orders: the member's own wallet is the only order signer; credentials never touch a FairWins server.
-- Attribution over intermediation: a `bytes32` builder code rides on signed request headers, not in the order struct — FairWins earns on volume without holding orders, credentials, or funds.
-- Honest fee disclosure: unlike an OpenSea referral that costs the user nothing, Polymarket's builder fee is *additive* — a real taker cost — so it gets its own labelled "FairWins builder fee" line, never folded into a total.
-- Boot-time cap enforcement: rates are config (default 50 bps taker / 0 maker), hard-capped at the program limits; a misconfigured fee refuses to boot.
+- Direct trading: the member's own wallet is the only thing that signs an order; credentials never touch a FairWins server.
+- Crediting over intermediation: a small referral tag rides alongside each order, not inside it — FairWins earns on volume without holding orders, credentials, or funds.
+- Honest fees: unlike a marketplace referral that costs the user nothing, Polymarket's builder fee is *additive* — a real trading cost — so it gets its own labeled line, never blended into a total.
+- A hard cap at startup: the rate is a setting (default 0.5% for takers, 0 for makers), capped at the program limits; misconfigure it and the server refuses to start.
 
-Participants remain subject to applicable law and Polymarket's own regional restrictions, which the app surfaces and never bypasses.
+Everyone who participates remains subject to applicable law and Polymarket's own regional restrictions, which the app surfaces and never bypasses. 🔗 <link>
 
-How do you decide which fees to itemize versus blend? 🔗 <link>
+How do you decide which fees to itemize versus blend?
 
-#PredictionMarkets #Polymarket #Web3 #NonCustodial #FinTech
+#PredictionMarkets #Polymarket #transparency #noncustodial #fintech
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/25-bitcoin-non-evm/blog.md
+++ b/docs/blog/posts/25-bitcoin-non-evm/blog.md
@@ -1,131 +1,70 @@
-# Bitcoin in an EVM-Native App: Guarding Every Boundary
+# Adding Bitcoin to an App That Was Never Built for It
 
-*How FairWins added its first non-EVM chain — string network ids, seed-derived BIP84/86 keys, and fail-safe UTXO handling — without corrupting a codebase built on numeric chainIds*
+*How FairWins added its first non-Ethereum blockchain without quietly breaking everything built around the old assumptions*
 
 | | |
 |---|---|
 | **Series** | Finance Surfaces (part 4) |
 | **Part** | 25 of 34 |
-| **Audience** | Multi-chain and wallet engineers |
-| **Tags** | `bitcoin`, `non-evm`, `bip84`, `bip86`, `hd-wallets`, `multi-chain` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product and engineering readers curious about multi-chain design |
+| **Tags** | `bitcoin`, `wallets`, `multi-chain`, `product` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-## The Assumption Buried in Every File
+## The assumption hiding in a mature app
 
-Imagine you maintain a mature EVM app. Every network is a numeric chainId: 137 is Polygon, 80002 is Amoy, 61 is Ethereum Classic. That number is a load-bearing key in dozens of places — `getContractAddressForChain(name, chainId)` resolves contract addresses, wagmi builds providers from it, the subgraph router selects endpoints by it, the testnet toggle flips between paired numbers. The assumption "a network is an integer with contracts on it" is not written down anywhere, because it never needed to be. It is simply everywhere.
+Picture a wallet app that has only ever spoken one dialect of blockchain: the Ethereum family. Polygon, Ethereum Classic, and the test networks are all cut from the same cloth. Deep in the code, each network is identified by a plain number, and that number quietly drives almost everything — which smart contract to talk to, which server to query, which network the app is pointed at right now.
 
-Then the roadmap says: add Bitcoin. Portfolio, send, receive — a real non-custodial wallet inside the existing passkey account.
+Nobody ever wrote down the rule "a blockchain is a number with contracts on it." They didn't have to. It was simply true everywhere, until the roadmap said: add Bitcoin.
 
-Bitcoin breaks every one of those silent assumptions at once. There is no chainId — [EIP-155](https://eips.ethereum.org/EIPS/eip-155) is an Ethereum construct. There are no contracts, so `getContractAddressForChain` is meaningless. There are no accounts or nonces — value lives in UTXOs, addresses are supposed to rotate rather than persist, and fees are priced in sat/vB against a transaction's virtual size, not gas. The tempting shortcut — assign Bitcoin a fake numeric id like `-1` or `99999` and let it flow through the existing plumbing — is exactly how multi-chain codebases rot: every consumer of chainId becomes a landmine that might receive a number that is not actually an EVM chain.
+Bitcoin does not fit that mold. It has no identifying number the way Ethereum networks do. It has no smart contracts, so "which contract do I talk to?" has no answer. And it doesn't even track balances the same way: instead of an account with a running total, Bitcoin holds value in discrete chunks of unspent coins, addresses are meant to be used once and rotated, and fees are priced by transaction size rather than by "gas."
 
-FairWins spec 061 took the opposite approach: Bitcoin is *structurally* different, so it gets a *structurally* different type, and every place the two worlds touch gets an explicit guard. This post walks the four boundaries that made it work.
+The tempting shortcut is to hand Bitcoin a fake number and let it ride through the existing plumbing. That is exactly how multi-chain codebases rot: every place that trusted "this number is an Ethereum network" becomes a hidden trap waiting to receive something that isn't one. FairWins took the opposite path. Bitcoin is genuinely different, so it gets its own separate identity, and every point where the two worlds touch gets an explicit checkpoint. The scope is deliberately small — portfolio, send, and receive — a real wallet you control, living inside your existing FairWins passkey account.
 
-## Boundary 1: A Parallel Registry, Not a New Row
+This is the story of the four boundaries that made that work.
 
-Bitcoin networks are string ids — `'bitcoin'` and `'bitcoin-testnet'` (testnet4) — in their own registry, `frontend/src/config/bitcoinNetworks.js`, deliberately parallel to and never merged into the numeric `NETWORKS` map:
+## Boundary 1: keep Bitcoin in its own lane
 
-```js
-export const BITCOIN_NETWORKS = Object.freeze({
-  bitcoin: Object.freeze({
-    id: 'bitcoin',
-    kind: 'bitcoin',
-    isTestnet: false,
-    gatewaySegment: 'mainnet',
-    addressHrp: 'bc',   // bech32 HRP — drives wrong-network rejection
-    coinType: 0,        // BIP44 coin type (hardened)
-    capabilities: CAPABILITIES,
-  }),
-  // 'bitcoin-testnet' → testnet4, hrp 'tb', coinType 1
-})
+Rather than smuggling Bitcoin into the list of Ethereum networks, FairWins gives it a small, separate registry of its own. Bitcoin's networks are named with words — a mainnet and a test network — not numbers, and they live apart from the numeric world on purpose.
 
-export function isBitcoinNetworkId(id) {
-  return typeof id === 'string' && Object.prototype.hasOwnProperty.call(BITCOIN_NETWORKS, id)
-}
-```
+A single yes/no check acts as the gatekeeper: *is this a Bitcoin network?* Any shared screen runs that check before handing an identifier to code that only understands Ethereum, so a Bitcoin identifier can never wander into Ethereum-only plumbing by accident.
 
-`isBitcoinNetworkId()` is the boundary type guard. Any shared code path — portfolio aggregation, the network switcher, activity feeds — checks it before handing an id to anything typed on numeric chainIds. A string id must never reach `getContractAddressForChain`, wagmi provider construction, or subgraph routing; the guard makes the crossing impossible to do by accident rather than merely discouraged.
+Two touches keep this honest. The app's single testnet toggle flips Bitcoin between its test and main networks in lockstep with the Ethereum side, so the two environments never mix. And a small capabilities list is the single source of truth for what Bitcoin can do: wagers, group pools, membership, and gasless transactions are switched off; sending and receiving are on. Anything switched off simply doesn't appear, so the interface never implies Bitcoin can do something it can't.
 
-Two details keep the parallel registry honest. First, `BITCOIN_TESTNET_MAINNET_PAIR` mirrors the existing EVM testnet/mainnet toggle semantics, so the app's single global toggle flips Bitcoin between testnet4 and mainnet in lockstep with 80002 ↔ 137 — the two environments never mix. Second, a frozen `capabilities` map (`wagers: false`, `pools: false`, `gasless: false`, `send: true`, …) is the single source of truth for what Bitcoin supports. Everything false hides its surface exactly like a disabled EVM capability. There are no wagers, pools, membership, or gasless transactions on Bitcoin, and the UI never implies otherwise.
+## Boundary 2: one backup, two kinds of keys
 
-## Boundary 2: One Seed, Two Cryptographies
+A FairWins passkey account already holds a single master secret that lives only in memory and can be recovered through the passkey itself — the same WebAuthn standard your phone uses for Face ID or fingerprint login. Bitcoin keys grow from that same secret. There is no second seed phrase to write down and no separate backup to lose.
 
-FairWins passkey accounts (spec 041) hold a 32-byte, PRF-recoverable, memory-only master seed. Bitcoin keys derive from that same seed — no separate backup, no new recovery phrase — through a domain-separated subtree defined in `specs/061-bitcoin-transactions/contracts/key-derivation-btc.md`:
+So the Bitcoin keys can never collide with the account's other uses of that master secret, they are grown through a one-way derivation stamped with a Bitcoin-specific label, following Bitcoin's own standard recipes for turning a seed into spending keys — the widely used approaches for modern "native SegWit" addresses (the `bc1...` addresses you've probably seen) and, optionally, newer Taproot addresses. Every constant in that recipe is wallet-breaking: real money lives at the resulting addresses, so those values are versioned and migrated, never quietly edited.
 
-```
-btcSeed     = HKDF-SHA256(ikm = masterSeed, salt = 32 zero bytes,
-                          info = "fairwins-btc-seed-v1", length = 64)
-root        = BIP32.fromMasterSeed(btcSeed)
-segwitAcct  = root.derive("m/84'/{coin}'/0'")   // BIP84 → P2WPKH bc1q…
-taprootAcct = root.derive("m/86'/{coin}'/0'")   // BIP86 → P2TR   bc1p…
-receive(i)  = acct/0/i                          // external chain only (v1)
-```
+Two rules shape everything downstream. First, the keys are memory-only: the seed and private keys are never saved to disk, logged, or sent anywhere, and the app forgets them the moment a transaction is signed. Second, even the "public" master keys that could reveal your whole history of addresses stay on your device. FairWins' server sees only bare addresses and already-signed transactions. A server that never holds keys cannot leak your wallet or quietly map out everywhere you've received money.
 
-The [HKDF](https://datatracker.ietf.org/doc/html/rfc5869) info string `"fairwins-btc-seed-v1"` is exclusive to this tree, so the Bitcoin subtree can never collide with the spec-041 key-encryption path or any future consumer of the master seed. Native segwit ([BIP-84](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki)) is the default; taproot ([BIP-86](https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki), key-path only, [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)-tweaked) is opt-in. Every constant in that block is marked **wallet-breaking**: funds live at the derived addresses, so changing the info string, paths, or coin-type mapping requires a versioned migration, never an edit.
+There's also a firm "no wrong keys" rule. If the master secret isn't available — say you're signed in with an outside wallet that doesn't support it — the Bitcoin wallet honestly reports itself as unavailable and explains why. It never improvises keys from some other source, because keys derived from the wrong material would be a *different wallet*, and someone's funds would be stranded behind a technical accident.
 
-Two invariants shape everything downstream. *Memory-only:* `btcSeed`, the BIP32 root, account xprvs, and child private keys are never persisted, logged, serialized, or transmitted — `frontend/src/lib/bitcoin/derivation.js` derives transiently and callers drop references after signing. *xpub confinement:* even the account xpubs stay in the client; the relay gateway sees bare addresses (at most 50 per call) and signed raw transactions, nothing else. A server that never holds keys or extended public keys cannot leak the wallet or link its full address graph.
+## Boundary 3: rotating addresses and coins that fail safe
 
-There is also a "no wrong keys" rule: if the master seed is unavailable — a non-PRF authenticator, an injected or WalletConnect EVM wallet — the Bitcoin wallet reports an honest `unavailable` state with the reason. It never falls back to deriving from other material, because a fallback derivation would be a *different wallet* holding someone's funds hostage to an implementation detail.
+Ethereum habits say "your address is your identity." Bitcoin practice says nearly the opposite: use a fresh receiving address every time. FairWins hands out a new address on each request, never reuses one, and keeps a simple forward-only counter of how far it has gone.
 
-## Boundary 3: Rotation, Recovery, and Coins That Fail Safe
+The saved list of addresses is treated as a convenience cache, not the source of truth. On a brand-new device, the wallet rediscovers your addresses by scanning forward until it sees a long-enough run of unused ones — the standard "gap limit" convention Bitcoin wallets have used for years — and picks up where it left off. Because the passkey seed plus the standard recipe *is* the backup, there's nothing Bitcoin-specific to write down.
 
-EVM habits say "your address is your identity." Bitcoin practice says the opposite: `frontend/src/lib/bitcoin/wallet.js` issues a fresh receive address per request and never repeats one. The rotation cursor per (network, address type) only increases, and the persisted ledger is explicitly a cache, never the source of truth. On a new device, gap-limit-20 discovery — scan sequential addresses, stop after 20 consecutive unused ones, the convention descended from [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)/BIP-44 wallets — rebuilds the issued set and resumes the cursor after the highest used index. Recovery needs no Bitcoin-specific backup because the passkey seed plus deterministic derivation *is* the backup.
+Spending is where Bitcoin's chunk-of-coins model bites hardest. Some Bitcoin coins carry collectible data ("Stamps") baked into that specific chunk; spend one as ordinary money and the collectible is destroyed forever. So FairWins classifies every coin before it can be selected for a payment, leaning deliberately cautious: a coin counts as spendable only when it has been *positively confirmed* to be an ordinary, collectible-free coin. If the service that recognizes collectibles is degraded or unreachable, those coins are held back from spending, not risked. Occasionally that means you can send a little less than your full balance during an outage — but the alternative, accidentally destroying a collectible, isn't reversible, so caution wins.
 
-Spending is where UTXO reality bites hardest. Bitcoin Stamps embed collectible data in specific UTXOs; spend one as ordinary money and the collectible is destroyed. FairWins classifies every coin before it can be selected:
+## Boundary 4: the fee you see is the most you'll pay
 
-```js
-if ((u.confirmations ?? 0) < 1) {
-  classification = 'pending'
-} else if (!recognitionHealthy) {
-  // Fail safe: nothing is positively stamp-free while recognition is down.
-  classification = 'unverified'
-} else if (stampByOutpoint.has(key)) {
-  classification = 'protected'
-} else {
-  classification = 'spendable'
-}
-```
+On the Ethereum side, FairWins can sometimes cover transaction fees for you. Bitcoin has no such arrangement, and the app says so plainly: **on Bitcoin, you pay the network fee.** What FairWins *can* promise is that the fee shown when you confirm is the ceiling — you will never be charged more than that.
 
-The polarity is the point: a coin is spendable only when *positively verified* stamp-free. If the stamps indexer is degraded or unreachable, coins classify `unverified` and coin selection treats them exactly like `protected` — excluded from sends and from spendable balance, shown as protected value. Over-protection temporarily shrinks what a member can send; the alternative is irreversibly destroying an asset during an outage.
+Fee estimates go stale fast, so a quote expires after about a minute; if it's older, the app throws it out and re-quotes before building anything, so a fee spike can't silently reprice your payment. The fee you confirm then becomes a hard limit at the last step: before signing, the app calculates the real fee and refuses to sign anything above what you approved. Tiny leftover change too small to be worth its own output is folded into the fee, and payments are sent in a way that lets a stuck transaction be bumped later if the network gets congested.
 
-## Boundary 4: Fees Are a Ceiling, Not an Estimate
+The server component for Bitcoin is deliberately dull: it checks that the feature is on, validates the request, enforces rate limits, and relays data to a public Bitcoin data provider. It never touches keys or funds, and the whole thing is optional — turn it off and every Bitcoin screen hides or degrades honestly. If it goes down entirely, none of the Ethereum-side money features are affected at all.
 
-On the EVM side, FairWins runs two gasless rails. Bitcoin has neither — there is no relayer and no paymaster for BTC, and the confirm UI says plainly that the member pays the network fee. What the platform *can* guarantee is that the fee the member confirmed is the most they will ever pay.
+## Why we built it this way
 
-Fee quotes (sat/vB tiers) expire after 60 seconds; `frontend/src/lib/bitcoin/send.js` rejects a stale quote with `stale_fee_quote` before a plan is even built, so a fee spike between quote and confirmation can never silently reprice a send. The confirmed fee then becomes a hard ceiling enforced at the signing layer in `frontend/src/lib/bitcoin/psbt.js`:
+A separate identity for Bitcoin beats a fake number: the shortcut would have been one line of code and an endless audit headache, whereas guarding every crossing turns a whole category of "wrong network" bugs into an impossibility. Reusing the passkey seed means no second recovery ritual, at the honest cost of a hard dependency — Bitcoin needs a passkey that supports it. Treating saved address state as a rebuildable cache means the wallet survives device loss with zero Bitcoin-specific backup. And throughout, the app prefers to fail safe over always acting: both the collectible check and the fee ceiling would rather refuse than act on unverified information, because a blocked send is recoverable while a destroyed collectible or a surprise fee is not.
 
-```js
-const feeSats = inSats - outSats
-if (feeSats < 0) throw new Error('psbt: outputs exceed inputs')
-if (feeSats > maxFeeSats) throw new FeeOverrunError(feeSats, maxFeeSats)
-```
+## Further reading
 
-`buildAndSignTx` computes the actual fee from inputs minus outputs *before* signing and refuses to produce a signature above `maxFeeSats` — the same shape as the EVM-side `maxFeeBps` rule from the FeeRouter work: the quote shown at confirmation is a binding maximum, not a talking point. Sub-dust change folds into the fee rather than creating an unspendable output, and sends are RBF-signaled per [BIP-125](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) so a stuck transaction has an escape hatch.
-
-The server side, `services/relay-gateway/src/bitcoin/routes.js`, is a deliberately dumb proxy: killswitch check, enable check, parameter validation, per-IP quotas, TTL cache, then Esplora upstream. It never touches intents, funds, or keys. And the whole module is optional — with `BTC_ENABLED=false` or the killswitch active, every Bitcoin surface in the frontend hides or degrades honestly rather than pretending. A total gateway outage leaves every EVM value path untouched.
-
-## Design Decisions
-
-**String ids over a fake chainId.** A synthetic numeric id would have been one line of code and an unbounded audit surface — every chainId consumer forever suspect. Distinct types plus `isBitcoinNetworkId` guards cost more upfront and make the wrong crossing a type error instead of a runtime surprise.
-
-**One seed, domain-separated.** Deriving from the passkey master seed means no second recovery ceremony, at the price of hard coupling: Bitcoin availability requires a PRF-capable passkey. The availability matrix in the derivation contract makes that an honest, explained limitation rather than a silent failure.
-
-**Cache-as-ledger.** Treating persisted state as a rebuildable cache (gap-limit discovery, never-decreasing cursor) trades extra lookups on unlock for a wallet that survives device loss with zero Bitcoin-specific backup.
-
-**Fail-safe over available.** Both the stamps classifier and the fee ceiling prefer refusing to act over acting on unverified data. A blocked send is recoverable; a destroyed Stamp or an unexpectedly expensive transaction is not.
-
-**Scope discipline.** Portfolio, send, receive — nothing else. No wagers, no gasless, no contracts on Bitcoin. The capabilities map turns that scope into enforced configuration instead of tribal knowledge.
-
-## Sources
-
-- `specs/061-bitcoin-transactions/` — spec.md, plan.md, `contracts/key-derivation-btc.md`
-- `docs/developer-guide/bitcoin.md`, `docs/runbooks/bitcoin-operations.md`
-- `frontend/src/config/bitcoinNetworks.js`
-- `frontend/src/lib/bitcoin/` — `derivation.js`, `wallet.js`, `send.js`, `psbt.js`
-- `services/relay-gateway/src/bitcoin/routes.js`
-- [BIP-32: Hierarchical Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
-- [BIP-84: Derivation scheme for P2WPKH](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki)
-- [BIP-86: Key derivation for single-key P2TR outputs](https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki)
-- [BIP-341: Taproot](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) · [BIP-125: Opt-in RBF](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki)
-- [RFC 5869: HKDF](https://datatracker.ietf.org/doc/html/rfc5869) · [EIP-155: Chain ID](https://eips.ethereum.org/EIPS/eip-155)
+- [Bitcoin BIP-32: Hierarchical Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) — how one seed grows a tree of keys
+- [BIP-84: native SegWit (`bc1...`) address derivation](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki) and [BIP-86: Taproot addresses](https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki)
+- [BIP-125: opt-in "replace-by-fee"](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) — bumping a stuck transaction
+- [WebAuthn / passkeys explained](https://webauthn.guide/) — the standard behind Face ID and fingerprint login

--- a/docs/blog/posts/25-bitcoin-non-evm/social.md
+++ b/docs/blog/posts/25-bitcoin-non-evm/social.md
@@ -2,26 +2,26 @@
 
 ## X (Twitter)
 
-Adding Bitcoin to an EVM app: the tempting shortcut is a fake numeric chainId. FairWins gave it string ids + an `isBitcoinNetworkId` guard so a wrong crossing is a type error, not a runtime landmine. BTC sends are never gasless — the member pays the network fee, quoted as a hard ceiling. 🔗 <link>
+Adding Bitcoin to an app built for Ethereum: the tempting shortcut is to give it a fake network number. FairWins gave Bitcoin its own separate identity and guarded every crossing, so a wrong turn is impossible, not just discouraged. Bitcoin sends are never free — you pay the network fee, shown as a hard ceiling before you confirm. 🔗 <link>
 
 #Bitcoin #Web3 #MultiChain
 
 ## LinkedIn
 
-In a mature EVM codebase, "a network is a numeric chainId with contracts on it" is an assumption baked into dozens of files — and never written down, because it never had to be. Then the roadmap says: add Bitcoin.
+In an app built only for Ethereum-family chains, "a network is a number with contracts on it" is an assumption baked into dozens of places — and never written down, because it never had to be. Then the roadmap says: add Bitcoin.
 
-Bitcoin breaks all of it at once — no chainId, no contracts, no accounts, value in UTXOs, fees in sat/vB. The post walks the four boundaries that made it work:
+Bitcoin breaks all of it at once — no network number, no contracts, no running-total accounts, value held in discrete coins, fees priced by transaction size. The post walks the four boundaries that made it work:
 
-- Parallel registry: Bitcoin gets string ids (`'bitcoin'`, `'bitcoin-testnet'`) with an `isBitcoinNetworkId` guard, so a string id can never reach EVM-typed plumbing by accident.
-- One seed, two cryptographies: BIP84/BIP86 keys derive from the same passkey master seed via a domain-separated HKDF subtree — no second recovery phrase, keys and xpubs never leave the client.
-- Fail-safe UTXO handling: a coin is spendable only when positively verified stamp-free; if the stamps indexer degrades, coins are protected, never destroyed.
-- Fees as a ceiling: quotes expire in 60s and the confirmed fee is a hard signing limit. BTC sends are never gasless — the confirm UI says plainly the member pays the network fee.
+- A separate lane: Bitcoin gets its own identity and a simple gatekeeper check, so it can never wander into Ethereum-only plumbing by accident.
+- One backup, two kinds of keys: Bitcoin keys grow from the same passkey master secret via a Bitcoin-specific derivation — no second seed phrase, and keys never leave your device.
+- Fail-safe spending: a coin is spendable only when positively confirmed collectible-free; if that check is degraded, the coin is protected, never risked.
+- Fees as a ceiling: quotes expire in about a minute and the confirmed fee is a hard signing limit. Bitcoin sends are never free — the confirm screen says plainly that you pay the network fee.
 
-The theme throughout: fail safe over available, and make the wrong crossing impossible rather than merely discouraged.
+The theme throughout: fail safe over always acting, and make the wrong crossing impossible rather than merely discouraged.
 
-How do you keep non-EVM chains from corrupting EVM-shaped abstractions? 🔗 <link>
+How do you keep a fundamentally different blockchain from corrupting abstractions built for another? 🔗 <link>
 
-#Bitcoin #Web3 #MultiChain #HDWallets #FinTech
+#Bitcoin #Web3 #MultiChain #Wallets #FinTech
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/26-clearpath-dao-registry/blog.md
+++ b/docs/blog/posts/26-clearpath-dao-registry/blog.md
@@ -1,247 +1,78 @@
 # ClearPath: A Registry That Owns Nothing
 
-*How FairWins references external DAOs as first-class, multi-network citizens without taking custody, keys, or authority*
+*How FairWins lets you see and act on DAOs across different networks without ever taking custody, keys, or authority*
 
 | | |
 |---|---|
 | **Series** | Multi-chain Infra (part 1) |
-| **Audience** | DAO tooling and infrastructure engineers |
-| **Tags** | `dao`, `registry`, `multi-chain`, `interoperability` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product and infrastructure readers curious about DAO tooling |
+| **Tags** | `dao`, `governance`, `multi-chain`, `interoperability` |
+| **Reading time** | ~7 minutes |
 
 ---
 
 ## The problem: someone else's DAO, your dashboard
 
-A FairWins member holds a governance position in ENS on Ethereum mainnet, a Uniswap
-delegation on the same chain, and membership in Olympia — an OpenZeppelin Governor DAO
-living on Ethereum Classic. Three DAOs, two frameworks, two networks, and no single
-place to see them together, let alone vote from.
+A FairWins member holds a governance position in ENS on Ethereum, a Uniswap delegation on the same network, and membership in a smaller DAO living on Ethereum Classic. Three DAOs, two different governance frameworks, two networks — and no single place to see them together, let alone vote from.
 
-The instinct of most "DAO aggregators" is to become a middleman: deploy a proxy, ask
-members to delegate to it, route votes through a contract you control. That instinct is
-exactly wrong for a platform whose entire product is non-custodial escrow. The moment a
-registry can act *on behalf of* a DAO it references, it becomes a liability — a new
-attack surface, a new trust assumption, a new thing an auditor has to reason about.
+(Quick refresher: a DAO is a "decentralized autonomous organization" — an on-chain group whose members vote on proposals, with the rules enforced by a governance smart contract rather than by a company.)
 
-ClearPath (specs `030-clearpath-standard-daos` and `042-clearpath-multi-network`) takes
-the opposite position. It treats an external DAO the way a phone book treats a business:
-it records that the DAO exists, who noticed it, and what kind of governance it runs — and
-nothing else. Every action a member takes is signed by that member, against the DAO's own
-contract, gated by the DAO's own rules. The registry is metadata for shared discovery. It
-holds no authority, no keys, and no funds.
+The instinct of most "DAO aggregators" is to become a middleman: deploy a contract of their own, ask members to delegate their voting power to it, and route votes through something the aggregator controls. That instinct is exactly wrong for a platform whose entire product is holding *nothing* on your behalf. The moment a registry can act on a DAO's behalf, it becomes a liability — a new thing to attack, a new party to trust, a new question every auditor has to reason through.
 
-This post walks the on-chain registry first, then the multi-network layer that was
-grafted on top of it without touching a single line of Solidity.
+ClearPath takes the opposite position. It treats an external DAO the way a phone book treats a business: it records that the DAO exists, who noticed it, and what kind of governance it runs — and nothing else. Every action a member takes is signed by that member, sent to the DAO's own contract, and judged by the DAO's own rules. The registry is shared metadata for discovery. It holds no authority, no keys, and no funds.
 
-## The data model: five fields and a code probe
+This post walks the on-chain registry first, then the multi-network layer that was added on top of it without changing a single line of contract code.
 
-The on-chain piece is `contracts/clearpath/ExternalDAORegistry.sol`, a UUPS-upgradeable
-contract that inherits the shared `contracts/upgradeable/UUPSManaged.sol` wiring. Its
-entire state is an append-only entry table:
+## The data model: a few facts and a sanity check
 
-```solidity
-struct Entry {
-    address dao;
-    Framework framework;
-    address registrant;
-    uint64  registeredAt;
-    string  label;
-}
+The on-chain piece is a small, upgradeable contract whose entire memory is an append-only list of entries. Each entry records just a handful of facts: the DAO's address, which governance framework it uses, who registered it, when, and a human-readable label.
 
-IMembershipManager public membershipManager;
-uint256 public externalCount;
-mapping(uint256 => Entry) private _entries;
-mapping(address => uint256) private _idByDao; // 0 = not registered (ids start at 1)
-mapping(address => uint256[]) private _byRegistrant;
+Two design touches are worth calling out. Entry numbering starts at one, so a "zero" unambiguously means "not registered" — no confusing empty slots. And the contract's storage layout is checked automatically before every upgrade, the same discipline every upgradeable FairWins contract follows, so a future version can never accidentally scramble the existing records.
 
-uint256[45] private __gap;
-```
+The "framework" field is intentionally minimal. Today it holds exactly one value: OpenZeppelin's widely-used Governor design (the framework behind countless DAOs). The registry commits on-chain only to what it can actually verify on-chain, and leaves room to add more frameworks — like Aragon or Moloch — later.
 
-Ids start at 1 so that a zero from `_idByDao` unambiguously means "not registered." The
-trailing `__gap` reserves storage slots for future fields, and the layout is registered in
-`npm run check:storage-layout`, which gates CI — the same discipline every upgradeable
-FairWins contract follows, so an implementation swap can never silently reorder state.
+## Checking that an address is really a DAO
 
-`Framework` is an enum, and today it holds exactly one value:
+Anyone can hand the registry any address. Its job is to reject ordinary wallets and random contracts before they pollute shared discovery. It does this with a two-tier check.
 
-```solidity
-enum Framework {
-    OZGovernor // 0 — OpenZeppelin Governor (Olympia + any IGovernor DAO)
-}
-```
+The clean path uses a common Ethereum convention called [ERC-165](https://eips.ethereum.org/EIPS/eip-165), which lets a contract answer "do you support this interface?" A well-behaved Governor says yes. But many older Governors never implemented that convention correctly, so there's a fallback: the registry asks two questions a real Governor can answer and a random contract chokes on — essentially "how do you count votes?" and "how long is your voting period?" Every probe is wrapped so that a hostile or broken contract simply fails the check rather than causing trouble.
 
-That single value is deliberate. The registry commits on-chain only to what it can
-actually validate on-chain, and leaves the enum extensible (Aragon, Moloch, Safe named as
-later candidates in the interface comments).
-
-## Validating that an address is really a DAO
-
-Anyone can pass an arbitrary address to a registration call. The registry's job is to
-reject EOAs and random contracts before they pollute shared discovery. It does this with a
-two-tier probe in `_isGovernor`:
-
-```solidity
-function _isGovernor(address dao) internal view returns (bool) {
-    if (dao.code.length == 0) return false; // EOA
-    try IERC165(dao).supportsInterface(type(IGovernor).interfaceId) returns (bool ok) {
-        if (ok) return true;
-    } catch {}
-    // Defensive fallback: a real Governor answers these views; a random contract reverts.
-    try IGovernor(dao).COUNTING_MODE() returns (string memory mode) {
-        if (bytes(mode).length == 0) return false;
-        try IGovernor(dao).votingPeriod() returns (uint256) {
-            return true;
-        } catch {
-            return false;
-        }
-    } catch {
-        return false;
-    }
-}
-```
-
-The primary path is the clean one: [ERC-165](https://eips.ethereum.org/EIPS/eip-165)
-`supportsInterface` against the `IGovernor` interface id. But not every governor implements
-ERC-165 correctly — many older Governor deployments don't — so the fallback probes two
-`IGovernor` views that a real governor answers and a random contract reverts on:
-`COUNTING_MODE()` (with a non-empty-string sanity check) and `votingPeriod()`. Every call
-is wrapped in `try/catch`, so a probe against a hostile contract that reverts, or one that
-returns garbage, degrades to `false` rather than propagating.
-
-Note what the contract imports: `IGovernor` from OpenZeppelin, the *interface only* — never
-the `Governor` implementation. That keeps the registry free of the Cancun `mcopy` opcode
-that OpenZeppelin 5.4.0's `GovernorUpgradeable` pulls in transitively, which is precisely
-why the registry compiles and deploys on pre-Cancun Ethereum Classic / Mordor where a full
-native Governor cannot. Today the registry is deployed only on Mordor (chain 63); its proxy
-and implementation are recorded in `deployments/mordor-chain63-v2.json` as
-`externalDAORegistry` / `externalDAORegistryImpl`.
+One quiet but important choice: the registry borrows only the *description* of a Governor — the shape of its questions — not a full Governor implementation. That keeps the contract lean enough to deploy on older networks like Ethereum Classic, and it's the same trick that lets one registry serve a small DAO there and ENS on Ethereum from the same code.
 
 ## Registration is metadata, not power
 
-The public entrypoint is small, and its comments are load-bearing:
+Registering a DAO is gated only by a light membership requirement — Silver tier or above — purely as spam control. But look at what registration deliberately does *not* do. There's no sanctions screen and no consumption of any "creation" quota, because registration moves no value and confers no power. Those heavier checks are reserved for actions that move money.
 
-```solidity
-function registerExternalDAO(address dao, Framework framework, string calldata label)
-    external
-    returns (uint256 id)
-{
-    if (dao == address(0)) revert ZeroAddress();
-    if (_idByDao[dao] != 0) revert AlreadyRegistered();
-    if (
-        uint8(membershipManager.getActiveTier(msg.sender, DAO_MEMBER_ROLE)) <
-        uint8(IMembershipManager.Tier.Silver)
-    ) revert InsufficientMembershipTier();
-    if (!_isGovernor(dao)) revert NotAGovernor(dao);
-    // ... assign id, store Entry, emit ExternalDAORegistered
-}
-```
+This is the core principle: **no external authority.** The registry gains no role, no key, and no ability to call anything on a DAO it records. The "who registered it" field notes who *noticed* the DAO, not who owns it. Every governance action a member takes later — voting, queueing, executing, proposing — is a transaction that member signs, sent to the DAO's own contract, authorized by the DAO's own rules. The registry is never in the loop. And registries are strictly per-network: a DAO tracked on one network never leaks into another's scope.
 
-Registration is gated by a MembershipManager tier of **Silver or above** — a light spam
-control. But look at what it deliberately does *not* do. There is no sanctions screen and
-no `recordCreate` quota consumption, because registration is read-only metadata: it moves
-no value and confers no power. Screening a signer and burning a creation quota are for
-value-moving actions; recording that a public governance contract exists is neither.
+## Adding multi-network support — without a contract change
 
-This is invariant **INV-4** from the spec's data model — *no external authority*: the
-registry confers ClearPath no role, key, or call-authority over a registered DAO. The
-`registrant` field records who noticed the DAO, not who owns it. Every governance action a
-member later takes — vote, queue, execute, propose — is constructed as a user-signed
-transaction against the DAO's own contract and authorized by the DAO's own rules. The
-registry is never in the loop. INV-5 pins the other axis: registries are per-network, and
-cross-network registration is rejected — a DAO tracked on one chain never leaks into
-another's scope.
+The first version of ClearPath tied its very availability to the registry: the whole feature switched itself off anywhere the registry wasn't deployed, which meant everywhere except the one network it launched on. That was a mistake, because reading a DAO's state is just a direct query to that network — no registry required. The fix removed the gate entirely, and the striking part is that it was a **frontend-only** change. No new or altered contract; the registry stays deployed only where it already was.
 
-## Layering multi-network on top — without a contract change
+The multi-network layer rests on three moves, all in configuration and app code:
 
-Spec 030 shipped the registry but wired ClearPath's *availability* to it: the whole module
-self-disabled anywhere `ExternalDAORegistry` wasn't deployed, which meant everywhere except
-Mordor. That was wrong, because the reads are pure client-side RPC — the gate was
-unnecessary. Spec 042 removed it, and the striking thing is that it did so as a
-**frontend-only** change. There is no new or changed on-chain contract; the registry stays
-deployed only where it already is.
+**1. An open network model.** Each network now declares whether it supports ClearPath. A ClearPath-only network — Ethereum is the first — can host governance while every other FairWins feature (wagers, swaps, and so on) honestly reports itself as unavailable there. Adding a network becomes pure configuration: a name, a connection URL, and a "supports ClearPath" flag.
 
-The multi-network layer rests on three moves, all in config and client code:
+**2. Registry-optional tracking, aggregated across every network.** The on-chain registry becomes an optional shared-discovery overlay used where it's deployed. On a network without one, a member can still track a DAO by address in local, device-only storage. When ClearPath builds your list, it scans every ClearPath-capable network in parallel, so an unreachable network degrades just that one entry honestly without blanking the rest. For each network it merges three sources — the on-chain registry (where one exists), your device-local tracked DAOs, and a curated list of well-known DAOs — de-duplicated and strictly scoped to that single network.
 
-**1. An open network model.** Networks are declared in
-`frontend/src/config/networks.js`, and each network's `capabilities` getter gained a
-`clearpath` flag. A ClearPath-only network — Ethereum mainnet is the first — sets
-`clearpath: true` while `dex`, `passkeyAccounts`, `polymarketSidebets`, and `friendMarkets`
-are all false and it carries no wager deployment. So mainnet can host governance without the
-app ever implying that wagers or swaps run there; each other feature self-discloses as
-unavailable. Adding a network is pure config: an entry with an RPC URL, USDC address, and
-`clearpath: true`.
+Tracking a DAO needs no transaction and no network switch. Only a *write* — registering, or voting, queueing, executing, proposing — requires being connected to that DAO's network, and those screens show a clear "Switch to X" button when you're on the wrong one.
 
-**2. Registry-optional tracking, aggregated across every network.** Availability is now
-capability-driven, not registry-gated: `useClearPath().isSupported = capabilities.clearpath
-&& !!reader`. The on-chain registry becomes an *optional shared-discovery overlay* used
-where deployed. On a registry-less network, a member tracks a DAO by address into a
-device-local store (`trackedDaoStore.js`, `localStorage` keyed by `chainId + wallet`).
-`listExternalDAOs()` then scans every `clearpath`-capable chain in parallel via
-`Promise.allSettled`, so an unreachable RPC on one chain degrades that chain honestly
-without blanking the others. For each chain it merges three sources, de-duplicated and
-strictly scoped to that one chain:
+**3. Pluggable per-framework connectors.** ClearPath reads any OpenZeppelin-style Governor generically, but Uniswap's governance uses a different, Compound-style design. So instead of one hard-wired reader, ClearPath has a small library of connectors, one per framework, and a detector that probes an unknown DAO to figure out which one it is. Adding support for a new framework is a new connector plus one line in an ordered list — the rest of the interface doesn't change.
 
-```
-on-chain registry entries  (iff a registry is deployed on THAT chain)
-+ device-local tracked DAOs (per chainId + wallet, on THAT chain)
-+ curated known DAOs        (config/clearpath/knownDaos.js, on THAT chain)
-```
+Underneath, reads prefer a fast indexed source when one is configured for a given DAO, fall back to reading the contract directly when it isn't, and otherwise show a truthful empty, partial, or error state — never fabricated data.
 
-Every row carries its own `chainId`. Tracking needs no transaction and no network switch;
-only a *write* — registering on a registry network, or voting/queueing/executing/proposing
-against a DAO — requires being on that DAO's chain, and those surfaces render a "Switch to
-X" button (via wagmi's `useSwitchChain`) when the connected chain differs.
+## Why we built it this way
 
-**3. Pluggable per-framework connectors.** ClearPath reads any OpenZeppelin `IGovernor`
-DAO generically, but Uniswap governance is GovernorBravo/Compound-style — a different
-interface. So the single connector became a connector layer in
-`frontend/src/components/clearpath/connectors/`: `ozGovernor.js` (framework 0) and
-`governorBravo.js` (framework 1, with id-based `queue`/`execute` and `getPriorVotes` voting
-power). `detectFramework(reader, address)` probes OZ via `COUNTING_MODE`, then Bravo via
-`proposalCount` + `quorumVotes`, else `'unknown'`. Adding a framework — Aragon, Morpho — is
-a new module plus one entry in an ordered resolver; the UI, data router, and notifications
-don't change.
+**Describe, don't embody.** Borrowing only the *shape* of a Governor, never a full implementation, is what lets one registry serve DAOs on a lightweight older network and on Ethereum alike. It also means the registry never needs to know how a DAO tallies votes — only that the address answers governor-shaped questions.
 
-Reads resolve subgraph-first (`daoDataSource.js`): a governance subgraph when one is
-configured for `(chainId, dao)` and a gateway key is present, otherwise the connector's
-bounded, chunked on-chain live indexer, otherwise a truthful empty/partial/error state —
-never fabricated data.
+**Validate on-chain, extend off-chain.** The contract's list of frameworks stays minimal because that's all it can truly verify. Support for other governance styles lives in the app, where detection is a lightweight probe. The chain commits only to what it can check.
 
-## Design decisions
+**Registry-optional, not registry-required.** Making the on-chain registry a shared overlay rather than an on/off switch is what unlocked Ethereum with zero new deployment. The honest trade-off: device-local tracking doesn't sync across your devices in this version. But shared discovery — the registry's real value — is available wherever the contract is deployed, and any member can promote a locally-tracked DAO onto a registry network.
 
-- **Interface over implementation.** Importing only `IGovernor` — not `Governor` — is what
-  lets one registry serve Olympia on pre-Cancun ETC and ENS on mainnet from the same
-  bytecode. It also means the registry never has to know how a governor tallies votes; it
-  only proves the address answers governor-shaped questions.
+**Degrade honestly.** Scanning networks in parallel, guarding every probe, and showing explicit empty/partial/error states is the same doctrine throughout FairWins: a feature that can't reach its data says so, rather than showing a plausible lie.
 
-- **Validate on-chain, extend off-chain.** The Solidity `Framework` enum stays minimal
-  (`OZGovernor` only) because that is all the contract can validate. GovernorBravo support
-  lives in the frontend ABI mirror and connector layer, where framework detection is a
-  client-side probe. The chain commits only to what it can check.
+## Further reading
 
-- **Registry-optional, not registry-required.** Making the on-chain registry a shared
-  overlay rather than an on/off switch is what unlocked mainnet with zero deploy. The
-  trade-off is honest: device-local tracking has no cross-device sync in this cut, and a
-  member's tracked list lives in their browser. Shared discovery — the registry's real
-  value — remains available wherever the contract is deployed, and any member can promote a
-  locally-tracked DAO onto a registry network.
-
-- **Degrade honestly.** `Promise.allSettled` across chains, `try/catch` around every probe,
-  and explicit empty/partial/error states are the same doctrine throughout FairWins: a
-  feature that can't reach data says so, rather than showing a plausible lie. A wrong
-  subgraph id is treated as worse than none, since the router simply falls back to the live
-  scan either way.
-
-## Sources
-
-- `contracts/clearpath/ExternalDAORegistry.sol` — the on-chain registry
-- `contracts/clearpath/interfaces/IExternalDAORegistry.sol` — public interface, events, errors
-- `specs/030-clearpath-standard-daos/spec.md`, `.../data-model.md` — pillars, invariants INV-1…INV-5
-- `specs/042-clearpath-multi-network/spec.md`, `.../data-model.md` — network-agnostic layer, connectors
-- `docs/developer-guide/clearpath-multi-network.md` — the three pillars, data sourcing, scoping
-- `deployments/mordor-chain63-v2.json` — recorded `externalDAORegistry` / `externalDAORegistryImpl`
-- `contracts/upgradeable/UUPSManaged.sol` — shared UUPS proxy/auth base
-- [ERC-165: Standard Interface Detection](https://eips.ethereum.org/EIPS/eip-165)
-- [OpenZeppelin Governance (`IGovernor`)](https://docs.openzeppelin.com/contracts/5.x/api/governance)
-- [Compound GovernorBravo](https://docs.compound.finance/v2/governance/)
+- [ERC-165: Standard Interface Detection](https://eips.ethereum.org/EIPS/eip-165) — how contracts advertise what they support
+- [OpenZeppelin Governance](https://docs.openzeppelin.com/contracts/5.x/api/governance) — the Governor framework behind many DAOs
+- [Compound's GovernorBravo](https://docs.compound.finance/v2/governance/) — the alternative governance design ClearPath also reads

--- a/docs/blog/posts/26-clearpath-dao-registry/social.md
+++ b/docs/blog/posts/26-clearpath-dao-registry/social.md
@@ -2,9 +2,9 @@
 
 ## X (Twitter)
 
-Most "DAO aggregators" make you delegate to a contract they control. ClearPath's
-ExternalDAORegistry owns nothing: an ERC-165 `IGovernor` probe records that a DAO exists —
-no key, no role, no authority. Every vote stays member-signed. 🔗 <link>
+Most "DAO aggregators" make you delegate your votes to a contract they control. ClearPath's
+registry owns nothing: a quick check confirms an address really is a DAO, then records that it
+exists — no key, no role, no authority. Every vote stays signed by you. 🔗 <link>
 
 #DAO #web3 #interoperability
 
@@ -14,26 +14,25 @@ The moment a DAO registry can act *on behalf of* the DAOs it references, it beco
 liability — a new key to steal, a new trust assumption, a new thing an auditor has to
 reason about. For a non-custodial platform, that's the wrong default.
 
-ClearPath (FairWins specs 030 + 042) takes the opposite position: a registry that owns
-nothing. The new post walks the design:
+ClearPath takes the opposite position: a registry that owns nothing. The new post walks the
+design:
 
-- The on-chain `ExternalDAORegistry` — five fields per entry, ids starting at 1, an
-  append-only storage layout gated in CI, and an ERC-165 + defensive-view probe that
-  proves an address is really a Governor before recording it.
-- Why it imports OpenZeppelin's `IGovernor` interface only (never the implementation) — the
-  trick that lets one registry serve DAOs on pre-Cancun Ethereum Classic and Ethereum
-  mainnet from the same bytecode.
-- Invariant INV-4: registration is metadata, not power. No sanctions screen, no quota, no
-  authority. Every governance action stays member-signed against the DAO's own contract.
-- How multi-network support was layered on as a frontend-only change — registry-optional
-  tracking, per-chain aggregation via `Promise.allSettled`, and pluggable per-framework
-  connectors (OZ Governor + GovernorBravo) — with zero new contract deploys.
+- The on-chain registry — a few facts per entry, an append-only layout checked before every
+  upgrade, and a two-tier probe that proves an address is really a DAO before recording it.
+- Why it borrows only the *shape* of a governance contract, never a full implementation — the
+  trick that lets one registry serve DAOs on a lightweight older network and on Ethereum from
+  the same code.
+- The core principle: registration is metadata, not power. No sanctions screen, no quota, no
+  authority. Every governance action stays signed by the member, sent to the DAO's own contract.
+- How multi-network support was added as a frontend-only change — registry-optional tracking,
+  parallel aggregation across networks, and pluggable per-framework connectors — with zero new
+  contract deployments.
 
 How do you draw the line between a useful DAO registry and an over-privileged one?
 
 🔗 <link>
 
-#DAO #SmartContracts #web3 #Ethereum #Interoperability
+#DAO #Governance #web3 #Ethereum #Interoperability
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/27-indexing-without-subgraph/blog.md
+++ b/docs/blog/posts/27-indexing-without-subgraph/blog.md
@@ -1,251 +1,80 @@
-# Indexing Without a Subgraph
+# When the Search Index Isn't There
 
-*Keeping every read path working on a chain The Graph has never heard of*
+*Keeping every screen working on a blockchain that no indexing service has ever heard of*
 
 | | |
 | --- | --- |
 | **Series** | Multi-chain Infra (part 2) |
 | **Part** | 2 |
-| **Audience** | Data and infrastructure engineers |
-| **Tags** | `the-graph`, `subgraph`, `indexing`, `rpc`, `graceful-degradation` |
-| **Reading time** | ~8 minutes |
+| **Audience** | Product and infrastructure readers curious about blockchain data |
+| **Tags** | `indexing`, `the-graph`, `resilience`, `multi-chain` |
+| **Reading time** | ~7 minutes |
 
-## The chain with no indexer
+## The chain with no index
 
-We were deploying FairWins to Ethereum Classic — specifically the Mordor
-testnet, chain 63 — as a step toward broadening past Polygon. The contracts
-compiled, deployed, and verified. A member could create a wager, an opponent
-could accept it, and USDC moved exactly as it did on Polygon. Then someone
-opened the "My Wagers" list and it was empty. Not an error. Just empty, on an
-account that had three live wagers on-chain.
+We were deploying FairWins to Ethereum Classic as a step toward broadening past Polygon. A member could create a wager, an opponent could accept it, and USDC moved exactly as it did on Polygon. Then someone opened the "My Wagers" list, and it was empty. Not an error — just empty, on an account that had three live wagers sitting right there on the blockchain.
 
-The cause was not in our code. It was that The Graph's hosted and decentralized
-networks do not index Ethereum Classic. There is no provider you can deploy a
-subgraph to for chain 63. We could — and do — keep a subgraph manifest with
-Mordor's addresses and start blocks in `subgraph/networks.json`, but a manifest
-is not an endpoint. Without a running indexer, `SubgraphSource` had nothing to
-POST a GraphQL query to, so the list came back empty.
+The cause wasn't in our code. To understand it, you need one piece of background about how apps read blockchain history.
 
-This is the recurring shape of a multi-chain app: the indexing layer you lean on
-for one network simply does not exist on the next one. You can treat that as a
-hard dependency and let features break on unsupported chains, or you can treat
-the indexer as one of several interchangeable data sources and degrade to a
-slower path that always works. FairWins takes the second route. The rule we
-settled on: **every read path has an RPC-only fallback, and whether a chain uses
-the fast path is per-network metadata, not a global flag.**
+Reading the *current* state of a blockchain is easy — "what's this account's balance right now?" is a single quick question. But reconstructing *history* — "show me every wager this person has ever been part of, newest first" — is slow and awkward if you ask the blockchain directly. So most blockchain apps don't. They lean on a **search-index service**: a separate system that watches the chain, records everything relevant into a fast database, and answers rich history questions in milliseconds. The dominant one is called The Graph, and the little indexing recipe you give it is a "subgraph." Think of it as Google for one app's on-chain activity — instead of re-reading the whole chain every time, you query a tidy pre-built index.
 
-## "Does this chain have an indexer?" is per-chain data
+The problem on Ethereum Classic was simply this: **The Graph doesn't index that chain.** There is no service to point a subgraph at. Our app knew the contract addresses, but with no running index behind it, the history query had nothing to talk to — so the list came back empty.
 
-The decision is encoded directly on each network. In
-`frontend/src/config/networks.js` every entry declares a `subgraphUrl`, and two
-helpers read it:
+This is the recurring shape of a multi-chain app: the indexing service you lean on for one network simply doesn't exist on the next. You can treat that as a hard dependency and let features break on unsupported chains, or treat the index as *one of several interchangeable data sources* and fall back to a slower path that always works. FairWins takes the second route. The rule we settled on: **every screen that reads history has a fallback that talks directly to the blockchain, and whether a network has an index is a per-network setting, not a global switch.**
 
-```js
-export function getSubgraphUrl(chainId) {
-  const net = getNetwork(chainId)
-  return net?.subgraphUrl || null
-}
-export function hasSubgraph(chainId) {
-  return Boolean(getSubgraphUrl(chainId))
-}
-```
+## "Does this chain have an index?" is per-chain data
 
-Polygon (137) and Amoy (80002) carry a Studio endpoint; Mordor (63) and local
-Hardhat (1337) carry `null`. Resolution is strictly per-chain, which matters for
-correctness as much as for coverage: a Polygon endpoint is never queried while
-the wallet is connected to Mordor, so a testnet session can never surface
-mainnet wagers. Adding another un-indexed network later is a config change —
-set `subgraphUrl: null` and record the contract addresses — not a code change.
+The decision is recorded on each network individually: every network entry declares whether it has an index. Polygon and its test network carry one; Ethereum Classic and the local development chain carry none.
 
-## One boundary, two sources
+Keeping this strictly per-chain matters for correctness as much as coverage. A Polygon index is never queried while you're connected to Ethereum Classic, so a testnet session can never accidentally surface mainnet wagers. And adding another un-indexed network later is a configuration change, not a code change.
 
-The UI never talks to a data source directly. It goes through
-`frontend/src/data/wagers/WagerRepository.js`, a thin boundary bound to a chain
-id that picks a source for that chain:
+## One doorway, two sources behind it
 
-```js
-function resolveSourceKey(explicit, chainId) {
-  if (explicit && SOURCE_REGISTRY[explicit]) return explicit
-  const envSource = import.meta.env?.VITE_WAGER_SOURCE
-  if (envSource && SOURCE_REGISTRY[envSource]) return envSource
-  if (chainId != null) return hasSubgraph(chainId) ? 'subgraph' : 'registry'
-  return 'subgraph'
-}
-```
+The interface never talks to a data source directly. It goes through a single thin boundary, tied to whichever network you're on, that picks the right source. Two sources sit behind that doorway, and both hand back wagers in the exact same shape, so the list, detail, and report screens neither know nor care which one produced them:
 
-Two live sources implement the same `WagerSource` interface —
-`listPage`, `getById`, `syncIndex` — and both emit the identical mapped `Wager`
-shape, so the list, detail, and report views are agnostic to which one produced
-a page:
+- **The index source** — asks The Graph. Used when the network has an index.
+- **The direct source** — reads the blockchain directly. The default for any network without an index.
 
-- **`SubgraphSource`** — GraphQL against the chain's `subgraphUrl`. Used when
-  `hasSubgraph(chainId)` is true.
-- **`RegistrySource`** — direct RPC reads of the v2 `WagerRegistry`. The default
-  for any chain without a subgraph.
+Because the screens only know the doorway and a common wager shape, we could swap The Graph for a different indexing product later, or fall back to direct reads today, and nothing above the data layer would notice.
 
-(A third, `EventsSource`, reads the retired `FriendGroupMarketFactory` and is no
-longer in the automatic path; it survives only behind an explicit
-`VITE_WAGER_SOURCE=events` override.)
+## Why reading the chain directly is usually painful — and how we avoid it
 
-## Why RPC reads are usually painful — and how the registry avoids it
+The naive way to rebuild someone's wager history by reading the chain is to scan its event log — every "a wager was created" event, filtered to that user, from the contract's first day to now. This is exactly what falls apart on public blockchain nodes. Free endpoints reject wide scans with errors like "query returned too many results," so a from-the-beginning scan collapses into a flood of throttled, range-limited requests. It's the very problem an index exists to solve.
 
-The naive way to reconstruct a user's wagers over RPC is to scan event logs:
-`eth_getLogs` for `WagerCreated` filtered by the user, from the deployment block
-to head. This is exactly what breaks on public RPC nodes. Free endpoints for
-Amoy and Mordor reject wide block ranges — "query returned more than N results,"
-"block range too large" — so a from-genesis scan turns into a flood of
-range-limited requests and rate-limit errors. It is the same problem that a
-subgraph exists to solve.
-
-`RegistrySource` sidesteps log scanning entirely because the v2 `WagerRegistry`
-was built with a per-user index on-chain. The contract exposes purpose-built
-pagination views (`contracts/wagers/WagerRegistry.sol`):
-
-```solidity
-function getUserWagerCount(address user) external view returns (uint256);
-function getUserWagerIds(address user, uint256 offset, uint256 limit)
-    external view returns (uint256[] memory);
-function getUserWagers(address user, uint256 offset, uint256 limit)
-    external view returns (Wager[] memory);
-function getWager(uint256 wagerId) external view returns (Wager memory);
-```
-
-These are plain `view` calls — `eth_call`, not `eth_getLogs` — so no node
-rejects them for range. `RegistrySource` reads the count, then pages through the
-structs in fixed windows, capping the total pulled per account so a pathological
-user can't stall the UI:
-
-```js
-async function fetchAllForUser(contract, userAddress) {
-  const total = Number(await contract.getUserWagerCount(userAddress))
-  if (!total) return []
-  const count = Math.min(total, MAX_USER_WAGERS) // 500
-  const wagers = []
-  for (let offset = 0; offset < count; offset += PAGE) { // PAGE = 100
-    const limit = Math.min(PAGE, count - offset)
-    const [ids, structs] = await Promise.all([
-      contract.getUserWagerIds(userAddress, offset, limit),
-      contract.getUserWagers(userAddress, offset, limit),
-    ])
-    for (let i = 0; i < ids.length; i++) wagers.push(toWager(String(ids[i]), structs[i]))
-  }
-  return wagers
-}
-```
-
-Sort, filter, and pagination then happen client-side over this bounded set. One
-detail the RPC path actually improves on: v2 stores explicit `acceptDeadline`
-and `resolveDeadline` on-chain, which the subgraph's events do not carry, so
-`RegistrySource` populates deadlines directly instead of rehydrating them later.
+FairWins sidesteps log scanning entirely because the wager contract was built with a per-user index *baked into the contract itself.* The contract can answer, directly and cheaply, "how many wagers does this user have?" and "give me their wagers, one page at a time." These are the cheap kind of question no node rejects, so the direct source asks for the count and pages through the wagers in fixed-size windows, capping the total per account so one extreme user can't stall the screen. Sorting, filtering, and pagination then happen on the device over that bounded set. As a bonus, the direct path reads each wager's deadlines straight from the contract — data the index's event history doesn't even carry.
 
 ## Fallback is automatic, not just configured
 
-Missing configuration is only one way a subgraph becomes unavailable. The other
-is a configured endpoint that errors or goes down. `SubgraphSource` handles both
-by delegating to `RegistrySource` — and it labels the result so the difference
-is observable in telemetry rather than silent:
+A missing index is only one way things go wrong. The other is a configured index that errors or goes down. FairWins handles both the same way: if a history query to the index fails, it quietly retries through the direct-blockchain source instead — and labels the result so the switch shows up in monitoring rather than passing silently.
 
-```js
-try {
-  const data = await postGraphQL(subgraphUrl, PAGE_QUERY, variables)
-  // ... map rows, return { ..., source: 'subgraph' }
-} catch (err) {
-  console.warn('[SubgraphSource] falling back to RegistrySource (RPC):', err?.message)
-  const fallback = await RegistrySource.listPage({ userAddress, cursor, pageSize, sortKey, filter, chainId })
-  return { ...fallback, source: 'subgraph-fallback' }
-}
-```
+So an Ethereum Classic member uses the direct source because that chain has no index at all, while a Polygon member whose index is briefly unreachable falls through to the direct source and still sees their wagers. The feature never hard-fails just because a data source had a bad day.
 
-So a Mordor user hits `RegistrySource` because the chain has no `subgraphUrl`; a
-Polygon user whose indexer is briefly unreachable transparently falls to
-`subgraph-fallback` over RPC and still sees their wagers. The feature never
-hard-fails on a data-source outage.
+## The harder case: reports that need data direct reads can't cheaply give
 
-## The harder case: reports that need data the RPC can't cheaply give
+Not everything degrades this cleanly. The tax and activity report needs the specific transaction reference and network fee for every transfer — details the contract's paginated views don't return. On indexed networks that's one query. On an un-indexed one it isn't, so the report falls back to two steps: first it *lists* the user's wagers through the same doorway (so enumeration always works), then it does a **bounded** event scan per wager for the transaction detail — never from the beginning. Each wager's creation time gives a tight window to search, and the scan adjusts its own chunk size on the fly under a hard request budget: shrink and retry when a node complains, grow back when things go smoothly.
 
-Not everything degrades this cleanly. The tax/activity report
-(`frontend/src/data/reports/reportDataSource.js`) needs per-transfer transaction
-hashes and gas fees — data the pagination views don't return. On indexed chains
-this is one query: spec 017 added an immutable `WagerTransfer` entity carrying
-txHash, party, direction, token, amount, and timestamp, so `listTransfers` reads
-a user's whole history from the index with no log scan at all.
-
-On an un-indexed chain that path returns `null` and the report falls back to two
-steps. First it *enumerates* the user's wagers over RPC through the same
-`WagerRepository` (so enumeration always works). Then, because it still needs the
-txHash and gas per value movement, it does a **bounded** event scan per wager —
-but never from genesis. Each wager's `createdAt` gives a tight block window, and
-the scan uses adaptive chunking with a hard request budget:
-
-```js
-if (budget.used >= budget.max) { // SCAN_BUDGET = 60 calls per wager
-  throw new Error(
-    'This report period is too large to read from the network without the ' +
-    'indexing subgraph. Try a shorter period, or configure VITE_SUBGRAPH_URL...')
-}
-// on a range/limit error, shrink the chunk and retry; grow it back on success
-if (/range|limit|exceed|too many|big/i.test(msg) && chunk > MIN_CHUNK) {
-  chunk = Math.max(MIN_CHUNK, Math.floor(chunk / 4)); continue
-}
-```
-
-This is degradation that stays honest about its limits: the report works on
-Mordor, but when a requested window genuinely can't be scanned within budget it
-says so and suggests a shorter period, rather than silently returning a partial
-history that a member might file taxes against.
+This is degradation that stays honest about its limits. The report works on Ethereum Classic, but when a window genuinely can't be scanned within budget, it says so and suggests a shorter period — rather than silently returning a partial history a member might file taxes against.
 
 ## Degrade honestly, or hide honestly
 
-Some views can't be reconstructed over RPC at a reasonable cost, and the right
-answer there is to tell the truth rather than fake it. The token holders and
-activity panels are aggregate rollups that only a subgraph produces; on Mordor,
-`tokenSubgraph.js` returns `{ available: false }` and `HoldersPanel` /
-`ActivityPanel` render a plain "unavailable on this network" message
-(`docs/developer-guide/token-mint.md`). The underlying balances and events are
-still enforced on-chain — only the aggregated view is absent — so nothing about
-the guarantee changes, only the convenience layer.
+Some views simply can't be rebuilt from direct reads at a reasonable cost, and the right answer there is to tell the truth rather than fake it. The "token holders" and aggregate activity panels are exactly this: rollups only an index can produce. On a network without one, they render a plain "unavailable on this network" message. The underlying balances and events are still fully enforced on-chain — only the convenient aggregated view is missing — so nothing about the actual guarantees changes.
 
-Membership and role reads never had this problem: `hasRoleOnChain` and the Quick
-Start banner have always read `MembershipManager` over RPC and are chain-aware,
-so they work identically on indexed and un-indexed networks.
+Membership and role checks never had this problem, since they always read the blockchain directly and work identically on indexed and un-indexed networks alike.
 
-## Design decisions
+## Why we built it this way
 
-- **Per-chain source selection over a global switch.** Treating "has an indexer"
-  as network metadata means the same code serves Polygon, Amoy, Mordor, and
-  Hardhat, and a fifth network is a config entry. A global flag would have forced
-  a branch at every call site.
-- **A stable repository boundary.** Because the UI only knows `WagerRepository`
-  and a mapped `Wager` shape, swapping The Graph for Envio, Ponder, or Goldsky
-  later — or falling back to RPC today — is invisible above the data layer.
-- **Contract-supported pagination instead of log scanning.** Investing in
-  on-chain `getUserWager*` views is what makes the RPC path viable on nodes that
-  reject wide `eth_getLogs` ranges. The fallback is only cheap because the
-  contract was designed to be read directly.
-- **Bounded work with honest failure.** The report scan carries an explicit
-  request budget and a windowed range; when a request genuinely exceeds what a
-  public RPC can serve, it surfaces an actionable error instead of a silent
-  partial result. Correctness of a financial report outranks always returning
-  something.
+**Per-chain source selection over a global switch.** Treating "has an index" as network metadata means the same code serves every network, and a fifth one is a config entry rather than a branch at every call site.
 
-The trade-off is real: RPC reads are slower and coarser than an indexed query,
-client-side pagination is bounded rather than unlimited, and a few aggregate
-views are simply absent off the indexed chains. What we buy is that no member on
-an un-indexed network hits a broken screen. Every feature either works, works
-slower, or says plainly that it can't — and which of those happens is a property
-of the network config, not a bug waiting on a chain The Graph may never support.
+**A stable doorway.** Because the interface only knows the doorway and a common wager shape, swapping indexing providers later — or falling back to direct reads today — is invisible to everything above the data layer.
 
-## Sources
+**Contract-supported pagination instead of log scanning.** A per-user index inside the contract is what makes the direct path viable on nodes that reject wide scans. The fallback is only cheap because the contract was designed to be read directly.
 
-- `docs/developer-guide/networks-without-subgraph.md` — the per-chain data-source strategy
-- `frontend/src/data/wagers/WagerRepository.js` — the source-selection boundary
-- `frontend/src/data/wagers/RegistrySource.js` — RPC reads via registry pagination views
-- `frontend/src/data/wagers/SubgraphSource.js` — GraphQL source with automatic RPC fallback
-- `frontend/src/data/reports/reportDataSource.js` — indexed vs. bounded-scan report paths
-- `frontend/src/config/networks.js` — `subgraphUrl`, `getSubgraphUrl`, `hasSubgraph`
-- `contracts/wagers/WagerRegistry.sol`, `contracts/interfaces/IWagerRegistry.sol` — `getUserWagerCount` / `getUserWagerIds` / `getUserWagers` / `getWager`
-- `subgraph/README.md`, `subgraph/networks.json`, `subgraph/schema.graphql` — what the subgraph provides (`Wager`, `WagerTransfer`)
-- `specs/017-subgraph-v2-wager-transfers/` — the `WagerTransfer` entity for reports
-- `specs/015-mordor-network-deployment/` — Ethereum Classic / Mordor deployment
-- `docs/developer-guide/token-mint.md` — truthful "unavailable here" fallback for aggregate panels
-- The Graph documentation — supported networks and subgraph deployment: https://thegraph.com/docs/
+**Bounded work with honest failure.** The report scan carries an explicit budget; when a request genuinely exceeds what a public node can serve, it surfaces an actionable error rather than a silent partial result. For a financial report, correctness outranks always returning something.
+
+The trade-off is real: direct reads are slower and coarser than an indexed query, on-device pagination is bounded, and a few aggregate views are simply absent off the indexed chains. What we buy is that no member on an un-indexed network hits a broken screen. Every feature either works, works slower, or says plainly that it can't — and which of those happens is a property of the network's configuration, not a bug waiting on a chain the indexing service may never support.
+
+## Further reading
+
+- [The Graph documentation](https://thegraph.com/docs/) — what a subgraph is and which networks it supports
+- [Ethereum's `eth_getLogs` reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs) — the event-scanning method that public nodes rate-limit
+- [Ethereum Classic](https://ethereumclassic.org/) — the network at the center of this story

--- a/docs/blog/posts/27-indexing-without-subgraph/social.md
+++ b/docs/blog/posts/27-indexing-without-subgraph/social.md
@@ -2,24 +2,24 @@
 
 ## X (Twitter)
 
-We deployed FairWins to Ethereum Classic and "My Wagers" came back empty — The Graph doesn't index chain 63. Fix: treat the indexer as one swappable source. No subgraph? Read the registry's on-chain pagination views over RPC. eth_call, not eth_getLogs. 🔗 <link>
+We deployed FairWins to Ethereum Classic and "My Wagers" came back empty — The Graph doesn't index that chain, so there was no search index to query. Fix: treat the index as one swappable data source. No index? Read the blockchain directly, using a per-user index baked into the contract instead of a slow log scan. 🔗 <link>
 
 #TheGraph #web3 #multichain
 
 ## LinkedIn
 
-Most multi-chain dApps lean on The Graph for reads — until they deploy to a chain no Graph provider indexes. For us that was Ethereum Classic (chain 63): contracts worked perfectly, but the wager list was empty because there was no indexer to query.
+Most blockchain apps read history through a search-index service — a system like The Graph that watches the chain and answers "show me everything this user did" in milliseconds. Until you deploy to a chain no such service supports. For us that was Ethereum Classic: contracts worked perfectly, but the wager list was empty because there was no index to query.
 
-Our new post walks through how FairWins keeps every read path working when the subgraph isn't there:
+Our new post walks through how FairWins keeps every screen working when the index isn't there:
 
-- Source selection as per-network metadata (`hasSubgraph(chainId)`), not a global flag — a fifth network is a config entry, not a code change.
-- A stable repository boundary so the UI is agnostic to whether a page came from The Graph or direct RPC.
-- Why we read purpose-built on-chain pagination views (`getUserWagerCount` / `getUserWagerIds` / `getUserWagers`) instead of `eth_getLogs` — public RPCs reject wide log ranges.
-- Automatic fallback when a configured indexer errors, and honest degradation for aggregate views that RPC can't cheaply rebuild.
+- "Has an index?" as per-network metadata, not a global flag — a fifth network is a config entry, not a code change.
+- A stable doorway so the interface is agnostic to whether a page came from the index or a direct blockchain read.
+- Why we read a per-user index built into the contract itself instead of scanning the raw event log — public nodes reject wide scans.
+- Automatic fallback when a configured index errors, and honest "unavailable here" messaging for aggregate views a direct read can't cheaply rebuild.
 
 The theme: features should either work, work slower, or say plainly that they can't — and which one happens should be a property of the network config, not a bug.
 
-How do you handle chains your indexing layer doesn't support? 🔗 <link>
+How do you handle chains your indexing service doesn't support? 🔗 <link>
 
 #TheGraph #web3 #blockchain #infrastructure #multichain
 

--- a/docs/blog/posts/28-unified-activity-ledger/blog.md
+++ b/docs/blog/posts/28-unified-activity-ledger/blog.md
@@ -1,142 +1,75 @@
-# The Unified Activity Ledger: One Timeline From Five Disagreeing Sources
+# One Timeline From Five Sources That Kept Disagreeing
 
-*How FairWins merges wagers, transfers, pools, earn, and memberships from subgraph and RPC into a single chronological feed that the dashboard, the transfer list, and the tax report can never contradict.*
+*How FairWins merges wagers, transfers, pools, earn, and memberships into a single activity feed so the dashboard, the transfer list, and the tax report can never contradict each other.*
 
 | | |
 |---|---|
 | **Series** | Multi-chain Infrastructure (part 3) |
-| **Audience** | Full-stack and data engineers |
-| **Tags** | `activity-feed`, `indexing`, `data-modeling`, `the-graph`, `rpc`, `full-stack` |
-| **Reading time** | ~9 minutes |
+| **Audience** | Product managers, founders, and curious builders |
+| **Tags** | `activity-feed`, `data-quality`, `product`, `blockchain` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-## The bug that only a ledger could kill
+## The bug that only a single source of truth could kill
 
-A member opens the Account tab and sees a wager payout dated "20645d ago." Fifty-six years in the future, more or less — the classic Unix epoch-zero timestamp rendered as a relative time. On the same screen, the running profit-and-loss tile disagrees with the number at the top of the tax report they downloaded ten minutes earlier. Neither figure is wrong, exactly; they were computed by two different code paths reading two different sources, and the paths had quietly drifted.
+A member opens their Account tab and sees a wager payout dated "20645d ago" — fifty-six years in the future, roughly. On the same screen, the running profit-and-loss tile disagrees with the total on the tax report they downloaded ten minutes earlier. Neither number is exactly *wrong* — they were each calculated by a different part of the app, reading a different source, and over time the two had quietly drifted apart.
 
-This is the ordinary fate of an activity feed that grows one feature at a time. FairWins accumulated six surfaces that each answered "what happened to my money?" in isolation: the Account dashboard derived wager transfers from cached wager state; the Pay & Transfer activity tab read a local `transferStore`; the tax report enumerated `WagerTransfer` rows from the subgraph; pools, earn, and membership purchases each had their own read path. The dashboard used synthetic timestamps and empty transaction hashes because deriving-from-state is all it had. The report used real block times and real hashes because the subgraph gives you those. When the two are supposed to sum to the same P&L, they can't — not reliably, not across a subgraph-less network like Mordor where one of them has no data at all.
+This is the ordinary fate of an activity feed that grows one feature at a time. FairWins had ended up with six different screens that each answered the same question — "what happened to my money?" — in isolation. The dashboard estimated wager transfers from whatever it had cached; the transfer tab read a small list kept on your device; the tax report pulled its rows from the blockchain index; pools, earn, and memberships each had their own path. And these sources have different fidelity: the blockchain index gives you real transaction times and IDs, while the cached-estimate path has neither, so it invented placeholder timestamps and left the transaction ID blank. When two screens that should add up to the same profit-and-loss are built on sources of different quality, they can't reliably agree — and on a network with no blockchain index at all, one of them has no data to show.
 
-Spec 051 — the unified activity ledger — replaces all six read paths with exactly one. The Account tab, the transfer activity list, `useAccountStats`, and the CSV/PDF tax report now consume the same normalized entry stream. That is the whole point of the design: **their line items and totals are structurally incapable of disagreeing, because there is only one place the numbers come from.** No new backend, no new subgraph entity, no contract change. The entire feature is a client-side aggregation layer living in `frontend/src/data/ledger/`.
+The fix was to replace all six reading paths with exactly one. Today the Account tab, the transfer list, the profit-and-loss tile, and the tax report all draw from the same normalized stream of activity, so their line items and totals are *structurally incapable* of disagreeing — there is only one place the numbers come from. No new server, no change to the blockchain index, no smart-contract change — just one shared layer, living in the app, that gathers and reconciles everything.
 
 ## The shape of one entry
 
-Everything the ledger does hangs off a single canonical value object, the `LedgerEntry`. Heterogeneous events — a USDC send, a wager payout, a pool refund, a failed gasless UserOp — all normalize into the same fields so downstream code never branches on "what kind of thing is this." The vocabulary is frozen in one file, `frontend/src/data/ledger/constants.js`, and shared by sources, repository, UI, and report:
+Everything hangs off a single, uniform record. A dollar send, a wager payout, a pool refund, a failed gasless transaction — they all flatten into the same fields, so the rest of the app never has to ask "what kind of thing is this?" before displaying it. Each record carries a category (wager, transfer, earn, pool, or membership), a more specific kind, a direction, a status, the amount, an optional US-dollar value, a transaction ID and timestamp where those exist, and — crucially — where the record came from. That last field, the record's origin, is how the system decides which of two records describing the same real event should win.
 
-```js
-export const LEDGER_CLASS = Object.freeze({
-  WAGER: 'wager', TRANSFER: 'transfer', EARN: 'earn',
-  POOL: 'pool', MEMBERSHIP: 'membership',
-})
-export const LEDGER_STATUS = Object.freeze({
-  SETTLED: 'settled', PENDING: 'pending',
-  FAILED: 'failed', CANCELLED: 'cancelled',
-})
-export const PROVENANCE = Object.freeze({
-  ONCHAIN: 'onchain', DERIVED: 'derived', CLIENT: 'client',
-})
-```
+## Three kinds of origin, one identity
 
-An entry carries a `class` and a class-specific `kind` (`deposit`, `payout`, `refund`, `send`, `pool_claim`, `voucher_purchase`, and so on), a `direction` (`in` / `out` / `none`), a `status`, the exact `amountRaw` in chain units, an optional `valueUsd` with a `valuationStatus`, a `txHash` and `timestamp` where they exist, and — crucially — a `provenance`. Provenance is not decoration. It is how the merge layer decides which of two rows describing the same event wins.
+Reconciliation begins with identity: every record gets a stable ID reflecting where it came from. There are three origins.
 
-## Three namespaces, one identity
+- **On-chain.** Read directly from confirmed blockchain history, always carries a real transaction ID. This is the high-fidelity truth.
+- **Derived.** Reconstructed from on-chain *state* when there is no indexed event to read — the fallback for networks with no blockchain index. Its ID is built only from the durable facts of the event — network, wager, kind, party — and never from a timestamp or random value, so recomputing yields the same ID every time. That repeatability lets a constantly re-polling system add records without creating phantom duplicates.
+- **Client-only.** Exists solely on this one device. A gasless transaction that failed before the chain ever recorded it lives here.
 
-Reconciliation begins with identity. Every entry gets a stable `entryId` in a namespace that mirrors its provenance, built by pure functions in `frontend/src/data/ledger/identity.js`:
+## The merge: a fixed pecking order, not guesswork
 
-```js
-export function onchainEntryId({ chainId, txHash, logIndex }) {
-  return `oc:${Number(chainId)}:${txHash}:${logIndex ?? 'x'}`
-}
-export function derivedWagerEntryId({ chainId, wagerId, kind, party }) {
-  return `dv:${Number(chainId)}:wager:${String(wagerId)}:${kind}:${String(party || '').toLowerCase()}`
-}
-export function clientEntryId(uuid) {
-  return `cl:${uuid}`
-}
-```
+The hard part of any unified feed is deciding what to do when the same real-world event shows up from two sources at once. FairWins does not try to compare-and-patch the two versions; it applies a fixed pecking order and drops or folds the loser. The rules are short:
 
-- `oc:` — on-chain, re-derivable, always carries a `txHash`. The high-fidelity truth.
-- `dv:` — derived from on-chain *state* when there is no indexed event to read (a subgraph-less network). Deterministic, so re-deriving on the next poll produces a byte-identical id and nothing duplicates.
-- `cl:` — client-only, existing solely on this device. A failed UserOp the chain never recorded lives here.
+1. **Same ID, first one wins** — records with the same ID are identical by construction, so this is just de-duplication.
+2. **On-chain beats derived for the same event.** Both the real indexed record and its derived stand-in are stamped with a shared key identifying the underlying event, so when a genuine on-chain record exists, the derived placeholder is dropped entirely.
+3. **Client-only folds into on-chain.** A device-only record that later matches a confirmed on-chain one isn't shown twice: the on-chain record wins the financial details and absorbs whatever extra context the local record carried.
 
-The derived id is the subtle one. Because it hashes only `(chainId, wagerId, kind, party)` — not a timestamp, not a nonce — calling `list()` twice yields the same id both times. Re-derivation is idempotent, which is what makes an append-only, poll-driven system safe.
+That logic is the antidote to the original bug. The old dashboard made the low-fidelity estimated path primary everywhere; the new design inverts it — the real indexed source is primary, the estimate is a clearly flagged fallback that yields the instant real data arrives, and dashboard and report agree because they read the same merged output.
 
-## The merge: precedence, not reconciliation
+## Sources that can fail without breaking the feed
 
-The hard part of any unified feed is what to do when the same real-world event shows up from two sources. FairWins does not "reconcile" in the sense of comparing and patching; it applies a fixed precedence and drops or folds the losers. The logic is in `mergeEntries` in `identity.js`, and it runs in three passes:
+Each activity domain — wagers, transfers, pools, earn, memberships — is handled by its own small adapter that only reads: none writes anything, crashes on an empty history, or returns data for the wrong network.
 
-1. **Union by `entryId`.** First occurrence wins. Append-only records with the same id are identical by construction, so this is a set union.
-2. **`oc:` beats `dv:` for the same underlying event.** Both the subgraph row and the derived fallback stamp the same `refs.dedupKey` — `wager:{wagerId}:{kind}` — so when a real indexed event exists, the derived stand-in for that event is filtered out entirely.
-3. **`cl:` folds into `oc:` by `txHash`.** A client record that later matches a confirmed on-chain entry is not shown twice: the on-chain entry wins the financial fields and gains the client record's context (its `route`, its linked id) as annotations.
+The feed runs all those adapters at once and waits for each to settle. The important property: if one fails, the feed does not go blank — that category is marked temporarily stale, and the app *discloses that honestly*. So if the blockchain index is down but your local transfer list is healthy, you still see your transfers, with a visible note that pool and membership history is momentarily out of date. Graceful degradation, earned one adapter at a time.
 
-```js
-merged = merged.filter(
-  (e) => !(namespaceOf(e.entryId) === 'dv'
-        && e.refs?.dedupKey
-        && onchainDedupKeys.has(e.refs.dedupKey)),
-)
-```
+## Rules that keep the numbers honest
 
-That single filter is the antidote to the original bug. The old Account tab made the derived path primary everywhere; the ledger inverts it — subgraph transfers are primary (they carry the `txHash` and real block time the tax report needs), and the derived path is a clearly flagged fallback that yields the moment real data arrives. Dashboard and report agree because they read the *same* merged output, with the *same* precedence, from the same query.
+Before any record is shown, a normalization step enforces the guarantees that killed the original defects:
 
-## Sources that fail without failing the ledger
+- **A timestamp is either a real date or explicitly nothing — the placeholder "zero" date never survives.** A missing or zero time becomes an honest "date unavailable," so "20645d ago" is now impossible.
+- **A failed operation counts as moving no money.** Failed items are still *listed everywhere* — a failed gasless send, with the exact reason it failed, is first-class history — but excluded from every total.
+- **An asset with no known price is flagged, never silently valued at zero,** so it can't quietly skew your profit-and-loss.
+- **Records are strictly scoped to the network you asked about,** so one network's data can never leak into another's totals.
 
-Each activity domain is a `LedgerSource` adapter under `frontend/src/data/ledger/sources/`, implementing a deliberately small contract: a `class` string and an async `list(ctx)` that performs reads only, never writes a store, never throws on empty history, and never returns an entry for a chain other than the one queried. The wager source (`wagerLedgerSource.js`) is the richest — it tries the subgraph's `WagerTransfer` rows first and, on a subgraph-less network, falls back to `deriveTransfersFromWagers` with block times hydrated by a bounded RPC scan:
+## Durability without keeping a dossier
 
-```js
-const indexed = await listTransfers({ account })
-if (indexed !== null && indexed !== undefined) {
-  return indexed.map((row) => wagerTransferToEntry(row, { chainId, account }))
-}
-// Subgraph-less network — derive from wager state (the My Wagers truth).
-let wagers = await listWagers({ account, chainId })
-wagers = await hydrate(wagers, chainId)   // real block times, bounded scan
-const derived = deriveTransfersFromWagers({ wagers, address: account })
-return derived.map((row) => derivedTransferToEntry(row, { chainId, account }))
-```
+On-chain and derived records are never stored — they rebuild from public blockchain data on any device, which keeps backups tiny and keeps FairWins from hoarding a profile of your activity. Only the device-only records need durable storage, kept as an append-only log inside the platform's existing encrypted backup and merged by de-duplication on restore, so history is never destructively overwritten.
 
-The repository (`ledgerRepository.js`) assembles all sources with `Promise.allSettled`. A source that rejects does not blank the feed — its class is added to `staleClasses`, which the UI discloses honestly rather than hiding:
+## Why we built it this way
 
-```js
-settled.forEach((res, i) => {
-  if (res.status === 'fulfilled') collected.push(...res.value)
-  else staleClasses.push(sources[i].class)
-})
-```
+- **Reconcile in the app, not on a server.** A server-side ledger would only see traffic that passed through our relayer, would add another thing that has to be online, and would mean keeping a dossier of every member's activity — against the platform's privacy stance. Every source was already readable from the app; all that was missing was one layer to gather and reconcile it.
+- **A fixed pecking order beats fuzzy reconciliation.** Assigning every event an origin and applying one clear precedence rule is simpler and more predictable than comparing two versions and patching them together — and repeatable derived IDs make it safe to run over and over.
+- **Honest degradation, and known limits stated plainly.** Stale categories, unpriced assets, and unavailable dates are all surfaced so limits are disclosed, never hidden; automatic cleanup can never touch the current or previous tax year. Earn actions taken outside the app aren't in the feed, and pool and membership history need the network's blockchain index — on index-free networks those return an honest empty list rather than a wrong guess.
 
-So if the subgraph is down but the local transfer store is healthy, you still see your transfers, with a visible note that pool and membership history is temporarily stale. Graceful degradation is a property of the whole ledger, earned one source boundary at a time.
+The result is boring in the best possible way: one reading path, five categories, three kinds of origin — and a dashboard and tax report that finally read from the same page.
 
-## Invariants that make the numbers honest
+## Further reading
 
-Normalization (`normalize.js`) is where pre-items become validated entries, and it enforces the guarantees that kill the original defects:
-
-- **`timestamp` is real epoch milliseconds or `null` — the value `0` never survives.** A missing or zero time becomes `null` with `timestampProvenance: 'unavailable'`, and `formatRelativeTime` returns `null` for invalid input so the UI renders an explicit "date unavailable." The "20645d ago" render is now unreachable.
-- **`status: 'failed'` forces `direction: 'none'`.** Failed operations moved no value. They are *listed everywhere* — a failed gasless send with its verbatim bundler reason is first-class history — but excluded from every total by the summary helpers, not by omission.
-- **`valuationStatus: 'unvalued'` entries are flagged, never zeroed or dropped.** An asset with no price source is honestly marked, so it can't silently distort a P&L.
-- **Entries are strictly scoped to the queried `chainId`;** normalization throws if a source leaks a cross-chain row.
-
-Because the repository returns immutable value objects and never mutates a returned entry, these invariants hold all the way to the render layer.
-
-## Durability without a dossier
-
-On-chain and derived entries are never persisted — they re-derive from public data on any device, which keeps backups small. Only the `cl:` records (failed UserOps, in-flight sends) need durable storage, and they live in an append-only `ledgerClientStore`: a status transition appends a superseding record via `refs.supersedes` rather than mutating history. That store rides along in the spec-032 encrypted backup as the `activityLedger` synced object, merged by `entryId` union in both restore modes — a destructive replace would violate the audit guarantee. A one-time, marker-guarded `migrate.js` imports the legacy `fairwins.transfers.v1` log with id-stable mapping, so pre- and post-migration data dedup cleanly.
-
-## Design decisions
-
-- **Client-side aggregation over a server ledger.** A relay-gateway ledger would only ever see relayed traffic, would add an availability dependency, and would violate the platform's no-dossier privacy stance. Every source the ledger needs already had a client read path; what was missing was one normalization and merge layer.
-- **Precedence over reconciliation.** Rather than compare-and-patch, the merge assigns each event to a namespace and applies a fixed `oc: > dv:`, `cl:`-folds-into-`oc:` order. Deterministic derived ids make this idempotent under polling.
-- **Subgraph primary, derived fallback — the inverse of the old dashboard.** This is the single change that lets the report and the dashboard agree: both consume the same merged stream where the high-fidelity source always wins.
-- **Honest degradation as a first-class output.** `staleClasses`, `prunedBefore`, `valuationStatus`, and `timestampProvenance` are all returned to the UI so limits are disclosed, never hidden. Pruning can never touch the current or previous tax year.
-- **Known limits, stated plainly.** Earn actions made outside the app aren't in the ledger (there's no fixed vault registry to scan); pool and membership history require the chain's subgraph and return an honest empty list on RPC-only networks.
-
-The result is boring in the best way. One read path, five classes, three provenance namespaces, and a merge that a test suite can pin down completely because every function in it is pure.
-
-## Sources
-
-- `specs/051-unified-activity-ledger/spec.md`, `plan.md`, `research.md` (decisions D1–D9), `data-model.md`
-- `specs/051-unified-activity-ledger/contracts/ledger-source.md`, `ledger-entry.md`, `backup-object.md`
-- `docs/developer-guide/activity-ledger.md`
-- `frontend/src/data/ledger/`: `ledgerRepository.js`, `identity.js`, `normalize.js`, `constants.js`, `ledgerClientStore.js`, `migrate.js`, `timestamps.js`
-- `frontend/src/data/ledger/sources/`: `wagerLedgerSource.js`, `transferLedgerSource.js`, `poolLedgerSource.js`, `earnLedgerSource.js`, `membershipLedgerSource.js`
-- The Graph documentation — https://thegraph.com/docs/
-- Unix epoch / timestamp conventions — https://en.wikipedia.org/wiki/Unix_time
+- The Graph — how blockchain data gets indexed for apps to read: https://thegraph.com/docs/
+- Unix time — why a "zero" timestamp renders as a date decades off: https://en.wikipedia.org/wiki/Unix_time
+- For more on how FairWins is built, see the FairWins developer documentation.

--- a/docs/blog/posts/28-unified-activity-ledger/social.md
+++ b/docs/blog/posts/28-unified-activity-ledger/social.md
@@ -1,29 +1,29 @@
-# Social & Image — The Unified Activity Ledger
+# Social & Image — One Timeline From Five Sources
 
 ## X (Twitter)
 
-Your dashboard says one P&L, your tax report says another. Both read different sources. We killed the drift with ONE ledger: 5 activity classes, 3 provenance namespaces (oc:/dv:/cl:), a merge where the on-chain row always beats the derived one. 🔗 <link>
+Your dashboard says one profit-and-loss number, your tax report says another. Both were reading different sources, and they drifted. We killed it with ONE activity feed: five categories, three kinds of origin, and a merge where the real on-chain record always beats the estimated one. 🔗 <link>
 
-#web3 #datamodeling #thegraph
+#web3 #dataquality #product
 
 ## LinkedIn
 
-An activity feed that grows one feature at a time eventually lies to you. At FairWins we had six read paths each answering "what happened to my money?" — the dashboard derived wager transfers from cached state, the tax report read real subgraph events, transfers lived in a local store. Predictably, the totals drifted, and one path even rendered a payout dated "20645d ago" from a zero timestamp.
+An activity feed that grows one feature at a time eventually lies to you. At FairWins we had six different screens each answering "what happened to my money?" — the dashboard estimated from cached state, the tax report read real blockchain history, transfers lived in a local list. Predictably, the totals drifted, and one path even rendered a payout dated "20645d ago" from a placeholder timestamp.
 
-Spec 051 replaces all six with a single client-side activity ledger. The new engineering post walks through:
+The new post replaces all six with a single activity feed built into the app, and walks through:
 
-- The canonical LedgerEntry: five activity classes (wager, transfer, earn, pool, membership) normalized into one value object.
-- Three identity namespaces — on-chain, derived, client-only — and a merge that applies fixed precedence instead of fragile reconciliation.
-- Source adapters that degrade honestly: a failing subgraph marks its class stale, it doesn't blank the feed.
-- Invariants that make totals trustworthy: zero timestamps become "date unavailable," failed operations are listed but never totaled, unpriced assets are flagged not zeroed.
+- One uniform record: five categories (wager, transfer, earn, pool, membership) flattened into the same shape.
+- Three kinds of origin — on-chain, derived, and device-only — and a merge that applies a fixed pecking order instead of fragile guesswork.
+- Sources that degrade honestly: if one fails, that category is marked stale, the whole feed doesn't go blank.
+- Rules that make totals trustworthy: placeholder dates become "date unavailable," failed operations are listed but never totaled, unpriced assets are flagged not zeroed.
 
-No new backend, no subgraph change, no contract change — just one read path the dashboard and the tax report both consume, so they can't disagree.
+No new server, no blockchain-index change, no contract change — just one reading path the dashboard and the tax report both consume, so they can't disagree.
 
 🔗 <link>
 
 How do you keep a multi-source activity feed from quietly contradicting itself?
 
-#Web3 #DataEngineering #TheGraph #Blockchain #FullStack
+#Web3 #DataQuality #Product #Blockchain
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/29-ai-security-review-ci/blog.md
+++ b/docs/blog/posts/29-ai-security-review-ci/blog.md
@@ -1,110 +1,77 @@
-# The LLM Reviewer That Never Merges Your Code
+# The AI Reviewer That Reads Every Contract Change — And Can Never Approve One
 
-*How FairWins wires an AI smart-contract security reviewer into CI as one layer among many — advisory by design, never the gate*
+*How FairWins adds an AI security reviewer to its pipeline as one layer among many — advisory by design, never the thing that lets code ship*
 
 | | |
 |---|---|
 | **Series** | Security & DevOps (Part 1 of 4) |
-| **Audience** | Security engineers, AI-curious contract devs |
-| **Tags** | smart-contract-security, ci-cd, llm, static-analysis, solidity |
-| **Reading time** | ~9 minutes |
+| **Audience** | Founders, product leads, and AI-curious builders |
+| **Tags** | smart-contract-security, ai, code-review, quality |
+| **Reading time** | ~7 minutes |
 
 ---
 
-A developer opens a pull request that touches `contracts/wagers/WagerRegistry.sol`. It adds a new refund path: if a wager expires unaccepted, the maker can pull their stake back. Straightforward — twelve lines, one external token transfer, one storage write.
+A developer opens a change to one of FairWins' core contracts — the one that escrows every wager. It adds a new refund path: if a wager expires before anyone accepts it, the creator can pull their stake back. A dozen lines, one token transfer, one bit of saved state.
 
-Within a few minutes, three different things look at that diff, and they disagree about what matters.
+Within a few minutes, three different things look at that change and disagree about what matters. An automated code scanner flags a known-risky pattern around the transfer. A test-coverage check reports that the new branch is exercised by exactly one test. And an AI teammate leaves a comment that reads less like a tool and more like a colleague: the refund quietly emits no notification event, the "only the creator can do this" rule should be stated explicitly rather than assumed, and touching this contract's stored data deserves a second look, since it is an upgradeable contract where the shape of stored data must stay stable.
 
-Slither, running in GitHub Actions, flags a reentrancy pattern on the transfer and notes the external call ordering. The coverage job reports that the new branch is exercised by exactly one test. And a fourth reviewer — an AI teammate configured in `.github/agents/smart-contract-security.agent.md` — leaves a PR comment that reads less like a linter and more like a colleague: it points out that the refund emits no event, that the maker-only check should be spelled out against `msg.sender` rather than inferred, and that the new path pushes the contract's storage layout in a way that deserves a second look given `WagerRegistry` is a UUPS proxy.
+None of the three is the final word. The scanner produces false alarms; the coverage number is a proxy for thoroughness, not proof; and the AI reviewer is a language model — fluent, confident, and occasionally wrong in ways that are *harder* to catch precisely because it writes so plausibly. So the interesting question was never "can an AI find bugs in a smart contract?" It was: **how do you place an AI reviewer into a pipeline so it adds signal without adding noise — and without anyone mistaking its output for a guarantee?**
 
-None of these three is authoritative. The static analyzer produces false positives on patterns it can't fully model. The coverage number is a proxy, not proof. And the AI reviewer is a language model — confident, fluent, and occasionally wrong in ways that are harder to spot precisely *because* it writes so plausibly. The interesting engineering problem is not "can an LLM find bugs in Solidity." It's: **how do you place an LLM reviewer into a pipeline so that it adds signal without adding noise, and without anyone mistaking its output for a guarantee?**
+## Several layers, each with a different blind spot
 
-This is how FairWins does it.
+FairWins treats every line of on-chain code as hostile until proven otherwise — it handles real money held in escrow. The project's own standards make the security bar non-negotiable, and deliberately name *several* mechanisms, not one:
 
-## Three layers, three failure modes
+- Automated static analysis must pass with no new serious findings.
+- Logic that manages state must survive automated stress-testing (throwing large volumes of random inputs at it) and, on a slower cadence, deeper mathematical exploration of the states it can reach.
+- Every contract change must be reviewed against the AI security reviewer.
+- Human security review — and, for the highest-risk paths, an external audit — remains the final word.
 
-FairWins treats every line of on-chain code as adversarial-by-default — it handles user funds in escrow. The project constitution (`.specify/memory/constitution.md`, Principle I) makes the security bar non-negotiable, and it names *four distinct mechanisms*, not one:
+Each has a *different* blind spot, which is exactly why they are stacked. The static scanner is fast and consistent but only catches patterns it was taught to recognize. The stress-testing tools explore far more behavior but are slow and finicky. Human review is the deepest but the scarcest resource — and human attention fatigues.
 
-- Static analysis (Slither) must pass with no new high/critical findings.
-- Stateful logic must survive fuzzing (Medusa) and, weekly, symbolic execution (Manticore).
-- Every `contracts/` change must be reviewed against the smart-contract security agent.
-- Human security review and, for the highest-risk paths, external audit remain the final word.
+The AI reviewer fills a specific gap. It reads a change the way a person does — in context, with an eye for intent — and reasons about things a pattern-scanner handles poorly: a missing notification event, an access-control comment that doesn't match the rule it describes, a refund path inconsistent with the rest of the contract. It is good at the "a careful teammate would raise an eyebrow here" category, and bad, unavoidably, at being consistent.
 
-Each of these has a *different* failure mode, and that's the entire point of stacking them. Slither is deterministic and fast but pattern-bound: it catches what its detectors encode and stays silent on novel logic errors. Medusa and Manticore explore state space but are expensive and fragile — Manticore is a best-effort weekly job precisely because its install is brittle and its runs are slow. Human review is the deepest but the scarcest resource, and it fatigues.
+## What the reviewer actually is
 
-The LLM reviewer occupies a specific gap. It reads a diff the way a reviewer does — in context, with intent — and it reasons about things a detector doesn't model well: is this event missing, is this NatSpec wrong, does this access-control comment actually match the modifier, is this refund path consistent with how the *rest* of `WagerRegistry` handles deadlines? It is good at the "a careful teammate would raise an eyebrow here" category. It is bad, unavoidably, at determinism.
+The reviewer is not a custom-trained model — it is an off-the-shelf AI coding agent, configured with a written brief that gives it a persona, a review method, and a strict scope. It wakes on changes that touch contract code and posts comments inline, the same place a human reviewer would.
 
-## What the agent actually is
+That brief is deliberately opinionated about *how* the reviewer may speak. Every finding must follow one fixed shape: a severity label, the precise location, a plain description, what could happen if it were exploited, a concrete recommended fix, and a reference to a recognized security standard. That template is a noise-control device: an AI asked to simply "review this contract" will generate paragraphs of generic advice, but forcing every comment to carry a severity, a location, a real consequence, and an actionable fix means a vague, un-pin-downable comment tends not to get written at all. Severity comes from a fixed scale with worked definitions, so "Critical" means "funds could be lost or the contract fully compromised," not "the model felt strongly."
 
-The agent is not a bespoke model or a fine-tune. It's a GitHub Copilot coding-agent configuration — a single markdown file that defines a persona, a review methodology, and a strict scope. It triggers on pull requests that modify `.sol` files under `contracts/` and posts review comments inline, the same surface a human reviewer uses.
+The review method mirrors the checklist a human security engineer would run — access control, reentrancy, arithmetic safety, oracle manipulation, and the extra care upgradeable contracts demand — and frames findings against a published, industry-recognized set of security levels, giving severity a shared external vocabulary instead of a per-reviewer gut call.
 
-The configuration is deliberately opinionated about *how* to speak. Every finding is forced into one shape (`.github/agents/smart-contract-security.agent.md`):
+## Scoped tight, so it stays worth reading
 
-```
-**[SEVERITY] Issue Title**
-
-**Location**: `contracts/Example.sol:123-145`
-
-**Description**: [what and why]
-**Impact**: [what happens if exploited]
-**Recommendation**: [specific fix, with code]
-**Reference**: [standard / EthTrust-SL level requirement]
-```
-
-That template is a noise-control mechanism. An unconstrained LLM asked to "review this contract" will happily generate paragraphs of generic advice. Forcing every comment to carry a severity, a precise location, a concrete impact, and an actionable fix means a comment that can't be pinned to a line and an exploit path tends not to get written at all. Severity is drawn from a fixed taxonomy — Critical, High, Medium, Low, Informational — with worked definitions, so "Critical" means "loss of funds or complete compromise," not "the model felt strongly."
-
-The methodology mirrors the same checklist a security engineer would run: access control, reentrancy and checks-effects-interactions, integer operations, unchecked external calls, oracle manipulation, DoS via unbounded loops, timestamp dependence, and — relevant to FairWins specifically — proxy initialization and delegatecall safety, because `WagerRegistry` and `MembershipManager` are UUPS proxies with append-only storage. Findings are framed against the [EthTrust Security Levels](https://entethalliance.org/specs/ethtrust-sl/), which gives severity a shared external vocabulary instead of a per-reviewer gut call.
-
-## Scoped to be signal, not noise
-
-The single most important configuration choice is what the agent *refuses* to review. Its scope section is explicit: Solidity contracts, deployment scripts, and contract-adjacent integration code — and **not** React/TypeScript frontend, backend APIs, generic CI/CD config, non-Ethereum code, or documentation-only changes.
-
-This narrowing does real work. An LLM that comments on everything trains reviewers to ignore it; the tenth reflexive "consider adding a comment here" on a docs PR is the one that gets the whole bot muted. By binding the agent to the highest-value, highest-risk file type and staying quiet elsewhere, its comments stay dense. The configuration guide (`docs/developer-guide/ethereum-security-agent-configuration.md`) goes further, letting a project exclude `contracts/mocks/` and test contracts, and tune review depth per contract — a full analysis on fund-custody paths, a lighter pass on interfaces and libraries. In FairWins' repo map, `mocks/` is test-only and `contracts-archive/` is reference-only; there's no value in an AI reviewer litigating code that never ships.
+The single most important choice was deciding what the reviewer *refuses* to look at. Its scope is explicit: smart contracts and the code directly around them — and *not* the web frontend, backend services, generic pipeline config, or documentation-only edits. That narrowing does real work. An AI that comments on everything trains people to ignore it — the tenth reflexive "consider adding a comment here" on a docs change is the one that mutes the whole bot. Keeping the reviewer bound to the highest-risk code and quiet elsewhere is what keeps its comments dense and worth reading.
 
 ## The line we do not cross: advisory, never the gate
 
-Here is the design decision that matters most, and the one most easily gotten wrong.
+This is the design decision that matters most. The AI reviewer has **no ability to block a change from shipping.** The deterministic layers — the test suite, the coverage check, the static scanner — are required checks that can turn the merge button red. The AI's output is *not* one of them: it posts comments; it never sets a required check.
 
-The AI reviewer does **not** have a merge-blocking status check of its own. Look at `.github/workflows/security-testing.yml` and you'll find the deterministic layers — Hardhat tests, coverage, and Slither — wired as jobs. Slither runs `slither . --config-file slither.config.json --checklist`; its output is deterministic and reproducible, which is what lets it be a gate. The LLM's output is not in that workflow. It posts comments; it does not set a required check that turns the merge button red.
+That asymmetry is intentional. A gate has to be *reproducible* — run it twice on the same code and get the same answer — or it becomes a flaky, resented obstacle. AI output is non-deterministic: the same change can yield differently-worded findings, or a finding on one run and silence on the next. Wiring that into a required check would either block work arbitrarily or, far worse, teach the team that a green "AI security passed" badge means the code is safe. It doesn't — it means one probabilistic reviewer didn't object this time.
 
-That asymmetry is intentional. A gate has to be *reproducible* — run it twice on the same commit and get the same answer — or it becomes a flaky, resented obstacle. LLM output is non-deterministic by construction; the same diff can yield differently-worded findings, or a finding on one run and silence on the next. Wiring that into a required check would either block merges arbitrarily or, worse, teach the team that a green "AI security" check means the code is safe. It doesn't. It means one probabilistic reviewer didn't object this time.
+So the tests and scanner are the gates, and the AI reviewer is a colleague whose comments a human still has to read and judge. The requirement is that a change *be reviewed against* the AI, not that the AI *approve* it — human security review remains the merge authority.
 
-So the enforcement structure is: Slither and the test suite are gates. Medusa and Manticore are scheduled deep-dives. The AI agent is a reviewer whose comments a human must still read and adjudicate — exactly like a human colleague's comments. The constitution requires that a change *be reviewed against* the agent, not that the agent *approve* it. Human security review remains the merge authority.
+## Being honest about what an AI reviewer can't do
 
-## Being honest about what an LLM reviewer can't do
+Any team adopting this should say the quiet parts out loud.
 
-Any team adopting this should say the quiet parts out loud:
+- **It hallucinates with confidence.** The failure mode isn't silence — it's a fluent, well-formatted finding that cites a real-sounding standard for a vulnerability that isn't there. Every finding still needs a human to confirm the risk is real.
+- **There is no guarantee of what it catches.** Unlike the static scanner, whose rule set is finite and knowable, you cannot say what the AI will and won't find. A missed problem leaves no trace, and silence is not evidence of safety.
+- **It sees the change, not the whole system.** It reasons well about local details and poorly about how contracts interact, economic attacks, and exploits that unfold across many transactions — exactly where stress-testing and human auditors earn their keep.
+- **It is not an attacker.** A real adversary chains together borrowed funds, reordered transactions, and manipulated price feeds. The AI is a careful reviewer, not a red team.
 
-- **It hallucinates with confidence.** The failure mode isn't silence; it's a fluent, well-formatted finding that cites a real-sounding standard for a vulnerability that isn't there. The structured template curbs this but does not eliminate it. Every finding still needs a human to confirm the exploit path is real.
-- **No ground truth, no recall guarantee.** Unlike Slither, whose detector set is enumerable, you cannot say what the LLM will and won't catch. A missed vulnerability leaves no trace. Absence of comments is not evidence of safety.
-- **It sees the diff, not the system.** It reasons well about local patterns and less well about cross-contract invariants, economic attacks, and multi-transaction state machines — precisely where Medusa's fuzzing and Manticore's symbolic execution earn their keep, and where human auditors are irreplaceable.
-- **It is not adversarial.** A real attacker composes flash loans, reorderings, and oracle manipulation across calls. The agent is a careful reviewer, not a red team.
-
-The right mental model is a tireless, well-read junior security engineer who reviews every single PR without fatigue, writes tidy comments, and must never be trusted as the last line of defense. Its value is catching the *ordinary* issues early — the missing event, the unchecked return value, the CEI violation, the undocumented access-control assumption — so that human reviewers and the deterministic tooling spend their scarce attention on the hard, systemic, economic questions that no current LLM can be trusted to answer.
+The right mental model is a tireless, well-read junior security engineer who reviews every change without fatigue and must never be trusted as the last line of defense. Its value is catching the *ordinary* issues early — so human reviewers and the deterministic tooling can spend their scarce attention on the hard, systemic questions no AI can be trusted to answer.
 
 ## Trade-offs
 
-- **Non-deterministic reviewer, deterministic gates.** We accept that the AI layer can't block merges, in exchange for never letting a probabilistic pass masquerade as a safety guarantee.
-- **Narrow scope over broad coverage.** Restricting the agent to Solidity keeps its signal-to-noise high at the cost of ignoring frontend and infra — which are covered by their own tooling.
-- **Structured comments over free-form insight.** Forcing severity/location/impact/fix reduces the occasional brilliant tangent but makes the median comment actionable and auditable.
-- **A layer that complements, never replaces.** The agent is cheap and continuous; Slither is reproducible; fuzzing and symbolic execution are deep; humans and auditors are final. Removing any one weakens the stack, but no single layer — least of all the LLM — is sufficient alone.
+The design comes down to a few deliberate exchanges. We accept that the AI layer can't block changes, so a probabilistic pass can never masquerade as a safety guarantee. We restrict it to contract code to keep its signal high. And we force every comment into a rigid severity/location/impact/fix shape, losing the occasional brilliant tangent but making the typical comment actionable. The through-line: the AI is cheap and continuous, the scanner is reproducible, stress-testing is deep, humans and auditors are final — remove any one and the stack weakens, but no single layer, least of all the AI, is sufficient alone.
 
 ---
 
 > **A note on responsible use:** FairWins is a platform for peer-to-peer wagers on public-information forecasting. The security tooling described here protects escrowed user funds; it is not a substitute for professional audit, and participants remain subject to applicable law.
 
-## Sources
+## Further reading
 
-- `.github/agents/smart-contract-security.agent.md` — agent persona, methodology, severity taxonomy, comment template, scope limits
-- `.github/agents/README.md` — trigger conditions and team-member framing
-- `docs/developer-guide/ethereum-security-agent.md` — full agent guide, how PR review works
-- `docs/developer-guide/ethereum-security-agent-configuration.md` — severity thresholds, exclusions, per-contract review depth, CI integration options
-- `docs/developer-guide/ethereum-security-quickstart.md` — developer workflow and the explicit "not a replacement for audits/human review" note
-- `docs/developer-guide/ethereum-security-agent-examples.md` — worked example findings
-- `.github/workflows/security-testing.yml` — deterministic CI gates (Hardhat tests, coverage, Slither)
-- `.github/workflows/torture-test.yml` — weekly Manticore symbolic execution and Medusa fuzzing
-- `.specify/memory/constitution.md` — Principle I, Security-First Smart Contracts (non-negotiable multi-mechanism requirement)
-- [EthTrust Security Levels](https://entethalliance.org/specs/ethtrust-sl/) — Enterprise Ethereum Alliance
-- [SWC Registry](https://swcregistry.io/) — Smart Contract Weakness Classification
-- [Slither](https://github.com/crytic/slither) and [building-secure-contracts](https://github.com/crytic/building-secure-contracts) — Trail of Bits
-- [Consensys Smart Contract Best Practices](https://consensys.github.io/smart-contract-best-practices/)
+- EthTrust Security Levels, Enterprise Ethereum Alliance — the security-level vocabulary findings are framed against: https://entethalliance.org/specs/ethtrust-sl/
+- Smart Contract Weakness Classification (SWC) Registry — a catalog of common contract vulnerabilities: https://swcregistry.io/
+- Consensys Smart Contract Best Practices — a widely used security reference: https://consensys.github.io/smart-contract-best-practices/
+- Trail of Bits, "Building Secure Contracts" — public guidance on tooling and secure design: https://github.com/crytic/building-secure-contracts

--- a/docs/blog/posts/29-ai-security-review-ci/social.md
+++ b/docs/blog/posts/29-ai-security-review-ci/social.md
@@ -1,30 +1,30 @@
-# Social & Image — The LLM Reviewer That Never Merges Your Code
+# Social & Image — The AI Reviewer That Reads Every Contract Change
 
 ## X (Twitter)
 
-We put an AI security reviewer in CI for our Solidity contracts. The key design call: it can NEVER block a merge. LLM output is non-deterministic — a green "AI-passed" check would be a lie. It's an advisory layer alongside Slither, fuzzing + humans. 🔗 <link>
+We put an AI security reviewer into our pipeline to read every smart-contract change. The key design call: it can NEVER let code ship. AI output is non-deterministic — a green "AI-passed" badge would be a lie. It's an advisory layer alongside automated scanners, stress-testing + humans. 🔗 <link>
 
-#SmartContractSecurity #Solidity #DevOps
+#SmartContractSecurity #AI #DevOps
 
 ## LinkedIn
 
-An LLM will happily "review" your smart contract. The hard part isn't getting findings — it's placing that reviewer in your pipeline so it adds signal instead of noise, and so nobody mistakes its output for a guarantee.
+An AI will happily "review" your smart contract. The hard part isn't getting findings — it's placing that reviewer in your pipeline so it adds signal instead of noise, and so nobody mistakes its output for a guarantee.
 
-Part 1 of our Security & DevOps series walks through how FairWins wires an AI smart-contract security reviewer into CI alongside — never in place of — the deterministic tooling. What the post covers:
+Part 1 of our Security & DevOps series walks through how FairWins adds an AI security reviewer that reads every contract change — alongside, never in place of, the deterministic tooling. What the post covers:
 
-- Why the AI reviewer is advisory only, with no merge-blocking status check, while Slither and the test suite are the actual gates (reproducibility is the dividing line).
-- How a strict comment template — severity, location, impact, fix, standard — turns a chatty model into an auditable reviewer.
-- Scoping it to Solidity only, so its comments stay dense and don't get muted.
-- An honest accounting of what LLM review can't do: confident hallucinations, no recall guarantee, no adversarial reasoning across transactions.
+- Why the AI reviewer is advisory only, with no ability to block a change, while the test suite and static scanner are the actual gates (reproducibility is the dividing line).
+- How a strict comment template — severity, location, impact, fix, standard — turns a chatty model into a reviewer you can actually act on.
+- Scoping it to contract code only, so its comments stay dense and don't get muted.
+- An honest accounting of what AI review can't do: confident hallucinations, no guarantee of what it catches, no adversarial reasoning across transactions.
 
-Four layers, four different failure modes — static analysis, fuzzing/symbolic execution, an LLM reviewer, and human audit. The LLM is the tireless junior engineer on that team, never the last line of defense.
+Several layers, each with a different blind spot — static analysis, stress-testing, an AI reviewer, and human audit. The AI is the tireless junior engineer on that team, never the last line of defense.
 
 🔗 <link>
 
-How are you drawing the line between AI assistance and AI authority in your security pipeline?
+How are you drawing the line between AI assistance and AI authority in your security process?
 
-#SmartContractSecurity #AISecurity #Solidity #DevSecOps #Web3
+#SmartContractSecurity #AISecurity #DevSecOps #Web3
 
 ## Image prompt (Gemini / Nano Banana)
 
-A clean, modern editorial illustration in isometric style depicting a smart-contract pull request passing through four distinct inspection stations arranged in a row along a conveyor belt: a rigid geometric scanner grid (deterministic static analysis), a turbulent particle field (fuzzing and symbolic execution), a softly glowing translucent lens shaped like a speech bubble that hovers and observes but does not touch the belt (the advisory AI reviewer), and a solid human-scale gatekeeping arch at the end (human review, the real gate). A stylized code block travels left to right; only the final arch has a physical barrier, while the glowing lens leaves gentle annotations floating beside the code. Deep navy and teal base palette with a single warm amber accent used only on the glowing AI lens and its floating notes. Soft directional lighting from upper left, subtle depth and long clean shadows, minimal background, plenty of negative space. No text, no logos, no watermarks. Aspect ratio 16:9.
+A clean, modern editorial illustration in isometric style depicting a smart-contract change passing through four distinct inspection stations arranged in a row along a conveyor belt: a rigid geometric scanner grid (deterministic static analysis), a turbulent particle field (stress-testing), a softly glowing translucent lens shaped like a speech bubble that hovers and observes but does not touch the belt (the advisory AI reviewer), and a solid human-scale gatekeeping arch at the end (human review, the real gate). A stylized code block travels left to right; only the final arch has a physical barrier, while the glowing lens leaves gentle annotations floating beside the code. Deep navy and teal base palette with a single warm amber accent used only on the glowing AI lens and its floating notes. Soft directional lighting from upper left, subtle depth and long clean shadows, minimal background, plenty of negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/30-coverage-audit-gates/blog.md
+++ b/docs/blog/posts/30-coverage-audit-gates/blog.md
@@ -1,6 +1,6 @@
-# Coverage and Audit Gates That Fail Loudly
+# Quality Gates That Fail Loudly
 
-*How a false 0% on the escrow contract taught us to wire quality gates so a regression physically cannot merge*
+*How a false 0% on our escrow contract taught us to build guardrails that physically stop a risky change from shipping*
 
 ---
 
@@ -8,114 +8,70 @@
 |---|---|
 | **Series** | Security & DevOps (part 2) |
 | **Part** | 30 of 34 |
-| **Audience** | Engineering leads, security-minded teams |
-| **Tags** | `ci`, `test-coverage`, `audit`, `quality-gates`, `slither` |
-| **Reading time** | ~8 minutes |
+| **Audience** | Engineering leads, founders, security-minded teams |
+| **Tags** | `quality-gates`, `test-coverage`, `ci`, `guardrails` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-## A green suite that was quietly lying
+## A green test suite that was quietly lying
 
-On July 6, 2026, the Weekly Torture Test went red. The Coverage Analysis job exited with code **182** — not a coincidence, a count: **182 contract tests had failed with "Transaction ran out of gas."** The tests that failed were exactly the ones exercising the core escrow contracts. So the report that landed in the run summary showed the wager escrow family — `WagerRegistry`, `WagerRegistryCore`, `WagerRegistryIntents`, the contracts that hold every participant's stake — sitting at a flat **0%**. The blended coverage total had dropped from **56.68%** the previous week to **31.21%**.
+On July 6, 2026, the weekly deep-test run went red. The number of failures was not a coincidence: 182 contract tests had all failed with the same error, "ran out of gas." Those tests were exactly the ones exercising the core escrow contracts — the code that holds every participant's stake — so the report showed the entire escrow family at a flat **0% tested**, and overall coverage had dropped from about 57% the week before to 31%.
 
-Here is the uncomfortable part. Nothing had actually broken in the contracts. The escrow logic was fine, its unit tests passed under a normal `npm test`, and funds were never at risk. What had broken was the *measurement*. Coverage instrumentation rewrites bytecode to record which lines execute, and that rewrite inflates code size and per-transaction gas. Several recently landed contracts — the passkey smart accounts with their elliptic-curve libraries, group wager pools, and the two-facet gasless registry that already sits against the 24 KB EVM code-size limit — pushed the instrumented bytecode past the run's gas headroom. Under instrumentation they ran out of gas before their tests could touch the escrow paths.
+Here is the uncomfortable part. Nothing had actually broken in the contracts. The escrow logic was fine, its tests passed under a normal run, and no funds were ever at risk. What had broken was the *measurement*.
 
-The failure mode is worse than a broken test. A broken test is loud. This was a *safety net reporting a false negative*: the single most important contract in the system read as untested, and the number was low enough that a real coverage regression could have hidden inside the noise and merged unnoticed. Spec `046-contract-audit-coverage` exists to fix both problems at once — restore a measurement you can trust, then wire it so a genuine regression fails the build loudly instead of drifting.
+To measure test coverage, tooling rewrites the contract code to record which lines run during a test — which makes it bigger and more expensive to execute. Several recently added contracts — the passkey smart wallets, the group wager pools, and the gasless registry that already sits right against the blockchain's hard size limit — got pushed past the run's execution budget once rewritten, and ran out of gas before their tests could reach the escrow paths.
 
-This post is about the gates, not the tests they protect. The interesting engineering is not "write more tests." It is: how do you build a quality gate that (a) measures the right thing, (b) can't be gamed into a false pass, and (c) blocks a merge rather than filing a complaint nobody reads.
+That failure mode is worse than a broken test. A broken test is loud and obvious; this was a *safety net reporting a false alarm in the wrong direction*. The most important contract read as untested, and the number was low enough that a *real* coverage regression could have hidden in the noise and merged unnoticed.
 
-## Fixing the measurement before trusting the number
+So the work had two goals — restore a measurement you can trust, then wire it so a genuine regression fails the build loudly instead of drifting by unseen. This post is about those guardrails. The interesting part is not "write more tests"; it is: how do you build a quality gate that measures the right thing, can't be tricked into a false pass, and actually blocks a risky change instead of filing a complaint nobody reads?
 
-The first job was to get instrumented tests to run at all. The fix is narrow on purpose. `npm run test:coverage` sets `COVERAGE=true`, and only under that flag does Hardhat apply coverage-scoped network settings — a raised `blockGasLimit` and adjusted `initialBaseFeePerGas` — so instrumented contracts have the headroom to execute:
+## Fix the measurement before trusting the number
 
-```
-test:coverage = COVERAGE=true TZ=UTC hardhat coverage --testfiles '{test/*.test.js,test/access/**,test/account/**,...}'
-```
+The first job was to get the measured tests to run at all. The fix was deliberately narrow: only in coverage mode does the system relax its execution budget, giving the rewritten, bloated contracts enough headroom to finish, while normal test runs and gas reports keep realistic, production-like limits. We restored the room needed to measure without pretending real-world gas is unlimited. A few days later the run was clean: 674 tests passing, zero out-of-gas failures.
 
-Because those relaxed limits are gated behind `COVERAGE=true`, a normal `npm test` and the gas report keep realistic mainnet-like limits. We restored instrumentation headroom without pretending production gas is unlimited. The result, captured on July 10, was a green run: **674 passing, zero out-of-gas failures**, and the escrow family reporting real numbers again.
+The second problem was subtler: *what* to measure. Even when green, the blended number was misleading, because it averaged in third-party code the project didn't write — cryptography libraries, wallet-standard code, other vendored components — plus test-only scaffolding, none of which FairWins owns or should be judged on.
 
-The second problem was subtler: *what* to measure. The blended 31.21% was meaningless even when green, because it averaged in vendored third-party code — FreshCryptoLib, solady, webauthn-sol, the account-abstraction libraries under `contracts/account/lib/**` — plus test-only fuzz harnesses. None of that is code the project owns or should be judged on.
+The obvious fix — telling the coverage tool to skip those files — is a trap. When a first-party contract *imports* a skipped file, skipping it corrupts the tool's line-attribution, and the importing contract's own coverage collapses to a fraction of the truth: the exact false-0% disease we were curing. So the design keeps measurement broad and does all the filtering *afterward*, in a separate accounting step that subtracts the vendored and test-only code so the headline number reflects only what the team owns.
 
-The obvious fix, adding those paths to solidity-coverage's `skipFiles`, is a trap, and `.solcover.js` carries a long comment explaining why. Skipping a directory that first-party contracts *import* corrupts source-map attribution for the importers. Skip `contracts/test/**` and `WagerRegistry`'s own coverage collapses to ~5%, because the harnesses that drive it are what map execution back to its source. So instrumentation stays deliberately broad, and all first-party filtering happens in **post-processing** instead:
-
-```
-scripts/coverage/lib/first-party.js   # pure helpers over istanbul's coverage-summary.json
-scripts/coverage/check-thresholds.js  # the gate that reads them
-```
-
-The separation matters. Measurement instruments everything (correct source maps); accounting excludes the vendored and test-only paths (honest headline number). One deliberate exception survives the exclusion: the deployed wallet contracts at the top of `contracts/account/` — `CoinbaseSmartWallet`, `ERC1271`, `MultiOwnable`, `CoinbaseSmartWalletFactory`. They are Coinbase/Solady-adapted, but they are deployed live and custody funds on Polygon, so they *are* counted, gated on the integration surface FairWins actually invokes. Only the deeper crypto libraries under `account/lib/**` stay excluded.
+One deliberate exception survives: a handful of wallet contracts adapted from third-party code but *deployed live and custodying real funds*. Because they hold money, they are counted. Only the deeper cryptography libraries beneath them stay excluded.
 
 ## The policy file is the whole argument
 
-Every threshold lives in one auditable place: `coverage-threshold-policy.json`, edited only by PR. There is no coverage config scattered across workflow YAML. The gate reads three risk-based tiers:
+Every threshold lives in one auditable place — a single policy file, changed only through a reviewed pull request, with no config scattered across pipeline scripts. The gate reads three risk-based tiers:
 
-- **Tier A** — funds custody and settlement: the `WagerRegistry` family, group pools (`WagerPool` / `WagerPoolFactory`), `MembershipVoucher` redemption, oracle auto-resolution. **≥95% statements / ≥90% branches.**
-- **Tier B** — security-critical supporting: the deployed `account/*` wallets, oracle adapters, access control, gasless-intent plumbing, the upgradeable base, `TokenFactory`. **≥90% / ≥80%.**
-- **Tier C** — other first-party. **≥80% / ≥70%.**
+- **Tier A — funds custody and settlement** (escrow contracts, group pools, voucher redemption, oracle auto-resolution): the highest bar, at least 95% of statements and 90% of branches.
+- **Tier B — security-critical supporting code** (deployed wallets, oracle adapters, access control, gasless plumbing): at least 90% / 80%.
+- **Tier C — everything else first-party:** at least 80% / 70%.
 
-Each gated contract carries its tier and, optionally, a per-contract `min` floor:
+Each gated contract carries its tier and, optionally, a per-contract floor that works as a **ratchet**. The tier is the audit-readiness *target*; the floor is the currently-enforced minimum for a contract that hasn't reached target yet. The gate fails the moment coverage drops below the floor, so it can never regress, while the target stays visible as the number to climb toward. As gaps close, you raise the floor and eventually delete it, at which point the full tier is enforced.
 
-```json
-{ "path": "contracts/wagers/WagerRegistry.sol",       "tier": "A", "min": { "statements": 92, "branches": 67 } },
-{ "path": "contracts/wagers/WagerRegistryCore.sol",   "tier": "A" },
-{ "path": "contracts/access/MembershipVoucher.sol",   "tier": "A", "min": { "statements": 76, "branches": 45 } }
-```
+Two more lists complete the policy. **Report-only** contracts are measured and printed but never able to fail the gate, so code that hasn't shipped is visible without blocking work; **excluded** vendored and test-only paths are dropped from accounting entirely. The rule is strict: never leave a shipped, fund-handling contract in report-only. When a new custody contract goes live, it moves into the gated tier, its tests come up to standard, and only then does the gate go green.
 
-The `min` is a **ratchet**. `tier` is the audit-readiness target; `min` is the currently-enforced floor for a contract that hasn't reached target yet. The gate fails below `min` — so coverage can never regress — while the target stays visible as the number to raise toward. As gaps close, you bump `min` up and eventually delete it, at which point the full tier is enforced. A contract with no `min` is held to its tier immediately. `MembershipVoucher` at `76/45` is honest about being mid-climb toward `95/90`; it just can't slide backward.
+## The gate itself: pass, fail, or bad input — no negotiation
 
-Two more lists complete the policy. `reportOnly` contracts (unlaunched token templates, `ExternalDAORegistry`) are measured and printed but **never** fail the gate — each with a written `rationale` — so not-yet-shipped code is visible without blocking PRs. `excluded` drops vendored and test-only paths from first-party accounting entirely. The doctrine is explicit: never leave a shipped fund-handling contract in `reportOnly`. When `custody/SafeProposalHub.sol` or a token template goes live, it moves into `gated`, tests come up to tier, and only then does the gate go green.
+The gate reads the coverage results and the policy, then returns one of three plain outcomes: pass, something below its floor (fail), or broken input (fail differently). Two design choices make it hard to fool.
 
-## The gate itself: three exit codes, no negotiation
+First, a gated contract that is **missing** from the coverage report is treated as a *failure*, not an oversight. "File present, essentially untested" in a security-critical area is exactly the July 6 scenario — so you cannot make the gate pass by deleting a contract's tests so it quietly drops out of the report.
 
-`scripts/coverage/check-thresholds.js` reads istanbul's `coverage-summary.json` and the policy, then exits with one of three codes:
+Second, beyond the per-contract tiers, the gate enforces a floor on the *overall* first-party number that only ratchets upward: after the fix it was raised to the new, honest baseline, and the blended total can only go up from there.
 
-```
-0 — all gated contracts meet their tier AND first-party total >= baseline
-1 — one or more gated contracts below tier, or a baseline regression
-2 — bad input (missing/invalid summary or policy, unresolved gated path)
-```
+The gate runs in two places. On **every pull request** it checks the gated contracts and blocks the merge if any security-critical contract is below its floor — coverage generation is a required step that can't be quietly skipped, so a regression is caught *before* merge, not a week later. **Weekly**, it runs across everything, printing the full first-party table into the run summary and failing on any gated breach.
 
-Two design choices make it hard to fool. First, a gated contract that is **absent** from the coverage summary is treated as a failure, not an omission — "file present, ~0% covered" in a security-critical area is exactly the July 6 scenario, and the gate now calls it what it is (FR-012). You cannot make the gate pass by deleting a contract's tests so it drops out of the report. Second, beyond per-contract tiers, the gate enforces a `baseline` on the first-party total that ratchets upward: after the fix it was raised to `91.51/73.04/89.76/91.14`, up from the old-baseline `56.68/48.88/58.05/62.28`. The blended total can only go up.
+## A second guardrail rides alongside
 
-The gate runs in two places, with two scopes:
-
-- **Per-PR** — `.github/workflows/test.yml`, the *Smart Contract Tests* job runs `--scope gated`. Coverage generation is a blocking step (no `continue-on-error`), then the gate blocks the merge if any security-critical contract is below its floor. A regression is caught before merge, not a week later.
-- **Weekly** — `.github/workflows/torture-test.yml`, the *Coverage Analysis* job runs `--scope all`, printing the full first-party table (report-only rows included) into the run summary and failing on any gated breach.
-
-The weekly job uses one careful shell idiom worth stealing: it tees the gate's output into the step summary but captures the exit code so the summary is always written *and* a non-zero exit still fails the job.
-
-```bash
-node scripts/coverage/check-thresholds.js --summary coverage/coverage-summary.json \
-  --policy coverage-threshold-policy.json --scope all | tee -a "$GITHUB_STEP_SUMMARY"; rc=${PIPESTATUS[0]}
-exit $rc
-```
-
-## The storage-layout gate rides alongside
-
-Coverage is not the only thing that fails loudly on every PR. FairWins runs several contracts as UUPS proxies — `WagerRegistry`, `MembershipManager`, `WagerPoolFactory`, `FeeRouter`, and others — where logic is swappable but state must be preserved. A well-meaning refactor that reorders a storage variable is invisible to a coverage number and catastrophic to a live proxy. So `npm run check:storage-layout` runs in the same *Smart Contract Tests* job, before the tests, and blocks the pipeline on any storage-incompatible or upgrade-unsafe implementation (`scripts/deploy/check-storage-layout.js`, spec 025). It even handles the two-facet registry: `WagerRegistry` and `WagerRegistryIntents` share one proxy's storage, so the check treats the facet as if it were an upgrade of the main implementation and diffs the layouts. Same doctrine, different invariant.
+Coverage is not the only thing that fails loudly. FairWins runs several contracts as upgradeable proxies, where the logic can be swapped out but the stored data must be preserved exactly. A well-meaning refactor that reorders a stored variable is invisible to a coverage number and catastrophic to a live proxy: it can silently scramble everyone's balances. So a storage-layout check runs in the same job, before the tests, and blocks the pipeline on any change that would make an upgrade unsafe. Same doctrine, a different invariant: catch the catastrophic-but-invisible change before it can ship.
 
 ## Design decisions and trade-offs
 
-**Post-processing over `skipFiles`.** Filtering vendored code in accounting rather than at instrumentation costs a little complexity (`first-party.js` plus a documented exclusion list) but is the only way to get an honest number *and* uncorrupted source maps. The alternative silently reports the escrow contract at 5% — the exact failure we were trying to eliminate.
+Two choices drove the design. We filter vendored code *in accounting, not in measurement* — the only way to get an honest number and uncorrupted line-attribution at once. And we made the threshold a *ratchet, not a cliff*: it locks in current coverage and only blocks a *drop*, which is the difference between a gate teams route around and one they live with.
 
-**A ratchet, not a cliff.** We could have demanded every Tier A contract hit 95/90 on day one. Instead the `min` floor locks in current coverage and lets targets rise over time. This is the difference between a gate teams route around and one they live with: it never blocks a green PR for coverage that already exists, only for coverage that *drops*.
+The subtler point is being **honest about what actually blocks.** Coverage thresholds, storage layout, unit tests, linting, and the frontend build are hard gates that cannot be bypassed. The heuristic security analyzers, by contrast, run as *informational* steps: their findings are saved and reviewed, but a raw finding does not automatically fail the pipeline, because their false-alarm rate would turn the gate into noise. A "fail loudly" culture is only credible when you are precise about which checks are loud and which are advisory.
 
-**Honest about what actually blocks.** Coverage thresholds, storage layout, unit tests, lint, and the frontend build are hard gates — no `continue-on-error`. Slither and Medusa, by contrast, run in the weekly torture test and the security workflow as **informational** steps: they run on every relevant push, their findings are uploaded as artifacts and reviewed (the security agents under `.github/agents/`), but a raw Slither finding does not auto-fail the pipeline, because its false-positive rate would make the gate noise. That is a deliberate line: gate on the checks with a crisp pass/fail (does coverage meet the floor? is storage append-only?), and treat the heuristic analyzers as review inputs rather than merge blockers. Calling that out honestly is the point — a "fail loudly" culture is credible only when you're precise about which checks are loud and which are advisory.
+The measurable outcome: 182 measurement-induced out-of-gas failures went to zero, the escrow family reports real coverage instead of a false 0%, and a deliberately weakened test on a security-critical contract now fails the gate — naming the contract and the metric — *before* it can merge, not a week after.
 
-The measurable outcome: 182 instrumentation-induced out-of-gas failures went to zero, the escrow family reports real coverage instead of a false 0%, and a deliberately weakened test on a security-critical contract now fails the gate with a message naming the contract and the metric — before it can merge, not a week after.
+## Further reading
 
-## Sources
-
-- `specs/046-contract-audit-coverage/spec.md` — feature spec, failure narrative (run `28764296740`), tiers, FR-001 through FR-019
-- `docs/developer-guide/coverage-and-audit-gates.md` — how the gate works, policy-file reference, common tasks
-- `docs/security/ci-configuration.md` — security workflow structure, tool versions, gating vs. informational jobs
-- `coverage-threshold-policy.json` — the tiered policy: `tiers`, `gated`, `reportOnly`, `excluded`, `baseline`
-- `scripts/coverage/check-thresholds.js` and `scripts/coverage/lib/first-party.js` — the gate and first-party accounting
-- `.solcover.js` — instrumentation config and the `skipFiles` source-map-corruption note
-- `.github/workflows/test.yml` (per-PR gate) and `.github/workflows/torture-test.yml` (weekly `--scope all`)
-- `scripts/deploy/check-storage-layout.js` — the upgrade-safety / storage-layout gate (spec 025)
-- `package.json` — `test:coverage`, `check:storage-layout` scripts
-- Istanbul / nyc coverage summary format: https://github.com/istanbuljs/istanbuljs
-- solidity-coverage: https://github.com/sc-forks/solidity-coverage
-- Slither: https://github.com/crytic/slither — Medusa: https://github.com/crytic/medusa
-- OpenZeppelin Upgrades (storage-layout safety): https://docs.openzeppelin.com/upgrades-plugins/
+- Istanbul — the code-coverage tooling standard behind these reports: https://github.com/istanbuljs/istanbuljs
+- solidity-coverage — how coverage is measured for smart contracts: https://github.com/sc-forks/solidity-coverage
+- OpenZeppelin Upgrades — the storage-layout safety rules for upgradeable contracts: https://docs.openzeppelin.com/upgrades-plugins/

--- a/docs/blog/posts/30-coverage-audit-gates/social.md
+++ b/docs/blog/posts/30-coverage-audit-gates/social.md
@@ -1,29 +1,29 @@
-# Social & Image — Coverage and Audit Gates That Fail Loudly
+# Social & Image — Quality Gates That Fail Loudly
 
 ## X (Twitter)
 
-Our escrow contract once reported 0% coverage in CI. Nothing was broken — instrumentation ran the tests out of gas and the safety net lied. Fixing it meant a gate that fails a merge when coverage *drops*, not a report nobody reads. 🔗 <link>
+Our escrow contract once reported 0% test coverage. Nothing was broken — the measurement tooling ran the tests out of gas and the safety net lied. Fixing it meant a guardrail that blocks a change when coverage *drops*, not a report nobody reads. 🔗 <link>
 
-#SmartContracts #DevSecOps #Solidity
+#SmartContracts #DevSecOps #QualityGates
 
 ## LinkedIn
 
-A test suite that reports a false negative is more dangerous than one that fails outright — a broken test is loud, but a safety net quietly reporting your most critical contract as "untested" lets a real regression slip through unnoticed.
+A test suite that reports a false alarm is more dangerous than one that fails outright — a broken test is loud, but a safety net quietly reporting your most critical contract as "untested" lets a real regression slip through unnoticed.
 
-That happened to us. Coverage instrumentation inflated bytecode past the gas limit, 182 tests ran out of gas, and our funds-handling escrow contract read as 0% covered while the actual logic was fine. The blended coverage number dropped by half and meant nothing either way.
+That happened to us. The coverage tooling inflated the contract code past its execution budget, 182 tests ran out of gas, and our funds-handling escrow contract read as 0% covered while the actual logic was fine. The overall coverage number dropped by half and meant nothing either way.
 
-The fix wasn't "write more tests." It was building quality gates that can't be gamed into a false pass. The new post walks through:
+The fix wasn't "write more tests." It was building quality gates that can't be tricked into a false pass. The new post walks through:
 
-- Restoring a trustworthy measurement (instrumentation headroom gated behind a COVERAGE flag, so production gas stays realistic)
-- First-party accounting in post-processing — not skipFiles — to avoid corrupting source maps while excluding vendored code
+- Restoring a trustworthy measurement (extra execution headroom only in coverage mode, so production limits stay realistic)
+- Filtering out third-party code in accounting, not in measurement, so the numbers stay honest without corrupting line-attribution
 - A tiered, ratcheting threshold policy in one auditable file, where coverage can only go up
-- Being honest about which checks hard-block a merge (coverage, storage layout) vs. which are advisory review inputs (Slither, Medusa)
+- Being honest about which checks hard-block a merge (coverage, storage layout) vs. which are advisory review inputs (the heuristic security analyzers)
 
 The theme running through all of it: a "fail loudly" culture is only credible when you're precise about which checks are loud.
 
 How does your team draw the line between a blocking gate and an advisory one? 🔗 <link>
 
-#SmartContracts #DevSecOps #CodeCoverage #Solidity #EngineeringLeadership
+#SmartContracts #DevSecOps #QualityGates #EngineeringLeadership
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/31-symbolic-execution-fuzzing/blog.md
+++ b/docs/blog/posts/31-symbolic-execution-fuzzing/blog.md
@@ -1,148 +1,81 @@
-# Three Ways to Break an Escrow: Slither, Manticore, and Medusa on a Wager Protocol
+# Three Ways to Break an Escrow: How We Stress-Test the Code That Holds the Money
 
-*A layered verification stack for peer-to-peer escrow — and the bug each layer is uniquely positioned to catch*
+*One small function decides who gets paid. Here are the three very different tools we point at it — and why no single one is enough.*
+
+| | |
+|---|---|
+| **Series** | Security & DevOps |
+| **Audience** | Founders, product managers, and the crypto-curious — no Solidity required |
+| **Tags** | `security`, `testing`, `smart-contracts`, `plain-english` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-> **Important Note**: FairWins is a platform for peer-to-peer wagers based on publicly available information and legitimate forecasting. Nothing here is a mechanism for trading on material non-public information or circumventing applicable law. All participants remain fully subject to applicable regulations and compliance requirements. This post is about verifying escrow code, not about the wagers themselves.
+> **A note on what FairWins is.** FairWins lets friends make peer-to-peer wagers based on public information and honest forecasting — who wins Sunday's match, not inside information. Everyone using it stays subject to the laws that apply to them. This post is about the code that holds the money safely, not about the wagers themselves.
 
 ---
 
 ## The function that can never be wrong
 
-Here is the single function in `WagerRegistry` that moves money to a winner. Two people staked USDC, an oracle (or a counterparty) declared an outcome, and now the winner claims the pot:
+Somewhere inside a FairWins wager, there is a single, tiny piece of code whose only job is to move money to the winner. Two people each put up some stablecoin. An outcome gets declared. The winner clicks "claim," and this code hands over the pot.
 
-```solidity
-function _claimPayout(address actor, uint256 wagerId) internal {
-    Wager storage w = _wagers[wagerId];
-    if (w.status != Status.Resolved) revert NotResolved();
-    if (actor != w.winner) revert NotWinner();
-    if (w.paid) revert AlreadyPaid();
+It is maybe a dozen lines long, and every one matters. It has to check three things before it pays: that the wager is actually resolved, that the person claiming is actually the winner, and that the pot has not already been paid out. It has to mark the wager "paid" *before* it sends the money, not after. And it has to add the two stakes together correctly, without the total silently wrapping around to a wrong number.
 
-    w.paid = true;
-    // Compute as uint256 to avoid uint128 overflow on sum
-    uint256 payout = uint256(w.creatorStake) + uint256(w.opponentStake);
-    IERC20(w.token).safeTransfer(w.winner, payout);
+Get the order of those steps wrong and a malicious token could trick the contract into paying twice. Get the "already paid" check wrong and anyone could claim someone else's winnings. Get the arithmetic wrong and the payout is simply incorrect. On a public blockchain, each mistake is permanent and there for attackers to find.
 
-    emit PayoutClaimed(wagerId, w.winner, payout);
-}
-```
+Here is the uncomfortable part: no single testing method catches all three. A tool that is brilliant at spotting a dangerous *ordering* of steps has no idea whether the math is right. A tool that can *prove* the math never overflows grinds to a halt if you ask it about ten wagers happening in an unpredictable order. And a tool that cheerfully throws ten thousand wagers at the contract in random orders can *find* failures but never *prove* their absence.
 
-Twelve lines, and every one of them is load-bearing. The three `if` checks are the *checks*. Setting `w.paid = true` before the transfer is the *effect*. The `safeTransfer` is the *interaction*. That ordering — checks-effects-interactions — is the difference between a contract that pays each winner once and a contract that a reentrant token can drain. The `uint256` cast on the sum is the difference between a correct payout and a silent `uint128` overflow. The `actor != w.winner` check is the difference between a winner claiming their pot and anyone claiming everyone's.
+So we point three different tools at that money-moving code, each chosen for what the others miss. Think of them as two automated ways to hammer on the code to find bugs a human might overlook — one explores every possible path, the other throws millions of random inputs — plus a fast pattern-checker that runs first.
 
-No single testing technique gives you confidence across all of those failure modes at once. A pattern matcher can see that `w.paid = true` sits before the transfer, but it has no idea whether `payout` is arithmetically correct. A path explorer can prove the arithmetic never overflows, but it will time out before it can reason about ten wagers created and settled in an arbitrary order. A fuzzer can hammer that arbitrary order until the escrow goes insolvent, but it will never *prove* anything — only fail to disprove it.
+## Layer one: the fast pattern-checker
 
-So `contracts/wagers/WagerRegistry.sol` sits under three tools that catch different things. This is a tour of what each one actually does to the escrow and payout logic, grounded in the configuration and harnesses that ship in the repo.
+The first tool is a *static analyzer*. "Static" means it reads the code without ever running it — the way a spell-checker reads a document without understanding the plot. It knows what dangerous code *shapes* look like and flags them.
 
-## Layer 1: Slither, on every pull request
+Because it is cheap and fast, it runs automatically on every code change, before anything can be merged. We tune it to be strict, and to look only at our own code, not the well-known libraries underneath.
 
-Slither is static analysis — it reads the compiled contract without ever executing it, and matches known-bad shapes. It is the cheap, fast layer, so it runs on every PR as the `slither-analysis` job in `.github/workflows/security-testing.yml`, gating merges alongside the Hardhat suite and coverage.
+What it is genuinely good at is the class of bug you can see in the *shape* of the code. Sending money before marking the wager paid? It flags the ordering instantly — that is the classic "reentrancy" trap, where an attacker re-enters the function mid-payment. A function that changes ownership with no lock on it, or a missing check for an empty address? It catches those too.
 
-The configuration is deliberately un-permissive (`slither.config.json`):
+What it *cannot* do is tell you whether the payout amount is right. To a pattern-checker, "add both stakes together" and "use just one stake" look almost identical. It sees grammar, not meaning. Closing that gap is the job of the next two layers.
 
-```json
-{
-  "filter_paths": "node_modules|test|contracts/mocks",
-  "exclude_dependencies": true,
-  "exclude_informational": false,
-  "exclude_low": false,
-  "exclude_medium": false,
-  "exclude_high": false,
-  "compile_force_framework": "hardhat"
-}
-```
+## Layer two: exploring every path
 
-Nothing below high severity is filtered out. Dependencies and mocks are excluded so the signal is about *our* code, but every severity band on our code is surfaced.
+The second tool does *symbolic execution*, and the plain-English version is worth pausing on.
 
-What Slither is good at, on `_claimPayout`, is exactly the class of bug that is visible in the *shape* of the code: a reentrancy detector notices when a function makes an external call before it finishes updating state. Point it at a version of this function where `w.paid = true` came *after* the `safeTransfer` and it flags the ordering immediately — the reentrancy-eth detector exists precisely for that. It also catches unprotected state-changing functions (a `setOwner` with no modifier), missing zero-address validation on constructor and setter inputs, and dangerous strict equalities like `require(msg.value == bondAmount)`.
+A normal test asks: "Does this work when the stake is 100?" You pick a number, run the code, check the answer. Symbolic execution asks a far bigger question: "Is there *any* stake — literally any value at all — that makes this go wrong?" Instead of a concrete number, it feeds the code an unknown and follows every branch, keeping track of the conditions that lead down each path. Where the code splits, it splits with it.
 
-What Slither cannot do is tell you whether the payout is *right*. `uint256(w.creatorStake) + uint256(w.opponentStake)` and `uint256(w.creatorStake)` on its own are the same shape to a pattern matcher. Static analysis sees syntax and control-flow, not the semantics of "the winner should receive both stakes and no more." That is the gap the next two layers exist to close.
+That means it can do something tests cannot: it can *prove* things. Point it at our payout math and it reasons across the entire range of possible stakes and confirms the sum can never overflow into a wrong number. It confirms there is no sneaky path that skips one of the three safety checks. This is the layer that turns "I'm pretty sure the math is fine" into "there is no input for which it isn't." Because it is slow and thorough, we run it on a schedule against the highest-risk contracts, not on every change.
 
-## Layer 2: Manticore, and the fix that made it real
+There is a lesson buried in how we got this working. For a while, this tool ran on schedule and reported success every time — while quietly doing nothing. It couldn't find the shared libraries our code depends on, so it failed to even assemble the code, and our automation counted that failure as a pass. A security tool that reports green because it never actually examined your code is worse than no tool: it manufactures confidence you haven't earned. The fix was unglamorous. The real lesson was noticing it had been asleep.
 
-Manticore is symbolic execution. Instead of running the contract with concrete inputs, it runs it with *symbolic* ones — each input is an unknown, and at every branch it forks the world, accumulating the constraints that lead down each path. Where a unit test asks "does it work for `amount = 100`?", Manticore asks "is there *any* `amount` for which this assertion can fail, this arithmetic can overflow, or this path can revert unexpectedly?" For a bounded number of transactions it explores paths exhaustively, which is why it is aimed at the highest-risk contracts: it runs weekly in the `torture-test.yml` workflow against `WagerRegistry`, `MembershipManager`, `KeyRegistry`, and every oracle adapter (Polymarket, both Chainlink adapters, and UMA).
+Its honest limit: it shines on one contract at a time with a bounded number of steps. Ask it to reason about ten wagers created and settled in an arbitrary order and it drowns in possibilities. That is exactly where the third tool takes over.
 
-That weekly run existed for a while before it was actually doing anything — and that is the most instructive part of the story. Manticore drives its own Solidity compiler, and it did not know where FairWins keeps its dependencies. Every run died on:
+## Layer three: throwing millions of random inputs
 
-```
-Error: Source "@openzeppelin/contracts/access/Ownable.sol" not found: File not found.
-```
+The third tool is a *fuzzer*. Its entire personality is chaos with a purpose. It stands up a realistic copy of the whole system and then throws long, random sequences of real actions at it — create a wager, accept it, claim it, refund it, cancel it, in wild combinations, up to a hundred moves in a row — and after *every single move* it checks whether a set of rules still holds.
 
-followed, in the finalizer, by an `AttributeError: 'NoneType' object has no attribute 'result'`. That second error is the tell: when compilation fails, Manticore has no transaction objects to finalize, so it crashes trying to read results that never existed. The CI step was catching the failure and moving on. The verification tool was green and inert — the worst state a security tool can be in, because it manufactures confidence it hasn't earned.
+It is hunting the kind of bug no single action causes but some *order* of actions does. The most important rule it checks is solvency: at every moment, in any history of moves, does the contract still hold at least enough money to cover every stake it still owes? If some sequence ever pays out twice, or releases a stake it already released, that rule goes false — and the fuzzer hands you the exact sequence that broke it.
 
-The fix, documented in `docs/MANTICORE_FIX.md`, is unglamorous and exactly right. A `remappings.txt` at the repo root tells the compiler where the imports live:
+It checks other rules the same way: that "paid" can never flip back to unpaid, that a wager's status only moves forward, that a winner is always one of the two participants, that the payout always equals the two stakes combined. There is even a clever one for private wagers: the fuzzer deliberately holds no secret key, so it *cannot* forge the signature needed to accept an open challenge. If it ever activates one anyway, the signature lock is broken.
 
-```
-@openzeppelin/=node_modules/@openzeppelin/
-@chainlink/=node_modules/@chainlink/
-@uma/=node_modules/@uma/
-```
+Crucially, we fuzz a copy built the way the real thing is deployed — same setup, same memberships — not a stripped-down toy. A rule that only holds for a system you don't actually ship is worthless.
 
-And a wrapper script, `scripts/run-manticore.py`, reads those remappings and passes them through to Manticore as `--solc-remaps` arguments, validates the environment before it starts, and handles timeouts gracefully so a partial exploration still yields artifacts. The workflow calls the wrapper instead of the bare binary:
+The fuzzer's weakness is the mirror of the path-explorer's strength: it is random, not exhaustive. A clean run means "no counterexample found this time," never "no counterexample exists." That is precisely why the payout math is checked by *both* the path-explorer (which proves it) and the fuzzer (which pressure-tests it under live sequences).
 
-```bash
-timeout 600 python scripts/run-manticore.py contracts/wagers/WagerRegistry.sol \
-  --contract WagerRegistry --timeout 600
-```
+## Why three, and why the overlap
 
-With imports resolving, Manticore compiles the registry and starts forking paths through `_claimPayout` and its siblings. Now the `uint256` cast earns its comment: symbolic execution reasons about the full `2^128` range of each stake and confirms the sum can't overflow the way a naive `uint128` addition would. It checks that the three guard clauses have no satisfiable path that skips them. This is the layer that turns "I'm pretty sure the arithmetic is fine" into "there is no input for which it isn't."
+A few deliberate choices tie this together.
 
-Its limits are honest and documented: state explosion means it struggles with deep multi-transaction sequences, unbounded loops, and external calls into contracts it can't model. Manticore proves things about a *bounded* exploration of one contract. It will not, on its own, discover a bug that only emerges after ten interleaved wagers.
+**We order the tools by cost.** The fast pattern-checker runs on every change for instant feedback. The two heavy tools run on a schedule, off the critical path, so nobody waits to save a file.
 
-## Layer 3: Medusa, on the whole stack at once
+**We overlap the math on purpose.** Payout correctness is checked twice — once proven exhaustively over all inputs, once stress-tested over all orderings. Neither replaces the other, and on code that moves money the redundancy is the point.
 
-That interleaving is Medusa's entire job. Medusa is a property-based fuzzer: it deploys a harness, then throws long, random sequences of real transactions at it — up to 100 calls per sequence, per `medusa.json` — and after every call it re-checks a set of invariants. It is looking for the emergent bug: the one that no single transaction causes, but some *order* of transactions does.
+**We test the real deployment, not a stand-in,** and we treat a silent tool as a failure. A guarantee that only holds for a contract you don't ship is a guarantee about nothing, and a verification tool asleep at its post is the most dangerous state it can be in.
 
-The harness for the escrow is `contracts/test/WagerRegistryFuzzTest.sol`, and critically it deploys the *production* stack the way production does — the real `MembershipManager` and `WagerRegistry` behind ERC-1967 proxies, initialized through the proxy, with tiers configured and memberships purchased. Medusa then fuzzes against the proxy. The invariants are plain `bool`-returning functions with a `property_` prefix (declared in `medusa.json` under `testPrefixes`). The one that matters most is escrow solvency:
+None of this makes bugs impossible. It makes whole *categories* of them very hard to ship — which, for code that quietly holds other people's money, is the entire job.
 
-```solidity
-function property_escrow_covers_active_stakes() public view returns (bool) {
-    uint256 totalLocked = 0;
-    uint256 count = registry.nextWagerId();
-    for (uint256 i = 1; i < count; i++) {
-        IWagerRegistryTypes.Wager memory w = registry.getWager(i);
-        if (w.status == IWagerRegistryTypes.Status.Open) {
-            totalLocked += w.creatorStake;
-        } else if (w.status == IWagerRegistryTypes.Status.Active && !w.paid) {
-            totalLocked += uint256(w.creatorStake) + uint256(w.opponentStake);
-        } else if (w.status == IWagerRegistryTypes.Status.Resolved && !w.paid) {
-            totalLocked += uint256(w.creatorStake) + uint256(w.opponentStake);
-        }
-    }
-    return token.balanceOf(address(registry)) >= totalLocked;
-}
-```
+## Further reading
 
-This is a claim no static or symbolic tool made: *at every point in any transaction history, the registry holds at least enough tokens to cover every stake it still owes.* If some sequence of create / accept / claim / refund / cancel ever pays out twice, or refunds a stake it already released, or leaks tokens on the open-challenge path, this property goes false and Medusa hands you the exact failing call sequence.
-
-The rest of the harness fences the state machine from every angle: `property_no_double_claim` asserts the `paid` flag is irreversible; `property_state_only_progresses_forward` tracks per-wager status across calls and rejects any backward transition (`Resolved` and `Refunded` are terminal); `property_winner_is_participant` requires every resolved winner to be the creator or the opponent; `property_payout_equals_total_stakes` guards the arithmetic that Manticore proved, now under live sequences; and `property_cannot_reinitialize` confirms the UUPS proxy's one-time initializer can never be called again to seize roles.
-
-There is a genuinely clever bit in the open-challenge invariants. The harness holds no private key for any claim authority, so it *cannot* forge the EIP-712 signature that accepts an open wager. `property_open_never_active_without_signature` turns that into a test: none of the harness's open wagers may ever reach `Active`, because reaching `Active` would require a signature the fuzzer can't produce. If Medusa ever finds a path that activates one anyway, the signature gate is broken.
-
-Medusa's weakness is the mirror of Manticore's strength: it is random, not exhaustive. A passing run means "no counterexample found in this campaign," never "no counterexample exists." That is precisely why the arithmetic invariant lives in *both* the fuzzer and the symbolic layer.
-
-## Design decisions
-
-**Cost-order the layers.** Slither is cheap and runs on every PR; Manticore and Medusa are expensive and run weekly in `torture-test.yml`. You get fast pattern feedback on the critical path and heavyweight proof/fuzzing off it. Nobody waits ten minutes per push for a symbolic run.
-
-**Overlap the arithmetic on purpose.** Payout correctness is checked by Manticore (exhaustive over inputs, one transaction) *and* Medusa (random over sequences, many transactions). Neither subsumes the other: one proves the sum never overflows, the other proves no ordering of settlements ever breaks solvency. The redundancy is the point.
-
-**Fuzz the real deployment shape.** The Medusa harness stands up UUPS proxies and buys memberships instead of poking a bare logic contract. An invariant that only holds for a contract you don't ship is worthless; the escrow-solvency property is only meaningful against the proxy users actually transact with.
-
-**Treat a silent security tool as a failure.** The Manticore import bug is the lesson that generalizes past this repo: a verification tool that green-lights because it never compiled your code is worse than no tool, because it launders false confidence. The fix wasn't cleverness — it was noticing the tool wasn't running and making it run.
-
-## Sources
-
-- `contracts/wagers/WagerRegistryCore.sol` — `_claimPayout` (checks-effects-interactions, payout formula)
-- `contracts/wagers/WagerRegistry.sol` — `claimPayout` / `claimRefund` / `createWager` externals
-- `contracts/test/WagerRegistryFuzzTest.sol` — Medusa invariant harness (escrow solvency, forward-only state, open-challenge signature gate)
-- `medusa.json` — fuzzing config (target contracts, `property_` prefixes, sequence length)
-- `slither.config.json` — Slither configuration (severity bands, remaps, filtered paths)
-- `remappings.txt` — OpenZeppelin / Chainlink / UMA import remaps
-- `docs/MANTICORE_FIX.md` — the import-resolution fix and the `run-manticore.py` wrapper
-- `docs/security/index.md`, `static-analysis.md`, `symbolic-execution.md`, `fuzz-testing.md` — the layered testing overview
-- `.github/workflows/security-testing.yml` — PR-gating Slither job
-- `.github/workflows/torture-test.yml` — weekly Manticore + Medusa runs
-- [Slither](https://github.com/crytic/slither), [Manticore](https://github.com/trailofbits/manticore), [Medusa](https://github.com/crytic/medusa) — Trail of Bits / crytic tooling
-- [SWC Registry](https://swcregistry.io/), [Smart Contract Best Practices](https://consensys.github.io/smart-contract-best-practices/)
-- ERC-1167 minimal proxy and EIP-712 typed-data signing — [eips.ethereum.org](https://eips.ethereum.org)
+- Reentrancy and the checks-effects-interactions pattern: [Ethereum smart contract best practices](https://consensys.github.io/smart-contract-best-practices/)
+- The Smart Contract Weakness Registry, a catalog of known contract bug classes: [swcregistry.io](https://swcregistry.io/)
+- A plain introduction to [symbolic execution](https://en.wikipedia.org/wiki/Symbolic_execution) and [fuzz testing](https://en.wikipedia.org/wiki/Fuzzing) on Wikipedia
+- Open-source tools in this space from Trail of Bits and crytic: [Slither](https://github.com/crytic/slither) (static analysis), [Manticore](https://github.com/trailofbits/manticore) (symbolic execution), and [Medusa](https://github.com/crytic/medusa) (fuzzing)

--- a/docs/blog/posts/31-symbolic-execution-fuzzing/social.md
+++ b/docs/blog/posts/31-symbolic-execution-fuzzing/social.md
@@ -2,24 +2,25 @@
 
 ## X (Twitter)
 
-12 lines move money to a wager winner. Slither checks the shape, Manticore proves the sum can't overflow, Medusa hammers 100-tx sequences at escrow solvency. Each catches what the others miss — and Manticore silently ran on nothing until we fixed one import. 🔗 <link>
+A tiny piece of code decides who gets paid in a wager. We point three very different tools at it: one checks the code's shape, one explores every possible path to prove the math can't overflow, one throws thousands of random action sequences at it to test that the pot always stays solvent. Each catches what the others miss. 🔗 <link>
 
-#SmartContractSecurity #Solidity #Fuzzing
+#SmartContractSecurity #Testing #Web3
 
 ## LinkedIn
 
-A payout function in a peer-to-peer wager protocol has to be right on every axis at once: checks-effects-interactions ordering so a reentrant token can't drain it, an irreversible paid flag so no one claims twice, and arithmetic that sums two stakes without overflowing. No single testing technique gives you confidence across all of that — so FairWins runs three, and this post is a tour of what each one actually catches on the escrow code.
+A single, tiny function inside a FairWins wager decides who gets paid. It has to be right on every axis at once: pay in the correct order so no one can trick it into paying twice, never let the same pot be claimed twice, and add two stakes together without the total silently overflowing.
 
-The post covers:
+No single testing method catches all of that — so we run three, and the new post is a plain-English tour of what each one actually does:
 
-- **Slither** (static analysis, every PR): catches the reentrancy ordering, missing access control, and zero-address gaps that are visible in the shape of the code — but can't tell you whether a payout is arithmetically correct.
-- **Manticore** (symbolic execution, weekly): explores paths with symbolic inputs to prove the payout sum can't overflow for any input — plus the story of the OpenZeppelin import bug that left it silently running on nothing.
-- **Medusa** (property fuzzing, weekly): throws 100-transaction sequences at the real proxy-deployed stack and re-checks escrow solvency after every call, hunting the emergent bug no single transaction causes.
-- **Why the layers overlap on purpose** — and why a green-but-inert security tool is worse than none.
+- A fast pattern-checker that reads the code without running it, catching dangerous code shapes on every change — but it can't tell you whether a payout amount is correct.
+- Symbolic execution, which explores every possible path with unknown inputs to *prove* the math can never overflow. (Including the story of when this tool reported success for weeks while quietly examining nothing at all.)
+- A fuzzer, which throws long random sequences of real actions at a realistic copy of the system and re-checks after every move that the contract still holds enough money to cover what it owes.
 
-How do you order your verification stack by cost vs. depth? 🔗 <link>
+The theme: on code that quietly holds other people's money, overlapping tools — and distrusting green checkmarks until you've proven the tool is actually looking — is the whole job.
 
-#SmartContractSecurity #Solidity #Fuzzing #SymbolicExecution #Web3Security
+How do you order your testing by cost versus depth? 🔗 <link>
+
+#SmartContractSecurity #Testing #Web3Security #Fintech
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/32-spec-driven-development/blog.md
+++ b/docs/blog/posts/32-spec-driven-development/blog.md
@@ -1,131 +1,79 @@
-# Sixty-Three Features, One Constitution: Spec-Driven Development on a Money Contract
+# Write It Down First: Shipping Money Software Repeatably When AI Agents Do the Building
 
-*How FairWins ships complex, security-critical crypto features repeatably — with coding agents in the loop and a binding constitution every plan must pass*
+*How FairWins keeps its fiftieth feature as safe as its first — by making the standards a gate the work has to pass through, not a document people are supposed to remember.*
 
 | | |
 |---|---|
-| **Series** | Security & DevOps (part 4) |
-| **Audience** | Engineering leaders, agent/tooling developers |
-| **Tags** | `spec-driven-development`, `spec-kit`, `process`, `ai-agents` |
-| **Reading time** | ~9 minutes |
+| **Series** | Security & DevOps |
+| **Audience** | Founders, product leaders, and anyone managing AI coding agents |
+| **Tags** | `process`, `ai-agents`, `spec-first`, `quality` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-## The problem with "just prompt the agent"
+## The problem with "just tell the agent what you want"
 
-A coding agent will happily write you a fee-charging smart contract in one shot. It will look plausible. It will compile. It might even pass a couple of tests the agent invents on the way. And then it will custody user funds on a public network where a single missed `nonReentrant` modifier, an inverted rounding direction, or a fee cap checked at write-time-but-not-charge-time is a permanent, on-chain, adversarially-exploitable mistake.
+An AI coding agent will happily write you a smart contract in one shot. It will look plausible. It will compile. It might even pass a couple of tests the agent invents along the way. And then that contract will custody real user funds on a public network, where a single missed safety check is a permanent, exploitable mistake that anyone in the world can find and nobody can quietly patch out.
 
-The FairWins repository is a peer-to-peer wager platform: Solidity contracts that escrow stakes and resolve them against external oracles, a React frontend that is the trust surface for non-technical users, a relay gateway for gasless flows, and a subgraph for indexing. At the time of writing it holds **63 feature specifications** under `specs/`, numbered through `061-bitcoin-transactions`. Many of them touch funds, access control, or oracle resolution — exactly the surfaces where an unstructured "describe it and let the agent cook" workflow fails quietly and expensively.
+FairWins is a peer-to-peer wager platform. Under the hood it is smart contracts that hold people's stakes and pay out winners, a web app that non-technical people trust with their money, and supporting services that make transactions cheap and searchable. It has grown to dozens of distinct features, and a lot of them touch funds, permissions, or the way outcomes get resolved — exactly the places where "describe it and let the agent cook" fails quietly and expensively.
 
-The interesting question isn't *can an agent write this feature?* It's *how do you ship the sixtieth feature to the same standard as the first, when a mix of humans and agents are writing them, and the codebase is already large enough that no one holds all of it in their head?*
+The interesting question was never *can an agent build this feature?* It was: *how do you ship the fiftieth feature to the same standard as the first, when humans and agents are both writing them, and the codebase is already too big for any one person to hold in their head?*
 
-FairWins' answer is process, made executable. The repo runs on [GitHub's Spec Kit](https://github.com/github/spec-kit) with a project constitution that no plan is allowed to skip.
+The answer is not more heroics from senior reviewers. It is process, made executable — writing down *what* and *why* before anyone builds, holding every plan to a shared set of standards, and letting the AI agents do the work inside those guardrails. FairWins builds this on top of an open-source framework (linked at the end), but the ideas travel to any team.
 
-## The pipeline: constitution → specify → clarify → plan → tasks → analyze → implement
+## The core move: describe before you build
 
-Spec Kit turns "build a feature" into a sequence of named, reviewable artifacts rather than a single conversation. Each stage is a `/speckit-*` skill the agent invokes, and each produces a file that outlives the chat:
+The heart of the method is a sequence of small, named steps that turn "build a feature" into a series of reviewable documents instead of one long chat that vanishes when you close the window.
 
-1. **`/speckit-constitution`** — establish or amend the binding standards.
-2. **`/speckit-specify`** — capture *what* and *why*, with **no technology choices yet**.
-3. **`/speckit-clarify`** — ask up to five targeted questions to kill ambiguity before design (optional).
-4. **`/speckit-plan`** — design the implementation against the chosen stack.
-5. **`/speckit-tasks`** — break the plan into ordered, actionable tasks.
-6. **`/speckit-analyze`** — cross-check spec, plan, and tasks for consistency (optional).
-7. **`/speckit-implement`** — execute the tasks.
+It works roughly like this:
 
-The separation is the point. Forcing the spec to describe behavior *before* anyone names a contract or a library keeps the "what" honest — you can't hide a design decision inside a requirement. A representative feature directory shows the full paper trail:
+1. **Write down the standards** — the non-negotiables every feature must meet (more on this below).
+2. **Specify the what and why** — user stories and acceptance criteria, deliberately with *no* technology choices yet.
+3. **Clarify** — ask a handful of sharp questions to kill ambiguity before any design starts.
+4. **Plan** — now, and only now, decide *how* to build it.
+5. **Break it into tasks** — an ordered, checkable list of concrete work.
+6. **Cross-check** — make sure the spec, the plan, and the tasks actually agree with each other.
+7. **Build** — execute the tasks.
 
-```text
-specs/060-platform-fee-wrapper/
-├── spec.md          # what & why: user stories, acceptance scenarios, FRs
-├── plan.md          # how: technical context + constitution check
-├── research.md      # decision log for the plan
-├── data-model.md    # entities and state
-├── quickstart.md    # phase-1 design output
-├── contracts/       # interface sketches
-├── checklists/      # generated review checklists
-└── tasks.md         # ordered, dependency-aware task list
-```
+The separation is the entire point. Forcing the specification to describe *behavior* before anyone names a tool or a library keeps the "what" honest — you cannot smuggle a design decision inside a requirement. And each step leaves behind a document that outlives the conversation: the same artifact the builder reads to do the work is the record a reviewer reads to check it. That is not documentation written after the fact. It is the input to the work.
 
-That is not documentation written after the fact. It is the input the implementing agent (or engineer) reads to do the work, and the record a reviewer reads to check it.
+## The standards are a gate, not a README
 
-## The constitution is a gate, not a README
+Every team has a document somewhere listing its engineering standards. Almost everywhere, that document is advisory — a wish list people are supposed to remember, which is to say the thing that gets quietly skipped the week a deadline looms. That is precisely the week a fund-custody bug ships.
 
-The reason this scales past a handful of features is `.specify/memory/constitution.md` — a versioned document (currently `1.0.0`, ratified 2026-06-05) that opens by declaring itself binding: *"When guidance here conflicts with convenience, this document wins."* It codifies five principles, two of them marked **NON-NEGOTIABLE**:
+FairWins does something different. It keeps a short, binding set of standards — think of it as a project constitution — and it wires that constitution directly into the pipeline. It opens by declaring itself binding: when the standards conflict with convenience, the standards win. And it covers the things that actually matter for software holding money:
 
-- **I. Security-First Smart Contracts** — checks-effects-interactions, reentrancy and overflow guards, EthTrust Security Level L2 targets for new value-bearing contracts, and a mandatory review against `.github/agents/smart-contract-security.agent.md` before merge. Static analysis (Slither) and, for stateful logic, fuzzing (Medusa) must pass with no new high/critical findings.
-- **II. Test-First and Comprehensive Coverage** — behavior isn't "done" until tests prove it; resolution, claim, refund, and timeout paths must be tested *including their failure cases*.
-- **III. Honest State, No Mocks in Shipped Paths** — no stubbed responses or placeholder finality in production; the UI never implies a finality the chain hasn't reached.
-- **IV. Fail Loudly in CI** — `continue-on-error: true` is forbidden on lint, type-check, build, and test steps.
-- **V. Accessible, Consistent Frontend** — WCAG 2.1 AA, axe/Lighthouse in CI, no hand-copied contract addresses.
+- **Security first.** Money-handling contracts follow strict ordering rules, guard against known attack classes, and get a dedicated security review before they can merge.
+- **Tests prove behavior.** A feature isn't "done" until tests demonstrate it works — *including* the failure cases: what happens when a claim is invalid, a refund is due, a deadline passes.
+- **No fakery in shipped code.** No stubbed-out responses standing in for the real thing; the interface never implies a transaction is final before the blockchain says it is.
+- **Fail loudly.** Automated checks are never allowed to be configured to pass-on-failure.
+- **Accessible and consistent** front-end, held to recognized accessibility standards.
 
-What makes this more than a wish list is where it plugs into the pipeline. **Every `plan.md` begins with a Constitution Check that must pass before design proceeds.** In the fee-router feature that check is a table mapping each principle to a status and the concrete reasoning for it — for the security principle:
+Here is the mechanism that makes it more than a wish list: **every plan has to open by checking itself against those standards, and it cannot proceed to the building stage until that check passes.** For each standard, the plan states how it complies — in concrete terms, not hand-waving. If a design has to *violate* a standard, that deviation must be written down explicitly, alongside why it is necessary and why the simpler alternative was rejected. An empty deviations list is the happy path. A non-empty one is a design smell you have to argue for in writing — *before* you write code, not in a post-mortem afterward.
 
-```text
-| I. Security-first contracts | PASS (design gate) | FeeRouter is value-bearing
-  (custodies funds transiently within one tx). CEI + `nonReentrant` on
-  depositToVaultWithFee; SafeERC20 everywhere; caps enforced in the setter AND
-  re-checked at charge time; maxFeeBps protects members from admin front-running;
-  role-gated setters; Slither + security-agent review before merge. |
-```
+That is the difference between "we should probably..." and "we cannot proceed until...". The friction is deliberate, and it lands exactly on the highest-risk work.
 
-The plan template (`.specify/templates/plan-template.md`) also carries a **Complexity Tracking** section that exists solely to catch deviations: if a design violates a principle, it must be listed here with *why it's needed* and *why the simpler alternative was rejected*. An empty Complexity Tracking table is the happy path. A non-empty one is a design smell you have to argue for in writing — before you write code, not in a post-mortem.
+## AI agents in the loop, bounded by documents
 
-## Tasks that encode test-first and parallelism
+FairWins is built *with* agents, not just *for* them — and the write-it-down-first method is what makes that safe rather than reckless.
 
-`/speckit-tasks` turns the approved plan into `tasks.md`: a phased, checkbox-tracked list where the constitution's rules are visible in the structure itself. The fee-router tasks open by declaring the test posture, then order the work so foundations block stories:
+An agent asked to build a feature doesn't improvise from a one-line prompt. It reads the specification for the requirements, the plan for the design and its standards-check, and the task list for the ordered work — the very same documents a human builder would read. The agent's freedom is bounded by documents a human already reviewed and approved.
 
-```text
-**Tests**: Included — the constitution makes test-first non-negotiable (Principle II).
+And the human approvals are built into the flow, not bolted on. There is a required human sign-off after the specification is written, and another after the plan is designed. Reject either one and the run stops. So the expensive, hard-to-reverse decisions — *what are we building* and *how* — always get human judgment before a single line of contract code exists. Agents even participate in the *review*: every change to the money-handling code gets checked by a dedicated security-review agent before it can merge. Humans set the standards; the tooling makes them impossible to quietly ignore.
 
-## Phase 2: Foundational (blocking all stories)
-- [X] T003 contracts/fees/FeeRouter.sol — UUPS via UUPSManaged; append-only
-      storage; atomic depositToVaultWithFee (nonReentrant, CEI, maxFeeBps consent)
-- [X] T004 test/feeRouter.test.js — fee math incl. floor-to-zero, cap enforcement,
-      maxFeeBps revert, atomic revert, role gating, events
-- [X] T006 [P] test/upgradeable/FeeRouter.upgrade.test.js + register in
-      scripts/deploy/check-storage-layout.js
-```
+## Why go to all this trouble
 
-Two details do a lot of work. `[X]` gives implementers and reviewers a shared, resumable state — an agent picking up the feature mid-stream knows exactly what's left. `[P]` marks tasks that touch disjoint files and can run in parallel, which matters when you fan work out to multiple agents. And the *ordering* is a policy: the contract and its tests land together (Principle II), storage-layout verification is registered in the same phase because these are UUPS proxies where a reordered storage slot corrupts live state.
+**Why such a heavyweight process for a fast-moving crypto project?** The cost is real — several stages, several documents, two human gates per feature. The payoff is that the *variance* between the first feature and the fiftieth collapses. When the standard lives in a gate rather than in a reviewer's memory, it applies the same whether the author is a senior engineer or an agent on its third attempt at 2 a.m.
 
-## Coding agents in the loop — bounded by artifacts
+**Why make the standards binding rather than advisory?** Because advisory standards degrade under deadline pressure, and deadline pressure is exactly when the dangerous bug ships. Turning the standards-check into a precondition converts good intentions into a hard stop.
 
-FairWins is built with agents, not just for them, and Spec Kit is what keeps that safe. An agent asked to "implement spec 060" doesn't improvise; it reads `spec.md` for the requirements, `plan.md` for the design and its constitution check, and `tasks.md` for the ordered work — the same artifacts a human implementer would. The agent's freedom is bounded by documents a human already reviewed and approved.
+**What the process deliberately does not do.** It does not, by itself, verify that the code is *correct* — a plan can pass every check and still be wrong. That is why the standards *also* mandate real tests, automated security scanning, a security review, and loud-failing checks. The write-it-down method is the scaffolding that guarantees those safeguards get built into every feature; the safeguards themselves are what catch the bugs. The lightest steps stay optional, and genuinely trivial changes can skip ahead — but nothing touching funds, permissions, or how outcomes resolve is ever allowed to skip the specification.
 
-The review gates are literally encoded. The Spec Kit workflow definition (`.specify/workflows/speckit/workflow.yml`) inserts human approval between machine stages:
+The result is a codebase where "build with AI agents" and "handle people's money safely" stop being in tension. The process is the thing that reconciles them.
 
-```yaml
-- id: review-plan
-  type: gate
-  message: "Review the plan before generating tasks."
-  options: [approve, reject]
-  on_reject: abort
-```
+## Further reading
 
-There is one such gate after the spec and another after the plan. A rejected gate aborts the run. So the expensive, hard-to-reverse decisions — *what are we building* and *how* — get a human sign-off before any task is generated or a line of Solidity is written.
-
-Agents also participate in review, not just authoring. The constitution requires every `contracts/` change to be reviewed against `.github/agents/smart-contract-security.agent.md` — a dedicated security-review agent — before merge. And the repo keeps its own agent context honest: the `speckit-agent-context-update` extension (`.specify/extensions/agent-context/scripts/bash/update-agent-context.sh`) regenerates the managed Spec Kit section of `CLAUDE.md` so the guidance every agent reads at the start of a session stays in sync with the specs. The humans set the standards; the tooling makes them impossible to quietly ignore.
-
-## Design decisions and trade-offs
-
-**Why a heavyweight process for a fast-moving crypto project?** The cost of the pipeline is real: seven stages, several artifacts, two human gates per feature. The payoff is that the *variance* between the first feature and the sixty-third collapses. When the standard lives in a gate rather than a reviewer's memory, it applies whether the author is a senior engineer or an agent on its third attempt.
-
-**Why make the constitution binding rather than advisory?** Advisory standards degrade under deadline pressure — that's precisely when a fund-custody bug ships. By making the Constitution Check a precondition of the plan and forcing violations into an explicit Complexity Tracking table, the process converts "we should probably..." into "we cannot proceed until...". The friction is deliberate and lands on the highest-risk paths.
-
-**What the process doesn't do.** It doesn't verify correctness — a plan can pass the Constitution Check and still be wrong. That's why the constitution *also* mandates test-first coverage, Slither, Medusa, a security-agent review, and fail-loud CI. Spec Kit is the scaffolding that makes sure those gates get built into every feature; the gates themselves are what catch the bugs. The lightweight stages (`clarify`, `analyze`) are marked optional, and the constitution permits skipping steps for genuinely trivial changes — but *never* skipping the spec for anything touching funds, access control, or oracle resolution.
-
-The result is a codebase where "build with agents" and "handle user money safely" aren't in tension. The process is the thing that reconciles them.
-
-## Sources
-
-- `CLAUDE.md` — Spec Kit workflow section and repository guardrails
-- `.specify/memory/constitution.md` — the binding standards (v1.0.0)
-- `.specify/templates/plan-template.md`, `.specify/templates/spec-template.md`, `.specify/templates/tasks-template.md` — the artifact templates
-- `.specify/workflows/speckit/workflow.yml` — pipeline steps and human review gates
-- `.specify/extensions/agent-context/scripts/bash/update-agent-context.sh` — managed agent-context refresh
-- `specs/060-platform-fee-wrapper/{spec,plan,tasks}.md` — representative feature artifacts (Constitution Check, phased tasks)
-- `.github/agents/smart-contract-security.agent.md` — the security-review agent
-- `package.json` — `compile`, `test`, `check:storage-layout`, `test:fork`, `test:coverage` scripts
-- GitHub Spec Kit — https://github.com/github/spec-kit
-- EthTrust Security Levels — https://entethalliance.org/
+- [Spec Kit](https://github.com/github/spec-kit) — the open-source spec-driven development framework this workflow is built on
+- A general primer on the idea of a [software specification](https://en.wikipedia.org/wiki/Software_requirements_specification)
+- The [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/), the accessibility standard referenced above
+- The [EthTrust Security Levels](https://entethalliance.org/) for smart contract assurance

--- a/docs/blog/posts/32-spec-driven-development/social.md
+++ b/docs/blog/posts/32-spec-driven-development/social.md
@@ -1,30 +1,29 @@
-# Social & Image — Sixty-Three Features, One Constitution
+# Social & Image — Write It Down First
 
 ## X (Twitter)
 
-63 features on a fund-custody crypto codebase, shipped to one standard — because every plan must pass a binding Constitution Check before design begins. A rejected review gate aborts the run. How Spec Kit + agents actually work: 🔗 <link>
+An AI agent will write you a fund-custody smart contract in one shot. It'll compile. Then it holds real money on a public network, where one missed check is permanent. So how do you ship your 50th feature as safely as your first? Write down what and why first, and make the standards a gate the work must pass. 🔗 <link>
 
-#SpecDrivenDevelopment #AIagents #web3
+#AIagents #Web3 #EngineeringProcess
 
 ## LinkedIn
 
-A coding agent will write you a fee-charging smart contract in one shot. It'll compile. It might pass a couple of tests it invented along the way. Then it custodies user funds on a public network, where one missed reentrancy guard is permanent.
+An AI coding agent will write you a fee-charging smart contract in one shot. It'll compile. It might pass a couple of tests it invented along the way. Then it custodies real user funds on a public network, where one missed safety check is permanent and exploitable by anyone.
 
-So how do you ship the 63rd feature to the same standard as the first, when humans and agents are both writing them?
+So how do you ship the fiftieth feature to the same standard as the first, when humans and AI agents are both writing them?
 
-FairWins' answer is process made executable — GitHub's Spec Kit plus a binding project constitution. The new post walks through:
+FairWins' answer is process made executable. The new post walks through the method in plain terms:
 
-- The pipeline: constitution → specify → clarify → plan → tasks → analyze → implement, each stage a reviewable artifact that outlives the chat.
-- The constitution as a gate, not a README: every plan.md opens with a Constitution Check that must pass before design proceeds — and any deviation goes in an explicit Complexity Tracking table.
-- Tasks that encode test-first: contracts and their tests land together, storage-layout checks in the same phase, parallel-safe work marked for fan-out.
-- Agents in the loop, bounded by artifacts: human approval gates after the spec and after the plan; a dedicated security-review agent required on every contract change.
+- Write down the *what* and *why* before anyone picks a tool — so a design decision can't hide inside a requirement.
+- Keep a short, binding set of standards — a project "constitution" — and make every plan open by proving it complies before any building starts. Any deviation gets argued for in writing, before code, not in a post-mortem.
+- Break work into small, ordered tasks, and let AI agents do the building inside those guardrails, with human sign-off on the what and the how.
 
-The takeaway: "build with agents" and "handle user money safely" stop being in tension when the standard lives in a gate instead of a reviewer's memory.
+The takeaway: "build with agents" and "handle people's money safely" stop being in tension when the standard lives in a gate instead of a reviewer's memory.
 
-How are you keeping quality constant as agents take on more of the authoring in your codebase? 🔗 <link>
+How are you keeping quality constant as agents take on more of the building? 🔗 <link>
 
-#SpecDrivenDevelopment #SmartContracts #AIagents #DevOps #Web3
+#AIagents #EngineeringProcess #Web3 #ProductDevelopment
 
 ## Image prompt (Gemini / Nano Banana)
 
-A clean modern editorial illustration in an isometric style depicting a factory assembly line where identical, precisely-formed geometric artifacts (representing software features as crystalline blocks) move along a conveyor belt, each one passing through a single glowing gate-arch that inspects and stamps it before it continues — the gate as the metaphor for a binding constitution check that every feature must pass. Show several blocks queued behind the gate and a uniform, orderly stream of approved blocks flowing out the other side, emphasizing consistency and repeatability at scale. Composition is wide and horizontal with the gate as the focal point slightly left of center, subtle depth-of-field falloff toward the edges. Color mood: deep navy and teal base tones with a single warm amber accent used only on the gate's glow and its stamp of approval. Soft directional lighting from upper left, gentle ambient occlusion, crisp vector-like edges, minimal texture. No text, no logos, no watermarks. Aspect ratio 16:9.
+A clean modern editorial illustration in an isometric style depicting a factory assembly line where identical, precisely-formed geometric artifacts (representing software features as crystalline blocks) move along a conveyor belt, each one passing through a single glowing gate-arch that inspects and stamps it before it continues — the gate as the metaphor for a binding standards check that every feature must pass. Show several blocks queued behind the gate and a uniform, orderly stream of approved blocks flowing out the other side, emphasizing consistency and repeatability at scale. Composition is wide and horizontal with the gate as the focal point slightly left of center, subtle depth-of-field falloff toward the edges. Color mood: deep navy and teal base tones with a single warm amber accent used only on the gate's glow and its stamp of approval. Soft directional lighting from upper left, gentle ambient occlusion, crisp vector-like edges, minimal texture. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/33-callsign-registry/blog.md
+++ b/docs/blog/posts/33-callsign-registry/blog.md
@@ -1,119 +1,76 @@
-# CallsignRegistry: An In-House ENS-Style Naming System That Nothing Depends On
+# Callsigns: A Human-Readable Name That Nothing Depends On
 
-*How FairWins built a commit–reveal naming registry as an optional perk — and kept it strictly off the value path*
+*How FairWins built an optional, ENS-style handle for members — and deliberately made sure you can send, receive, and settle every wager without ever using one.*
+
+| | |
+|---|---|
+| **Series** | FairWins Engineering |
+| **Audience** | Product teams, founders, and the crypto-curious — no Solidity required |
+| **Tags** | `naming`, `identity`, `usability`, `plain-english` |
+| **Reading time** | ~7 minutes |
 
 ---
 
-- **Series:** Standalone
-- **Part:** 33 of 34
-- **Audience:** Naming/identity engineers, product teams, Solidity engineers
-- **Tags:** `naming`, `ens`, `commit-reveal`, `identity`, `uups`
-- **Reading time:** ~9 minutes
+## The forty-two-character problem
 
----
+Maya wants to invite her friend Dev to a wager on Sunday's match. The invite form asks for a wallet address. Dev's address is `0x7f3a…` — forty-two characters of hex that Maya has to dig out of a chat thread, paste, and then squint at, because one wrong character sends the invite, and eventually the stake, to a stranger.
 
-## The Forty-Character Problem
+Every crypto product hits this wall. The best-known answer is ENS, the Ethereum Name Service — register a name like `dev.eth` and type that instead of the hex. But ENS lives on Ethereum's main network, and FairWins runs its wagers elsewhere. More importantly, FairWins already has its own notion of identity that ENS knows nothing about: an on-chain membership system with tiers, sanctions screening, and role-based access. A name that resolves to "some wallet, somewhere" is less useful than a name that resolves to "a screened member of this platform."
 
-Maya wants to invite her friend Dev to a wager on Sunday's match. The invite form wants a wallet address. Dev's address is `0x7f3a…` — forty-two characters of hex that Maya has to fetch from a chat thread, paste, and then squint at, because a wrong character means the invite (and eventually the stake) goes to a stranger.
+So FairWins built its own: a **callsign**. A member can optionally claim a handle like `%chipprbots`, and it resolves to their wallet everywhere the app asks you to enter or display an address.
 
-Every crypto product hits this wall, and the ecosystem's standard answer is ENS: register `dev.eth`, type a name instead of hex. But ENS is an Ethereum-mainnet system, and FairWins runs its wager escrow on Polygon and the Mordor testnet. More importantly, FairWins already has an identity spine ENS knows nothing about: an on-chain `MembershipManager` with tiers, sanctions screening, and role-gated access. A name that resolves to "some wallet somewhere" is less useful than a name that resolves to "a screened, top-tier member of this platform."
+The interesting part isn't that we built a naming system. It's the two disciplines wrapped around it. It borrows the hardest-won safety mechanism from ENS while deliberately refusing ENS's most dangerous flexibility — and, the part to remember, **the whole thing is engineered so that nothing of value ever depends on it.** You can create, accept, and settle every wager you'll ever make without ever registering or using a callsign. That is not a marketing line; it is a property the test suite actively verifies.
 
-So spec 054 built the thing in-house: the **CallsignRegistry** (`contracts/naming/CallsignRegistry.sol`), a UUPS-proxied naming contract where a Gold-tier-or-above member may optionally register a `%callsign` — `%chipprbots`, say — that resolves trustlessly to their wallet across every address-entry and display surface in the app.
+## Optional, and we mean it
 
-The interesting part isn't that FairWins built an ENS-lite. It's the two disciplines wrapped around it: the registry borrows ENS's hardest-won mechanism (commit–reveal registration) while deliberately rejecting its most flexible one (separating name controller from resolution target), and the whole system is engineered so that *nothing of value ever depends on it*. A member can create, accept, and settle every wager they'll ever make with a raw address and never touch the registry. That optionality is a tested invariant, not a marketing line.
+Start here, because it shapes everything else. **A callsign is a perk, never a requirement.** No wager, no pool, no transfer, and no payout ever checks the naming system as a precondition. Money moves on wallet addresses, full stop.
 
-## A Name Format Chosen for Safety, Not Expressiveness
+This isn't left to good intentions. The automated tests include an account with no callsign at all, below the tier that could even register one, completing a full wager from start to finish. The naming system can be switched off on a given network, be unreachable, or be paused entirely, and every dollar-moving flow works exactly the same. If callsigns vanished tomorrow, every wager would still settle — some screens would just show hex again.
 
-A callsign is 3–20 characters of `a-z0-9` plus single interior hyphens — no leading, trailing, or consecutive hyphens, no uppercase, no Unicode. The on-chain validator (`_validate` in `CallsignRegistry.sol`) enforces this byte by byte, and the frontend mirrors it in `frontend/src/lib/callsigns/normalizeCallsign.js`.
+Because it never touches the money, the naming system is deliberately kept off to the side. It holds no funds and has no ability to move anyone's money. Its worst-case failure is cosmetic: a name doesn't show up, and you see a raw address instead. That containment is the whole design philosophy in one sentence.
 
-The ASCII whitelist is the impersonation defense. ENS supports Unicode names and inherits an entire research area of homoglyph attacks — Cyrillic `а` versus Latin `a`, and thousands of confusable pairs that ENSIP-15 normalization tries to tame. Spec 054's research explicitly rejected Unicode normalization in favor of the blunter tool: if the only registrable characters are lowercase ASCII letters, digits, and hyphens, there is no confusable pair to defend against. Names are keyed by `keccak256` of the canonical string, and case variants normalize to the same lookup before they reach the chain.
+## A name format chosen for safety, not flair
 
-## Commit → Reveal, Plus a Griefing Fix
+A callsign is 3 to 20 characters: lowercase letters, digits, and single interior hyphens. No uppercase, no spaces, no emoji, no accented or non-Latin characters.
 
-Naming registries have a classic front-running problem: you broadcast `register("chipprbots")`, a mempool observer sees it, and their bot registers the name one block ahead of you. ENS's `.eth` registrar solved this with commit–reveal, and CallsignRegistry adopts the same pattern:
+That last restriction is doing serious security work. ENS supports the full range of Unicode characters, and in doing so inherits an entire category of impersonation attack: homoglyphs — characters that look identical but aren't, like a Cyrillic "а" standing in for a Latin "a." A scammer can register a name that looks pixel-for-pixel like a trusted one. FairWins simply removes the possibility: if the only characters you can register are plain lowercase letters, digits, and hyphens, there is no look-alike to defend against. Less expressive, categorically safer. Names that differ only in capitalization collapse to the same handle, so there's no trickery there either.
 
-1. `makeCommitment(callsign, owner, salt)` — a pure function returning `keccak256(abi.encode(callsignHash, owner, salt))`.
-2. `commit(commitment)` — stores only the opaque hash on-chain. Observers learn nothing.
-3. Wait at least `minCommitmentAge` (default 1 minute).
-4. `register(callsign, salt)` — the reveal. By the time the name is visible, your priority is already locked; a sniper's own commitment can't be old enough.
+## Claiming a name without getting sniped
 
-Commitments expire after `maxCommitmentAge` (default 1 day), which prevents commitment squatting. But the implementation also closes a subtler hole that the naive version of this pattern leaves open. A commitment hash is public calldata — anyone can see it once you've committed. If `commit` blindly overwrote the stored timestamp, an attacker could replay *your* commitment every few blocks, perpetually resetting its age so your reveal forever fails with `CommitmentTooNew`:
+Naming systems have a classic front-running problem. You broadcast "register `chipprbots`," a bot watching the network sees it, and it registers the name one step ahead of you. ENS solved this years ago with a two-step "commit then reveal" dance, and FairWins uses the same idea:
 
-```solidity
-function _commit(bytes32 commitment) internal {
-    // Reject re-committing a still-unexpired commitment — re-commit is
-    // allowed only once the prior one has expired (ENS anti-snipe pattern).
-    uint64 existing = commitments[commitment];
-    if (existing != 0 && block.timestamp <= uint256(existing) + maxCommitmentAge) {
-        revert CommitmentPending();
-    }
-    commitments[commitment] = uint64(block.timestamp);
-    emit CallsignCommitted(commitment, uint64(block.timestamp));
-}
-```
+1. First you quietly commit — you publish a scrambled fingerprint of the name you want, which reveals nothing to onlookers.
+2. You wait a short mandatory period (about a minute).
+3. Then you reveal and register. By the time your desired name is visible, your claim to it is already locked in, and a sniper's own commitment can't possibly be old enough to jump the queue.
 
-This reveal-griefing fix was one of two MEDIUM findings hardened during the spec's security review; the other appears below in the repoint flow.
+The FairWins version also closes a subtler hole. That committed fingerprint is public. In a naive design, an attacker could keep re-submitting *your* fingerprint every few blocks, forever resetting its clock so your reveal never becomes eligible — a way to grief you out of your own name. The registry refuses to reset a commitment that's still pending, which quietly defeats that attack. It was one of two issues caught and hardened during the security review.
 
-## The Gold Gate — and the Optionality Doctrine
+## One name, one address — on purpose
 
-Registration is gated on membership: `_requireEligible` checks `membershipManager.getActiveTier(user, membershipRole) >= minTier`, where the role is `WAGER_PARTICIPANT_ROLE` and `minTier` initializes to Gold. The gate is tunable but only upward — `setMembershipGate` reverts with `TierBelowFloor` if an admin tries to drop it below Gold. A hard floor in code, not a policy document. Sanctions screening rides along in the same check when a guard is configured.
+Here's the design choice that most sharply distinguishes callsigns from ENS. ENS separates who *owns* a name from what the name *points at*, and lets the owner freely repoint it. That flexibility is also a fraud vector: point the name at a new address and every future payment aimed at that name silently goes somewhere else.
 
-The mirror-image rule is the one that shapes the whole design: **nothing on the value path may require a callsign** (FR-001a). No wager creation, pool join, transfer, or claim reads the registry as a precondition. This isn't left to convention — the integration suite (`test/integration/callsignRegistry.membership.test.js`) includes a below-Gold, callsign-less account completing a full wager end to end. The registry can be undeployed on a chain, unreachable, or paused, and every dollar-moving flow works identically.
+A callsign points at exactly one address, and moving it is treated as a rare, deliberate migration. When you request to move a callsign to a new wallet, the name enters a visible "address changing" state, refuses to resolve for any payment during that window, and only completes after a built-in delay of about two days. If someone hijacked your session and tried to redirect your name, you get two days of visible warning to cancel it. And repointing is genuinely rare to begin with, because FairWins' smart-account wallets keep the same address even when you recover access with a new credential.
 
-That's also why the registry is a *standalone* UUPS proxy. It is not routed through `WagerRegistry`, holds no funds — there are no payable functions and no token custody, so its worst-case failure is cosmetic — and it lives at a stable address with append-only storage, a trailing `__gap`, and the CI-gated `npm run check:storage-layout` shared by the platform's other proxies. Deployment keys are `callsignRegistry` / `callsignRegistryImpl` in `deployments/<network>.json`, resolved in app code via `getContractAddressForChain('callsignRegistry', chainId)`.
+A few more touches serve the same goal: a name that once routed payments can never silently start routing them elsewhere. A released or changed name goes into a long quarantine during which *nobody* — not even its former owner — can re-register it, so a stranger can't capture payments aimed at the old name. And moderators can reserve obvious names (brand terms, `admin`, `support`) or suspend a name — but crucially, **no one, not even the platform operator, can ever reassign a callsign to a different wallet.** Suspension can stop a name from resolving; it can never move it or touch funds.
 
-## Lifecycle: Quarantine, Cooldown, Repoint, Lapse
+## How the app uses a name — carefully
 
-A name that routes payments needs a careful lifecycle. Callsigns move through six statuses — `NONE`, `ACTIVE`, `REPOINTING`, `QUARANTINED`, `SUSPENDED`, `LAPSED_RECLAIMABLE` — governed by bounded, operator-tunable policy parameters:
+When you look up a callsign, the match is exact — no "did you mean," no fuzzy matching, because a near-match on an address field is a payment-misdirection bug waiting to happen. And a name only displays if it currently points back at the address showing it; a suspended or mid-move name simply disappears rather than telling you a stale story.
 
-- **Release and change enter quarantine.** A released or replaced callsign is unregistrable by *anyone* — including its former owner — for `quarantinePeriod` (default 90 days). Payments and invitations aimed at the old name cannot be silently captured by a stranger who re-registers it. Changes are additionally rate-limited by `changeCooldown` (default 30 days).
-- **Repointing is delayed, visible, and cancellable.** Here's where the design diverges from ENS on purpose. ENS separates the name's owner from its resolver record, which is flexible — and is exactly the payout-redirect vector spec 054 guards against. A callsign points at one address, and moving it (`requestRepoint` → wait `repointDelay`, default 48 hours → `finalizeRepoint`) puts the name into `REPOINTING`, during which it is refused for value-bearing resolution and surfaces show an honest "address changing" state. A compromised session that requests a repoint gives the real owner two days of visible warning to `cancelRepoint`. Requesting is tier-exempt (a downgraded owner is never stranded holding their own identity), but the security review added a second hardening: `finalizeRepoint` requires the *incoming* owner to be Gold-eligible — otherwise a lapsed member could repoint names around a ring of wallets to reset the lapse clock and hoard them for free. Finalizing also clears the `verified` marker, because verification was granted to a reviewed identity, not to a name. Suspension, deliberately, persists across a repoint.
-- **Lapse is grace-then-release.** If Gold coverage ends, the callsign stays `ACTIVE` until the membership term expires, then survives a `lapseGrace` window (default 365 days). Only after that does the permissionless `reclaimLapsed` push it into standard quarantine.
+Callsigns also slot politely into a chain of name sources rather than taking over. When the app shows who's on the other side of a wager, it prefers, in order: your own private nickname for that address, then their callsign, then an ENS name, and finally a friendly auto-generated two-word label so no card ever shows raw hex or a spinner. Every step fails softly — if the naming system is off on your network or a lookup times out, the app falls through to the next option. When you type a `%callsign` into an address field, it resolves it and shows you the full address plus whether the name is verified, so you can confirm before anything is committed.
 
-Moderation follows least privilege: `REGISTRY_CURATOR_ROLE` reserves terms (brand names, `admin`, `support`), `MODERATOR_ROLE` suspends, `VERIFIER_ROLE` marks business callsigns verified. None of these roles — nor the platform operator — can ever reassign a callsign to a different wallet. Suspension stops resolution; it never moves a name or touches funds.
+## Why we built it this way
 
-## Resolution: Exact-Match Forward, Guarded Reverse
+- **In-house instead of leaning on ENS.** We needed membership gating, sanctions screening, moderation, and presence on the networks we actually run on — none of which ENS offers here. ENS still participates, as one option in the display chain.
+- **A plain ASCII name format instead of full Unicode.** Less expressive, but it *eliminates* the look-alike impersonation attack rather than trying to mitigate it.
+- **One name, one address.** Splitting a name's owner from its target invites redirect fraud; keeping them fused makes the common case safe and the rare migration deliberate.
+- **A perk, not a primitive.** Making callsigns an optional membership benefit — and actively testing that wagers work without one — keeps a nice-to-have from ever hardening into a load-bearing requirement.
 
-Forward resolution (`resolve(string)`) is exact-match only — no fuzzy matching, no "did you mean," because a near-match substitution on an address-entry field is a payment misdirection bug. Reverse resolution is guarded by a forward==reverse invariant: an address's displayed callsign must currently resolve back to that address.
+The result is a naming system with the registration safety of the best in the ecosystem, a narrower and safer way of pointing names at addresses, and a blast radius engineered down to zero. It makes the product friendlier. It is not allowed to make the product more fragile.
 
-```solidity
-function callsignOf(address account) external view returns (string memory) {
-    bytes32 h = callsignHashOf[account];
-    if (h == bytes32(0)) return "";
-    // Reverse only reports a callsign whose forward resolution is ACTIVE.
-    if (_statusOf(h) != CallsignStatus.ACTIVE) return "";
-    return _records[h].callsign;
-}
-```
+## Further reading
 
-A suspended, repointing, or lapsed callsign simply disappears from display rather than telling a stale story.
-
-On the frontend, callsigns slot into an existing name-resolution chain rather than replacing it. `frontend/src/hooks/useOpponentName.js` resolves any counterparty in priority order: **address book > callsign > ENS > generated**. Your own private nickname for an address always wins; a registered `%callsign` beats an ENS name; and a deterministic two-word generated name is always available synchronously so no card ever shows a spinner or raw hex. Every step soft-fails — if the registry is undeployed on the current chain or a lookup times out, the chain falls through silently. Address entry (`frontend/src/components/ui/AddressInput.jsx`) accepts `%callsign` input, resolves it, and shows the full resolved address plus verification status for explicit confirmation before anything is committed. Only an `ACTIVE` callsign is committable.
-
-## Gasless Twins, Same Three-Way Sync
-
-Like every actor-facing contract on the platform, each callsign action has an EIP-712 `…WithSig` twin via `SignerIntentBase`: `commitWithSig`, `registerWithSig`, `changeCallsignWithSig`, `releaseWithSig`, `requestRepointWithSig`, `cancelRepointWithSig`, under the domain `"FairWins CallsignRegistry"` / version `"1"`. The six intent structs must stay byte-identical in three places — the contract typehashes, `frontend/src/lib/relay/intentTypes.js`, and `services/relay-gateway/src/intent/intentTypes.js` — and the release/repoint intents pin the exact `callsignHash` so a relayed signature can't be applied to a different name. `finalizeRepoint` and `reclaimLapsed` are permissionless and need no signed twin. Per the platform's never-stranded rule, every gasless path keeps a self-submit fallback.
-
-## Design Decisions
-
-- **In-house over ENS integration.** The registry needed membership gating, sanctions screening, role-based moderation, and presence on chains where ENS doesn't live. ENS still participates — as step three of the display chain — but the platform-native handle is anchored to platform-native identity.
-- **ASCII whitelist over Unicode normalization.** Less expressive, categorically safer. The homoglyph attack surface is eliminated rather than mitigated.
-- **One name, one address — no resolver indirection.** Splitting controller from target invites payout-redirect fraud; FairWins' passkey smart accounts already keep their address across credential recovery, so repointing is a rare migration action worth a 48-hour delay, not an everyday record edit.
-- **Direct chain reads over a subgraph.** Callsign→address routes value; an indexer would add a second, laggier source of truth. The trade-off shows up in the admin console: with no on-chain counters, registry metrics come from a bounded client-side event scan with an honest "recent window only" banner.
-- **Perk, not primitive.** Gating registration at Gold makes the callsign a membership benefit; hard-flooring the gate and testing the no-callsign wager path keeps it from ever hardening into a requirement.
-
-The result is a naming system with ENS's registration security, a narrower and safer resolution model, and a blast radius engineered to zero: if the CallsignRegistry vanished tomorrow, every wager would still settle — some screens would just show hex again.
-
-## Sources
-
-- `specs/054-callsign-registry/spec.md`, `plan.md`, `research.md`, `data-model.md`
-- `contracts/naming/CallsignRegistry.sol` (interface: `contracts/interfaces/ICallsignRegistry.sol`)
-- `docs/developer-guide/callsigns.md`
-- `docs/developer-guide/upgradeable-contracts.md`
-- `frontend/src/hooks/useOpponentName.js`, `frontend/src/lib/callsigns/normalizeCallsign.js`, `frontend/src/components/ui/AddressInput.jsx`
-- `frontend/src/lib/relay/intentTypes.js`, `services/relay-gateway/src/intent/intentTypes.js`
-- `test/integration/callsignRegistry.membership.test.js`
-- ENS `.eth` registrar commit–reveal registration: https://docs.ens.domains/
-- ENSIP-15 (ENS name normalization): https://docs.ens.domains/ensip/15
-- EIP-712 (typed structured data signing): https://eips.ethereum.org/EIPS/eip-712
-- ERC-1822 / UUPS proxies: https://eips.ethereum.org/EIPS/eip-1822 and OpenZeppelin upgradeable contracts docs: https://docs.openzeppelin.com/contracts/5.x/api/proxy
+- [ENS (Ethereum Name Service)](https://docs.ens.domains/) and its commit–reveal registration, the model this borrows from
+- [ENS name normalization (ENSIP-15)](https://docs.ens.domains/ensip/15), the standard that wrestles with the Unicode look-alike problem we sidestep
+- A general explainer on [homoglyph / look-alike attacks](https://en.wikipedia.org/wiki/IDN_homograph_attack)
+- The broader FairWins developer documentation for how identity and address entry fit together

--- a/docs/blog/posts/33-callsign-registry/social.md
+++ b/docs/blog/posts/33-callsign-registry/social.md
@@ -1,27 +1,27 @@
-# Social & Image — CallsignRegistry: An In-House ENS-Style Naming System That Nothing Depends On
+# Social & Image — Callsigns: A Human-Readable Name That Nothing Depends On
 
 ## X (Twitter)
 
-FairWins built an ENS-style naming registry — commit–reveal, ASCII-only to kill homoglyph attacks — then engineered its blast radius to zero. A callsign is optional and never gates the value path: undeploy the registry and every wager still settles, some screens just show hex again. 🔗 <link>
+FairWins built an ENS-style handle — claim a %callsign instead of pasting 42 characters of hex — then made sure nothing depends on it. A callsign is fully optional and never gates sending or receiving money. Switch the whole thing off and every wager still settles; some screens just show hex again. 🔗 <link>
 
-#Ethereum #Solidity #Identity
+#Crypto #Identity #Usability
 
 ## LinkedIn
 
-A forty-two-character hex address is a payment-misdirection bug waiting to happen. The ecosystem's answer is ENS — but ENS is Ethereum-mainnet-only, and FairWins runs on Polygon and Mordor with an on-chain membership spine ENS knows nothing about.
+A forty-two-character wallet address is a payment-misdirection bug waiting to happen. The ecosystem's answer is ENS — but it lives on Ethereum's main network, and FairWins runs elsewhere, with its own membership identity ENS knows nothing about.
 
-So spec 054 built the CallsignRegistry in-house — and wrapped two disciplines around it. The post covers:
+So we built an in-house handle: claim an optional %callsign and it resolves to your wallet everywhere you'd otherwise paste hex. The new post covers, in plain terms:
 
-- Commit–reveal registration borrowed from ENS, plus a hardening fix that stops an attacker from replaying your public commitment to perpetually reset its age.
-- An ASCII-only name format (`a-z0-9`, interior hyphens): less expressive, but the homoglyph attack surface is eliminated rather than mitigated.
-- One name, one address — deliberately rejecting ENS's controller/resolver split, the classic payout-redirect vector; repointing is a delayed, cancellable migration, not an everyday edit.
-- The optionality doctrine: nothing on the value path may require a callsign (FR-001a). A below-Gold, callsign-less account completing a full wager is a tested invariant, not a marketing line.
+- The optionality doctrine, first and loudest: a callsign is a perk, never a requirement. Nothing on the money path checks it — and a callsign-less account completing a full wager is a test we actually run, not a promise.
+- A plain lowercase-ASCII name format that *eliminates* look-alike impersonation attacks instead of trying to mitigate them.
+- Commit-then-reveal registration borrowed from ENS, hardened so no one can grief you out of your own name.
+- One name, one address — deliberately rejecting the split that lets a name be silently repointed at a new wallet. Moving a callsign is a rare, delayed, cancellable migration, and no one can ever reassign your name for you.
 
-The result: ENS's registration security, a narrower resolution model, and a blast radius engineered to zero. If the registry vanished tomorrow, every wager would still settle.
+The result: real usability, with a blast radius engineered to zero. If the naming system vanished tomorrow, every wager would still settle.
 
-Where's the line for you between a nice-to-have perk and a load-bearing primitive? 🔗 <link>
+Where's your line between a nice-to-have perk and a load-bearing primitive? 🔗 <link>
 
-#Ethereum #Solidity #Identity #ENS #SmartContracts
+#Crypto #Identity #ProductDesign #Usability
 
 ## Image prompt (Gemini / Nano Banana)
 

--- a/docs/blog/posts/34-token-factory/blog.md
+++ b/docs/blog/posts/34-token-factory/blog.md
@@ -1,140 +1,72 @@
-# TokenFactory: Minting From Vetted Templates, Not Arbitrary Bytecode
+# Minting Tokens From Vetted Templates, Not Arbitrary Code
 
-*How FairWins lets authorized issuers mint their own ERC-20s, ERC-721s, and restricted tokens without ever deploying unaudited code — and what that constraint buys you*
+*How FairWins lets approved issuers create their own tokens without ever deploying code nobody reviewed — and what that one constraint buys everyone downstream.*
 
 | | |
 |---|---|
 | **Series** | FairWins Engineering |
-| **Part** | 34 — TokenFactory: templated token minting |
-| **Audience** | Solidity / web3 engineers, protocol integrators |
-| **Tags** | solidity, erc20, erc1404, minimal-proxy, upgradeable, factory-pattern |
-| **Reading time** | ~9 minutes |
+| **Audience** | Founders, product teams, and the crypto-curious — no Solidity required |
+| **Tags** | `tokens`, `security`, `compliance`, `plain-english` |
+| **Reading time** | ~7 minutes |
 
 ---
 
 ## The token nobody audited
 
-An issuer on the platform wants to spin up a fungible token — say, a points balance for a community, or a restricted instrument that only vetted wallets can hold. The naive path is familiar: write a Solidity contract, compile it, deploy the bytecode, hope it does what the constructor comment claims.
+An issuer on the platform wants to spin up a token — say, a points balance for a community, or a restricted instrument only vetted wallets are allowed to hold. The obvious path is the familiar one: write a smart contract, deploy it, and hope it does what its author claims.
 
-That path is a problem the moment more than one person relies on it. Whose eyes were on the transfer hook? Did the `mint` function check the sanctions list, or did it quietly skip it? When the platform's frontend later renders a "Holders" tab or an "Activity" feed for that token, is it reading a real ERC-20, or something that *looks* like one until the third `transferFrom`? Arbitrary bytecode deployment means every new token is a fresh, un-reviewed attack surface, and every downstream consumer — the subgraph, the wallet UI, the sanctions screen — has to defensively assume the worst.
+That path becomes a problem the moment more than one person relies on it. Whose eyes were actually on that code? Does its transfer logic check the sanctions list, or quietly skip it? When the platform later shows a "Holders" tab for that token, is it reading a real, well-behaved token — or something that merely *looks* like one until the third transfer does something surprising?
 
-FairWins takes the opposite stance. There is exactly one contract on each network authorized to bring tokens into existence: `contracts/tokens/TokenFactory.sol`. It does not accept bytecode. It does not `CREATE2` whatever an issuer hands it. It clones from a small, fixed set of implementation templates that the platform team wrote, audited, and pinned — and it stamps a sanctions screen into every one on the way out the door.
+Letting anyone deploy arbitrary code means every new token is a fresh, un-reviewed attack surface — and everything downstream, from the wallet interface to the compliance screen, has to defensively assume the worst about every token it encounters.
 
-This post walks through what that template model constrains, why the constraint is worth it, and how a new template gets added when the fixed set needs to grow.
+FairWins takes the opposite stance. On each network there is exactly one contract authorized to bring tokens into existence, and it does not accept code. You cannot hand it a program and say "deploy this." Instead, it stamps out copies from a small, fixed set of templates that the platform team wrote, audited, and locked in — and it presses a sanctions check into every single one on the way out the door.
 
-## One authority, a handful of templates
+This post walks through what that template model gives up, why it's worth it, and how the fixed menu grows when it needs to.
 
-The factory is the single upgradeable, state-bearing contract for token issuance. Everything it emits is an immutable minimal-proxy clone. The design splits cleanly along that line: the *authority* can be upgraded and re-templated; the *tokens* it produces can never change their own logic.
+## One authority, a short menu
 
-The template set is deliberately short. Each supported standard has a v1 (Ownable) template and a v2 (role-based) template:
+Think of the token factory as a licensed mint. It is the single, upgradeable contract responsible for issuance, and everything it produces is a permanent, unchangeable copy of a template. That split is deliberate: the *mint* can be improved over time; the *coins* it stamps out can never rewrite their own rules afterward.
 
-| Standard | v1 template | v2 template | Character |
-|---|---|---|---|
-| Open ERC-20 | `OpenERC20` | `OpenERC20V2` | Fungible; burnable/pausable flags; optional supply cap (v2) |
-| Open ERC-721 | `OpenERC721` | `OpenERC721V2` | NFT; per-token URIs; batch mint |
-| Restricted ERC-1404 | `RestrictedERC20` | `RestrictedERC20V2` | Eligibility allowlist + restriction codes + freeze |
-| Permissioned ERC-3643 (T-REX) | — | — | **Deferred** (see below) |
+The menu is intentionally short. It covers the standard token types a platform actually needs — a plain fungible token (think community points), a standard collectible/NFT, and a *restricted* token that can enforce an eligibility list and freeze or block specific holders. Each comes in two variants: a simpler single-owner version and a more flexible role-based version.
 
-That is the entire menu. An issuer picks a standard and a few parameters — name, symbol, decimals, supply, a cap, an eligibility list — and gets back a token address. They never choose *code*. The `TokenStandard` enum in `contracts/tokens/interfaces/ITokenFactory.sol` enumerates exactly what can be minted, and a value with no configured template simply reverts.
+That's the entire menu. An issuer picks a type and fills in a few parameters — name, symbol, supply, a cap, an eligibility list — and gets back a token. They never choose *code*. Ask for a type that has no template configured and the request simply fails.
 
-The clone mechanism is OpenZeppelin's EIP-1167 minimal proxy (`Clones.clone`). Each `create*` call deploys a ~45-byte proxy that `DELEGATECALL`s a shared, already-audited implementation, then calls a one-time `initialize` to set the token's own storage. The implementation itself is initialization-locked in its constructor (`_disableInitializers()`), so the master copy can never be hijacked — only cloned.
+The copying mechanism itself is a well-established Ethereum pattern called a minimal proxy (the ERC-1167 standard): each new token is a tiny, cheap stub that borrows its behavior from one shared, already-audited master copy. The master is permanently locked against being initialized or hijacked itself — it can only be *copied from*, never taken over.
 
-## What gets stamped in on the way out
+## What gets pressed in on the way out
 
-The factory's issuance path is not a pass-through. Before any clone happens, `_beforeCreate` runs three checks that no issuer can opt out of:
+The factory's issuance path is not a rubber stamp. Before any token is created, it enforces three things no issuer can opt out of: the name and symbol can't be empty, a template must exist for the requested type, and the issuer themselves must pass the platform's shared sanctions screen — the same fail-closed check the rest of FairWins uses, not a bespoke parallel one. On top of that, the ability to issue at all is a permission the platform grants deliberately; simply holding a wallet isn't enough.
 
-```solidity
-function _beforeCreate(
-    string calldata name,
-    string calldata symbol,
-    address impl,
-    TokenStandard standard
-) internal view {
-    if (bytes(name).length == 0 || bytes(symbol).length == 0) revert EmptyMetadata();
-    if (impl == address(0)) revert TemplateNotSet(standard);
-    ISanctionsGuard guard = sanctionsGuard;
-    if (address(guard) != address(0) && !guard.isAllowed(msg.sender)) revert SanctionedAddress(msg.sender);
-}
-```
+The screening doesn't stop at creation. Every template carries that same sanctions check *into* the token it stamps out, and every one of those tokens re-runs the check on every transfer — screening both sender and recipient, and stepping aside only for the mint-and-burn endpoints, where there's just one real party.
 
-Metadata must be non-empty. A template must be configured for the requested standard. And the issuer must pass the platform's shared `ISanctionsGuard` — fail-closed, the same screen the rest of FairWins uses, not a parallel bespoke one. Issuance itself is gated behind `TOKEN_ISSUER_ROLE`, granted out-of-band by the platform admin; holding a wallet is not enough to mint.
+Here is the payoff, and it's the whole reason for refusing arbitrary code: because the template is the *only* code an issuer can deploy, the platform *knows* this check exists in every token it has ever minted. A property proven once on a template holds for the entire population of copies. Sanctions aren't non-bypassable because of a policy memo — they're non-bypassable because there is no code path that omits them.
 
-The screen does not stop at creation. Every template injects that same `sanctionsGuard` reference into the token it clones, and every token re-checks it on every transfer inside its `_update` hook — skipping only the zero endpoint so mints and burns are screened on their one real party. Here is the open ERC-20's hook:
+The restricted token type pushes the same idea one step further. Before offering a transfer, a well-built interface asks the token "would this transfer succeed?" and the token, at the moment of transfer, decides whether to allow it. A whole class of bug lives in the gap between those two answers — the preview says "yes," the transfer then says "no." The restricted template forecloses that by construction: the preview and the enforcement run through the *exact same* internal check, evaluated most-restrictive-first (sanctioned, then frozen, then not-eligible). What you're told will happen is what happens.
 
-```solidity
-function _update(address from, address to, uint256 value)
-    internal override(ERC20Upgradeable, ERC20PausableUpgradeable)
-{
-    ISanctionsGuard guard = sanctionsGuard;
-    if (address(guard) != address(0)) {
-        if (from != address(0) && !guard.isAllowed(from)) revert SanctionedAddress(from);
-        if (to != address(0) && !guard.isAllowed(to)) revert SanctionedAddress(to);
-    }
-    super._update(from, to, value);
-}
-```
+## Discovery you don't have to trust the tokens for
 
-Because the template is the only code an issuer can deploy, the platform *knows* this check exists in every token it has ever minted. That is the whole point of refusing arbitrary bytecode: a property proven once on the template holds for the entire population of clones. Sanctions are non-bypassable not because of policy, but because there is no code path that omits them.
+Copying solves creation. The other half is discovery: if tokens are just addresses floating around on-chain, how does the app list "everything this issuer minted," and how does anything know a given address genuinely came from the factory rather than an impostor?
 
-The restricted ERC-1404 template pushes the same idea further. It evaluates a transfer policy most-restrictive-first — sanctioned, then frozen, then not-eligible — and, critically, the pre-transfer detector and the enforcing hook call the *same* internal function:
+The factory keeps its own registry. Every successful creation records the token — its type, address, issuer, metadata, and timestamp — and indexes it by issuer. So the app can answer "show me my tokens" straight from the chain, even on networks without a separate indexing service. And a simple lookup — is this address in the registry? — is a proof of provenance: a "yes" means this really is a factory-minted token, not something dressed up to look like one. Importantly, that registry entry is written only *after* the token is fully and successfully created, so a failed creation never leaves a phantom record behind.
 
-```solidity
-function _detect(address from, address to) internal view returns (uint8) {
-    ISanctionsGuard guard = sanctionsGuard;
-    if (address(guard) != address(0)) {
-        if (from != address(0) && !guard.isAllowed(from)) return SANCTIONED;
-        if (to != address(0) && !guard.isAllowed(to)) return SANCTIONED;
-    }
-    if (from != address(0) && frozen[from]) return SENDER_FROZEN;
-    if (from != address(0) && !eligible[from]) return SENDER_NOT_ELIGIBLE;
-    if (to != address(0) && !eligible[to]) return RECIPIENT_NOT_ELIGIBLE;
-    return SUCCESS;
-}
-```
+## Why we built it this way
 
-`detectTransferRestriction` (the ERC-1404 view a UI calls before offering a transfer) and `_update` (the hook that actually reverts) both route through `_detect`. A pre-check that says "this will succeed" and a transfer that then fails is a whole class of bug the template design forecloses by construction.
+**Templates instead of arbitrary code.** The obvious cost is flexibility: an issuer can't ship a token with some exotic novel behavior. The benefit is that the platform can make and *keep* guarantees across every token it has ever issued — sanctions are enforced, the transfer preview matches reality, the data the app loads matches the token it's loading. For a platform whose wallet, search, and compliance surfaces all consume these tokens, that uniformity is worth more than open-ended expressiveness. Arbitrary deployment pushes the audit burden onto every reader; templates pay it once.
 
-## The registry: discovery without trusting the tokens
+**Immutable tokens, an upgradeable mint.** Only the factory itself can be upgraded, and only in a careful append-only way. The tokens it issues are frozen — a holder's token can never have its rules changed out from under them by a later upgrade. Improving a template means registering a *new* one for *future* mints, never rewriting tokens already in circulation. The role-based variants were added exactly this way: new templates appended for new issuance, existing tokens untouched.
 
-Cloning solves creation. Discovery is the other half. If tokens are just addresses floating on-chain, how does a frontend enumerate "everything this issuer minted" without an indexer, and how does anything know a given address came from the factory at all?
+**Growing the menu is an admin act, reviewed and deliberate.** Adding or replacing a template is restricted to the platform admin and is treated as what it is: a considered, audited, one-way addition. The new template is written, put through the same automated security tooling as everything else, deployed once as a locked master, and only then made available. The audit story works *because* the surface is small — a handful of token types is something a human can actually review, unlike an open firehose of user-supplied code.
 
-The factory keeps a network-scoped registry. Every successful creation appends a `TokenRecord` — id, standard, address, issuer, metadata, flags, timestamp — and updates a reverse lookup:
-
-```solidity
-id = ++tokenCount;
-_tokens[id] = TokenRecord({ /* ...standard, tokenAddress, issuer, name, symbol... */ });
-_issuerTokens[msg.sender].push(id);
-tokenAddressToId[token] = id;
-emit TokenCreated(id, standard, token, msg.sender, name, symbol);
-```
-
-`getTokenIdByAddress(token)` returning non-zero is a provenance proof: this address is a factory clone, not an impostor. `getTokensByIssuer(issuer)` powers the "My Tokens" view directly from chain on networks without a subgraph. And the registry write happens *after* the clone-and-init succeeds — checks-effects-interactions applied to issuance, so a revert mid-creation never leaves a phantom row.
-
-## Design decisions
-
-**Templates over arbitrary bytecode.** The obvious cost is flexibility: an issuer cannot ship a token with a novel bonding curve or a custom rebasing rule. The obvious benefit is that the platform can make and keep guarantees across *every* token it has issued — sanctions are enforced, the ERC-1404 detector matches its hook, the ABI the frontend loads is the ABI the contract actually has. For a platform whose wallet, subgraph, and compliance surface all consume these tokens, that uniformity is worth more than open-ended expressiveness. Arbitrary deployment would push the audit burden onto every reader; templates pay it once.
-
-**Immutable tokens, upgradeable factory.** Only `TokenFactory` is UUPS-upgradeable (via the shared `UUPSManaged` base, with append-only storage gated by `npm run check:storage-layout` in CI). Issued clones are immutable — a holder's token cannot have its rules changed out from under them by a later upgrade. Fixing template logic means registering a *new* template for *future* mints, never rewriting existing tokens. The v2 role-based templates were added exactly this way: three new implementation slots appended to storage (consuming reserved `__gap` space), new `create*V2` entrypoints, and a `setV2Template` admin call. Existing v1 Ownable tokens were untouched.
-
-**Adding or replacing a template is an admin operation, not a user one.** `setTemplate` and `setV2Template` are `onlyRole(DEFAULT_ADMIN_ROLE)` and reject `address(0)`. A new template class is a deliberate, reviewed, append-only factory upgrade — the implementation is written, audited (Slither and Medusa run in CI with clone/proxy/UUPS/AccessControl detectors), deployed once as a locked master, and only then registered. The audit story is *because* the surface is small: three standards, two variants each, is a set a human can actually review, unlike an open firehose of user bytecode.
-
-**Deferring rather than faking ERC-3643.** The permissioned security-token class is intentionally *not* shipped. The canonical T-REX suite pins OpenZeppelin 4.x and Solidity 0.8.17, incompatible with this repo's OZ 5.4.0 pin (chosen as the newest ETC/Mordor-compatible release — OZ ≥ 5.5 needs the Cancun `mcopy` opcode pre-Cancun ETC lacks). Rather than ship a broken or downgraded implementation, the `PERMISSIONED_ERC3643` enum value and the `TokenRecord.suite` field are *reserved* so the registry layout stays forward-stable, and the class lands only when an OZ-5-native suite exists. Honest absence beats a template nobody can stand behind.
+**Saying "not yet" instead of shipping something shaky.** One more advanced token type — a permissioned security-token standard — is intentionally *not* offered yet, because the mature, canonical implementation of it isn't yet compatible with the library versions this platform is pinned to. Rather than ship a downgraded version, its slot is reserved so the registry stays forward-compatible, and it'll land when a solid implementation exists. Honest absence beats a template nobody can stand behind.
 
 ## Where it runs
 
-`TokenFactory` is deployed behind a UUPS proxy on Mordor (ETC testnet, chain 63) and Polygon (chain 137); the proxy and implementation addresses are recorded in `deployments/`, which is the source of truth. The frontend self-disables its Tokens tab on any network without a deployed `tokenFactory`, so there is no UI promising issuance where the authority does not exist.
+The token factory runs on the networks FairWins supports, with its addresses recorded as the source of truth. The app simply hides its token-issuance feature on any network where the factory isn't deployed, so there's never a button promising something the underlying system can't actually do.
 
-The template model is not glamorous. It says no to a lot of things an issuer might want to do. But it is precisely that refusal — no arbitrary code, one screened path in, a short auditable menu of what comes out — that lets everything downstream treat a FairWins-minted token as a known quantity.
+The template model isn't glamorous. It says no to a lot of things an issuer might want. But it's precisely that refusal — no arbitrary code, one screened way in, a short and auditable menu of what comes out — that lets everything downstream treat a FairWins-minted token as a known, trustworthy quantity.
 
-## Sources
+## Further reading
 
-- `contracts/tokens/TokenFactory.sol` — factory authority, registry, `create*`/`setTemplate`/`_beforeCreate`
-- `contracts/tokens/interfaces/ITokenFactory.sol` — `TokenStandard` enum, `TokenRecord`, events, errors
-- `contracts/tokens/templates/OpenERC20.sol` — open fungible clone template + `_update` sanctions hook
-- `contracts/tokens/templates/RestrictedERC20.sol` — ERC-1404 template, `_detect` shared policy
-- `docs/developer-guide/token-mint.md` — standards table, v2 roles/caps, deploy/sync, deferral notes
-- `specs/028-token-mint/` — spec, `contracts/token-factory.md`, `data-model.md`
-- `deployments/mordor-chain63-v2.json`, `deployments/polygon-chain137-v2.json` — recorded proxy/impl addresses
-- EIP-1167 Minimal Proxy Contract — https://eips.ethereum.org/EIPS/eip-1167
-- ERC-1404 Simple Restricted Token Standard — https://erc1404.org / https://github.com/ethereum/EIPs
-- OpenZeppelin Contracts (Clones, ERC20, AccessControl, UUPS) — https://docs.openzeppelin.com/contracts/5.x/
+- [ERC-1167 Minimal Proxy Contract](https://eips.ethereum.org/EIPS/eip-1167) — the cheap-clone pattern behind each minted token
+- [ERC-1404 Simple Restricted Token Standard](https://erc1404.org/) — the restricted-transfer model
+- [OpenZeppelin Contracts](https://docs.openzeppelin.com/contracts/5.x/) — the audited, open-source building blocks the templates are built on

--- a/docs/blog/posts/34-token-factory/social.md
+++ b/docs/blog/posts/34-token-factory/social.md
@@ -1,29 +1,27 @@
-# Social & Image — TokenFactory: Minting From Vetted Templates, Not Arbitrary Bytecode
+# Social & Image — Minting Tokens From Vetted Templates, Not Arbitrary Code
 
 ## X (Twitter)
 
-FairWins' TokenFactory never deploys issuer bytecode. It clones from a short, audited set of EIP-1167 templates and stamps the same sanctions screen into every one. A property proven on the template holds for every clone ever minted. 🔗 <link>
+FairWins never lets an issuer deploy their own token code. One authorized mint stamps out copies from a short, audited menu of templates and presses the same sanctions check into every one. A property proven once on a template holds for every token ever minted. 🔗 <link>
 
-#Solidity #web3 #smartcontracts
+#Tokens #Crypto #Compliance
 
 ## LinkedIn
 
-Every time a platform lets someone deploy arbitrary token bytecode, it inherits a fresh un-reviewed attack surface — and every downstream consumer (the wallet UI, the indexer, the compliance screen) has to defensively assume the worst.
+Every time a platform lets someone deploy arbitrary token code, it inherits a fresh un-reviewed attack surface — and every downstream consumer (the wallet, the search index, the compliance screen) has to defensively assume the worst.
 
-FairWins' TokenFactory takes the opposite stance: one authorized contract per network, and it does not accept bytecode. It clones from a small, fixed set of templates the team wrote, audited, and pinned. Our latest engineering post walks through what that constraint buys you:
+FairWins takes the opposite stance: one authorized "mint" per network, and it does not accept code. It stamps out copies from a small, fixed set of templates the team wrote, audited, and locked in. The new post walks through what that one constraint buys you:
 
-- EIP-1167 minimal-proxy clones of immutable, initialization-locked templates — issuers pick a standard and parameters, never code.
-- A shared sanctions screen injected into every token and re-checked on every transfer, non-bypassable by construction.
-- A short auditable menu (Open ERC-20, ERC-721, Restricted ERC-1404 — each with v1 Ownable and v2 role-based variants) instead of an open firehose.
-- An on-chain registry that doubles as provenance: a non-zero id proves an address is a real factory clone.
+- Cheap, permanent copies of immutable, locked templates — issuers pick a token type and parameters, never code.
+- A shared sanctions check pressed into every token and re-run on every transfer, non-bypassable by construction because there's no code path that omits it.
+- A short, auditable menu (a plain fungible token, a collectible, and a restricted token — each in a simple and a role-based variant) instead of an open firehose.
+- An on-chain registry that doubles as proof of origin: a lookup confirms an address is a genuine factory token, not an impostor.
 
-The immutable-token / upgradeable-factory split means fixes ship as new templates for future mints — existing holders' rules never change underneath them.
+The immutable-token / upgradeable-mint split means fixes ship as new templates for future tokens — existing holders' rules never change underneath them.
 
-Read the full breakdown: 🔗 <link>
+Where do you draw the line between issuer flexibility and platform-wide guarantees? 🔗 <link>
 
-Where do you draw the line between issuer flexibility and platform-wide guarantees?
-
-#Solidity #Ethereum #SmartContracts #web3 #TokenEngineering
+#Tokens #Ethereum #Compliance #Crypto
 
 ## Image prompt (Gemini / Nano Banana)
 


### PR DESCRIPTION
## Summary

Follow-up to the blog program merged in #943. Rewrites **all 34 posts** (and aligns each social kit) so the content is approachable for a **semi-technical audience** — product managers, founders, crypto-curious readers, and developers new to the space — rather than crypto engineers.

The originals described each system in implementation terms. These rewrites describe each system **conceptually**: what problem it solves, how it works in plain language, and why the design choices matter.

## What changed in every post

**Removed** (per the request):
- Internal spec numbers and spec references
- File names and repo paths
- Function / method / event / variable names
- FR references
- Solidity/JS code blocks

Each of those was replaced with a plain-language description of the same behavior and, where it helps, an everyday analogy (Face ID, "renovating a building without changing its address", "a strict page limit that forced splitting one contract into two", "the trusted referee that tells the contract who won").

**Kept / improved:**
- The concrete human opening scenarios that make these readable
- The "why we built it this way" trade-off sections
- External standards (WebAuthn, ERC-4337, ERC-7677, EIP-712/3009, ERC-1167, BIP-39, etc.), now explained in plain terms on first use
- The **responsible-use note** on wagering posts (14, 15, 16, 17, 24)
- The **honest fee-disclosure** framing on fee posts (22, 23, 24), stated plainly ("the number you see is the number you pay; there are hard ceilings")
- Updated **Audience** metadata and softened jargon-only tags
- Each repo-path **Sources** section replaced with an external-only **Further reading** list

Posts are also tightened — most dropped ~25–35% in length; approachable means leaner.

## Notes

- Docs-only change; scope is limited strictly to `docs/blog/posts/**` (68 files: 34 `blog.md` + 34 `social.md`). No code, config, or nav touched.
- Post 18 remains a short pointer to the already-published envelope-encryption article.
- Post 21 keeps its honest design-history framing (a shelved, reference-only mechanism), now told conceptually without naming archived code.
- Post 32 (spec-driven development) describes the methodology conceptually; the open-source framework it builds on is named once, in Further reading only.
- Validated the whole set for leftover spec numbers, FRs, function names, code fences, and repo paths — the only remaining internal `.md` references are intentional inter-post navigation links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjwYbKV9hUFKjuKrqprmoi)_