### PR TITLE
docs(blog): add 20 Knowledge Base concept primers + publication schedule

### DIFF
--- a/docs/blog/knowledge-base-inventory.md
+++ b/docs/blog/knowledge-base-inventory.md
@@ -1,0 +1,178 @@
+# FairWins Knowledge Base — Inventory & Publication Schedule
+
+*Beginner-friendly concept primers for the FairWins user base, and the schedule
+that interleaves them with the engineering deep-dives.*
+
+The FairWins content program now has three layers, each for a different reader:
+
+1. **User Guide** (`docs/user-guide/`) — task-oriented *how do I do X in the app*.
+2. **Knowledge Base** (`docs/blog/knowledge/`, this document) — concept primers:
+   *what is X, and why does it matter*. Written for everyday, non-technical users.
+3. **Engineering Blog** (`docs/blog/posts/`) — architecture deep-dives: *how we
+   built X*. Written for semi-technical readers.
+
+The Knowledge Base exists to build the user base's general understanding over
+time. Each primer is short (700–1,100 words), assumes no technical background,
+and links to its matching engineering deep-dive for readers who want to go
+deeper. The two sets are published **interleaved** so a concept is explained in
+plain language shortly before the deep-dive that assumes it (see the schedule
+at the end).
+
+---
+
+## The 20 primers
+
+Level key: **B** = Beginner, **B–I** = Beginner–Intermediate.
+
+### Track A — Wallets & Keys
+
+| # | Primer | Level | Pairs with deep-dive |
+|---|--------|-------|----------------------|
+| 01 | Self-custody: what "be your own bank" really means | B | Account recovery |
+| 02 | Passkeys & smart accounts: the fingerprint wallet | B | Passkey smart accounts |
+| 03 | Gas fees & going gasless | B | Sponsored gas / paymaster |
+
+- **01 Self-custody** — Keys, wallets, and "not your keys, not your coins"; the
+  freedom and the responsibility of holding your own funds. Tags: `self-custody`,
+  `wallets`, `security`, `basics`.
+- **02 Passkeys & smart accounts** — Why your phone's Face ID / fingerprint can
+  now be a real crypto wallet, and what a "smart account" is in plain terms.
+  Tags: `passkeys`, `wallets`, `onboarding`, `basics`.
+- **03 Gas fees & gasless** — What the network fee ("gas") is, why it exists, and
+  what it means when an app covers it for you. Tags: `gas`, `fees`, `basics`.
+
+### Track B — Payments & Markets
+
+| # | Primer | Level | Pairs with deep-dive |
+|---|--------|-------|----------------------|
+| 04 | Stablecoins explained (USDC) | B | Wager lifecycle |
+| 05 | Escrow & trustless settlement | B | Wager lifecycle |
+| 06 | Prediction markets 101 | B | Oracle adapters |
+
+- **04 Stablecoins** — What a stablecoin is, how it stays near a dollar, and why
+  apps use them for real-money features. Tags: `stablecoins`, `usdc`, `payments`,
+  `basics`.
+- **05 Escrow & trustless settlement** — A neutral party holding the stakes — done
+  by code so neither side can walk away. Tags: `escrow`, `settlement`, `basics`.
+- **06 Prediction markets 101** — Backing a considered view with a stake; skill-based
+  forecasting on public information. Carries the responsible-use note. Tags:
+  `prediction-markets`, `forecasting`, `basics`.
+
+### Track C — Earning & Yield
+
+| # | Primer | Level | Pairs with deep-dive |
+|---|--------|-------|----------------------|
+| 07 | DeFi lending & yield: earning on idle funds | B–I | Earn |
+| 08 | Morpho & vaults explained | B–I | Earn |
+| 09 | Reading APY & understanding risk | B–I | Earn |
+| 10 | Fees & basis points: reading what you pay | B | FeeRouter |
+
+- **07 DeFi lending & yield** — Lending idle funds to earn interest without a bank,
+  and where that yield actually comes from. Honest about risk. Tags: `defi`,
+  `lending`, `yield`, `basics`.
+- **08 Morpho & vaults** — What the Morpho lending protocol is, and what a curated
+  "vault" does on your behalf. Tags: `morpho`, `vaults`, `defi`, `lending`.
+- **09 APY & risk** — How to read a yield number, why it moves, and how to spot
+  "too good to be true." Tags: `apy`, `risk`, `yield`, `defi`.
+- **10 Fees & basis points** — What a fee is, what "basis points" mean, and the
+  promise that you always see the exact cost before you approve. Tags: `fees`,
+  `basis-points`, `transparency`, `basics`.
+
+### Track D — Security & Custody
+
+| # | Primer | Level | Pairs with deep-dive |
+|---|--------|-------|----------------------|
+| 11 | Multisig wallets: why several signatures beat one | B | Safe custody |
+| 12 | Spending guardrails: rules that outrank approvals | B–I | Policy engine |
+| 13 | Sanctions screening & compliance | B | Compliance gating |
+
+- **11 Multisig wallets** — A shared account where several people must approve
+  before money moves, and why treasuries rely on them. Tags: `multisig`, `security`,
+  `custody`, `basics`.
+- **12 Spending guardrails** — On-chain rules that can block a transaction even when
+  enough people approved it. Tags: `security`, `policy`, `custody`.
+- **13 Sanctions & compliance** — Why an app screens wallet addresses against
+  blocklists, and how it does so without collecting personal data. Tags:
+  `compliance`, `sanctions`, `basics`.
+
+### Track E — Oracles & Trading
+
+| # | Primer | Level | Pairs with deep-dive |
+|---|--------|-------|----------------------|
+| 14 | Oracles: how a contract learns real-world outcomes | B | Oracle adapters |
+| 15 | Polymarket & builder fees explained | B | Predict |
+
+- **14 Oracles** — The "trusted referee" that tells a contract what happened in the
+  real world, and why contracts can't see out on their own. Tags: `oracles`,
+  `basics`.
+- **15 Polymarket & builder fees** — What Polymarket is and what a small, disclosed
+  "builder fee" is. Carries the responsible-use note. Tags: `polymarket`, `fees`,
+  `trading`.
+
+### Track F — Identity, Privacy & Networks
+
+| # | Primer | Level | Pairs with deep-dive |
+|---|--------|-------|----------------------|
+| 16 | NFTs, soulbound tokens & memberships | B | Soulbound memberships |
+| 17 | On-chain names (ENS & callsigns) | B | CallsignRegistry |
+| 18 | Private & encrypted: keeping activity confidential | B | Envelope encryption |
+| 19 | Blockchain networks & layer-2s | B | Bitcoin (non-EVM) |
+| 20 | What is a DAO? | B | ClearPath DAO registry |
+
+- **16 NFTs, soulbound & memberships** — What an NFT is, what "soulbound"
+  (non-transferable) means, and how a membership differs from a giftable voucher.
+  Tags: `nft`, `soulbound`, `memberships`, `basics`.
+- **17 On-chain names** — Turning a long wallet address into a readable name; names
+  are a convenience, never required to move money. Tags: `naming`, `ens`, `identity`.
+- **18 Private & encrypted** — What end-to-end encryption means, and how a public
+  blockchain can still keep some details confidential. Tags: `privacy`, `encryption`,
+  `basics`.
+- **19 Networks & layer-2s** — What a blockchain network is, why "layer-2s" like
+  Polygon are cheaper and faster, and why Bitcoin is a different kind of network.
+  Tags: `networks`, `layer-2`, `polygon`, `basics`.
+- **20 What is a DAO** — Coordinating and deciding with shared on-chain rules instead
+  of a traditional company. Tags: `dao`, `governance`, `basics`.
+
+---
+
+## Interleaved publication schedule
+
+A suggested running order for BOTH sets at a cadence of **two posts per week**.
+Primers (**K**) lead the engineering deep-dives (**A**) that build on them, and
+the foundational primers (self-custody, stablecoins, gas) come first so newer
+users have footing before anything technical. Adjust cadence to taste — the
+ordering is the point, not the exact dates.
+
+| Wk | Post 1 | Post 2 |
+|----|--------|--------|
+| 1  | K01 Self-custody | K02 Passkeys & smart accounts |
+| 2  | A04 Passkey smart accounts | K03 Gas fees & gasless |
+| 3  | A06 Sponsored gas / paymaster | A09 Intent-based gasless payments |
+| 4  | K04 Stablecoins | K05 Escrow & trustless settlement |
+| 5  | A14 Wager lifecycle | K06 Prediction markets 101 |
+| 6  | K14 Oracles | A15 Oracle adapter abstraction |
+| 7  | A16 Draws & open challenges | A17 Wager pools |
+| 8  | K11 Multisig wallets | A07 Safe custody |
+| 9  | K12 Spending guardrails | A08 Multisig policy engine |
+| 10 | K13 Sanctions & compliance | A03 Compliance gating |
+| 11 | K07 DeFi lending & yield | K08 Morpho & vaults |
+| 12 | A23 Earn (vaults) | K09 APY & risk |
+| 13 | K10 Fees & basis points | A22 FeeRouter |
+| 14 | K15 Polymarket & builder fees | A24 Predict (builder codes) |
+| 15 | K16 NFTs, soulbound & memberships | A02 Soulbound memberships |
+| 16 | A01 Role-based access control | A05 Account recovery |
+| 17 | K17 On-chain names | A33 CallsignRegistry |
+| 18 | K18 Private & encrypted | A18 Envelope encryption (published) |
+| 19 | A19 Multi-recipient encryption | A20 Encrypted data sync |
+| 20 | A21 Nullifier system | A32 Spec-driven development |
+| 21 | K19 Networks & layer-2s | A25 Bitcoin (non-EVM) |
+| 22 | A13 Deterministic deployment | A10 Relayer gateway |
+| 23 | A11 UUPS upgrades | A12 Two-facet proxy |
+| 24 | K20 What is a DAO | A26 ClearPath DAO registry |
+| 25 | A27 Indexing without a subgraph | A28 Unified activity ledger |
+| 26 | A29 AI security review | A30 Coverage & audit gates |
+| 27 | A31 Symbolic execution & fuzzing | A34 TokenFactory |
+
+That is 54 posts across ~27 weeks. The first ~six weeks are deliberately
+primer-heavy to onboard newcomers; later weeks lean toward the engineering
+deep-dives once the foundational concepts are established.

--- a/docs/blog/knowledge/01-self-custody-explained/blog.md
+++ b/docs/blog/knowledge/01-self-custody-explained/blog.md
@@ -1,0 +1,69 @@
+# What "Be Your Own Bank" Actually Means
+
+*Self-custody in plain English: what a key is, why "not your keys, not your coins" caught on, and the responsibility that comes with the freedom*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Wallets & Keys |
+| **Level** | Beginner |
+| **Audience** | Curious newcomers who use a bank app but have never held crypto |
+| **Tags** | `self-custody`, `wallets`, `keys`, `security`, `basics` |
+| **Reading time** | ~5 minutes |
+
+## Who holds the vault key?
+
+Think about the money in your bank account. You can see the balance in an app, tap to send some, and trust that it will be there tomorrow. But you are not the one actually holding it. The bank holds it. If you forget your password, the bank can reset it. If someone drains your account, the bank can often claw the money back. That safety net exists because a company sits in the middle, holding your money on your behalf.
+
+That arrangement is called **custody** — someone else has custody of your funds. It is comfortable and familiar. It also means the bank can freeze your account, decline a payment, or close your access if it decides to.
+
+Crypto offers a different arrangement, and it has a name that sounds bold: **self-custody**. It means *you* hold your own money directly, with no company standing in the middle. People sometimes call this "being your own bank." This primer is about what that really involves — the freedom and the responsibility, honestly.
+
+## What self-custody actually is
+
+In crypto, your money lives on a shared public ledger — a giant, tamper-resistant record that thousands of computers keep in sync. Nobody "has" your coins in a drawer. Instead, the ledger says a certain balance belongs to a certain account, and the only way to move that balance is to prove you control the account.
+
+You prove it with a **key** — think of it as a secret password that also acts as a signature. Whoever holds the key can move the money. There is no manager to appeal to, no "forgot password" button that a company can press for you. The key *is* the ownership.
+
+That is the whole idea. Self-custody means the key lives with you, not with a company. In older wallets, that key was often shown to you as a list of twelve or twenty-four words — a **seed phrase** — that you were told to write on paper and never lose. (Newer wallets, including FairWins, replace that with your phone's built-in security — more on that in the next primer.)
+
+## Why people care: "not your keys, not your coins"
+
+You will hear this phrase everywhere in crypto: **"not your keys, not your coins."** It is a warning, and it comes from hard experience.
+
+When you leave your crypto on an exchange or app that holds the keys for you, you are trusting that company the same way you trust a bank — except most crypto companies are not banks and have none of a bank's protections. Several large ones have collapsed or been hacked, and people who thought they "owned" coins there discovered they only owned an IOU that the company could no longer honor.
+
+The phrase means: if you do not personally hold the keys, you do not truly own the coins — you own a promise. Self-custody removes the middleman and the promise. Your money cannot be frozen by a company, cannot vanish in someone else's bankruptcy, and does not require anyone's permission to move.
+
+## The trade-off, stated honestly
+
+Freedom has a price, and it would be dishonest to skip it: **with self-custody, you are responsible for your own keys.** There is no support line that can undo a mistake.
+
+- If you lose the only key and have no backup, the money is gone. Not "frozen pending review" — gone.
+- If someone tricks you into revealing your key or signing something you did not understand, they can take everything, and no one can reverse it.
+- Nobody can help you recover access the way a bank can, precisely because nobody else has your key.
+
+This is not meant to scare you off. Millions of people self-custody safely by doing two simple things: keeping a backup so a single lost device is not the end, and slowing down before approving anything involving money. The rest of this track is about making those two things easy.
+
+## How this shows up in FairWins
+
+FairWins is a self-custody app. When you join, an account is created that only *you* control — the keys never touch a FairWins server, and the company holds no master switch over your funds. That is a deliberate design choice: it is what lets FairWins honestly say your money is yours.
+
+FairWins tries to keep the good part of self-custody (you are in control) while softening the scary part (one mistake ends everything). It does this two ways worth knowing now. First, it uses your phone's own security hardware instead of a seed phrase you have to write down. Second, it strongly encourages you to add a **backup controller** — a second way to get into your account — *before* anything goes wrong, so a lost or broken phone is an inconvenience, not a catastrophe. The app will nudge you until you have one, on purpose.
+
+## What to watch out for
+
+- **A backup is not optional.** The single most common way people lose self-custodied money is having exactly one way in, then losing it. Set up a backup early, while everything is working.
+- **No one legitimate ever needs your key or recovery words.** Anyone who asks — "support," a giveaway, a friend in a hurry — is trying to rob you. Real apps never ask.
+- **Read before you approve.** Signing a transaction is like signing a check that cannot bounce or be cancelled. FairWins shows you exactly what you are approving before you approve it; take the extra second to look.
+- **Self-custody is a responsibility, not a personality test.** If you are not ready for it on day one, that is fine — just do not keep more on any app than you would be comfortable managing.
+
+## Related deep-dive
+
+Want the engineering details? Read [Losing Every Passkey Shouldn't Mean Losing the Account](../../posts/05-account-recovery-unified-connect/blog.md) — how FairWins makes a self-custody account recoverable without bringing back the seed phrase.
+
+## Learn more
+
+- What is a crypto wallet? (Ethereum.org): <https://ethereum.org/en/wallets/>
+- Custodial vs. non-custodial wallets, explained (Coinbase Learn): <https://www.coinbase.com/learn/crypto-basics/what-is-a-crypto-wallet>
+- Self-custody, in plain terms (MetaMask Learn): <https://learn.metamask.io/lessons/what-is-a-crypto-wallet>

--- a/docs/blog/knowledge/01-self-custody-explained/social.md
+++ b/docs/blog/knowledge/01-self-custody-explained/social.md
@@ -1,0 +1,23 @@
+# Social & Image — What "Be Your Own Bank" Actually Means
+
+## X (Twitter)
+"Not your keys, not your coins" — but what's a key, and why does it matter? Self-custody means you hold your own money directly: no company can freeze it, and no one can lose it for you. The catch: no one can recover it for you either. A plain-English primer 👇 🔗 <link> #SelfCustody #CryptoBasics #Web3
+
+## LinkedIn
+Who actually holds the money in your bank account? Not you — the bank does. Crypto offers a different deal called self-custody, sometimes described as "being your own bank." But what does that really involve, beyond the slogan?
+
+This beginner primer breaks it down without jargon:
+
+- What a "key" is, and why in crypto the key literally *is* ownership
+- Where "not your keys, not your coins" came from — and the real collapses behind it
+- The honest trade-off: freedom from middlemen, but full responsibility for your own backup
+- How FairWins keeps the control while softening the risk, by nudging you to add a backup before anything goes wrong
+
+Self-custody is powerful, but it is a responsibility, not a magic trick. The goal of this piece is to help you understand what you are actually holding.
+
+Would you rather a company hold your money, or hold it yourself? 🔗 <link>
+
+#SelfCustody #CryptoEducation #Fintech #Web3 #DigitalWallets
+
+## Image prompt (Gemini / Nano Banana)
+A clean, modern editorial illustration for a 16:9 banner: a single elegant key resting in an open human palm, positioned beside a small, sturdy bank vault door that stands slightly ajar — visually contrasting "you hold it yourself" with "a company holds it for you." Deep navy and teal background with soft, warm golden light catching the key as the single accent color. Friendly and approachable, not corporate or cold; simple geometric shapes, gentle shadows, a sense of quiet trust and responsibility. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/02-passkeys-and-smart-accounts/blog.md
+++ b/docs/blog/knowledge/02-passkeys-and-smart-accounts/blog.md
@@ -1,0 +1,71 @@
+# Passkeys and Smart Accounts: A Wallet With No Password to Write Down
+
+*What a passkey is, what a "smart-contract wallet" means, and why together they let you have a real crypto account without ever seeing a seed phrase*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Wallets & Keys |
+| **Level** | Beginner |
+| **Audience** | Newcomers who unlock their phone with Face ID and want to know what's under the hood |
+| **Tags** | `passkeys`, `smart-accounts`, `webauthn`, `wallets`, `basics` |
+| **Reading time** | ~6 minutes |
+
+## The twelve words nobody wants to write down
+
+If you have tried a crypto wallet before, you may remember the moment it handed you twelve random words and told you, sternly, to write them on paper and never lose them, never photograph them, never type them anywhere. That list — called a **seed phrase** — is the master key to the account. Lose it and your money is gone; let someone see it and they can take everything.
+
+For most normal people, that is where crypto ends. Guarding twelve words like a launch code is nobody's idea of a fun Tuesday night.
+
+Here is the good news: you almost certainly already use a better system every day, and you probably do not even think of it as security. It is the fingerprint or face scan that unlocks your phone and signs you into apps. This primer explains that system — called **passkeys** — and the second piece that lets it control real money: a **smart account**.
+
+## What a passkey is
+
+A **passkey** is a login credential built into your device that you unlock with your face or fingerprint instead of a password. It is the everyday name for a technology called WebAuthn, the same standard behind Face ID sign-in and fingerprint logins on banking and shopping sites you already trust.
+
+Here is the part that makes it powerful. When you create a passkey, your phone generates a secret key and stores it inside a tiny, tamper-resistant security chip. That secret **never leaves the chip** — not to the app, not to a server, not even to you. When something needs approval, the chip proves it is you (after your face or fingerprint check) without ever revealing the secret itself.
+
+Compare that to a seed phrase or a password, which you can be tricked into typing into a fake website or reading aloud to a scammer posing as support. A passkey has nothing to type and nothing to hand over — there is simply no secret sitting around for a thief to phish. That is exactly the security property crypto wallets have wanted for years.
+
+## What a smart account is
+
+So passkeys are a great way to prove it is you. But there is a catch when you try to point one at a crypto account.
+
+An ordinary crypto account is basically a single key and nothing else — a plain lockbox with one lock. It expects signatures written in one specific mathematical "handwriting." Your phone's security chip signs in a *different* handwriting. The two do not recognize each other, so a passkey cannot directly open an old-style account.
+
+The fix is to make the account itself a little smarter. Instead of a plain lockbox, your account becomes a small program that lives on the blockchain — a **smart account** (you may also hear "smart-contract wallet" or "account abstraction"). Because it is a program, it can be taught to read your passkey's handwriting and check your phone's signatures directly.
+
+That upgrade quietly unlocks conveniences a plain account never could:
+
+- **No seed phrase.** Your face or fingerprint is the key. There is nothing to write on paper.
+- **More than one way in.** A smart account keeps a *list* of approved controllers, not a single fixed key. You can add a second passkey on your tablet, or link an existing wallet as a backup — any of them can get you in.
+- **It can protect itself.** Because it is a program, the account can enforce its own rules — for example, refusing to remove its very last controller so you cannot accidentally lock yourself out forever.
+
+Think of an old account as a padlock, and a smart account as a small, programmable door with a guest list you can update as your life changes.
+
+## How the two fit together
+
+Put them side by side and the experience clicks. The **passkey** is who you are — proven by your face or fingerprint, backed by a secret that never leaves your phone. The **smart account** is where your money lives — a program on the blockchain that recognizes that passkey and follows rules you can trust. You unlock it the same way you unlock your phone: the account confirms the approval came from a passkey on its guest list, and only then does anything move. No password, no seed phrase, no browser extension.
+
+## How this shows up in FairWins
+
+When you join FairWins, this is exactly what happens — usually in a few seconds and without you thinking about any of it. Your face or fingerprint creates a passkey, and a smart account is set up that recognizes it. There is no twelve-word phrase to record, because there isn't one.
+
+FairWins leans on the smart account's guest-list design in a friendly, practical way. It encourages you to add a backup controller — a second passkey or a linked wallet — so that if your phone is lost or broken, another approved device can still get you in. Adding one is a single face or fingerprint approval. And when you link something as a backup, the app tells you plainly that a backup controller has *full* control of the account, because on the guest list everyone is an equal peer.
+
+## What to watch out for
+
+- **A passkey is only as safe as your device's backup.** Most phones automatically sync passkeys to your cloud account (iCloud Keychain, Google Password Manager), so a new phone restores them. But a passkey made in a browser profile that wasn't syncing can be genuinely lost — which is exactly why adding a *second* controller in the app matters.
+- **"No seed phrase" is not "no responsibility."** You still hold your own account. The responsibility shifted from guarding a paper phrase to keeping a backup way in. Do that early.
+- **Anyone with a controller has full power.** Only link a wallet or add a passkey you actually trust and control. The app says so, and means it.
+- **Your face and fingerprint never leave your phone.** The biometric check happens on your device to unlock the passkey; FairWins never sees it.
+
+## Related deep-dive
+
+Want the engineering details? Read [Passkey Smart Accounts: A Wallet You Open With Your Fingerprint](../../posts/04-passkey-smart-accounts/blog.md) — how FairWins turned Face ID into a real, self-custodial account with no seed phrase.
+
+## Learn more
+
+- What passkeys are, in plain terms (FIDO Alliance): <https://fidoalliance.org/passkeys/>
+- Passkeys / WebAuthn overview (Ethereum.org): <https://ethereum.org/en/wallets/>
+- Account abstraction, explained (Ethereum.org): <https://ethereum.org/en/roadmap/account-abstraction/>

--- a/docs/blog/knowledge/02-passkeys-and-smart-accounts/social.md
+++ b/docs/blog/knowledge/02-passkeys-and-smart-accounts/social.md
@@ -1,0 +1,23 @@
+# Social & Image — Passkeys and Smart Accounts
+
+## X (Twitter)
+You already use the best crypto security tool every day: the Face ID / fingerprint that unlocks your phone. Passkeys keep a secret that never leaves your device — nothing to phish, nothing to write down. Pair one with a "smart account" and you get a real wallet, no seed phrase. 🔗 <link> #Passkeys #SmartAccounts #CryptoBasics
+
+## LinkedIn
+Remember the crypto wallet that handed you twelve random words and told you to guard them with your life? That is where most normal people quit.
+
+There is a better way, and you likely already use it: the face or fingerprint scan that unlocks your phone. This beginner primer explains the two pieces that turn it into a real crypto account:
+
+- **Passkeys** — a login backed by a secret that never leaves your phone's security chip, so there's nothing to type, screenshot, or hand to a scammer
+- **Smart accounts** — a wallet that's actually a small program, so it can recognize your passkey and follow rules you trust
+- Why a smart account keeps a *list* of controllers, not one fragile key — so you can add a backup before anything goes wrong
+- How FairWins puts both together: join with your face, no seed phrase, ever
+
+No jargon, no launch-code paper to hide in a drawer.
+
+Would "unlock it like your phone" change how you feel about crypto? 🔗 <link>
+
+#Passkeys #SmartAccounts #CryptoEducation #Web3 #Fintech
+
+## Image prompt (Gemini / Nano Banana)
+A clean, modern editorial illustration for a 16:9 banner: a friendly smartphone glowing softly with a fingerprint sensor at its center, and flowing from it a stylized doorway with a small "guest list" of simple icon figures beside it — visually pairing "unlock with your fingerprint" (the passkey) with "an account that recognizes you and keeps a list of trusted controllers" (the smart account). Deep navy and teal background, a single warm amber accent glowing from the fingerprint and doorway. Soft lighting, rounded approachable shapes, welcoming and human, not corporate. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/03-gas-fees-and-gasless/blog.md
+++ b/docs/blog/knowledge/03-gas-fees-and-gasless/blog.md
@@ -1,0 +1,70 @@
+# What Are "Gas Fees," and How Can a Transaction Be "Gasless"?
+
+*The network's transaction fee, explained in plain English — why it exists, why it can trip up beginners, and what "sponsored" really means*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Wallets & Keys |
+| **Level** | Beginner |
+| **Audience** | Newcomers who've seen "gas fee" pop up and weren't sure what it was |
+| **Tags** | `gas-fees`, `gasless`, `transactions`, `wallets`, `basics` |
+| **Reading time** | ~5 minutes |
+
+## The tiny fee that surprises everyone
+
+Imagine you finally get some crypto — say a friend sends you a few dollars of a stablecoin — and you go to send ten of it onward. You tap confirm. And it fails.
+
+You had the money. So what happened? The blockchain wanted a small, separate fee to actually process your transaction, and you did not have the right kind of coin to pay it. This little speed bump has confused nearly everyone who has ever started with crypto. This primer explains what that fee is, why it exists, and how some apps make it disappear for you.
+
+## What "gas" is
+
+Every time you move crypto or interact with an app on a blockchain, thousands of independent computers around the world have to do a bit of work to check your transaction and record it on the shared ledger. That work is not free, and no single company is footing the bill. So the network charges a small fee for each transaction to pay the people running those computers.
+
+That fee is nicknamed **gas** — like the fuel a car needs to make a trip. A simple transfer needs a little gas; a more complicated action needs more. The busier the network is at that moment, the more each unit of gas costs, the same way a ride-share surges in price during rush hour.
+
+Two details trip up beginners, and they are worth stating plainly:
+
+1. **Gas is paid in the network's own coin — not the coin you're sending.** On most networks the fee is paid in that chain's native token (for example, the native coin on Ethereum or on Polygon), even if you are only trying to move a stablecoin like USDC. So you can hold plenty of the thing you want to send and still be unable to send it, because you have none of the coin the *fee* is charged in. That mismatch is the classic first-timer stumble.
+2. **Even your very first action needs gas.** With a smart account, your very first transaction also has to register the account on the blockchain — which itself costs a bit of gas. So a brand-new, freshly funded account can be stuck at the starting line.
+
+## Why gas exists at all
+
+It is tempting to see gas as a pointless tax, but it does two genuinely useful jobs.
+
+**It pays for the work.** Someone has to run the computers that keep the ledger honest and available. Gas is how they get paid, without any company owning the network.
+
+**It keeps the network usable.** If transactions were free, anyone could flood the network with junk and grind it to a halt. A small cost per action makes spam expensive and keeps room for real transactions. Gas is both the wage for honest work and the toll that keeps out abuse.
+
+## What "gasless" really means
+
+Here is the part that matters for you as a user. When an app advertises a **gasless** or **sponsored** transaction, it does *not* mean the fee magically vanished — the network still charges it. It means **someone else pays it for you.**
+
+Usually that someone is the app itself. It quietly covers the network fee on your behalf so you can act using only the coin you actually hold, without needing to first go buy some native token just to pay a fee you did not expect. Think of it like a store that offers free shipping: the shipping still costs money, the store just absorbs it so checkout is simple for you.
+
+This is a real convenience, especially for that painful first transaction. But it is worth understanding honestly: gasless is a courtesy an app *chooses* to offer, not a law of the blockchain. A well-built app is upfront about when a fee is truly covered and when it is not.
+
+## How this shows up in FairWins
+
+FairWins is built around this exact problem, because the whole point is that a newcomer should be able to receive a stablecoin and start using it — not get stranded needing a second, unfamiliar coin just to pay a fee.
+
+So many everyday actions in FairWins are sponsored: the app covers the network fee for you behind the scenes, including that tricky first transaction where your account gets set up. When that happens, the confirm screen tells you the transaction has no network fee for you.
+
+Two honesty promises are worth knowing. First, FairWins only says "no network fee" when it is actually true — when the app is genuinely covering it. If a fee ever falls to you, the screen says so plainly rather than pretending. Second, sponsorship is a nice-to-have, not a crutch: if the app's fee-covering service is ever unavailable, FairWins quietly lets your transaction go through paying its own fee instead, so you are never simply stuck. You always see the real cost before you approve anything.
+
+## What to watch out for
+
+- **"Gasless" doesn't mean "no cost anywhere" — it means someone else covered *this* fee.** Read the confirm screen; it tells you whether the fee is on you.
+- **On networks or apps that don't sponsor, keep a little native token around.** If you use a wallet that isn't covering your gas, you'll need a small amount of the network's own coin to pay fees. Running out is the most common reason a transaction fails.
+- **Gas prices move.** Fees rise when the network is busy. If a fee looks unusually high, it's often just a busy moment — waiting can help.
+- **A sponsored fee is not a hidden charge in disguise.** With FairWins the covered fee is genuinely covered, not quietly billed back to you in stablecoin. And any *platform* fee, when one applies, is always shown to you in full before you approve.
+
+## Related deep-dive
+
+Want the engineering details? Read [Sponsored Gas Without a Vendor: How "No Network Fee" Became True](../../posts/06-sponsored-gas-verifying-paymaster/blog.md) — how FairWins covers the fee itself and keeps the promise honest.
+
+## Learn more
+
+- What is gas? (Ethereum.org): <https://ethereum.org/en/developers/docs/gas/>
+- Gas fees, explained for beginners (MetaMask Learn): <https://learn.metamask.io/lessons/what-is-gas>
+- Transaction fees, in plain terms (Coinbase Learn): <https://www.coinbase.com/learn/crypto-basics/what-are-gas-fees>

--- a/docs/blog/knowledge/03-gas-fees-and-gasless/social.md
+++ b/docs/blog/knowledge/03-gas-fees-and-gasless/social.md
@@ -1,0 +1,23 @@
+# Social & Image — What Are "Gas Fees," and How Can a Transaction Be "Gasless"?
+
+## X (Twitter)
+You have the money but the transaction still fails? Welcome to gas fees. The network charges a small fee to process every transaction — often in a *different* coin than the one you're sending. "Gasless" doesn't mean free; it means someone else pays it for you. Plain-English primer 👇 🔗 <link> #GasFees #CryptoBasics #Web3
+
+## LinkedIn
+Here's a scenario that has confused nearly every crypto beginner: you have the funds, you tap send, and the transaction fails anyway. Why?
+
+The answer is "gas" — the small fee a blockchain charges to process each transaction. This primer explains it without jargon:
+
+- What gas actually pays for, and why free transactions would break the network
+- The classic first-timer trap: the fee is often charged in a *different* coin than the one you're trying to send
+- What "gasless" or "sponsored" really means — hint: the fee didn't vanish, someone else covered it (like a store offering free shipping)
+- How FairWins sponsors many everyday actions, including that tricky first transaction — and only says "no network fee" when it's genuinely true
+
+Understanding this one concept removes a huge amount of early crypto frustration.
+
+Ever had a transaction fail when you *knew* you had the money? 🔗 <link>
+
+#GasFees #CryptoEducation #Fintech #Web3 #DigitalPayments
+
+## Image prompt (Gemini / Nano Banana)
+A clean, modern editorial illustration for a 16:9 banner: a friendly car-style fuel gauge or a small fuel pump nozzle rendered as a soft, approachable icon, gently "filling" a glowing coin or transaction envelope that's on its way along a simple path — conveying "the network needs a little fuel to move your transaction." Deep navy and teal background with a single warm amber accent glowing from the fuel and the coin. Soft lighting, rounded shapes, optimistic and simple, not corporate or technical. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/04-stablecoins-explained/blog.md
+++ b/docs/blog/knowledge/04-stablecoins-explained/blog.md
@@ -1,0 +1,71 @@
+# What Is a Stablecoin?
+
+*Why a dollar-shaped digital coin makes real-money apps possible — and how it actually stays worth about a dollar*
+
+---
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Payments & Markets |
+| **Level** | Beginner |
+| **Audience** | Crypto-curious beginners — no technical background needed |
+| **Tags** | `stablecoins`, `usdc`, `payments`, `how-it-works` |
+| **Reading time** | ~5 minutes |
+
+---
+
+## The price-tag problem
+
+Imagine you agreed to split dinner with a friend, and by the time the bill came, the value of the money in your wallet had jumped or dropped 8%. You'd never know what a fair share was. That is roughly what it feels like to use a typical cryptocurrency — like Bitcoin or Ether — for everyday amounts. The technology is fine; the *price* just won't sit still.
+
+For a lot of what crypto promises — sending money to a friend, holding a shared pot, settling a bet — that wobble is a dealbreaker. You want the digital dollar in your app to be worth a dollar tomorrow, the same way the balance in your bank app is. That is exactly the gap a stablecoin fills.
+
+## What it is
+
+A **stablecoin** is a digital coin designed to hold a steady value, almost always one US dollar. It lives on a blockchain — a shared public ledger that many computers keep in sync — so it moves with the speed and openness of crypto, but it's meant to *behave* like cash.
+
+The one you'll meet most often is **USDC**, issued by a regulated company called Circle. One USDC is intended to always be redeemable for one real US dollar. There are others (USDT, and dollar-pegged coins from various issuers), but USDC is the default across FairWins because it's transparent and widely trusted.
+
+Think of it as a **digital gift card denominated in dollars** that you can freely send to anyone, spend, or cash back out — not a lottery ticket whose value swings around.
+
+## Why it exists
+
+Money apps need a stable unit. If you escrow a stake, hold a group pot, or pay someone across the world, every party needs to agree on what the amount *is*. Regular bank dollars can't travel on a blockchain, and volatile crypto can't hold a steady price. A stablecoin is the bridge: dollar-priced like your bank balance, but programmable and portable like crypto.
+
+That's why nearly every serious "real-money" crypto app settles in stablecoins rather than in Bitcoin or Ether. It's the difference between a bet for "200 dollars" and a bet for "however much this coin happens to be worth on payout day."
+
+## How it stays at about a dollar
+
+A well-run stablecoin like USDC keeps its value through a simple, boring, and reassuring idea: **every coin is backed by a real dollar (or a safe dollar-equivalent, like short-term US government debt) held in reserve.**
+
+Picture a coat check. For every coat handed in, the attendant issues exactly one ticket. Anyone holding a ticket can always walk up and get a coat back. Because the tickets are always redeemable one-for-one, a ticket is never worth more or less than a coat. USDC works the same way: Circle issues a coin only when a real dollar comes in, and burns the coin when someone cashes out. Reputable issuers publish regular reports from outside accountants confirming the reserves are really there.
+
+That redeemability is what pins the price. If a coin ever drifted to 98 cents on an exchange, traders would happily buy it and redeem it for a full dollar, pocketing the difference — and that buying pressure pushes the price right back to a dollar. The promise of "always worth one real dollar on demand" is the anchor.
+
+## How it shows up in FairWins
+
+In FairWins, stablecoins are simply the money. When you place a wager, join a group pool, or send funds to a friend, the amount is denominated and settled in a stablecoin like USDC, so every number you see is a plain dollar amount. Stakes held in escrow are held in stablecoins; payouts arrive in stablecoins. FairWins only ever handles a short, vetted list of these dollar-pegged tokens — not volatile coins — precisely so the amount you agreed to is the amount that changes hands.
+
+Whenever a fee applies, FairWins shows you the exact cost, in dollars, before you approve anything.
+
+## What to watch out for
+
+Stablecoins are steadier than other crypto, but "stable" isn't "risk-free." A few honest caveats:
+
+- **It's only as good as its backing.** A stablecoin's promise depends on the issuer actually holding the reserves. This is why the *quality* of the issuer matters, and why transparent, regulated coins like USDC are preferred over obscure ones.
+- **Rare "de-peg" moments.** In stressful markets a stablecoin can briefly trade slightly below a dollar. Fully-reserved coins have generally recovered, but it's a reminder that the peg is maintained, not magic.
+- **Avoid the algorithmic kind.** Some past "stablecoins" tried to hold their price with clever code and trading tricks instead of real reserves. Several collapsed dramatically. Reserve-backed coins like USDC are a different, sturdier design — but the word "stablecoin" alone doesn't guarantee safety.
+- **You're moving real money.** A stablecoin transfer is final, like handing over cash. Double-check amounts and recipients.
+
+For everyday use inside a well-designed app, though, a reserve-backed stablecoin does exactly what you want: it keeps a dollar looking and acting like a dollar.
+
+## Related deep-dive
+
+Want the engineering details? Read [The Wager Lifecycle: How a Handshake Bet Becomes a Payout Nobody Can Strand](../../posts/14-wager-lifecycle-contract/blog.md).
+
+## Learn more
+
+- [What is USDC? (Circle)](https://www.circle.com/usdc) — the issuer's own explainer and reserve reporting
+- [Stablecoin (Investopedia)](https://www.investopedia.com/terms/s/stablecoin.asp) — a plain-English overview of the different types
+- [Stablecoins (ethereum.org)](https://ethereum.org/en/stablecoins/) — how dollar-pegged coins work on a blockchain

--- a/docs/blog/knowledge/04-stablecoins-explained/social.md
+++ b/docs/blog/knowledge/04-stablecoins-explained/social.md
@@ -1,0 +1,28 @@
+# Social & Image — What Is a Stablecoin?
+
+## X (Twitter)
+
+A stablecoin is a digital coin built to always be worth ~$1. USDC works like a coat check: every coin is backed by a real dollar you can redeem on demand — which is exactly why it stays at a dollar. That's why real-money apps settle in it, not in volatile crypto. 🔗 <link> #Stablecoins #USDC #Crypto
+
+## LinkedIn
+
+Ever wonder how a crypto app can hold "200 dollars" for you when crypto prices swing all day? The answer is stablecoins — and they're the quiet foundation under nearly every real-money crypto product.
+
+Our newest Knowledge Base primer explains, in plain English:
+
+- What a stablecoin actually is (and why USDC is the one you'll meet most)
+- How a reserve-backed coin stays pinned to ~$1 — the "coat check" mental model
+- Why money apps settle in stablecoins instead of Bitcoin or Ether
+- The honest caveats: reserve quality, rare de-pegs, and why the algorithmic kind is a different animal
+
+No jargon, no hype — just a clear picture of the dollar-shaped coin doing the work behind the scenes.
+
+Read the full primer: <link>
+
+What was the first thing that finally made stablecoins "click" for you?
+
+#Stablecoins #USDC #Fintech #Crypto #Payments
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern editorial illustration of the "stablecoin as coat check" idea: on one side, a neat row of identical glowing dollar-round coin tokens; on the other side, a matching row of stored reserve bars in a simple vault, connected by calm one-to-one lines showing each coin maps to exactly one reserve. A steady, perfectly level horizon line runs through the middle to suggest stability, contrasted against a faint jagged volatile line fading into the background. Deep navy and teal base palette with a single warm amber accent glowing on the central coin. Soft studio lighting, friendly and approachable rather than corporate, generous negative space, balanced composition. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/05-escrow-and-trustless-settlement/blog.md
+++ b/docs/blog/knowledge/05-escrow-and-trustless-settlement/blog.md
@@ -1,0 +1,72 @@
+# What Is Escrow — and How Can Code Hold the Money "Trustlessly"?
+
+*The everyday idea of a neutral third party holding the stakes, and how a smart contract does the same job without anyone to trust*
+
+---
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Payments & Markets |
+| **Level** | Beginner |
+| **Audience** | Crypto-curious beginners — no technical background needed |
+| **Tags** | `escrow`, `smart-contracts`, `trustless`, `how-it-works` |
+| **Reading time** | ~6 minutes |
+
+---
+
+## Two people, one bet, and a worry
+
+Say you and a friend put 100 dollars each on a game this weekend. The nervous part isn't the prediction — it's the payout. If you hand your friend your stake up front, what stops them from going quiet when they lose? If they hand you theirs, what's their guarantee? And if you give it to a mutual friend to hold, now you're both trusting *that* person not to spend it, lose it, or take a side.
+
+This is one of the oldest problems in dealing with money between people who don't fully trust each other. The classic solution has a name: **escrow.** The newer solution — a smart contract — does the same job but removes the person you'd otherwise have to trust. Let's take them in order.
+
+## What escrow is
+
+**Escrow** is when a neutral third party holds money (or property) on behalf of two sides until agreed conditions are met, then releases it to the right person.
+
+You've almost certainly relied on it. When you buy a house, you don't hand the seller a suitcase of cash — an escrow company holds the funds until the paperwork clears, then pays the seller. An online marketplace that holds your payment until the item arrives is doing escrow, as is a referee holding the prize money before a match.
+
+The idea is simple and powerful: **neither side can touch the money mid-deal, and neither can run off with it.** The stakes sit safely to the side until the outcome is clear, and only then do they move — to whoever the rules say should get them.
+
+## Why it matters
+
+Escrow solves the "who goes first?" standoff. Without it, someone has to take the money out of their pocket and *hope*. With it, both people commit at the same time, knowing the money is locked away from both of them and can only be released under the agreed conditions. It turns "I trust you" into "we both trust the arrangement."
+
+The catch, historically, is that the neutral third party has to *actually be neutral* — and reliable, and solvent, and still around when it's time to pay. That's a real person or company you now have to trust. Which is where the newer version comes in.
+
+## How a smart contract does it "trustlessly"
+
+A **smart contract** is a small program that lives on a blockchain — the shared public ledger many computers keep in sync. Once it's deployed, it runs exactly as written, the same way every time, and no single person can quietly change it or reach in and grab what it's holding.
+
+When a smart contract acts as the escrow agent, the "neutral third party" is no longer a person or a company — it's **code that everyone can inspect and no one can override.** That's what "trustless" means here. It doesn't mean "no trust exists." It means you don't have to trust the *other person*, or a middleman's honesty. You trust that published rules will run as written — something you can check in advance and that behaves identically for everyone.
+
+Here's the mental model. Both people send their stakes into the contract. The money is now held by the program, not by either player and not by any company. The contract knows the rules agreed at the start: who decides the winner, and by when. When the outcome is settled, the contract — and only the contract — releases the full pot to the winner. Neither side can pull their money back mid-deal, and neither can redirect the other's.
+
+Crucially, a well-built escrow contract also plans for the *unhappy* endings. What if the other person never puts their money in? What if the event never happens? What if it's a genuine tie? Good design gives every one of those situations a defined exit — a refund, a cancellation, a returned stake — so money is never stuck with no way out. The neutral agent doesn't just hold the pot; it guarantees the pot always has somewhere honest to go.
+
+## How it shows up in FairWins
+
+When you create or accept a wager in FairWins, your stake goes into a smart-contract escrow — held by code, not by FairWins and not by the other participant. It stays there, untouchable by either side, until the wager is settled. Then the contract releases the funds to the winner in a single payout.
+
+The same logic protects you if things go sideways. If your opponent never accepts, you can reclaim your stake. If the deadline to settle passes with no result, each person's stake is returned. If both agree it was a draw, everyone gets their money back. There's a defined way out of every situation — because the whole point of escrow is that nobody can get stranded, including you.
+
+## What to watch out for
+
+Trustless doesn't mean careless. A few honest points:
+
+- **"Trustless" moves the trust, it doesn't delete it.** You're now trusting that the code is correct and honestly built. That's why serious contracts are audited and security-reviewed — and why *how* they're built matters as much as *what* they do.
+- **Blockchain transactions are final.** Once funds move under the rules, there's no "undo" button and no support line to reverse a settled payout. The upside is certainty; the responsibility is care.
+- **The rules are set at the start.** Who decides the winner, and by when, is locked in when the wager is created. It's worth reading those terms up front, because the contract will follow them exactly — that reliability is the entire feature.
+
+Used well, escrow-by-code gives you the old comfort of a trusted middleman without needing to trust a middleman at all: the stakes are safe, the exits are guaranteed, and the rules are the same for everyone.
+
+## Related deep-dive
+
+Want the engineering details? Read [The Wager Lifecycle: How a Handshake Bet Becomes a Payout Nobody Can Strand](../../posts/14-wager-lifecycle-contract/blog.md).
+
+## Learn more
+
+- [Escrow (Investopedia)](https://www.investopedia.com/terms/e/escrow.asp) — the everyday financial concept, explained
+- [Smart contracts (ethereum.org)](https://ethereum.org/en/smart-contracts/) — what they are and how they run
+- [How escrow works with smart contracts (ethereum.org intro)](https://ethereum.org/en/developers/docs/smart-contracts/) — a beginner-friendly technical overview

--- a/docs/blog/knowledge/05-escrow-and-trustless-settlement/social.md
+++ b/docs/blog/knowledge/05-escrow-and-trustless-settlement/social.md
@@ -1,0 +1,28 @@
+# Social & Image — What Is Escrow, and How Can Code Hold the Money Trustlessly?
+
+## X (Twitter)
+
+Escrow is old: a neutral party holds the stakes until the deal is done. Smart contracts make it "trustless" — the neutral party is now code everyone can inspect and nobody can override. You stop trusting the other person and trust published rules instead. 🔗 <link> #SmartContracts #Escrow #Web3
+
+## LinkedIn
+
+Two friends want to bet 100 dollars each. The hard part isn't the prediction — it's "who holds the money, and what stops them from running off with it?"
+
+That's the escrow problem, and it's centuries old. Our new Knowledge Base primer walks through both the classic answer and the modern one:
+
+- What escrow is, in everyday terms (think house closings and marketplace payments)
+- Why a neutral third party solves the "who goes first?" standoff
+- How a smart contract does the same job "trustlessly" — the neutral agent becomes code you can inspect, not a middleman you must trust
+- Why good escrow design guarantees an exit for every ending, so money never gets stuck — including refunds and draws
+
+Plus the honest caveats: "trustless" moves trust to the code, and blockchain payments are final.
+
+Read the full primer: <link>
+
+Where have you personally relied on escrow without thinking of it that way?
+
+#SmartContracts #Escrow #Fintech #Web3 #Trustless
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern editorial illustration of trustless escrow: two friendly abstract figures on the left and right, each sliding a glowing coin token toward a calm, transparent vault in the center that clearly holds both stakes. The vault is depicted as a see-through mechanism of gears and rules rather than a person — signaling neutral code anyone can inspect. Balanced, symmetric composition so neither side is favored, with a single outgoing beam ready to release to a winner. Deep navy and teal base palette with one warm amber accent glowing inside the central vault. Soft studio lighting, approachable and reassuring rather than corporate, generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/06-prediction-markets-101/blog.md
+++ b/docs/blog/knowledge/06-prediction-markets-101/blog.md
@@ -1,0 +1,82 @@
+# Prediction Markets 101
+
+*What it means to back a view with a stake — and why forecasting on public information is a skill, not a slot machine*
+
+---
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Payments & Markets |
+| **Level** | Beginner |
+| **Audience** | Crypto-curious beginners — no technical background needed |
+| **Tags** | `prediction-markets`, `forecasting`, `how-it-works`, `responsible-use` |
+| **Reading time** | ~6 minutes |
+
+---
+
+> **Responsible-use note.** Prediction markets are for skill-based forecasting on publicly available information. They are not a way to trade on secret or inside information, and they are not a substitute for professional financial advice. Whether and how you can take part depends on where you live — participants remain fully subject to the laws and rules of their own jurisdiction. Only ever stake money you can afford to lose.
+
+---
+
+## An office pool, formalized
+
+You've probably been in an office pool: everyone chips in a few dollars, picks a winner for the big game or guesses a product's launch date, and whoever's right takes the pot. Nobody thinks of that as casino gambling — it's a friendly contest of who read the situation best.
+
+A **prediction market** is that same idea, made more serious and a lot more useful. Instead of a slip of paper in a jar, you back your view of a future event with a stake, and if your view turns out right, you're rewarded. The interesting part isn't the money — it's what the crowd's collective guessing reveals.
+
+## What it is
+
+A **prediction market** is a place where people put money behind their forecast of whether some clearly-defined future event will happen. "Will this project ship before the quarter ends?" "Will this measure pass?" "Will this number land above a certain level by Friday?" Each is a plain yes-or-no question with a knowable answer.
+
+You take a side by staking on it. When the event resolves — when the real answer becomes known — the people who were right share the pot, and the people who were wrong don't. That's the whole mechanism: a clear question, a stake behind your view, and a definite settlement once reality decides. The best-known public example is **Polymarket**, where people forecast everything from elections to economic figures.
+
+## Why it exists — the surprising part
+
+Here's what makes prediction markets more than a betting novelty: **the price becomes a forecast.**
+
+If lots of thoughtful people are willing to stake money that an event *will* happen, and few will stake against it, that lopsidedness reflects a shared confidence. Read across a whole market, the balance of stakes turns into a number that behaves like a probability — a crowd-sourced estimate of how likely something is.
+
+Because real money is on the line, people have a reason to be honest with themselves rather than loud. Idle opinions are cheap; a stake is a cost. That's why prediction markets have often forecast outcomes as well as or better than pundits — they aggregate what a diverse crowd actually believes, weighted by how much each person will back it.
+
+## How it works — a simple mental model
+
+Think of it in three steps:
+
+1. **A clear question with a deadline.** The event has to be specific enough that, when the time comes, everyone agrees on the answer. Vague questions can't settle cleanly, so good markets are precise.
+2. **You back a side with a stake.** You look at the public evidence, form a view, and put money behind it. You're not buying a lottery ticket with random odds — you're expressing a judgment about the world.
+3. **Reality settles it, and the pot is paid.** When the event resolves, an agreed source of truth — often called an **oracle**, a trusted referee that reports what actually happened — settles the outcome, and the winning side is paid.
+
+Notice what you're really doing: reading public information, forming a better estimate than the average participant, and being rewarded when your read is good. That's a skill — and like any skill it can be done carefully or carelessly.
+
+## Skill, not luck (mostly)
+
+This is the honest heart of it. A roulette wheel is pure chance — no amount of study changes your odds. Forecasting a real-world event is different: someone who follows a topic closely, weighs the evidence, and avoids wishful thinking really can be right more often than someone guessing.
+
+But "more skill-based than roulette" is not "guaranteed." The future is genuinely uncertain, and no forecast is a sure thing. Treat it as a test of judgment on public information — not as income, and not as a way to chase losses.
+
+## How it shows up in FairWins
+
+FairWins lets you make peer-to-peer forecasts: you and another person (or a group) back opposite sides of a clearly-defined question, and the stakes are held safely in escrow until the outcome is known. For questions an outside source can settle — a public market or a data feed — FairWins reads that source of truth and pays the correct side automatically, so no one has to be trusted to "call it" by hand. Everything settles in a dollar-pegged stablecoin, so the amounts you see are plain dollars.
+
+The design goal throughout is honest settlement: the right side gets paid, and when a question genuinely can't produce a winner — a tie, or an event that never happens — the stakes are simply returned. Any fee that applies is shown to you, in full, before you approve anything.
+
+## What to watch out for
+
+- **Only stake what you can afford to lose.** Even a skilled forecaster loses sometimes. Never stake money you need.
+- **It's forecasting, not investing advice.** A prediction market reflects a crowd's guess, not a certainty, and nothing here is financial advice.
+- **The rules and the "source of truth" matter.** Before you back a side, understand exactly how and by what source the question settles. Clean settlement depends on a precise question.
+- **Know your local rules.** What's permitted varies by location; it's on each participant to stay within the law where they live.
+- **Watch the tone in your own head.** If it starts feeling like chasing losses rather than testing your judgment, that's the signal to step away.
+
+Used thoughtfully, a prediction market is a genuinely interesting thing: a way to turn scattered public knowledge into a shared, honest estimate of what's likely to happen — and to be rewarded for reading the world a little better than the crowd.
+
+## Related deep-dive
+
+Want the engineering details? Read [Three Kinds of Truth, One Referee Slot](../../posts/15-oracle-adapter-abstraction/blog.md).
+
+## Learn more
+
+- [Prediction market (Investopedia)](https://www.investopedia.com/terms/p/prediction-market.asp) — the concept and its history, explained plainly
+- [Polymarket](https://polymarket.com/) — a widely-used public prediction market
+- [The Wisdom of Crowds (overview)](https://en.wikipedia.org/wiki/The_Wisdom_of_Crowds) — why aggregated guesses can beat individual experts

--- a/docs/blog/knowledge/06-prediction-markets-101/social.md
+++ b/docs/blog/knowledge/06-prediction-markets-101/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Prediction Markets 101
+
+## X (Twitter)
+
+A prediction market is an office pool made serious: back your read of a future event with a stake, and the balance of everyone's stakes becomes a crowd-sourced probability. Because real money means honest guessing, it's a skill — not a slot machine. Stake only what you can lose. 🔗 <link> #PredictionMarkets #Forecasting
+
+## LinkedIn
+
+Ever been in an office pool for the big game? You've already used a prediction market — you just didn't call it that.
+
+Our new Knowledge Base primer explains the real idea behind it:
+
+- What a prediction market is: backing your view of a clearly-defined future event with a stake
+- The surprising part — why the balance of stakes turns into a crowd-sourced probability
+- Why it's skill-based forecasting on public information, not casino luck
+- How honest settlement works, including what happens on a tie or an event that never occurs
+
+And it's honest about the guardrails: forecasting isn't investing advice, no forecast is a sure thing, local rules vary, and you should only ever stake what you can afford to lose.
+
+Read the full primer: <link>
+
+What's a public question you'd genuinely trust a crowd to forecast better than the experts?
+
+#PredictionMarkets #Forecasting #Fintech #Web3 #ResponsibleUse
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern editorial illustration of a prediction market as collective forecasting: a diverse cluster of small abstract figures each placing a glowing coin token onto one of two balanced scales representing "yes" and "no," with the tilt of the scales resolving into a smooth probability gauge or dial above them. The mood is thoughtful and communal, like a town of people reading public signals together, not a casino. Deep navy and teal base palette with a single warm amber accent glowing on the probability dial. Soft studio lighting, approachable and optimistic rather than corporate, generous negative space, balanced composition. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/07-defi-lending-and-yield/blog.md
+++ b/docs/blog/knowledge/07-defi-lending-and-yield/blog.md
@@ -1,0 +1,71 @@
+# What Is DeFi Lending, and Where Does the Yield Come From?
+
+*Lending out money you're not using, without a bank in the middle — and an honest look at what pays the interest*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Earning & Yield |
+| **Level** | Beginner–Intermediate |
+| **Audience** | Curious beginners who have used a bank app but never DeFi |
+| **Tags** | `lending`, `yield`, `defi`, `interest`, `savings` |
+| **Reading time** | ~6 minutes |
+
+---
+
+## The money that just sits there
+
+Think about the cash in your checking account. Between paydays and payments, some of it just sits there doing nothing. Your bank, quietly, does *not* let it sit — it lends your deposit to other people (mortgages, car loans, business loans), collects interest from them, and hands you back a sliver of that interest as your "savings rate." The bank keeps the rest.
+
+That arrangement is centuries old, and it works. But it has a catch: you have to trust the bank completely. You can't see where your money went, you can't choose the terms, and the bank is the one deciding how much of the earnings you get to keep.
+
+**DeFi lending** is the same basic idea — lending out idle money to earn interest — rebuilt so that no single company sits in the middle holding your funds. "DeFi" is short for *decentralized finance*: financial services that run as open software on a blockchain instead of inside one company's private computers.
+
+## What DeFi lending actually is
+
+In plain terms: DeFi lending lets you lend your idle digital dollars to borrowers directly, through open software, and collect the interest they pay — most of it, not a sliver.
+
+The "digital dollars" here are usually a **stablecoin** — a crypto token designed to stay worth one real dollar, like USDC. You deposit some stablecoins into a shared lending pool. Borrowers take loans out of that pool and pay interest. That interest flows back to everyone who deposited, in proportion to how much they put in. There's no bank branch, no loan officer, and no company quietly keeping the difference — the rules are just software that everyone can inspect.
+
+## Where the yield actually comes from
+
+This is the most important question to ask about *any* place that promises to grow your money, so let's be blunt about it.
+
+**The yield comes from borrowers paying interest.** That's it. Someone on the other side wants to borrow those digital dollars and is willing to pay to do it, and that payment is your return. It is not magic, it is not "the blockchain printing money," and it is not a company subsidizing you out of goodwill.
+
+Why would anyone borrow? Often to trade, to avoid selling an asset they want to keep, or to fund a business — the same reasons people borrow in the ordinary economy. And crucially, in well-built DeFi lending, **borrowers must post collateral worth more than they borrow.** If someone wants to borrow $1,000, they might lock up $1,500 of another asset first. If they don't pay it back, that collateral is sold automatically to cover the loan. This "over-collateralization" is what protects the pool — and, indirectly, you.
+
+When you understand that yield is just borrower interest, a useful instinct follows: if a return seems far too high, ask *who is paying it and why*. A healthy answer names real borrowers paying real rates. A suspicious one can't.
+
+## How it differs from a savings account
+
+A bank savings account and a DeFi lending pool rhyme, but the differences matter:
+
+- **Who holds your money.** In a bank, the bank holds it. In DeFi lending, your funds sit in open software you can withdraw from directly — nobody has to approve it for you.
+- **Who guarantees it.** Bank deposits (up to a limit) are often backed by government insurance. **DeFi deposits are not.** There is no FDIC here. If something breaks, there's no agency that makes you whole.
+- **How the rate is set.** A bank sets your savings rate by policy. A DeFi rate floats with supply and demand — more borrowers means higher rates, fewer means lower. It changes constantly.
+- **How much of the earnings you keep.** Because there's no bank keeping the spread, more of the borrower interest reaches you.
+
+That trade is the whole story: you give up the safety net and the hand-holding, and in exchange you get transparency, control, and usually more of the yield. Neither is "better" in the abstract — they're different deals.
+
+## How it shows up in FairWins
+
+FairWins has an **Earn** section that does exactly this. If you're holding stablecoins between wagers, you can lend them out through Morpho — a well-established lending protocol — and earn a return over time. The money goes straight from your own wallet into the lending pool; FairWins never holds it, and you can withdraw whenever you like. FairWins charges **no fee** on Earn, and — as with everything on the platform — you always see the exact cost of any action before you approve it. The estimated rate is shown right on each pool, clearly labeled as an estimate, not a promise.
+
+## What to watch out for
+
+- **Yield is never guaranteed.** The rate you see is an estimate based on today's conditions. It will move, and it can fall.
+- **There's no insurance.** DeFi lending carries real risks — the software could have a flaw, or extreme market conditions could cause losses. Only lend what you could afford to have at risk.
+- **"Too good to be true" usually is.** A sky-high rate with no clear borrower paying for it is a red flag, not an opportunity.
+
+Lending idle money to earn interest is one of the oldest ideas in finance. DeFi just lets you do it without handing the keys to a bank — which is powerful, and which is also why the responsibility comes back to you.
+
+## Related deep-dive
+
+Want the engineering details? Read [Earn Without Surprises: Putting Idle Funds to Work, With a Fee You Can See](../../posts/23-earn-erc4626-vaults/blog.md).
+
+## Learn more
+
+- [Ethereum.org — Decentralized finance (DeFi)](https://ethereum.org/en/defi/)
+- [Morpho — Lending documentation](https://docs.morpho.org/)
+- [Investopedia — Decentralized Finance (DeFi)](https://www.investopedia.com/decentralized-finance-defi-5113835)

--- a/docs/blog/knowledge/07-defi-lending-and-yield/social.md
+++ b/docs/blog/knowledge/07-defi-lending-and-yield/social.md
@@ -1,0 +1,28 @@
+# Social & Image — What Is DeFi Lending, and Where Does the Yield Come From?
+
+## X (Twitter)
+
+Your bank already lends out your deposits and keeps most of the interest. DeFi lending does the same thing — lend idle digital dollars, earn the interest borrowers pay — but without the bank in the middle. The catch: no insurance, and the rate always moves. 🔗 <link>
+
+#DeFi #yield #crypto
+
+## LinkedIn
+
+Where does crypto "yield" actually come from? It's worth being blunt about, because the honest answer separates real earning from too-good-to-be-true schemes.
+
+DeFi lending is the oldest idea in finance — lend money you're not using, earn interest — rebuilt so no single company holds your funds. Our new primer walks a curious beginner through it:
+
+- What DeFi lending is, in plain terms (no bank required).
+- Where the yield really comes from: borrowers paying interest, backed by collateral worth more than they borrow.
+- How it differs from a savings account — including the big one: there's no FDIC here.
+- How to sniff out a yield that's "too good to be true."
+
+In FairWins' Earn section this is real: you lend idle stablecoins through Morpho, the funds never leave your control, and the rate is always labeled an estimate — never a promise. 🔗 <link>
+
+When you see a yield number, do you ask who's paying for it?
+
+#DeFi #yield #fintech #crypto #financialliteracy
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration of a small stream of coins flowing out from an open, friendly vault and branching to several distant borrowers, with a thin return-stream of interest flowing back — a gentle circular loop conveying "lend out, earn back." No bank building in the middle, just an open, transparent conduit. Set against a deep navy and teal base with a single warm amber accent lighting the returning interest stream. Soft, approachable lighting from the upper left, generous negative space, trustworthy and calm rather than corporate. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/08-morpho-and-vaults/blog.md
+++ b/docs/blog/knowledge/08-morpho-and-vaults/blog.md
@@ -1,0 +1,73 @@
+# What Is Morpho, and What's a "Vault"?
+
+*A shared pool that lends on your behalf, a professional who manages its risk, and a receipt that proves your share*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Earning & Yield |
+| **Level** | Beginner–Intermediate |
+| **Audience** | Curious beginners deciding whether to try Earn |
+| **Tags** | `morpho`, `vaults`, `erc4626`, `lending`, `yield` |
+| **Reading time** | ~6 minutes |
+
+---
+
+## Two words you'll see the moment you open Earn
+
+Open the Earn section in FairWins and two unfamiliar words show up almost immediately: **Morpho** and **vault**. Neither is complicated once you have the right everyday picture for it, and getting them straight makes everything else about lending click into place.
+
+Here's the short version, which the rest of this primer unpacks: Morpho is the lending *protocol* — the open rulebook that makes lending possible. A vault is a *shared pool* inside that world, run by a professional, that lends your money out for you so you don't have to make loan-by-loan decisions yourself.
+
+## What Morpho is
+
+**Morpho is a lending protocol** — a set of open, published rules, running as software on a blockchain, for lending and borrowing digital dollars. Think of it less like a company and more like a public utility: a shared piece of financial plumbing that anyone can connect to.
+
+Because Morpho is open software rather than a private company's app, lots of different apps can plug into the same lending system — the same way many different banking apps can all connect to the same payment network. FairWins is one of those apps. When you lend through FairWins' Earn feature, your money isn't going "to FairWins" or even "to Morpho the company" — it's flowing into Morpho's open lending pools, following rules that anyone can read.
+
+Morpho is well-established and widely used, which is part of why FairWins chose it. But "well-established" is not the same as "risk-free," and we'll come back to that.
+
+## What a "vault" is
+
+Now the more useful word. A **vault** is a shared pool that lends on your behalf.
+
+Picture a well-run investment club. Instead of each member researching every loan themselves, everyone pools their money and a trusted, experienced manager decides where it goes — which borrowers, on what terms, with how much caution. Members don't have to be experts; they lean on the manager's judgment, and each member owns a slice of the pool proportional to what they put in.
+
+A Morpho vault works just like that:
+
+- **Many people deposit** the same kind of digital dollar (say, USDC) into one pool.
+- **A professional runs it.** This person or team is called the **curator** — the risk manager who decides which borrowers the vault lends to and how conservatively it behaves. Their whole job is managing the trade-off between earning more and staying safe.
+- **The pool earns interest** from borrowers, and that return is shared among depositors.
+- **You own a proportional slice.** Deposit more, own more; the slice grows as interest accrues.
+
+The curator is doing the work you'd otherwise have to do yourself — spreading the lending across borrowers, setting limits, watching for trouble. That's the value of a vault: you get to lend without becoming a lending expert. It's also why *which* vault you pick matters, since you're effectively choosing whose judgment to trust.
+
+## "Tokenized vault" and the receipt-token idea
+
+You may see a vault described as **tokenized**, or hear about a "receipt token." This sounds technical but the idea is homely.
+
+When you deposit into the vault, you get back a **receipt** — a digital token that represents your slice of the pool. It's like the coat-check ticket you get when you hand over your coat: the ticket isn't the coat, it's *proof of your claim* to the coat. Hand the ticket back later and you get your coat returned.
+
+Your vault receipt works the same way. It proves how big your slice is, and when you want your money, you hand the receipt back and receive your share of the pool — your original deposit plus the interest it earned. Because this receipt is a standard kind of token, it lives in your own wallet, under your control, and any compatible app can read it and honor it. There's a widely used standard for how these vault receipts behave (its name is ERC-4626), which is exactly why FairWins can connect to Morpho's vaults cleanly and show you an accurate balance.
+
+## How it shows up in FairWins
+
+FairWins' Earn feature lets you lend into **curated Morpho vaults**. When you open Earn, you see a list of vaults, each showing the asset it accepts, an estimated yearly rate, how much everyone has deposited in total, and who curates it. You pick one, enter an amount, and confirm — the deposit goes straight from your wallet into the vault, and your slice appears under "Your positions" with its current value. FairWins doesn't run these vaults and charges **no fee** on Earn. As always, the exact cost of any action is shown before you approve it, and every rate is clearly marked as an estimate rather than a guarantee.
+
+## What to watch out for
+
+- **You're trusting the curator's judgment.** A vault is only as careful as the professional running it. FairWins shows who curates each vault so you can see whose hands your money is in.
+- **The receipt is real, so keep your wallet safe.** Your slice lives in your wallet as that receipt token. Guarding your wallet is guarding your deposit.
+- **Yield still isn't guaranteed.** A vault can earn less than its estimate, and — like any on-chain system — it carries smart-contract risk. Only deposit what you can afford to have at risk.
+
+Morpho is the open lending system; a vault is a professionally managed pool inside it; and your receipt token is proof of your slice. That's the whole vocabulary — and it's enough to use Earn with your eyes open.
+
+## Related deep-dive
+
+Want the engineering details? Read [Earn Without Surprises: Putting Idle Funds to Work, With a Fee You Can See](../../posts/23-earn-erc4626-vaults/blog.md).
+
+## Learn more
+
+- [Morpho — Documentation](https://docs.morpho.org/)
+- [Morpho — What is a vault (Earn concepts)](https://docs.morpho.org/build/earn/)
+- [Ethereum.org — ERC-4626 tokenized vault standard](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/)

--- a/docs/blog/knowledge/08-morpho-and-vaults/social.md
+++ b/docs/blog/knowledge/08-morpho-and-vaults/social.md
@@ -1,0 +1,26 @@
+# Social & Image — What Is Morpho, and What's a "Vault"?
+
+## X (Twitter)
+
+"Morpho" and "vault" scare people off lending before they start. They shouldn't. Morpho = an open lending system anyone can plug into. A vault = a shared pool run by a professional who lends your money for you. Your receipt token is just a coat-check ticket for your slice. 🔗 <link>
+
+#DeFi #Morpho #yield
+
+## LinkedIn
+
+Open any DeFi "earn" screen and two words stop beginners cold: Morpho and vault. Our new primer defines both in plain English — no coding required.
+
+- Morpho is a lending protocol: open, shared financial plumbing that many apps (including FairWins) plug into — not a company holding your money.
+- A vault is a shared pool run by a professional "curator" who lends your funds for you, so you don't have to be a lending expert.
+- A "tokenized vault" just means you get a receipt token — a coat-check ticket proving your slice of the pool, held in your own wallet.
+- The catch worth naming: a vault is only as careful as the curator running it, and yield is never guaranteed.
+
+FairWins' Earn feature lends into curated Morpho vaults, shows you who curates each one, charges no fee, and marks every rate as an estimate — never a promise. 🔗 <link>
+
+When you deposit somewhere, do you check who's actually managing the risk?
+
+#DeFi #Morpho #yield #fintech #financialliteracy
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration of a friendly, well-organized vault chamber shown in cutaway, with several small coins from different depositors flowing into one shared pool, and a calm professional figure (abstract, faceless silhouette) tending it like a gardener tending a shared plot. Off to the side, a small glowing receipt-ticket floats back toward a depositor's open hand. Deep navy and teal base with a single warm amber accent on the receipt ticket. Soft approachable lighting, generous negative space, trustworthy and human rather than corporate. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/09-apy-and-risk/blog.md
+++ b/docs/blog/knowledge/09-apy-and-risk/blog.md
@@ -1,0 +1,78 @@
+# How to Read APY (and Spot Yields That Are Too Good to Be True)
+
+*What that yearly percentage really means, why it moves, and the risks nobody should hide from you*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Earning & Yield |
+| **Level** | Beginner–Intermediate |
+| **Audience** | Curious beginners comparing yields before depositing |
+| **Tags** | `apy`, `yield`, `risk`, `defi`, `safety` |
+| **Reading time** | ~6 minutes |
+
+---
+
+## The number everyone stares at
+
+You open a lending app and every option shows a single, tempting number: **4.1% APY**. **7.8% APY**. **142% APY**. Your eye goes straight to the biggest one — that's human. But that number is the *most* misunderstood thing on the whole screen, and learning to read it properly is the difference between earning steadily and getting burned.
+
+This primer does three things: explains what APY actually means, explains why it's a moving estimate rather than a fixed promise, and gives you an honest tour of the risks — including how to smell a yield that's too good to be true.
+
+## What APY means
+
+**APY stands for Annual Percentage Yield** — roughly, "if conditions stayed exactly as they are right now for a full year, this is about how much your deposit would grow, including earnings on your earnings."
+
+That last part is the "yield" bit: as you earn interest, that interest starts earning interest too (compounding). So APY is a slightly fuller measure than a plain interest rate. If you deposit $1,000 at a steady 5% APY and leave it untouched, you'd have roughly $1,050 after a year.
+
+But read that definition again and notice the load-bearing phrase: *"if conditions stayed exactly as they are right now."* They won't.
+
+## Why APY is variable, not fixed
+
+Here's the single most important thing to internalize: **in DeFi lending, APY is a live estimate, not a fixed rate.** It is a snapshot of this instant's conditions, and it changes constantly — sometimes by the hour.
+
+Why does it move? Because the yield comes from borrowers paying interest, and borrowing demand is always shifting. When lots of people want to borrow, rates rise and your APY goes up. When borrowing dries up, rates fall and your APY drops. Nobody is guaranteeing you the number on the screen — it's simply "the rate right now, projected forward as if nothing changed."
+
+This is very different from, say, a bank CD that locks a fixed rate for a fixed term. A DeFi APY is more like a weather forecast: useful, honestly presented, and definitely subject to change. Treat a displayed APY as "about what I'd earn if today's weather held," never as a contract.
+
+## The risks, stated plainly
+
+Anywhere that grows your money carries risk, and anyone who tells you otherwise is selling something. Here are the real ones, in plain terms:
+
+**Smart-contract risk.** The lending pool is a piece of software. Good software is audited by independent security experts, but no code is provably perfect. A flaw — or a clever attacker — could, in a bad case, cause losses. This risk never fully goes to zero.
+
+**Market and liquidity risk.** These pools lend your money out, so at any given moment much of it is working, not sitting idle. Usually you can withdraw instantly, but in turbulent times the immediately available amount can be temporarily less than your full balance — you may need to withdraw what's free now and come back shortly for the rest. In extreme market events, collateral can also fall in value faster than the system can react.
+
+**Rate risk.** The APY that lured you in can simply drop. You're not locked into today's number, for better or worse.
+
+**No safety net.** This bears repeating because it surprises people coming from banking: DeFi deposits are **not** government-insured. There is no FDIC, no agency that reimburses you if something breaks. The upside of self-custody — nobody can freeze or take your funds — comes with the flip side that nobody backstops your losses either.
+
+## The "too good to be true" test
+
+Now the practical skill. When you see an eye-popping yield, run it through one question: **who is paying this, and why?**
+
+Legitimate yield has a boring, traceable source — real borrowers paying real interest, backed by collateral worth more than they borrowed. If a yield is modestly higher than the pack, it usually just reflects slightly more risk or higher borrowing demand. Fine.
+
+But when a yield is *dramatically* higher than everything around it — 3x, 10x, "guaranteed 40%" — the honest question rarely has a good answer. Often the extra return is really an extra risk in disguise, a temporary bonus that will vanish, or, at the worst end, a scheme paying early depositors with later depositors' money. A useful rule of thumb: **the higher the promised yield, the harder you should look for who's funding it — and the more suspicious you should be if nobody can tell you.** "Guaranteed" and "yield" almost never belong in the same sentence.
+
+## How it shows up in FairWins
+
+FairWins' Earn section shows an estimated APY on each lending vault, and it's honest about what that number is. The rate comes live from Morpho's data, is clearly labeled an **estimate** rather than a promise, and is described as something that changes constantly. FairWins doesn't invent or inflate these figures, charges **no fee** on Earn, and — as everywhere on the platform — shows you the exact cost of any action before you approve it. The app also tells you plainly that returns are variable and not guaranteed, and that you should only deposit what you can afford to have at risk. When a withdrawal is temporarily limited by how much is lent out, the app shows you exactly how much is available right now rather than pretending.
+
+## What to watch out for
+
+- **Treat APY as a forecast, not a promise.** It moves; plan for it to move.
+- **Match the deposit to your risk tolerance.** Only lend what you could afford to have at risk — genuinely.
+- **Interrogate outsized yields.** If the return is spectacular and the source is fuzzy, walk away. Boring and traceable beats dazzling and unexplained.
+
+Reading APY well isn't about a formula. It's a mindset: the number is real, honestly presented — and it's an estimate about the future, which nobody can guarantee.
+
+## Related deep-dive
+
+Want the engineering details? Read [Earn Without Surprises: Putting Idle Funds to Work, With a Fee You Can See](../../posts/23-earn-erc4626-vaults/blog.md).
+
+## Learn more
+
+- [Investopedia — Annual Percentage Yield (APY)](https://www.investopedia.com/terms/a/apy.asp)
+- [Ethereum.org — Decentralized finance (DeFi)](https://ethereum.org/en/defi/)
+- [Morpho — Documentation](https://docs.morpho.org/)

--- a/docs/blog/knowledge/09-apy-and-risk/social.md
+++ b/docs/blog/knowledge/09-apy-and-risk/social.md
@@ -1,0 +1,26 @@
+# Social & Image — How to Read APY (and Spot Yields That Are Too Good to Be True)
+
+## X (Twitter)
+
+That "5.2% APY" isn't a promise — it's a forecast. In DeFi lending the rate moves by the hour, because it's just borrowers' interest passed through to you. And when a yield looks spectacular, ask one question: who's paying for it? 🔗 <link>
+
+#DeFi #APY #yield
+
+## LinkedIn
+
+The biggest APY on the screen is the most misunderstood number in DeFi. Our new beginner primer teaches you to read it honestly:
+
+- What APY actually means (including why compounding makes it a fuller measure than plain interest).
+- Why it's variable, not fixed — a live snapshot of borrowing demand, more like a weather forecast than a bank CD.
+- The real risks nobody should hide: smart-contract risk, market and liquidity risk, rate risk, and the big one — no FDIC, no safety net.
+- The "too good to be true" test: for any eye-popping yield, ask who is paying it and why. If nobody can tell you, walk away.
+
+FairWins' Earn section shows estimated APYs pulled live from Morpho, labels them as estimates rather than promises, charges no fee, and shows the exact cost of any action before you approve it. 🔗 <link>
+
+What's your rule of thumb for a yield that looks too good?
+
+#DeFi #APY #yield #financialliteracy #fintech
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration of a large percentage-yield figure rendered as a gently fluctuating line-graph forecast — like a weather chart — with a small honest "estimate" cloud drifting above it, and one absurdly tall spike in the distance quietly flagged by a small warning glow to suggest "too good to be true." Deep navy and teal base with a single warm amber accent on the warning glow. Soft calm lighting, generous negative space, trustworthy and educational mood rather than corporate or alarmist. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/10-fees-and-basis-points/blog.md
+++ b/docs/blog/knowledge/10-fees-and-basis-points/blog.md
@@ -1,0 +1,75 @@
+# What Is a Fee, and What on Earth Is a "Basis Point"?
+
+*How to read the little numbers that decide what something actually costs you — and the promise FairWins makes about them*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Earning & Yield |
+| **Level** | Beginner |
+| **Audience** | Anyone curious about crypto apps who wants to understand what they're paying |
+| **Tags** | `fees`, `basis-points`, `bps`, `transparency`, `beginner` |
+| **Reading time** | ~5 minutes |
+
+## The line you skim past
+
+You've seen it a hundred times. You book a flight and there's a "service charge." You send money abroad and the app quietly takes a cut. You buy something and a "processing fee" appears at the very end. Most of us glance at the total, shrug, and tap confirm.
+
+Crypto apps have fees too — and they have a habit of describing them in a unit almost nobody grew up with: the **basis point**. If you've ever seen "50 bps" on a screen and had no idea whether that was a rounding error or a rip-off, this primer is for you. By the end you'll be able to read any fee with confidence.
+
+## What a fee actually is
+
+A fee is simply a charge for a service. Someone did something useful — moved your money, matched your trade, kept your funds safe, ran the machinery in the background — and they take a small slice as payment. That's it. Fees aren't sinister; they're how the lights stay on.
+
+Two things make fees feel confusing rather than simple. First, they're often expressed as a *percentage* of the amount rather than a flat dollar figure, so the same fee costs more on a bigger transaction. Second — especially in finance and crypto — they're often quoted in basis points instead of plain percentages.
+
+## Basis points, decoded
+
+A **basis point** (often shortened to "bps," said "bips") is just a tiny slice of a percent. One basis point equals one hundredth of one percent.
+
+Here's the only conversion you need:
+
+- **100 basis points = 1%**
+- **50 basis points = 0.5%** (half a percent)
+- **10 basis points = 0.1%**
+- **1 basis point = 0.01%**
+
+So if you see "50 bps," read it as "half of one percent." On a $100 transaction, that's 50 cents. On a $1,000 transaction, it's $5.
+
+Why do finance people use this clunky unit at all? Because it removes ambiguity. If someone says a rate "went up by 1%," do they mean from 5% to 6%, or from 5% to 5.05%? Nobody knows. But "the rate went up by 100 basis points" can only mean one thing. Basis points are a precise way to talk about small changes, which is exactly why professionals lean on them — and why you'll keep bumping into them.
+
+## How to read a fee in three steps
+
+When a fee appears on a screen, ask three quick questions:
+
+1. **How much, in real money?** Convert the percentage or bps into an actual dollar (or USDC) figure for *your* amount. A good app does this math for you and shows the exact number.
+2. **What is it a percentage of?** A fee on the amount you deposit is different from a fee on the profit you earn. Make sure you know the base.
+3. **Is there a ceiling?** Some fees can, in principle, change over time. The honest question is: how high could this ever go?
+
+If an app answers all three clearly and *before* you approve, that's a good sign. If it hides the fee until after you've committed, or buries it in fine print, that's a red flag — in any industry.
+
+## How this shows up in FairWins
+
+FairWins takes one firm position on fees: **you always see the exact cost before you approve anything.** Whenever a fee applies, the app shows it to you as its own clearly labeled line — never folded silently into a total, never described as "free" when it isn't — and you approve that specific number. The amount you were shown is the most you can be charged. If the rate somehow changed in the moment between you reading the screen and your transaction going through, the transaction protects you rather than quietly charging you more.
+
+Fees at FairWins also have **hard ceilings** built into the system itself, not just into a policy document. Each type of fee has a maximum it can never exceed, and that maximum is locked in place — an administrator can nudge a rate up or down beneath the ceiling, but no one can raise the ceiling. Every rate is published openly, and every change to it is recorded permanently and publicly, so the history is there for anyone to check.
+
+One more honest note: **many actions carry no fee at all.** When there's no fee, there's no fee line, and nothing about your experience changes. FairWins only charges for value it actually delivers.
+
+## What to watch out for
+
+- **Small percentages add up on big numbers.** Half a percent sounds like nothing, but on a large or frequently repeated transaction it's real money. Always look at the dollar figure, not just the bps.
+- **A fee is not the same as a loss.** A fee is a known, disclosed cost. It's separate from market risk — the chance that an investment itself goes down. If an app earns you yield, remember that **yield carries risk and is never guaranteed**, and the fee is charged on top of whatever the market does.
+- **"Free" deserves a second look.** Sometimes free really is free (a partner covers the cost). Sometimes the cost is just hidden elsewhere. The good version is the one that tells you plainly which it is.
+
+Once you can translate bps into plain percentages and dollars, fees stop being intimidating fine print and become just another number you can check — which is exactly how it should be.
+
+## Related deep-dive
+
+Want the engineering details — how FairWins keeps every fee in a single, capped, tamper-evident price list? Read [One Place for Every Fee](../../posts/22-fee-router/blog.md).
+
+## Learn more
+
+- [Investopedia: Basis Point (BPS)](https://www.investopedia.com/terms/b/basispoint.asp)
+- [Investopedia: What Is a Fee?](https://www.investopedia.com/terms/f/fee.asp)
+- [USDC — what a stablecoin is (Circle)](https://www.circle.com/usdc)

--- a/docs/blog/knowledge/10-fees-and-basis-points/social.md
+++ b/docs/blog/knowledge/10-fees-and-basis-points/social.md
@@ -1,0 +1,26 @@
+# Social & Image — What Is a Fee, and What on Earth Is a "Basis Point"?
+
+## X (Twitter)
+Ever seen "50 bps" on a screen and had no idea if that was tiny or a rip-off? Here's the whole trick: 100 basis points = 1%. So 50 bps = half a percent = 50 cents on $100. And at FairWins, you always see the exact fee before you approve. 🔗 <link> #crypto #fintech #DeFi
+
+## LinkedIn
+"What does 50 bps actually mean?"
+
+If you've ever squinted at a fee quoted in "basis points" and just tapped confirm, this beginner primer is for you. In a few minutes you'll never be confused by a fee screen again.
+
+Here's what you'll learn:
+- What a fee really is — a charge for a service, not something sinister
+- The one conversion that unlocks everything: 100 basis points = 1%
+- A three-question checklist for reading any fee (how much in real money, a percentage of what, and is there a ceiling?)
+- How FairWins keeps it honest — the exact cost shown before you approve, with hard ceilings the system itself enforces
+
+We also keep it real: a fee is a known cost, separate from market risk, and yield is never guaranteed.
+
+Once bps stops being a mystery, fees become just another number you can check. 🔗 <link>
+
+What's the most confusing fee you've ever been charged?
+
+#PersonalFinance #Fintech #Crypto #FinancialLiteracy #DeFi
+
+## Image prompt (Gemini / Nano Banana)
+A clean, modern editorial illustration for a 16:9 banner: a friendly oversized magnifying glass hovering over a simple paper receipt, with one small line on the receipt gently highlighted and lifted into focus, as if being examined and understood rather than hidden. A subtle measuring-ruler motif runs along one edge to suggest precise, small units. Deep navy and teal base palette with a single warm amber accent on the highlighted line. Soft, warm lighting, approachable and reassuring, not corporate or cold. Flat vector style with gentle depth. No text, no numbers, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/11-multisig-wallets/blog.md
+++ b/docs/blog/knowledge/11-multisig-wallets/blog.md
@@ -1,0 +1,75 @@
+# What Is a Multisig Wallet?
+
+*A joint account for the blockchain age — where money only moves when enough people say yes*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Security & Custody |
+| **Level** | Beginner |
+| **Audience** | Anyone curious how groups hold money safely on-chain |
+| **Tags** | `multisig`, `custody`, `security`, `shared-treasury`, `beginner` |
+| **Reading time** | ~5 minutes |
+
+## The problem with one key
+
+Imagine your family's entire savings sat in a single drawer, and there was exactly one key to that drawer. Whoever holds the key can take everything, anytime, no questions asked. Lose the key and the money is gone forever. Have it stolen and the thief owns it all. You'd never run a household — let alone a business — that way.
+
+Yet that's how an ordinary crypto wallet works. A normal wallet is controlled by one secret key. Whoever has that key controls the money, completely. For a personal wallet that's manageable. But what about a group — a club treasury, a company's funds, a shared pot between friends? Handing all of it to one person's single key is asking for trouble. A **multisig wallet** solves exactly this.
+
+## What it is
+
+**Multisig** is short for "multi-signature." A multisig wallet is a shared wallet that requires *several* approvals before any money can move — not just one.
+
+The closest everyday comparison is a **joint checking account that needs two signatures on every check**, or a bank vault with several keyholders where the door only opens when enough of them turn their keys at the same time. No single person can walk off with the contents. The group decides together, by design, not by good manners.
+
+## Why it exists: "M-of-N"
+
+Every multisig is set up with two numbers, usually written as **M-of-N**.
+
+- **N** is the total number of owners — the people who each hold one key.
+- **M** is how many of them must approve before money moves.
+
+A **2-of-3** multisig has three owners, and any two of them must agree to send funds. A **3-of-5** has five owners and needs three. You choose the numbers to fit the group.
+
+This simple setup buys you two kinds of protection at once:
+
+- **No single point of failure.** If one person's phone is stolen, one laptop is hacked, or one owner goes rogue, the money is still safe. A thief with one key out of three in a 2-of-3 wallet can't do anything alone.
+- **No single point of lockout.** You don't lose everything if one key is lost. In that same 2-of-3, the other two owners can still move the funds and set things right.
+
+That balance — safety without fragility — is why serious on-chain organizations, company treasuries, investment funds, and careful groups of friends overwhelmingly hold their money in a multisig rather than a single-key wallet.
+
+## How it works, step by step
+
+You don't need to understand the cryptography to grasp the flow. A multisig transaction goes like this:
+
+1. **Someone proposes a transaction** — say, "send 500 USDC to this address." Proposing isn't sending; it just puts the request on the table.
+2. **The other owners review it.** Each can see exactly what's being asked: the amount, the destination, the purpose.
+3. **Owners approve.** Each approval is signed with that owner's own key. Approvals accumulate.
+4. **Once the threshold is met** — enough owners have approved to satisfy the M-of-N rule — the transaction can execute, and only then does the money actually move.
+
+Until that threshold is reached, nothing happens. The funds sit safely, waiting for the group to agree. It's genuinely a group decision, enforced by the wallet itself rather than by trust or paperwork.
+
+## How this shows up in FairWins
+
+FairWins lets a group hold a **shared vault** — a treasury that belongs to the whole group rather than to any one person. Under the hood, these vaults use **Safe**, the most widely used and battle-tested multisig on Ethereum and related networks, rather than anything home-grown. The group can then act *as the group*: place a wager or send a payment from the shared vault, with the money only moving once enough co-owners have approved.
+
+Because it's a standard Safe, a group's existing multisig can be brought in just by its address, and the vault works with the wider Safe ecosystem too. FairWins deliberately builds this so the group's control never depends on a company server being online — the coordination happens on the blockchain itself. The point is simple: a group's shared money should require the group's shared consent, and no single person, not even FairWins, should be able to move it alone.
+
+## What to watch out for
+
+- **Choose M and N thoughtfully.** Too few required signatures and you lose the safety benefit; too many and day-to-day spending becomes painful, or a couple of unavailable owners can stall the group. Many treasuries land on 2-of-3 or 3-of-5 for a reason.
+- **Losing keys still matters.** A multisig protects you from losing *one* key. Lose enough keys to drop below the threshold — for good — and the funds can become unreachable. Owners should each safeguard and back up their own key.
+- **Approvals deserve real attention.** A multisig only helps if owners actually check what they're approving. Two people who both rubber-stamp a proposal without reading it have simply agreed to the same mistake. (There's a companion idea — spending guardrails — that adds automatic rules on top of approvals; that's a topic of its own.)
+
+A multisig turns "trust one person completely" into "let the group decide together." For anyone holding money on behalf of others, that shift is the whole point.
+
+## Related deep-dive
+
+Want the engineering details — how FairWins coordinates a shared vault using nothing but the blockchain, no company server required? Read [Shared Vaults Where No One Person Can Move the Money](../../posts/07-safe-multisig-custody/blog.md).
+
+## Learn more
+
+- [Ethereum.org: What is a multisig wallet?](https://ethereum.org/en/developers/docs/smart-contracts/security/#multisignature-wallets)
+- [Safe — the multisig FairWins uses](https://safe.global/)
+- [Investopedia: Multisignature Wallet](https://www.investopedia.com/terms/m/multisignature.asp)

--- a/docs/blog/knowledge/11-multisig-wallets/social.md
+++ b/docs/blog/knowledge/11-multisig-wallets/social.md
@@ -1,0 +1,25 @@
+# Social & Image — What Is a Multisig Wallet?
+
+## X (Twitter)
+A normal crypto wallet has one key: whoever holds it owns everything. A multisig wallet needs several people to approve before money moves — like a joint account that needs two signatures. "2-of-3" = three owners, any two must agree. No single point of failure. 🔗 <link> #crypto #security #multisig
+
+## LinkedIn
+"Who should be able to move the money?"
+
+For a personal wallet, the answer is you. But for a club treasury, a company's funds, or a shared pot between friends, handing everything to one person's single key is a recipe for disaster. This beginner primer explains the tool serious teams use instead: the multisig wallet.
+
+Here's what you'll learn:
+- What "multisig" (multi-signature) means — a shared wallet where several approvals are required before money moves
+- The "M-of-N" idea, in plain English (a 2-of-3 needs any two of three owners to agree)
+- Why it protects you two ways at once: no single point of failure, and no single point of lockout
+- How the propose → review → approve → execute flow actually works
+- Honest trade-offs: choosing your numbers, guarding keys, and actually reading what you approve
+
+It's the difference between "trust one person completely" and "let the group decide together." 🔗 <link>
+
+If your team holds shared funds, who can move them today?
+
+#Security #Crypto #Treasury #Fintech #SelfCustody
+
+## Image prompt (Gemini / Nano Banana)
+A clean, modern editorial illustration for a 16:9 banner: a sturdy shared vault door with three distinct keyholes, and two friendly hands turning two keys at once while the door begins to open — clearly conveying that several people together unlock it, not one alone. A calm, cooperative mood. Deep navy and teal base palette with a single warm gold accent on the turning keys. Soft, warm lighting, approachable and trustworthy, not corporate or cold. Flat vector style with gentle depth. No text, no numbers, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/12-spending-guardrails/blog.md
+++ b/docs/blog/knowledge/12-spending-guardrails/blog.md
@@ -1,0 +1,69 @@
+# What Are Spending Guardrails?
+
+*Why "enough people approved" sometimes isn't enough — and how automatic rules can stop a bad transaction before the money moves*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Security & Custody |
+| **Level** | Beginner–Intermediate |
+| **Audience** | Anyone responsible for shared or organizational funds |
+| **Tags** | `guardrails`, `spending-policy`, `treasury-controls`, `security`, `beginner` |
+| **Reading time** | ~6 minutes |
+
+## The transaction that had every approval it needed
+
+Picture a small team treasury run as a shared wallet where any two of three owners must approve before money moves. One Tuesday, a request appears: send a large payment to an address. The amount looks about right for a routine bill, and the note says exactly that. One owner approves it from their phone between meetings. An hour later, a second owner approves for the same reason. Two approvals — the rule is satisfied — and the money goes out.
+
+Except the address belonged to a scammer who had tricked one of the owners into queuing the request. Every approval was real. Nothing about the wallet "failed." And that's the uncomfortable lesson: a shared wallet has exactly one control — *enough people agreed* — and once that bar is cleared, it will send any amount, to any destination, at any time.
+
+Requiring multiple approvals is powerful (it's the topic of its own primer). But approvals answer only one question: *do enough people say yes?* They can't answer *should this particular transaction be allowed at all?* That second question is what spending guardrails are for.
+
+## What they are
+
+**Spending guardrails** — also called spending policies or transaction guardrails — are automatic rules that can block a transaction even when enough people have approved it. They're a second gate, sitting after "everyone agreed" and before "the money actually moves."
+
+The everyday comparison is a **corporate credit card with built-in policy**. Your company card might be declined at a casino, or above a certain amount, or outside approved vendors — not because someone reviewed the purchase in the moment, but because the rules were set in advance and the card enforces them automatically. You could have every intention of buying something legitimate; if it breaks a rule, it simply doesn't go through. Guardrails bring that same idea to a shared crypto wallet.
+
+## Why they exist: rules in people's heads don't bind
+
+Most teams *think* they have spending controls. In practice, those controls are usually procedures — "we review destinations carefully," "we never approve big transfers on mobile," "anything over $10,000 gets a phone call first." Procedures are rules that live in people's heads. And people approve things between meetings, trust a familiar-looking note, and make mistakes when they're busy or rushed.
+
+A guardrail is different because it isn't advice — it's enforcement. The rule is written into the system itself, so it applies every single time, automatically, whether or not anyone remembers it that day. It doesn't get tired, doesn't trust a convincing story, and can't be talked out of it. That's exactly what you want standing between a phished approval and your treasury.
+
+## How it works: rules checked at the last moment
+
+The key idea is *where* the rule lives. A warning inside an app is only advice — a determined user, or an attacker, can go around it. A rules service running on some company's server is just one more party you have to trust, and one more thing that can be offline or overridden.
+
+Guardrails work because they're checked at the final step, right before execution, by the wallet's own logic. Just before an approved transaction runs, the wallet consults its rules. If the transaction breaks one, it's blocked — no matter how many people approved it. Common rules include:
+
+- **A per-transaction limit** — no single payment may exceed a set amount.
+- **A daily limit** — total spending is capped over a rolling window of time.
+- **An allowlist** — money may only go to a list of pre-approved destinations.
+- **A cooldown** — a required waiting period between transactions, so nothing can be drained in a rapid burst.
+
+Notice how each of these would have stopped the phished payment from earlier — the wrong address isn't on the allowlist, or the amount is over the limit, or the cooldown hasn't elapsed. The scammer collected real approvals and still walked away with nothing.
+
+## How this shows up in FairWins
+
+FairWins lets a group add these guardrails on top of a shared vault. A group can switch on rules like a per-transaction cap, a daily cap, an allowlist of approved recipients, and a cooldown between spends — each one optional and chosen by the group. Once set, they're enforced automatically at the moment of every spend.
+
+Two design choices make this trustworthy. First, the guardrail can only ever *restrict* — it can block a transaction, but it can never start one, approve one, or touch the money itself. It's a brake, never an accelerator. Second, **the group is the only authority over its own rules**: changing a vault's guardrails is itself a transaction that must clear the group's normal approval process. There's no hidden administrator who can quietly loosen the rules, and FairWins built this so no master key exists that could override a group's own enforcement. The rules belong to the group, full stop.
+
+## What to watch out for
+
+- **Guardrails complement approvals; they don't replace them.** Multiple approvals make sure the group agrees. Guardrails make sure even an agreed-upon transaction obeys the rules. You want both layers — neither alone is enough.
+- **Set limits you can actually live with.** Too tight, and legitimate spending gets blocked at the worst moment; too loose, and the guardrail isn't really protecting anything. Revisit them as the group's needs change (which, done right, itself requires group approval).
+- **They stop rule-breaking, not bad judgment within the rules.** A guardrail can block an unknown address, but it can't tell a good approved vendor from a bad one if both are on your allowlist. Guardrails narrow the blast radius of a mistake; they don't remove the need to think.
+
+Approvals ask *do we agree?* Guardrails ask *and does it follow the rules?* For anyone guarding shared money, having the system enforce that second question — automatically, every time — is what turns good intentions into real protection.
+
+## Related deep-dive
+
+Want the engineering details — how a small, restriction-only guard contract enforces these rules on-chain with no admin key? Read [Enough Signatures Is Not Enough](../../posts/08-multisig-policy-engine/blog.md).
+
+## Learn more
+
+- [Safe — modules and transaction guards](https://safe.global/)
+- [Ethereum.org: Smart contract security](https://ethereum.org/en/developers/docs/smart-contracts/security/)
+- [Investopedia: Internal Controls](https://www.investopedia.com/terms/i/internalcontrols.asp)

--- a/docs/blog/knowledge/12-spending-guardrails/social.md
+++ b/docs/blog/knowledge/12-spending-guardrails/social.md
@@ -1,0 +1,26 @@
+# Social & Image — What Are Spending Guardrails?
+
+## X (Twitter)
+A shared wallet needs several approvals before money moves. But what if a scammer tricks two owners into approving a bad payment? Every signature is real, and the money's gone. Spending guardrails are the second gate: automatic rules that block it anyway — like a corporate card with built-in policy. 🔗 <link> #security #crypto #treasury
+
+## LinkedIn
+"Enough people approved it — so it must be fine, right?"
+
+Not always. Even a shared wallet that requires multiple approvals will send any amount, to any address, the moment the threshold is met. If a phished owner queues a bad payment and a second owner rubber-stamps it, every signature is genuine and the money is gone.
+
+This primer explains the missing layer: spending guardrails.
+
+Here's what you'll learn:
+- What guardrails are — automatic rules that block a transaction even when it's fully approved
+- Why "rules in people's heads" (we always review destinations, never approve on mobile) don't actually bind
+- Common controls: per-transaction limits, daily caps, recipient allowlists, and cooldowns
+- Why guardrails only restrict — a brake, never an accelerator — and why the group stays the only authority over its own rules
+
+Think of it as a corporate card with policy built in. Approvals ask "do we agree?" Guardrails ask "and does it follow the rules?" 🔗 <link>
+
+What spending rule would you put on your team's treasury first?
+
+#Security #Treasury #Crypto #RiskManagement #Fintech
+
+## Image prompt (Gemini / Nano Banana)
+A clean, modern editorial illustration for a 16:9 banner: a payment arrow or coin traveling toward a destination, intercepted mid-path by a friendly gate or barrier arm lowering to stop it — clearly conveying an automatic rule catching a transaction before it completes. Nearby, a subtle checklist motif suggests preset policy. Deep navy and teal base palette with a single warm amber accent on the gate barrier. Soft, warm lighting, calm and reassuring rather than alarming, approachable not corporate. Flat vector style with gentle depth. No text, no numbers, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/13-sanctions-and-compliance/blog.md
+++ b/docs/blog/knowledge/13-sanctions-and-compliance/blog.md
@@ -1,0 +1,66 @@
+# What Is Sanctions Screening? (And Why an App Checks Your Wallet)
+
+*Why a crypto app looks up wallet addresses against a blocklist — and how it does that without collecting your name, ID, or personal data*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Security & Custody |
+| **Level** | Beginner |
+| **Audience** | Anyone curious about crypto, no technical background needed |
+| **Tags** | `sanctions`, `compliance`, `privacy`, `security`, `basics` |
+| **Reading time** | ~5 minutes |
+
+## A quick everyday scene
+
+When you open a bank account, the bank runs a check in the background. It's making sure you're not on a government list of people and organizations that businesses are legally forbidden from doing business with — think terrorist financiers, drug cartels, and sanctioned regimes. You never see this happen. You just fill out the form, and either the account opens or it doesn't.
+
+Crypto apps have the same legal obligation. But they have a very different tool to work with, because in crypto there often isn't a "form" full of your personal details — there's just a wallet. So the check looks different, too. This is called **sanctions screening**, and once you understand it, you'll know exactly what's happening the moment an app checks your wallet.
+
+## What it actually is
+
+A **sanction** is a legal restriction a government places on doing business with a specific person, company, or country. Governments publish these as public lists. In the United States, the main one is kept by an office of the Treasury Department called OFAC (the Office of Foreign Assets Control). If someone is on that list, businesses are not allowed to move money for them — full stop.
+
+**Sanctions screening** is simply the act of checking a customer against those lists before doing business. It's the same idea whether you're a bank, an airline, or a crypto app.
+
+The twist in crypto is *what* gets checked. A traditional bank checks your name and date of birth. A crypto app usually checks your **wallet address** — the long string of letters and numbers that identifies your account on the blockchain, a bit like an email address for money. Investigators and governments have publicly flagged certain wallet addresses as belonging to sanctioned people or to stolen-funds operations. Screening asks one narrow question: *is this particular address on a known blocklist?*
+
+## Why it exists (and why apps take it seriously)
+
+Two reasons, and they reinforce each other.
+
+**The legal one.** Sanctions law is strict. It generally doesn't matter whether a business *meant* to help a sanctioned party — if the money moved, the violation happened. That makes screening a hard requirement, not a nice-to-have. An app that skips it is exposed no matter how good its intentions were.
+
+**The keep-the-neighborhood-clean one.** Blocking known-bad addresses keeps stolen funds, scam proceeds, and sanctioned money from flowing through the app. That protects every honest user, because it keeps the platform from becoming a laundromat for criminal money — which is bad for everyone who uses it legitimately.
+
+## How it works — the "guest list at the door" model
+
+Picture a doorkeeper with a clipboard. The clipboard holds a list of addresses that are not allowed in. When you try to do something that moves money — join, deposit, place a wager — the doorkeeper glances at your wallet address and checks the list. Not on it? You go through, no fuss. On it? The action is refused.
+
+Here's the part that surprises people: **this check doesn't need to know who you are.** A wallet address isn't a name, an email, or a passport number. The doorkeeper isn't asking "what's your identity?" — it's asking "is this specific address flagged?" It's more like a bouncer checking whether your ticket number was reported stolen than checking your ID against a photo.
+
+Where does the list come from? Usually a specialized service that publishes, right on the blockchain, whether a given address matches the official government sanctions lists. The app reads that answer. A careful app also adds a rule for when the list can't be reached: if the answer isn't available, it blocks by default rather than waving everyone through. Better to pause than to accidentally let a forbidden transaction slip past. In security terms this is called **failing closed** — when in doubt, deny.
+
+## How it shows up in FairWins
+
+FairWins screens wallet addresses at the moments money enters the system — creating or accepting a wager, joining a pool, buying or renewing a membership. The check runs quietly in the background against a public sanctions blocklist. It doesn't ask for your name, your ID, or any personal documents; it looks at the wallet address, which you're already using anyway.
+
+One deliberate design choice is worth calling out, because it's the fair one: screening blocks *new* money going **in**, but never blocks you from taking **out** what's already yours. If an address became blocked while its funds were still sitting in the app, freezing those funds would be a much heavier act than simply declining new business. So refunds and payouts of your own money are always allowed to leave. The check guards the entrance, not the exit.
+
+## What to watch out for
+
+- **Screening is not the same as identity verification (KYC).** Checking an address against a blocklist is a narrow, privacy-preserving check. It is *not* the app collecting your passport or building a profile of you. Don't assume one means the other.
+- **A block isn't always a personal accusation.** Addresses can be flagged for reasons that have nothing to do with the current holder — for example, funds that passed through a sanctioned service. If you're ever unexpectedly blocked, it's worth understanding your wallet's history.
+- **It's one layer, not a force field.** Screening keeps known-bad actors out; it doesn't make an app risk-free or vouch for anyone who *isn't* on the list. Keep your normal guard up.
+
+The good news for the everyday user: a legitimate wallet passes screening invisibly. You'll almost never notice it — which is exactly how a well-built compliance check is supposed to feel.
+
+## Related deep-dive
+
+Want the engineering details? Read [Sanctions Screening as a Shared Building Block](../../posts/03-sanctions-compliance-gating/blog.md).
+
+## Learn more
+
+- [OFAC Sanctions List Service (US Treasury)](https://ofac.treasury.gov/sanctions-list-service) — the official source of US sanctions lists
+- [Chainalysis sanctions screening oracle](https://go.chainalysis.com/chainalysis-oracle-docs.html) — how sanctioned wallet addresses are published on-chain
+- [What are economic sanctions? (Investopedia)](https://www.investopedia.com/terms/s/sanctions.asp) — plain-language background

--- a/docs/blog/knowledge/13-sanctions-and-compliance/social.md
+++ b/docs/blog/knowledge/13-sanctions-and-compliance/social.md
@@ -1,0 +1,28 @@
+# Social & Image — What Is Sanctions Screening?
+
+## X (Twitter)
+
+When a crypto app "checks your wallet," it's usually sanctions screening: looking up your address against a public blocklist of sanctioned actors. It doesn't need your name or ID — just the address you're already using. A clean wallet passes invisibly. 🔗 <link> #crypto #compliance #privacy
+
+## LinkedIn
+
+Ever wonder what's happening when a crypto app checks your wallet before letting you deposit? It's called sanctions screening — and it's the same legal duty your bank quietly performs when you open an account.
+
+In this beginner primer, you'll learn:
+
+- What a sanction is, and why businesses (banks and crypto apps alike) are legally required to check
+- Why crypto screens a *wallet address* against a public blocklist instead of collecting your name or ID
+- The "doorkeeper with a clipboard" model — and why a careful app blocks by default when the list can't be reached
+- The fair line good apps draw: screening blocks new money coming *in*, but never traps the money that's already yours
+
+The reassuring part: a legitimate wallet passes screening invisibly, with no personal data collected. That's exactly how a well-built compliance check should feel.
+
+Read the primer: <link>
+
+Did you know your bank runs this same check in the background?
+
+#Compliance #Crypto #Privacy #Fintech #Sanctions
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration: a friendly translucent doorkeeper figure holding a glowing clipboard, standing beside an open archway through which small geometric wallet-token shapes flow smoothly inward, while one token is gently paused at the threshold by a softly raised barrier; on the far side of the arch, an unguarded outbound lane lets tokens leave freely. The clipboard shows abstract check-mark glyphs rather than any readable text, emphasizing that no personal identity is being read. Deep navy and teal base palette with a single warm amber accent on the clipboard glow and the paused token, soft diffuse lighting, subtle depth shadows, generous negative space, approachable and reassuring rather than corporate or surveillance-like. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/14-oracles-explained/blog.md
+++ b/docs/blog/knowledge/14-oracles-explained/blog.md
@@ -1,0 +1,74 @@
+# What Is a Blockchain Oracle? The Trusted Referee
+
+*Why a smart contract can't see the outside world on its own — and how an "oracle" tells it who won, what the price is, and what actually happened*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Oracles & Trading |
+| **Level** | Beginner |
+| **Audience** | Anyone curious about crypto, no technical background needed |
+| **Tags** | `oracles`, `smart-contracts`, `prediction-markets`, `basics` |
+| **Reading time** | ~5 minutes |
+
+---
+
+> **A note on responsible use.** This primer describes prediction and forecasting based on publicly available information and ordinary skill. It is not about trading on secret, non-public information or sidestepping any rules. Everyone who takes part remains fully subject to the laws that apply where they live.
+
+---
+
+## A bet between two friends
+
+Say you and a friend bet on whether it rains tomorrow. You each put $10 on the table. Simple — until the moment of truth. Who decides if it "rained"? A drizzle at dawn? You'll want someone you both trust to look outside and make the call: a referee.
+
+Now imagine that same bet handled by a **smart contract** — a small program on a blockchain that automatically holds the money and pays out the winner, with no human in the middle. It's brilliant at holding the $20 safely and following its rules exactly. But it has one strange limitation, and it's the whole reason this article exists: **the contract has no way to look outside and see whether it rained.**
+
+## Why a contract is "blind"
+
+A blockchain is a shared, tamper-proof record that thousands of computers agree on. For them to agree, every computer must be able to check every fact for itself and get the identical answer. That works beautifully for things *inside* the system — who sent what to whom.
+
+But the outside world doesn't work that way. Yesterday's rainfall, the price of Bitcoin at noon, who won an election — none of that lives on the blockchain. If the contract tried to "go check a website," different computers might get different answers (the site changed, went down, or lied), and the agreement would fall apart. So blockchains are deliberately sealed off: a contract can't browse the web or peek out a window. It only knows what's already written on the blockchain.
+
+That's the gap an oracle fills.
+
+## What an oracle is
+
+An **oracle** is the trusted bridge that carries a real-world fact *onto* the blockchain so a contract can use it. It's the referee for the digital bet: it looks at reality, decides the answer, and writes it down where the contract can read it.
+
+The name is old — an oracle was a source you consulted for truth. Same idea here: the contract asks "did the 'yes' side win?" and the oracle answers. The contract trusts that answer and pays out accordingly. Everything hinges on the oracle being reliable, which is why designing oracles is one of the most scrutinized parts of any serious crypto app.
+
+## The different styles of referee
+
+Not all facts are alike, so there isn't one kind of oracle. Here are the main styles, in plain terms.
+
+**The live scoreboard (price feeds).** Some facts are numbers that update constantly, like the price of Bitcoin. A price-feed oracle publishes those numbers onto the blockchain around the clock, whether or not anyone's asking. When the contract needs the price, it just reads the latest posted value — like glancing at a scoreboard that's always lit up. Cheap and fast, but only for things already being measured and posted.
+
+**The messenger you send out (on-demand lookups).** Some facts sit on a website and nobody's put them on the blockchain yet — say, a city's official rainfall reading. Here the oracle acts like a messenger: the contract asks a question, a network of computers fetches the answer from the source and brings it back. More flexible — it can fetch almost anything public — but it takes a round trip, and you're trusting the messenger and the source.
+
+**The panel of judges (dispute-based).** Some facts are messy human judgments with no official feed at all — "did this company merger close before June?" For these, someone *asserts* the answer and puts down a cash deposit backing it up. If nobody challenges the claim within a set window, it's accepted as true; if someone does, it escalates to a wider vote. It's slower and needs money on the line, but it can settle almost any question a scoreboard or messenger can't.
+
+**Reading another referee's final score (settled markets).** Sometimes the answer has *already* been decided somewhere reputable — like a large prediction-market platform that officially resolved its own question and posted the result. The oracle just reads that finished result. Almost free, because someone else did the hard part; the catch is you can only ask questions that platform already answered.
+
+## How it shows up in FairWins
+
+When you make a wager on FairWins that settles from real-world data, an oracle is the referee that decides who won. You don't have to manage any of this — you pick an outcome to bet on, and behind the scenes the app consults the appropriate referee when it's time to settle, then pays the winner automatically.
+
+FairWins is built so any of these referee styles can plug into the same "settlement slot," and it leans toward the safest behavior: if the answer genuinely can't be determined — an unavailable feed, a tied or invalid outcome — the wager doesn't guess a winner. It returns everyone's stakes instead. Failing toward a refund, never a coin flip.
+
+## What to watch out for
+
+- **An oracle is a point of trust.** The contract will faithfully pay out whatever the oracle says — so a wrong or manipulated oracle means a wrong payout. "It's on the blockchain" doesn't make the *input* true; garbage in, garbage out still applies.
+- **Different styles, different trade-offs.** Live feeds are cheap but narrow. Messengers are flexible but slower. Dispute panels answer anything but cost time and money. There's no single best oracle — only the right one for the question.
+- **Timing isn't always exact.** A feed read "after the deadline" is the latest value at the moment someone checks, not necessarily the value at the precise instant. Good systems bound this, but it's worth knowing.
+
+Once you see oracles as referees, a lot of crypto stops feeling like magic. The contract handles the money honestly; the oracle handles the truth. Keep an eye on *who your referee is*, and you've grasped the most important question in the whole system.
+
+## Related deep-dive
+
+Want the engineering details? Read [Three Kinds of Truth, One Referee Slot](../../posts/15-oracle-adapter-abstraction/blog.md).
+
+## Learn more
+
+- [What is a blockchain oracle? (Chainlink)](https://chain.link/education/blockchain-oracles) — a clear primer from a leading oracle provider
+- [Oracles (ethereum.org)](https://ethereum.org/en/developers/docs/oracles/) — Ethereum's own explainer
+- [Prediction market (overview)](https://en.wikipedia.org/wiki/Prediction_market) — background on markets that settle on real-world outcomes

--- a/docs/blog/knowledge/14-oracles-explained/social.md
+++ b/docs/blog/knowledge/14-oracles-explained/social.md
@@ -1,0 +1,28 @@
+# Social & Image — What Is a Blockchain Oracle?
+
+## X (Twitter)
+
+A smart contract can't look outside its own blockchain — it can't tell if it rained or what Bitcoin costs. An "oracle" is the trusted referee that carries that fact in. Different facts need different referees: live feeds, messengers, or a panel of judges. 🔗 <link> #crypto #blockchain #oracles
+
+## LinkedIn
+
+Here's a fact that surprises most people new to crypto: a smart contract is "blind." It can hold your money and follow its rules perfectly — but it can't see the outside world. It has no idea whether it rained, who won the game, or what Bitcoin costs right now.
+
+So how does a contract ever settle a real-world bet? A blockchain oracle — the trusted referee that brings a real-world fact onto the chain.
+
+This beginner primer covers:
+
+- Why blockchains are deliberately sealed off from the outside world (and why that's a feature)
+- What an oracle actually is, using the "referee for a friendly bet" analogy
+- The main oracle styles in plain terms: the live scoreboard, the messenger, the panel of judges, and reading another referee's final score
+- The one question that matters most in any crypto system: *who is your referee?*
+
+Read the primer: <link>
+
+What real-world outcome would you want a contract to settle automatically?
+
+#Blockchain #Crypto #SmartContracts #Fintech #Web3
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration: a friendly translucent referee figure standing at the boundary between two worlds — on one side, a soft impressionistic real world (a raincloud, a rising price line, a stadium glow); on the other, a crisp geometric blockchain lattice of connected cubes. The referee gently carries a single glowing orb of "truth" across the boundary and places it into the waiting lattice, where a small contract shape lights up in response. Deep navy and teal base palette with a single warm amber accent on the orb of truth, soft diffuse lighting, subtle depth, generous negative space, approachable and story-like rather than corporate. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/15-polymarket-and-builder-fees/blog.md
+++ b/docs/blog/knowledge/15-polymarket-and-builder-fees/blog.md
@@ -1,0 +1,72 @@
+# What Is Polymarket? And What's a "Builder Fee"?
+
+*A plain-English look at prediction markets, and the small, honestly-disclosed fee an app can earn for routing your trade*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Oracles & Trading |
+| **Level** | Beginner |
+| **Audience** | Anyone curious about crypto, no technical background needed |
+| **Tags** | `prediction-markets`, `polymarket`, `fees`, `transparency`, `basics` |
+| **Reading time** | ~5 minutes |
+
+---
+
+> **A note on responsible use.** Prediction markets are for forecasting real-world events using publicly available information and ordinary skill. They are not a way to trade on secret, non-public information or to sidestep the rules that govern these markets — and they carry real financial risk; you can lose what you put in. Everyone who takes part remains fully subject to the laws that apply where they live, and to the platform's own regional restrictions. Only take part where it's legal for you to do so.
+
+---
+
+## Betting on the news
+
+You've probably had an opinion about a future event and felt pretty sure you were right. "That product will launch late." "This team makes the finals." A **prediction market** is a place where opinions like that become tradable. People buy and sell shares in outcomes — "yes, it happens" or "no, it doesn't" — and when the event is decided, the correct side gets paid.
+
+The interesting part is that the *price* of a "yes" share behaves like a crowd-sourced probability. If "yes" trades around 70 cents on the dollar, the market is collectively saying there's roughly a 70% chance it happens. That's why prediction markets are often surprisingly good forecasters: real money sharpens people's guesses.
+
+## What Polymarket is
+
+**Polymarket** is one of the largest prediction-market platforms in the world. It runs on a blockchain network called **Polygon** (a fast, low-cost network related to Ethereum), and it lets people trade shares in the outcomes of real-world questions — elections, sports, economics, current events. Trades settle in **USDC**, a digital dollar (a "stablecoin" designed to stay worth about one US dollar).
+
+A key thing about Polymarket: it's **non-custodial**, meaning it never takes hold of your funds the way a traditional betting site does. Every order is signed by your own wallet and stays under your control. Nobody can place a trade for you; only your wallet can authorize your trades. That's a genuine safety feature — but it also shapes how other apps can connect to it, which brings us to fees.
+
+## What a "builder fee" (or referral code) is
+
+Here's a normal, everyday version of the idea. When you book a hotel through a travel site, that site often earns a small commission for sending the hotel your booking. The hotel offers it on purpose, to reward partners who bring customers. You still get the room; the site gets a cut for making the connection.
+
+A **builder fee** — sometimes called a referral code — is the crypto version. Polymarket runs an official program where an app that helps route your order can attach a small "this trade came through us" tag. In return, that app earns a small fee (and a share of a weekly rewards pool). It's a legitimate, built-in way for a helpful app to earn without taking custody of your money or getting between you and the exchange.
+
+## The honest part: it's a real added cost
+
+This is the part to read slowly, because it's where transparency matters most.
+
+Unlike a hotel commission — which the hotel pays out of its own pocket, costing you nothing — a builder fee is **additive**. It stacks *on top of* Polymarket's own trading fee, and it comes out of *your* trade. It is a real, extra cost to you as the trader. Small, yes, but real.
+
+Because it's a genuine added cost, the only fair way to handle it is to **show it to you before you trade** — as its own clearly labeled line, never folded silently into a total, and never described as "free." An app that hides a fee like this, or pretends it's free, is not being straight with you. An app that shows it plainly, every time, is.
+
+## How it shows up in FairWins
+
+FairWins offers prediction-market trading powered by Polymarket, in a section of the app for exactly that. A few things are worth knowing as a user:
+
+- **Your wallet is the only signer.** FairWins never holds your funds or your credentials; your trades go from your device to Polymarket directly. FairWins earns by *attributing* the trade with its builder code, not by sitting in the middle of your money.
+- **The fee is disclosed as its own line, before you approve.** You see the FairWins builder fee spelled out on the confirmation screen. Polymarket's own separate fee is noted too. What you see is what you're charged for the part FairWins controls.
+- **It only appears on Polygon.** Because Polymarket runs only on the Polygon network, the trading section simply isn't shown elsewhere.
+- **Regional rules are respected.** Polymarket restricts trading from certain regions, and FairWins surfaces those limits rather than trying to bypass them. If it's not available where you are, you'll be told honestly.
+
+## What to watch out for
+
+- **You can lose money.** Prediction markets are real financial risk, not entertainment with guaranteed returns. A "70% yes" can still turn out "no." Never stake more than you can comfortably lose.
+- **Fees add up.** Between Polymarket's own fee and the builder fee, there's a real cost to each trade. Read the disclosure and factor it in — especially if you trade often.
+- **"Additive" means on top.** Don't confuse a builder fee with a cost-free referral. This one comes out of your trade. The right response isn't alarm — it's simply expecting to *see* it clearly before you tap approve.
+- **Know your local rules.** Whether you can legally use prediction markets depends on where you live. That's on each participant to check.
+
+The takeaway: prediction markets are a fascinating way to turn opinions into forecasts, and referral fees are a normal way apps earn for connecting you. The line between a trustworthy app and an untrustworthy one isn't *whether* there's a fee — it's whether they tell you about it, in plain sight, before you agree.
+
+## Related deep-dive
+
+Want the engineering details? Read [Predict: Earning From Prediction-Market Trades Without Ever Touching One](../../posts/24-predict-polymarket-builder-codes/blog.md).
+
+## Learn more
+
+- [Polymarket documentation](https://docs.polymarket.com/) — the prediction-market platform, including its builder-code referral program
+- [Prediction market (overview)](https://en.wikipedia.org/wiki/Prediction_market) — background on how these markets work
+- [What is USDC? (Circle)](https://www.circle.com/usdc) — the digital dollar these trades settle in

--- a/docs/blog/knowledge/15-polymarket-and-builder-fees/social.md
+++ b/docs/blog/knowledge/15-polymarket-and-builder-fees/social.md
@@ -1,0 +1,28 @@
+# Social & Image — What Is Polymarket? And What's a "Builder Fee"?
+
+## X (Twitter)
+
+Prediction markets turn opinions into tradable forecasts — a "70¢ yes" means the crowd sees ~70% odds. Apps that route your trade can earn a "builder fee." The honest rule: it's a real added cost, so it should be shown before you trade, never hidden. 🔗 <link> #Polymarket #crypto #prediction
+
+## LinkedIn
+
+A "70% yes" share on a prediction market is really the crowd betting real money on a forecast — which is why these markets are often surprisingly accurate. But if an app earns a fee for routing your trade, how should it tell you?
+
+This beginner primer explains:
+
+- What a prediction market is, and why prices act like crowd-sourced probabilities
+- What Polymarket is — a large, non-custodial prediction platform on the Polygon network
+- What a "builder fee" (referral code) is, using a familiar travel-booking analogy
+- The honest part: unlike a cost-free referral, a builder fee is *additive* — a real cost to you — so it must be shown plainly before you trade, never folded into a total or called "free"
+
+The line between a trustworthy app and an untrustworthy one isn't whether there's a fee. It's whether you see it clearly before you approve. (And yes — prediction markets carry real risk; only take part where it's legal for you.)
+
+Read the primer: <link>
+
+How much does upfront fee disclosure shape whether you trust an app?
+
+#PredictionMarkets #Crypto #Transparency #Fintech #Polymarket
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration: a friendly marketplace scene rendered in soft geometric shapes, where two balanced scales tip between a glowing "yes" orb and a "no" orb, representing a prediction market. To one side, a small transparent receipt-like panel floats, showing a clearly itemized fee line highlighted in warm accent — conveying honest, up-front disclosure without any readable words. Abstract wallet-token shapes flow directly from a person's hand to the market, bypassing any middleman. Deep navy and teal base palette with a single warm amber accent on the highlighted fee line and the "yes" orb, soft diffuse lighting, subtle depth, generous negative space, approachable and trustworthy rather than corporate. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/16-nfts-soulbound-and-memberships/blog.md
+++ b/docs/blog/knowledge/16-nfts-soulbound-and-memberships/blog.md
@@ -1,0 +1,64 @@
+# NFTs, Soulbound Tokens, and Memberships: What You Actually Own
+
+*A plain-English guide to unique digital tokens — the kind you can trade, the kind welded to you forever, and the "gift card" that sits between them.*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Identity, Privacy & Networks |
+| **Level** | Beginner |
+| **Audience** | Crypto-curious beginners — no technical background needed |
+| **Tags** | `nfts`, `soulbound`, `memberships`, `identity`, `plain-english` |
+| **Reading time** | ~5 minutes |
+
+## Start with a concert ticket
+
+Imagine two things in your wallet. The first is a $20 bill. It doesn't matter *which* $20 bill you hand over at the coffee shop — any twenty is worth exactly the same as any other. The second is a concert ticket with your seat number on it. That one is *unique*. Seat 14, Row C is not the same as Seat 88 in the balcony, and you can't swap one for the other and pretend they're identical.
+
+Most crypto you've heard of — USDC, a stablecoin worth about one US dollar, or Bitcoin — behaves like the $20 bill. One unit is interchangeable with the next. But sometimes you want the concert ticket: a token that stands for one specific, one-of-a-kind thing. That's an NFT.
+
+## What an NFT is
+
+**NFT** stands for "non-fungible token." "Non-fungible" is a fancy word for "not interchangeable" — the concert-ticket property. Strip away the hype and an NFT is simply **a unique token that lives at your wallet address and that only you control.**
+
+That token can *represent* almost anything: a piece of digital art, a ticket, a certificate, a membership card. The token itself is just a record on a blockchain — a public, shared ledger that everyone can read but no one can secretly rewrite — saying "this particular item belongs to this particular wallet." Because it's unique, you can prove you hold it, and (usually) you can send it to someone else, the way you'd hand a friend your concert ticket.
+
+The key word there is *usually*. Being sendable is what makes an NFT feel like property you own. But sometimes you specifically *don't* want a thing to be sendable — and that's where the next idea comes in.
+
+## What "soulbound" means
+
+A **soulbound** token is an NFT with the transfer button switched off. Once it's yours, it stays yours. You can't sell it, gift it, or hand it to anyone — it's bound to you.
+
+That sounds like a downside until you think about what it's good for. A university diploma is soulbound in real life: it says *you* earned the degree, and it would be worthless if you could sell it to a stranger. A driver's license is soulbound — it's proof about *you*, not a thing to trade. Anything that's meant to be a statement about a specific person is safer when it can't move.
+
+The reason is simple: **a credential you can transfer is a credential that can be stolen, rented, or borrowed.** If a membership that grants access could be sold, someone could rent it out for an hour to slip past a check, or a bad actor could buy their way in. Making it non-transferable closes that door by design.
+
+## Where memberships and vouchers fit
+
+This is exactly the tension FairWins had to solve, and it's a nice way to see all three ideas at once.
+
+A FairWins **membership** — the thing that lets your wallet create and accept wagers — is soulbound. It's tied to your wallet, it can't be transferred, and there's no market for it. That's on purpose: the platform screens you against sanctions lists when you get a membership and tracks your usage per wallet, so a membership that could hop between people would break those safeguards.
+
+But people reasonably want to *gift* a membership to a friend, or resell one they aren't using — the everyday stuff gift cards are made for. You can't do that with something welded to your wallet. So FairWins splits the idea in two:
+
+- The **membership** stays soulbound and non-transferable — the credential itself never moves.
+- A **membership voucher** is a normal, freely tradable NFT — think of it as a **prepaid gift card** for a membership. While you hold a voucher it grants you *nothing*: no access, no clock ticking. It just sits there, and you can gift it or sell it like any other NFT.
+
+The magic happens at **redemption**. When someone turns a voucher into an actual membership, that's the moment the platform runs its checks — sanctions screening, "do you already have one?" — and only then writes the soulbound membership to their wallet and destroys the voucher. So the tradable thing (the voucher) and the personal credential (the membership) are kept cleanly separate, and the safety checks land exactly where access is granted.
+
+## What to watch out for
+
+- **"NFT" doesn't mean "expensive art."** It just means a unique token. A membership voucher and a million-dollar monkey picture are the same *kind* of thing under the hood; what they represent is wildly different.
+- **A voucher is only worth what it can be redeemed for.** Holding one grants you no access until you redeem it. Treat it like a gift card, not a magic key.
+- **Soulbound is a feature, not a bug.** If something is bound to you and can't be moved, that's usually protecting you — it means no one can quietly transfer your credential away, and no one can buy their way into being "you."
+- **Selling a voucher is not selling access.** The person who redeems it still has to pass the same checks anyone else would. Buying a voucher second-hand doesn't skip the line.
+
+## Related deep-dive
+
+Want the engineering details? Read [Soulbound Memberships, Transferable Vouchers: Splitting a Token in Two](../../posts/02-soulbound-memberships-vouchers/blog.md).
+
+## Learn more
+
+- [What is an NFT? (ethereum.org)](https://ethereum.org/en/nft/)
+- [ERC-721: the standard behind most NFTs (ethereum.org)](https://ethereum.org/en/developers/docs/standards/tokens/erc-721/)
+- [Non-Fungible Token (NFT), explained (Investopedia)](https://www.investopedia.com/non-fungible-tokens-nft-5115211)

--- a/docs/blog/knowledge/16-nfts-soulbound-and-memberships/social.md
+++ b/docs/blog/knowledge/16-nfts-soulbound-and-memberships/social.md
@@ -1,0 +1,26 @@
+# Social & Image — NFTs, Soulbound Tokens, and Memberships: What You Actually Own
+
+## X (Twitter)
+
+An NFT is just a unique token you own — like a concert ticket, not a $20 bill. A "soulbound" one has the transfer switched off: welded to you, like a diploma. That's why a membership can be soulbound while a *voucher* for it trades freely. 🎟️ 🔗 <link> #NFT #web3 #crypto101
+
+## LinkedIn
+
+What do you actually own when you own an NFT — and why would anyone want a token they *can't* sell?
+
+Our new beginner primer untangles three ideas people constantly mix up, using nothing more technical than a concert ticket and a gift card:
+
+- What an NFT really is — a unique token tied to your wallet, not "expensive digital art"
+- What "soulbound" means — a token welded to you, like a diploma or driver's license, and why that's a safety feature
+- How a soulbound membership can still be gifted — by making a separate, tradable "voucher" that only becomes a membership when it's redeemed
+- Why the safety checks land at redemption, not at the moment of trade
+
+No jargon, no hype — just a clear mental model you can actually use.
+
+Read it here: <link>
+
+Would you rather own a credential you can sell, or one no one can ever take from you? #NFT #crypto #web3 #digitalidentity
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern editorial illustration, friendly and approachable, showing a simple visual metaphor split into two halves: on the left, a glowing paper gift ticket being passed freely between two abstract rounded hands (the tradable voucher); on the right, a warm badge or medal fused permanently into a small stone pedestal with a subtle chain-link base, conveying "soulbound / cannot move." A soft luminous arc connects the two halves, suggesting a ticket transforming into a badge. Deep navy and teal base palette with a single warm amber accent on the ticket and the connecting light. Soft ambient lighting, gentle rim highlights, generous negative space, an inviting fintech feel — not corporate, not cold. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/17-onchain-names/blog.md
+++ b/docs/blog/knowledge/17-onchain-names/blog.md
@@ -1,0 +1,72 @@
+# On-Chain Names: Turning a 42-Character Address Into Something You Can Read
+
+*Why crypto addresses look like a typo, how naming systems like ENS fix that, and why a friendly name is always a convenience — never a requirement to move your money.*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Identity, Privacy & Networks |
+| **Level** | Beginner |
+| **Audience** | Crypto-curious beginners — no technical background needed |
+| **Tags** | `naming`, `ens`, `identity`, `usability`, `plain-english` |
+| **Reading time** | ~5 minutes |
+
+## The address that looks like a cat walked across the keyboard
+
+You want to send your friend Dev twenty dollars in crypto. The app asks for Dev's wallet address, and it looks like this:
+
+`0x7f3a9c2b8e14dD6...` — forty-two characters of letters and numbers, no spaces, no rhyme.
+
+Now compare that to how you send Dev money in a normal bank app: you tap their name. "Dev." Done. Nobody memorizes their friend's account number and routing number; the app hides that behind a name and a photo.
+
+Crypto's raw addresses are the account numbers — long, unforgiving strings where a single wrong character sends your money to a stranger, permanently. **On-chain naming** is the effort to give those addresses a human face, so you're tapping "Dev" instead of squinting at hex.
+
+## What on-chain naming is
+
+An on-chain name is simply **a readable label that points to a wallet address.** Instead of typing (or trusting) forty-two characters, you type a short name, and the system looks up the address behind it.
+
+Think of it like the contacts app on your phone. You don't dial a ten-digit number every time; you tap "Mom," and the phone knows which digits that means. A naming system is a shared contacts book: the name is what you see, the address is what actually moves the money underneath.
+
+The important shift is that the name is *for humans*, and the address is *for the machine*. Both are still there. The name just spares you from handling the scary part by hand.
+
+## ENS, in plain terms
+
+The best-known naming system is **ENS**, short for the Ethereum Name Service. It lets you register a name like `dev.eth` and have it stand in for a wallet address on Ethereum, the largest programmable blockchain.
+
+Once Dev owns `dev.eth`, apps that support ENS let you type `dev.eth` where they'd normally demand the long address. Behind the scenes, the app quietly looks up which wallet `dev.eth` points to and sends there. It's the internet's own trick, actually: web addresses like `example.com` are really friendly names for hard-to-remember numbers, and a system called DNS does the lookup. ENS is that same idea for wallets.
+
+ENS names are themselves owned — you register one, a bit like registering a web domain — and one name can point at your wallet across many apps. That's the appeal: claim a name once, use it everywhere that understands it.
+
+## App-level nicknames and callsigns
+
+ENS isn't the only way to get a readable name, and it doesn't work everywhere. Many apps also let you set names *inside the app itself.*
+
+There are two flavors, and it's worth telling them apart:
+
+- **A private nickname / address book entry.** Just like saving "Dev" in your phone contacts, you can label an address so *you* see a friendly name. Nobody else sees it; it's your personal note. This is the safest kind, because you set it yourself and it never leaves your control.
+- **A shared app-level name (a "callsign").** Some platforms let members claim a public handle — something like `%dev` — that resolves to their wallet *for everyone on that platform.* It's more like a username: reserved by one person, visible to others, and useful for inviting or paying people without swapping raw addresses.
+
+The difference from ENS is scope. ENS is a broad, cross-app naming system anchored on Ethereum. An app-level callsign is a name that lives inside one platform, and it can be tuned to that platform's needs — for instance, only resolving to *members who've already been screened*, which a general-purpose name can't promise.
+
+## How it shows up in FairWins
+
+FairWins uses all three layers, and stacks them in a sensible order of trust. When it needs to show you who's who, it prefers a name you saved yourself in your own address book first, then your optional in-app callsign, then an ENS name if you have one, and only falls back to the raw address if none of those exist.
+
+The callsign is an **optional perk** — you can claim a short handle so friends can find and invite you by name instead of by hex. But here's the part that matters most: **nothing about moving your money depends on having a name.** Every wager, every payout, every transfer runs on wallet addresses underneath. If the naming system is switched off, unreachable, or you simply never claimed a callsign, everything still works — you'll just see an address where a name would have been. A name is polish on top of a system that runs fine without it.
+
+## What to watch out for
+
+- **Names are convenience, not security by themselves.** A friendly name is only as trustworthy as the system that maps it to an address. Before sending real money to a name for the first time, confirm it points where you expect.
+- **Beware look-alikes.** Some naming systems allow tricky characters, so a scammer can register a name that looks almost identical to a real one (a "0" that's really an "O," say). When in doubt, verify through a second channel — ask the person directly.
+- **A name is a convenience, never a requirement.** You never *need* a name to receive or send funds. The address always works. If a service tells you a name is mandatory to move money, be skeptical.
+- **Owning a name can cost money and can expire.** Registering an ENS name involves a fee and a renewal, like a web domain. Read the terms before you assume a name is yours forever.
+
+## Related deep-dive
+
+Want the engineering details? Read [Callsigns: A Human-Readable Name That Nothing Depends On](../../posts/33-callsign-registry/blog.md).
+
+## Learn more
+
+- [Ethereum Name Service — official site](https://ens.domains/)
+- [ENS documentation: what ENS is](https://docs.ens.domains/)
+- [How DNS works — the same idea for the web (Cloudflare Learning)](https://www.cloudflare.com/learning/dns/what-is-dns/)

--- a/docs/blog/knowledge/17-onchain-names/social.md
+++ b/docs/blog/knowledge/17-onchain-names/social.md
@@ -1,0 +1,26 @@
+# Social & Image — On-Chain Names: Turning a 42-Character Address Into Something You Can Read
+
+## X (Twitter)
+
+Crypto addresses look like a cat walked across your keyboard — 42 characters where one typo loses your money. On-chain names (like ENS, or in-app "callsigns") are the contacts app for wallets: tap a name, not the hex. But the name is always optional — money moves on addresses. 🔗 <link> #ENS #crypto101 #web3
+
+## LinkedIn
+
+Why does a crypto wallet address look like a random string of 42 characters — and how do people avoid retyping it every time they send money?
+
+Our new beginner primer explains on-chain naming with nothing more than your phone's contacts app:
+
+- Why raw addresses are so error-prone, and what a "name" actually does (points a readable label at an address)
+- ENS in plain terms — a registered name like `dev.eth` standing in for a wallet, the same way `example.com` stands in for a number
+- The difference between a private nickname you save yourself and a public app-level "callsign" others can see
+- The rule that matters most: a name is a convenience, never a requirement — your money always moves on the address underneath
+
+A short, jargon-free read for anyone who's ever stared at a wallet address and thought "there has to be a better way."
+
+Read it here: <link>
+
+What's stopped you from trusting a crypto name the first time you sent to one? #ENS #crypto #web3 #digitalidentity
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern editorial illustration, friendly and approachable, showing a phone-contacts metaphor for crypto: a simple rounded card with a warm name label on the front, and behind it a long faint ribbon of hexadecimal characters folding away into soft focus — the readable name in front, the raw address quietly behind it. A gentle magnifying-glass or lookup arrow connects the two, suggesting "name resolves to address." Deep navy and teal base palette with a single warm amber accent on the name card and the lookup arrow. Soft ambient lighting, gentle rim highlights, generous negative space, an inviting fintech feel — not corporate, not cold. No text that spells real words, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/18-private-and-encrypted/blog.md
+++ b/docs/blog/knowledge/18-private-and-encrypted/blog.md
@@ -1,0 +1,71 @@
+# Private and Encrypted: How a Public Blockchain Can Still Keep a Secret
+
+*What encryption and "end-to-end" really mean in everyday terms — and how an app built on a public ledger can still keep the terms of a private wager confidential.*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Identity, Privacy & Networks |
+| **Level** | Beginner |
+| **Audience** | Crypto-curious beginners — no technical background needed |
+| **Tags** | `encryption`, `privacy`, `end-to-end`, `plain-english` |
+| **Reading time** | ~5 minutes |
+
+## A locked box on a public shelf
+
+Picture a glass display case in the middle of a busy train station. Anyone walking by can see what's inside. Now picture putting a small locked strongbox *inside* that case. Everyone can see the box is there. Nobody but the keyholder can see what's in it.
+
+That's the situation a blockchain app lives in. A **blockchain** is a public, shared ledger — a record that everyone can read and no one can secretly rewrite. It's the glass case: transparency is the whole point, and it's what lets a smart contract hold your money honestly without a bank in the middle.
+
+But some things you genuinely don't want the whole station to see. If you and a colleague make a private wager on a public outcome, you might not want the *terms* of that bet broadcast to the world. So how do you keep a secret on a shelf everyone can see? You put it in a locked box. That box is **encryption.**
+
+## What encryption is
+
+**Encryption** is scrambling information so that only someone with the right key can unscramble it. Locked, it looks like meaningless noise. Unlocked with the correct key, it snaps back into the original message.
+
+A useful mental model: encryption turns your message into a locked box, and the "key" is a secret only the right people hold. Anyone can carry the box around, photograph it, store it, even keep a copy forever — and it's still just a lump of metal to them. Without the key, there's nothing to read.
+
+You already rely on this constantly. When your browser shows a little padlock, when your messaging app protects your chats, when your phone locks its contents behind your Face ID — that's encryption working quietly in the background.
+
+## What "end-to-end" adds
+
+You'll often hear the phrase **end-to-end encryption**, and it's worth understanding because it's stronger than plain encryption.
+
+Imagine sending a locked box through the postal service. Plain encryption might mean the post office *can* open the box in the middle if it wants to — it holds a master key "for your convenience." End-to-end encryption means the box can only be opened by **you and the person you're sending it to** — the two *ends*. The postal service, the app maker, the servers in between: none of them hold a key. They carry a sealed box they physically cannot open.
+
+The difference is *who holds the keys.* If a company can read your message, it can be forced to hand it over, or leak it in a breach. If only the two ends hold keys, there's no master key to steal, subpoena, or lose. The trade-off is real: if *you* lose your key, no help desk can recover the contents, because nobody else ever had it.
+
+## How it works, without the math
+
+The clever part is how a secret gets shared between exactly the right people. Here's a correct mental model:
+
+1. When a private message is created, the app makes up one brand-new random key and locks the message with it. Now it's a sealed box.
+2. That single key then gets **re-wrapped separately for each person allowed to read it** — locked again inside a little envelope only *that* person's wallet can open.
+3. The sealed box and those personal envelopes get stored. The public ledger keeps only a tiny reference — a claim ticket pointing at the box — not the contents.
+
+So the message is encrypted *once*, but the key to it is handed out privately to each participant, wrapped so only their own wallet can unwrap it. No central service ever holds a master key. If a third party grabs everything that's stored, they get a locked box and a pile of envelopes they can't open.
+
+## How it shows up in FairWins
+
+FairWins settles wagers on a public blockchain — the escrow, the payouts, the fact that a wager exists are all transparent, exactly as they should be. But the **private terms** of a confidential wager don't need to be shouted to the world. Two people can back opposing views of a public outcome without publishing their reasoning or positioning on a public board.
+
+The way that works matches the model above: the sensitive details are sealed with encryption and only the participants hold keys derived from their own wallets. What lives on the public chain is the money-handling and a small reference — not the confidential contents. The platform never holds a master key to your private terms, which is the point: privacy that doesn't depend on trusting the platform to keep quiet.
+
+One honest boundary worth stating plainly: this kind of privacy protects your *competitive information* — your strategy, your terms — from onlookers. It is not a tool for hiding illegal activity, and all participants remain subject to applicable law. FairWins wagers are meant as skill-based forecasting on publicly available information, not a way around the rules.
+
+## What to watch out for
+
+- **"Encrypted" is only as strong as key custody.** The real question is always *who holds the key.* End-to-end means only the ends do — which is safest, but also means losing your key can mean losing access for good.
+- **Public chain, private contents — both are true at once.** A blockchain being public does not mean *everything* about you is exposed. The ledger can show that a transaction happened while its sensitive details stay sealed.
+- **Privacy is not anonymity.** Keeping the *terms* of a wager confidential is different from hiding *who* you are. Wallet activity can often still be observed, even when the contents can't be read.
+- **Encryption doesn't excuse anything.** Confidentiality protects legitimate privacy; it doesn't place you above the law. Treat it as a shield for your strategy, not a cloak for misconduct.
+
+## Related deep-dive
+
+Want the engineering details? Read [Private Prediction Markets: Confidential Terms with Trustless Settlement](../../posts/18-envelope-encryption/blog.md).
+
+## Learn more
+
+- [What is encryption? (Cloudflare Learning)](https://www.cloudflare.com/learning/ssl/what-is-encryption/)
+- [What is end-to-end encryption? (Cloudflare Learning)](https://www.cloudflare.com/learning/privacy/what-is-end-to-end-encryption/)
+- [Encryption, explained (Electronic Frontier Foundation — Surveillance Self-Defense)](https://ssd.eff.org/module/what-should-i-know-about-encryption)

--- a/docs/blog/knowledge/18-private-and-encrypted/social.md
+++ b/docs/blog/knowledge/18-private-and-encrypted/social.md
@@ -1,0 +1,26 @@
+# Social & Image — Private and Encrypted: How a Public Blockchain Can Still Keep a Secret
+
+## X (Twitter)
+
+A blockchain is a glass case everyone can see into. So how do you keep a secret on it? Put a locked box inside. That box is encryption — and "end-to-end" just means only you and the recipient hold the key, not the app. Public ledger, private contents, both at once. 🔒 🔗 <link> #encryption #privacy #web3
+
+## LinkedIn
+
+If a blockchain is public and anyone can read it, how can an app keep the terms of a private wager confidential?
+
+Our new beginner primer answers that with one image: a locked box sitting inside a glass display case. Everyone sees the box; only the keyholder sees inside. Along the way it explains, in plain English:
+
+- What encryption actually is — scrambling a message so only the right key unlocks it (the padlock in your browser, the lock on your phone)
+- What "end-to-end" adds — only the two ends hold keys, so not even the app maker can read the contents
+- How a secret gets shared with exactly the right people, without any central master key
+- The honest trade-offs: privacy is not anonymity, and losing your key can mean losing access for good
+
+No math, no jargon — just a mental model you can actually use.
+
+Read it here: <link>
+
+Would you trust an app more if it *couldn't* read your data, even if it wanted to? #encryption #privacy #web3 #security
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern editorial illustration, friendly and approachable, showing a small sturdy locked strongbox resting inside a transparent glass display case — the case fully see-through, the box opaque and sealed, with a subtle keyhole and a faint warm glow suggesting a secret safely held. Around the glass case, soft translucent geometric panels evoke a public ledger without any readable text. One small key floats to the side, connected to the box by a thin luminous thread, hinting that only the right holder can open it. Deep navy and teal base palette with a single warm amber accent on the keyhole, the key, and the connecting light. Soft ambient lighting, gentle rim highlights, generous negative space, an inviting fintech feel — not corporate, not cold. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/19-blockchain-networks-and-l2s/blog.md
+++ b/docs/blog/knowledge/19-blockchain-networks-and-l2s/blog.md
@@ -1,0 +1,79 @@
+# Blockchain Networks and "Layer 2s," Explained Simply
+
+*What a blockchain network actually is, why some are cheaper and faster than others, and why Bitcoin is a different animal from Ethereum*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Identity, Privacy & Networks |
+| **Level** | Beginner |
+| **Audience** | Anyone curious about crypto who has a phone and a bank app |
+| **Tags** | `networks`, `layer-2`, `ethereum`, `polygon`, `bitcoin`, `basics` |
+| **Reading time** | ~6 minutes |
+
+---
+
+## "Which network?" — the question that keeps popping up
+
+You go to send some money in a crypto app, and before it lets you, it asks a question that sounds a little strange: *which network?* Ethereum? Polygon? Something called Bitcoin? Maybe there's a warning that fees will be higher on one than another.
+
+If you've ever wondered what that choice actually means, this primer is for you. The good news: the idea underneath is simpler than the jargon makes it sound.
+
+## What a blockchain network is
+
+A **blockchain** is a shared record book that thousands of computers around the world keep at the same time. Instead of one bank holding the official copy of who owns what, every participant holds a matching copy, and they constantly agree on updates. Once something is written in — you sent money, you joined a group — it's extremely hard to secretly change, because everyone would have to be fooled at once.
+
+A **network** is simply *one particular* shared record book, run by its own crowd of computers. Ethereum is one network. Bitcoin is another. Polygon is another. They are separate systems, each with its own record, its own rules, and its own community of computers keeping it honest. Money and information on one network don't automatically exist on another — the same way an account at one bank isn't automatically an account at a different bank.
+
+That's really the whole idea. A "network" is a self-contained ledger with its own crowd running it.
+
+## Why "layer 2" exists — and why it's cheaper
+
+Here's the catch. A popular network like Ethereum can get crowded. Because every computer has to process and agree on every transaction, there's only so much room. When lots of people want in at once, they effectively bid against each other for space, and the **fee** — the small charge you pay to get your transaction recorded — goes up. On a busy day, a simple action on Ethereum can cost real money in fees alone.
+
+A **layer 2** (often written "L2") is a clever fix. Think of Ethereum as a busy courthouse where every case is heard one at a time, slowly and expensively, but with ironclad authority. A layer 2 is like a fast side office that handles a big batch of everyday paperwork quickly and cheaply, then periodically walks a single summary back to the courthouse to be stamped as official.
+
+Because the layer 2 bundles up many transactions and only settles a compact summary onto the main network, everyone shares the cost of that one trip to the courthouse. The result: **transactions that are much cheaper and much faster**, while still leaning on the security of the big network underneath.
+
+**Polygon** is the most familiar example you'll meet in this app. It behaves almost exactly like Ethereum — same style of wallet, same kind of addresses — but transactions cost a tiny fraction as much and confirm in seconds. For everyday-sized activity, that difference is night and day.
+
+## Why an app supports more than one network
+
+If Polygon is cheaper, why not use it for everything? Because different networks are good at different things. Some features and communities live on **Ethereum** specifically. **Polygon** is ideal for frequent, everyday-sized actions where you don't want fees eating into small amounts. And **Bitcoin** is where many people prefer to hold and move value (more on that below).
+
+Supporting several networks lets an app meet you where your money and your community already are, instead of forcing everything onto one. The trade-off is that *you* pick the right lane for each task — and a well-built app makes that choice clear rather than hiding it.
+
+## Bitcoin is a genuinely different kind of network
+
+Ethereum, Polygon, and several others belong to one big family. In that family, a network is essentially "a number with programmable contracts on it." These networks run little programs called **smart contracts** — self-operating agreements that live on the chain — and they're often called **EVM** networks, after the shared "engine" (the Ethereum Virtual Machine) they all run. Because they speak the same dialect, a wallet or app can treat them very similarly.
+
+**Bitcoin is not in that family.** It's **non-EVM** — a different design with different rules:
+
+- It doesn't run general smart contracts. It's built to do one thing exceptionally well: hold and move Bitcoin securely.
+- It doesn't track balances as a running total in an account. Instead it holds value in discrete chunks of coins, a bit like carrying specific bills and coins in a wallet rather than a single account balance.
+- Its addresses are meant to be **used once and rotated**, and its fees are priced by the size of the transaction rather than by "gas."
+
+None of this makes Bitcoin better or worse — just fundamentally *different*. It's why an app can't simply treat Bitcoin as "one more Ethereum network." It has to speak a second language entirely.
+
+## How this shows up in FairWins
+
+When you use FairWins, that "which network?" moment is the choice we've been describing. Most everyday activity happens on Polygon, where fees are small and confirmations are quick. Some features connect to Ethereum, where certain communities and tools live. And Bitcoin appears as its own thing — a straightforward wallet to hold, send, and receive Bitcoin — rather than pretending to do everything the EVM networks do.
+
+The app tries to make each network's strengths and limits honest: a feature that isn't available on a given network says so, instead of quietly failing.
+
+## What to watch out for
+
+- **Networks don't automatically talk to each other.** Sending Bitcoin to an Ethereum-style address (or vice versa) can lose your funds. Always match the network to the destination.
+- **Fees are real, and they vary.** Cheaper isn't always available for every task. A good app shows you the exact cost before you approve — never approve a transaction whose fee you can't see.
+- **"Layer 2" doesn't mean "no risk."** It means cheaper and faster, still anchored to a big network's security. It's a scaling tool, not a magic shield.
+
+## Related deep-dive
+
+Want the engineering details? Read [Adding Bitcoin to an App That Was Never Built for It](../../posts/25-bitcoin-non-evm/blog.md) — how FairWins added its first non-EVM network without breaking the assumptions built around the old ones.
+
+## Learn more
+
+- [ethereum.org: What is Ethereum?](https://ethereum.org/en/what-is-ethereum/) — a plain-language introduction
+- [ethereum.org: Layer 2 explained](https://ethereum.org/en/layer-2/) — why L2s make transactions cheaper and faster
+- [Polygon: official site](https://polygon.technology/) — the layer-2 network you'll use most here
+- [Bitcoin.org: How Bitcoin works](https://bitcoin.org/en/how-it-works) — the original, non-EVM network in its own words

--- a/docs/blog/knowledge/19-blockchain-networks-and-l2s/social.md
+++ b/docs/blog/knowledge/19-blockchain-networks-and-l2s/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Blockchain Networks and "Layer 2s," Explained Simply
+
+## X (Twitter)
+
+"Which network?" — the crypto question that trips up newcomers. A network is just one shared record book with its own crowd running it. A "layer 2" (like Polygon) batches transactions so they're way cheaper & faster than Ethereum. And Bitcoin? A totally different animal. 🔗 <link>
+
+#Crypto101 #Ethereum #Polygon
+
+## LinkedIn
+
+Ever opened a crypto app, tried to send something, and been stopped by a question that felt oddly technical — "which network?" This beginner primer unpacks what that choice actually means, in plain English.
+
+Here's what you'll walk away understanding:
+
+- **What a blockchain network really is** — one shared record book kept by a crowd of computers, not a bank's single official copy.
+- **Why "layer 2" networks like Polygon are cheaper and faster** — they bundle up many transactions and settle a compact summary onto Ethereum, so everyone shares the cost of one trip to the "courthouse."
+- **Why one app supports several networks** — different networks are good at different things, and the app meets your money and community where they already are.
+- **Why Bitcoin is fundamentally different** — it's non-EVM: no general smart contracts, no running-total accounts, addresses meant to be used once. Not better or worse, just a different language entirely.
+
+No jargon assumed, no hype — just the mental model that makes the "which network?" moment finally click.
+
+Which network confused you most when you started? 🔗 <link>
+
+#Crypto101 #Blockchain #Ethereum #Polygon #Web3
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean, friendly editorial illustration showing three distinct "islands" of activity connected by simple bridges: one large orderly island representing a main network, a smaller fast-moving satellite island beside it representing a layer-2 (with a little bundle of papers being carried back to the big island to be stamped), and a separate, differently-styled island off on its own representing Bitcoin. Each island has its own small crowd of tiny figures keeping shared ledgers in sync. Deep navy and teal base palette with a single warm amber accent highlighting the bridge to the fast satellite island. Soft directional lighting, approachable and modern, generous negative space, calm and clear rather than corporate. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/20-what-is-a-dao/blog.md
+++ b/docs/blog/knowledge/20-what-is-a-dao/blog.md
@@ -1,0 +1,88 @@
+# What Is a DAO?
+
+*A group that coordinates and makes decisions using shared on-chain rules instead of a boss, a head office, or a filing cabinet*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Identity, Privacy & Networks |
+| **Level** | Beginner |
+| **Audience** | Anyone curious about how online groups make decisions together |
+| **Tags** | `dao`, `governance`, `community`, `voting`, `basics` |
+| **Reading time** | ~6 minutes |
+
+---
+
+## A club where nobody holds the only key
+
+Imagine a group of friends who pool money for a shared purpose — say, a neighborhood fund. In the normal version, one person is the treasurer. They hold the account, they sign the checks, and everyone else has to trust them. If they vanish, or get sloppy, or simply disagree, the whole thing stalls.
+
+Now imagine a different arrangement. The group writes down its rules in advance — *how proposals are made, who gets to vote, how many yes-votes it takes to spend money* — and those rules run themselves automatically. No single treasurer holds the only key. Decisions happen because enough members voted yes, and the outcome is carried out without anyone needing to trust one person's honesty.
+
+That second arrangement is, in spirit, a **DAO**.
+
+## What it stands for, in plain words
+
+**DAO** stands for **decentralized autonomous organization**. That's a mouthful, so let's take it one word at a time:
+
+- **Organization** — a group of people coordinating toward a shared goal, like a club, a co-op, or a company.
+- **Decentralized** — no single boss or head office is in charge. Authority is spread across the members.
+- **Autonomous** — the group's core rules run on their own, enforced by code on a blockchain, rather than depending on any one person to follow through.
+
+Put together: **a DAO is a group that coordinates and makes decisions using shared rules recorded on a blockchain, instead of the usual company structure of managers, contracts, and a filing cabinet.**
+
+The rules live in a **smart contract** — a self-operating program on a blockchain that does exactly what it's programmed to do and can't be quietly overridden. When members vote, the votes are recorded on the blockchain for anyone to check, and if a proposal passes, the smart contract carries it out. The org's "bylaws" aren't a document in a drawer; they're live code everyone can see.
+
+## Why DAOs exist — the problem they solve
+
+Traditional organizations run on trust in *people and paperwork*: you trust the treasurer, the board, the bank. That works, but it has weak spots. Members far from the head office have little say, it's hard to verify the rules are actually being followed, and a small group at the top can change things without everyone's agreement.
+
+DAOs try to swap "trust the people in charge" for "trust the rules everyone agreed to." Because the rules and the votes are on a public blockchain:
+
+- **Anyone can verify what happened.** The tally isn't a claim; it's a record.
+- **No one can secretly override the outcome.** The smart contract does what it was set up to do.
+- **Membership can be global and open.** You don't need to be in the room to take part.
+
+The honest trade-off: rules written in code are only as good as how they were written, and getting a crowd to agree can be slower than one manager making a call. DAOs trade *speed and central control* for *transparency and shared authority.* That's a genuine trade, not a free lunch.
+
+## How it works — a simple mental model
+
+Most DAOs follow a rhythm that will feel familiar to anyone who's been in a well-run club:
+
+1. **A proposal is made.** A member suggests something concrete — "let's fund this project," "let's change this rule."
+2. **Members vote.** Usually within a set window of time. Voting power might be one-member-one-vote, or weighted by how much of a group token someone holds — that's part of the rules the DAO chose up front.
+3. **The rules decide the outcome.** If enough yes-votes arrive to clear the bar the DAO set (its "threshold"), the proposal passes.
+4. **It's carried out automatically.** The smart contract executes the decision — releasing funds, updating a setting — without waiting on any one person.
+
+The key shift from a normal company is step 4. There's no boss who could ignore the vote. The group's own rules are the executive.
+
+## How this connects to a prediction-market community
+
+A **prediction market** is a place where people forecast real-world outcomes — who'll win an election, whether a milestone gets hit — and the community's collective guesses turn into a kind of shared, honest signal about what's likely.
+
+A community built around that has plenty to decide together: which questions are worth running, how disputes get settled, how any shared funds are used, what the standards for fair play are. Those are exactly the kinds of decisions a DAO structure is built for — letting the community set and enforce its own rules transparently, rather than a hidden operator making every call.
+
+In other words, prediction markets are about *pooling many people's judgment into a trustworthy signal.* DAOs are about *pooling many people's votes into trustworthy decisions.* They rhyme, which is why the two so often show up together.
+
+## How it shows up in FairWins
+
+FairWins is built around communities of people making and settling friendly wagers and forecasts. Part of that world is being able to see and take part in on-chain groups — DAOs — that a community cares about, all in one place.
+
+The guiding principle is important and worth stating plainly: **FairWins never takes control of a DAO on your behalf.** It helps you *see* the groups you're part of and *act* within them, but every vote you cast is signed by you and sent to that group's own rules. FairWins is a window and a doorway, not a proxy holding your authority. Your voice stays yours.
+
+## What to watch out for
+
+- **A DAO is only as good as its rules and its members.** "On-chain" doesn't automatically mean "wise" or "safe." Read what you're voting on.
+- **Voting power isn't always equal.** Some DAOs weight votes by token holdings, which means large holders carry more sway. Know the rules before you join.
+- **Your keys, your vote.** Taking part means signing with your own wallet. Guard it the way you'd guard the only key to a shared vault — because that's what it is.
+- **Participation is optional and legal responsibility is yours.** Forecasting and community decisions should be based on public information and applicable law where you live.
+
+## Related deep-dive
+
+Want the engineering details? Read [ClearPath: A Registry That Owns Nothing](../../posts/26-clearpath-dao-registry/blog.md) — how FairWins lets you see and act on DAOs across networks without ever taking custody, keys, or authority.
+
+## Learn more
+
+- [ethereum.org: Decentralized autonomous organizations (DAOs)](https://ethereum.org/en/dao/) — a clear, plain-language overview
+- [Investopedia: What Is a DAO?](https://www.investopedia.com/decentralized-autonomous-organization-dao-6455887) — definitions and real-world examples
+- [OpenZeppelin Governance](https://docs.openzeppelin.com/contracts/5.x/governance) — the widely-used framework behind many DAOs' voting rules

--- a/docs/blog/knowledge/20-what-is-a-dao/social.md
+++ b/docs/blog/knowledge/20-what-is-a-dao/social.md
@@ -1,0 +1,28 @@
+# Social & Image — What Is a DAO?
+
+## X (Twitter)
+
+A DAO = decentralized autonomous organization. In plain words: a group that makes decisions using shared rules recorded on a blockchain, instead of a boss and a filing cabinet. Members propose, everyone votes, and the outcome runs itself — no treasurer to trust. 🔗 <link>
+
+#DAO #Web3 #Governance
+
+## LinkedIn
+
+Picture a club that pools money for a shared purpose. The normal version has one treasurer everyone has to trust. A DAO flips that: the group writes its rules up front, and those rules run themselves — so decisions happen because enough members voted yes, not because one person signed off.
+
+This beginner primer breaks down the buzzword:
+
+- **What "DAO" actually stands for** — decentralized (no single boss), autonomous (rules run on their own), organization (a group with a shared goal).
+- **The problem it solves** — swapping "trust the people in charge" for "trust the rules everyone agreed to," with votes recorded publicly for anyone to verify.
+- **How it works** — propose, vote within a window, clear the threshold, and the outcome executes automatically. No boss who can ignore the result.
+- **Why it fits prediction-market communities** — pooling many people's judgment into a trustworthy signal rhymes with pooling many people's votes into trustworthy decisions.
+
+We're honest about the trade-offs too: code-based rules are only as good as how they're written, and crowds can be slower than a single manager. Transparency and shared authority in exchange for speed and central control.
+
+Ever been in a group that could've used clearer, self-enforcing rules? 🔗 <link>
+
+#DAO #Governance #Web3 #Community #Blockchain
+
+## Image prompt (Gemini / Nano Banana)
+
+A warm, approachable editorial illustration of a circular gathering of diverse tiny figures seated as equals around a shared glowing ledger at the center — no head of the table, no raised podium, emphasizing that no single person is in charge. Small hands raise tokens or markers to cast votes, and a gentle mechanism at the center visibly carries out the decision on its own. Deep navy and teal base palette with a single warm amber accent glowing from the shared central ledger. Soft, inviting lighting, a sense of fairness and openness, generous negative space, friendly rather than corporate. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/README.md
+++ b/docs/blog/knowledge/README.md
@@ -1,0 +1,56 @@
+# FairWins Knowledge Base
+
+Plain-language concept primers for everyday users. If you have ever clicked
+something in a crypto app and thought *"wait, what does that actually mean?"* —
+this is for you. No technical background needed.
+
+These sit alongside two other content sets:
+
+- The **[User Guide](../../user-guide/overview.md)** shows you *how to do things*
+  in the app.
+- The **[Engineering Blog](../posts/README.md)** explains *how the systems are
+  built*, for semi-technical readers.
+- The **Knowledge Base** (here) explains *what the underlying concepts are and
+  why they matter* — in everyday language.
+
+Each primer is a 5–8 minute read and links to a matching engineering deep-dive
+if you want to go further. The full list, with a suggested reading order that
+interleaves these primers with the deep-dives, is in the
+**[Knowledge Base inventory & schedule](../knowledge-base-inventory.md)**.
+
+## Index
+
+### Wallets & Keys
+- [Self-custody: what "be your own bank" really means](01-self-custody-explained/blog.md)
+- [Passkeys & smart accounts: the fingerprint wallet](02-passkeys-and-smart-accounts/blog.md)
+- [Gas fees & going gasless](03-gas-fees-and-gasless/blog.md)
+
+### Payments & Markets
+- [Stablecoins explained](04-stablecoins-explained/blog.md)
+- [Escrow & trustless settlement](05-escrow-and-trustless-settlement/blog.md)
+- [Prediction markets 101](06-prediction-markets-101/blog.md)
+
+### Earning & Yield
+- [DeFi lending & yield: earning on idle funds](07-defi-lending-and-yield/blog.md)
+- [Morpho & vaults explained](08-morpho-and-vaults/blog.md)
+- [Reading APY & understanding risk](09-apy-and-risk/blog.md)
+- [Fees & basis points: reading what you pay](10-fees-and-basis-points/blog.md)
+
+### Security & Custody
+- [Multisig wallets: why several signatures beat one](11-multisig-wallets/blog.md)
+- [Spending guardrails: rules that outrank approvals](12-spending-guardrails/blog.md)
+- [Sanctions screening & compliance](13-sanctions-and-compliance/blog.md)
+
+### Oracles & Trading
+- [Oracles: how a contract learns real-world outcomes](14-oracles-explained/blog.md)
+- [Polymarket & builder fees explained](15-polymarket-and-builder-fees/blog.md)
+
+### Identity, Privacy & Networks
+- [NFTs, soulbound tokens & memberships](16-nfts-soulbound-and-memberships/blog.md)
+- [On-chain names (ENS & callsigns)](17-onchain-names/blog.md)
+- [Private & encrypted: keeping activity confidential](18-private-and-encrypted/blog.md)
+- [Blockchain networks & layer-2s](19-blockchain-networks-and-l2s/blog.md)
+- [What is a DAO?](20-what-is-a-dao/blog.md)
+
+Each folder also contains a `social.md` with ready-to-use X and LinkedIn copy
+and a banner image prompt.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,35 @@ nav:
     - API Reference: reference/api.md
     - Contract Interfaces: reference/contracts.md
     - Configuration: reference/configuration.md
+  - Knowledge Base:
+    - Overview: blog/knowledge/README.md
+    - Inventory & Schedule: blog/knowledge-base-inventory.md
+    - Wallets & Keys:
+      - Self-Custody Explained: blog/knowledge/01-self-custody-explained/blog.md
+      - Passkeys & Smart Accounts: blog/knowledge/02-passkeys-and-smart-accounts/blog.md
+      - Gas Fees & Going Gasless: blog/knowledge/03-gas-fees-and-gasless/blog.md
+    - Payments & Markets:
+      - Stablecoins Explained: blog/knowledge/04-stablecoins-explained/blog.md
+      - Escrow & Trustless Settlement: blog/knowledge/05-escrow-and-trustless-settlement/blog.md
+      - Prediction Markets 101: blog/knowledge/06-prediction-markets-101/blog.md
+    - Earning & Yield:
+      - DeFi Lending & Yield: blog/knowledge/07-defi-lending-and-yield/blog.md
+      - Morpho & Vaults Explained: blog/knowledge/08-morpho-and-vaults/blog.md
+      - Reading APY & Risk: blog/knowledge/09-apy-and-risk/blog.md
+      - Fees & Basis Points: blog/knowledge/10-fees-and-basis-points/blog.md
+    - Security & Custody:
+      - Multisig Wallets: blog/knowledge/11-multisig-wallets/blog.md
+      - Spending Guardrails: blog/knowledge/12-spending-guardrails/blog.md
+      - Sanctions & Compliance: blog/knowledge/13-sanctions-and-compliance/blog.md
+    - Oracles & Trading:
+      - Oracles Explained: blog/knowledge/14-oracles-explained/blog.md
+      - Polymarket & Builder Fees: blog/knowledge/15-polymarket-and-builder-fees/blog.md
+    - Identity, Privacy & Networks:
+      - NFTs, Soulbound Tokens & Memberships: blog/knowledge/16-nfts-soulbound-and-memberships/blog.md
+      - On-Chain Names: blog/knowledge/17-onchain-names/blog.md
+      - Private & Encrypted: blog/knowledge/18-private-and-encrypted/blog.md
+      - Blockchain Networks & Layer-2s: blog/knowledge/19-blockchain-networks-and-l2s/blog.md
+      - What Is a DAO?: blog/knowledge/20-what-is-a-dao/blog.md
   - Engineering Blog:
     - Overview: blog/posts/README.md
     - Topic Inventory: blog/blog-topics-inventory.md
@@ -212,6 +241,7 @@ nav:
 # Companion social/image-prompt assets live beside each post but are not nav pages.
 not_in_nav: |
   /blog/posts/*/social.md
+  /blog/knowledge/*/social.md
   /blog/private-prediction-markets-envelope-encryption.md
 
 extra:


### PR DESCRIPTION
## Summary

Adds a **Knowledge Base** — a beginner-friendly third content layer aimed squarely at the user base. These are short concept primers (*what is X, and why does it matter*), distinct from the two existing layers:

| Layer | Reader | Answers |
|-------|--------|---------|
| User Guide (`docs/user-guide/`) | app users | *how do I do X* |
| **Knowledge Base (`docs/blog/knowledge/`, new)** | **crypto-curious beginners** | ***what is X, and why does it matter*** |
| Engineering Blog (`docs/blog/posts/`) | semi-technical readers | *how we built X* |

They're written to be published **interleaved** with the engineering deep-dives so a concept is explained in plain language shortly before the deep-dive that assumes it.

## What's included

**20 primers** (700–1,100 words each), every one with a social kit (X + LinkedIn + banner image prompt), grouped into six tracks:

- **Wallets & Keys** — self-custody · passkeys & smart accounts · gas fees & going gasless
- **Payments & Markets** — stablecoins · escrow & trustless settlement · prediction markets 101
- **Earning & Yield** — DeFi lending & yield · **Morpho & vaults** · reading APY & risk · fees & basis points
- **Security & Custody** — **multisig wallets** · spending guardrails · sanctions & compliance
- **Oracles & Trading** — oracles explained · Polymarket & builder fees
- **Identity, Privacy & Networks** — NFTs/soulbound/memberships · on-chain names · private & encrypted · networks & layer-2s · what is a DAO

Plus a **`knowledge-base-inventory.md`** with the topic list and a week-by-week **interleaved publication schedule** across both sets (54 posts, ~27 weeks, primer-heavy at the start to onboard newcomers), a Knowledge Base **index README**, and **mkdocs nav** wiring.

## How they're written

- Everyday language and analogies (bank vaults, joint accounts, referees, receipts); every term defined on first use; no technical background assumed.
- Same forbidden-reference rules as the user-facing posts: no spec numbers, file/function names, FR references, or code blocks. External product/protocol names users actually encounter (USDC, Morpho, Merkl, Polymarket, Safe, Polygon, ENS) are kept and explained plainly.
- **Honest about money:** yield primers state plainly that yield carries risk and is never guaranteed (no FDIC/safety net); fee primers state that FairWins always shows the exact cost before you approve. Grounded in the real Earn integration (curated Morpho MetaMorpho vaults + Merkl rewards; Earn currently carries no FairWins fee).
- Responsible-use note on the prediction-market primers.
- Each primer links to its matching engineering deep-dive for readers who want more.

## Validation

- All 20 directories present with both files; scanned clean for spec numbers, FRs, code fences, function-name soup, and repo paths (only external ethereum.org doc URLs remain in Learn-more sections).
- Every "Related deep-dive" cross-link resolves; mkdocs config parses and all 20 pages are wired into the nav with `social.md` companions excluded via `not_in_nav`.
- Docs-only; scope limited to `docs/blog/knowledge/**`, the new inventory doc, and `mkdocs.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjwYbKV9hUFKjuKrqprmoi)_