### PR TITLE
docs(blog): add 18 Finance Professional Series briefings

### DIFF
--- a/docs/blog/finance-professional-inventory.md
+++ b/docs/blog/finance-professional-inventory.md
@@ -1,0 +1,94 @@
+# FairWins Finance Professional Series — Inventory
+
+*Intermediate and advanced briefings for non-technical readers with a
+financial-services background.*
+
+This is the fourth layer of the FairWins content program, written for a
+specific reader: a professional fluent in traditional finance — asset
+management, treasury, operations, compliance, risk, advisory, or fintech
+product — who is **not** a developer. Where the other layers explain crypto on
+its own terms, this series **bridges**: it starts from a concept the reader
+already knows (custody, settlement, counterparty risk, collateral, NAV,
+KYC/AML, best execution, cost disclosure) and maps it onto the on-chain
+mechanism, with an honest read on where the two genuinely differ and what the
+risk-and-controls picture looks like.
+
+The four layers:
+
+| Layer | Reader | Depth |
+|-------|--------|-------|
+| User Guide | app users | how-to |
+| Knowledge Base | crypto-curious beginners | beginner |
+| Engineering Blog | semi-technical | how it's built |
+| **Finance Professional Series** (this) | **finance pros, non-technical** | **intermediate / advanced** |
+
+> **Informational, not advice.** Every briefing is educational. Nothing here is
+> investment, legal, tax, or regulatory advice, and analogies to regulated
+> products are for building intuition — not claims of legal equivalence.
+> Regulatory treatment of tokens, yield, and markets varies by jurisdiction and
+> is evolving. Yield carries risk and is never guaranteed.
+
+---
+
+## The 18 briefings
+
+Level key: **I** = Intermediate, **A** = Advanced.
+
+### Track 1 — Custody & Settlement
+
+| # | Briefing | Lvl | TradFi anchor | Pairs with |
+|---|----------|-----|---------------|------------|
+| 01 | Self-custody vs. qualified custodians | I | Custody, segregation, insolvency remoteness | Passkey accounts |
+| 02 | Trustless escrow and the end of counterparty risk | I | Escrow agents, clearinghouses | Wager lifecycle |
+| 03 | Atomic settlement: delivery-versus-payment at T+0 | A | DvP/PvP, settlement finality, Herstatt risk | Wager lifecycle |
+| 04 | Institutional controls on-chain: multisig & segregation of duties | I | Maker-checker, four-eyes, treasury controls | Safe custody |
+| 05 | Programmable spending policy as pre-trade controls | A | Investment mandates, pre-trade compliance | Policy engine |
+
+### Track 2 — Money, Yield & Markets
+
+| # | Briefing | Lvl | TradFi anchor | Pairs with |
+|---|----------|-----|---------------|------------|
+| 06 | Stablecoins as a settlement asset | I | Tokenized cash, e-money, bank deposits | Wager lifecycle |
+| 07 | On-chain lending vs. money markets & repo | A | Money-market funds, repo, securities lending | Earn |
+| 08 | Tokenized vaults as fund structures | A | Fund shares, NAV, subscriptions/redemptions | Earn |
+| 09 | A practitioner's risk framework for DeFi yield | A | Credit/liquidity/operational risk taxonomy | Earn |
+| 10 | Oracles as reference-data and benchmark infrastructure | A | Market-data vendors, benchmark administration | Oracle adapters |
+| 11 | Prediction markets as information markets & event contracts | I | Binary options, event contracts | Oracle adapters |
+| 12 | Builder codes and best execution | A | Payment for order flow, best-execution duty | Predict |
+
+### Track 3 — Compliance, Disclosure & Governance
+
+| # | Briefing | Lvl | TradFi anchor | Pairs with |
+|---|----------|-----|---------------|------------|
+| 13 | Programmatic compliance: screening, KYC/AML & the travel rule | A | AML programs, FATF travel rule | Compliance gating |
+| 14 | Fee transparency and cost disclosure | I | MiFID II ex-ante cost disclosure | FeeRouter |
+| 15 | Confidentiality on a public ledger | A | Bilateral OTC, dark pools, information barriers | Envelope encryption |
+| 16 | Operational risk in upgradeable systems | A | Change management, key governance | UUPS upgrades |
+| 17 | Assurance for smart contracts: audits & formal verification | I | SOC 2, model validation, third-party assurance | Symbolic execution & fuzzing |
+| 18 | DAOs and member-owned governance | I | Mutuals, cooperatives, member-owned structures | ClearPath DAO registry |
+
+Each briefing is 1,100–1,600 words, contains a **Risk & controls** section, links
+to its matching engineering deep-dive, and carries a **Further reading** list
+that mixes traditional-finance references (BIS/IOSCO/FATF/CFTC/MiFID and
+practitioner explainers) with the relevant technical standards.
+
+---
+
+## Where this fits the publication program
+
+The Knowledge Base and Engineering Blog interleave into a single beginner→
+technical stream (see `knowledge-base-inventory.md`). The Finance Professional
+Series is best run as a **parallel monthly track** — a "Finance Desk" cadence —
+rather than folded into that weekly stream, because its reader and register are
+distinct. A workable rhythm: publish one briefing every two weeks, sequenced by
+track (Custody & Settlement → Money, Yield & Markets → Compliance, Disclosure &
+Governance), so professional readers get a coherent arc while the main stream
+continues for general users.
+
+Recommended lead-offs (highest resonance for a finance audience):
+
+1. Trustless escrow and the end of counterparty risk (02)
+2. Atomic settlement at T+0 (03)
+3. On-chain lending vs. money markets & repo (07)
+4. A practitioner's risk framework for DeFi yield (09)
+5. Programmatic compliance and the travel rule (13)

--- a/docs/blog/finance/01-self-custody-vs-qualified-custodians/blog.md
+++ b/docs/blog/finance/01-self-custody-vs-qualified-custodians/blog.md
@@ -1,0 +1,72 @@
+# Custody Without a Custodian: Rethinking Safekeeping When Nobody Holds Your Assets
+
+*What self-custody actually changes about segregation, insolvency remoteness, and operational responsibility — and how passkey-based smart accounts turn a scary phrase into a controls story*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Custody & Settlement |
+| **Level** | Intermediate |
+| **Audience** | Treasury and operations leads, custody and fund-ops specialists, compliance and risk officers, allocators |
+| **Tags** | `custody`, `self-custody`, `segregation`, `insolvency-remoteness`, `operational-risk`, `smart-accounts` |
+| **Reading time** | ~8 minutes |
+
+## The question a custody review is supposed to answer
+
+Every custody due-diligence checklist, whatever its length, is really trying to answer three questions. Are the assets *segregated* from the custodian's own balance sheet? Are they *insolvency-remote* — safe if the custodian fails? And who bears the *operational* burden of keys, reconciliation, and access control? A qualified custodian exists precisely so that a professional can answer "yes, yes, them" and move on.
+
+Self-custody breaks that shorthand. There is no third party holding the asset, no omnibus account, no custodial agreement to paper. For a finance professional, the instinct is unease: if nobody is the custodian, who is accountable? The honest answer is that self-custody does not remove the three questions — it *relocates* them. Segregation becomes structural rather than contractual. Insolvency remoteness becomes near-absolute rather than negotiated. And operational responsibility, which a custodian used to absorb, comes home to the asset owner. Whether that trade is attractive depends entirely on the quality of the controls that replace the custodian. That is the subject worth examining closely.
+
+## The traditional model: a custodian as intermediary and shock absorber
+
+In the traditional world, a qualified custodian is both a safekeeping agent and a legal firewall. Client assets are held in segregated accounts, recorded as belonging to the client rather than the custodian, and — where the structure is sound — placed beyond the reach of the custodian's creditors if it fails. Layered on top are the operational services you are really paying for: reconciliation, access controls, dual authorization, insured vaults, audited processes (often evidenced by a SOC 2 report, an independent attestation of a service organization's controls), and a claims path when something goes wrong.
+
+Those benefits are real, and so are the frictions. Assets sit inside someone else's balance sheet and legal perimeter. Segregation is only as good as the paperwork and the jurisdiction's insolvency law. Access is gated by the custodian's hours, systems, and risk appetite. And the arrangement introduces the very thing custody is meant to reduce elsewhere — a concentrated counterparty whose failure, freeze, or error becomes your problem. History offers enough examples of client assets caught in a failed intermediary to make the point without belaboring it.
+
+## What changes on-chain: the asset never enters a balance sheet
+
+Self-custody on a public blockchain rearranges the picture at the root. A stablecoin such as USDC held in a self-custodial account is recorded on the network as belonging to that account's address. It is not on FairWins' balance sheet, not in an omnibus pool, and not subject to any transfer that the account's own keys do not authorize. Segregation stops being a promise in a custody agreement and becomes a property of where the asset lives: one address, one owner, no commingling by construction.
+
+Insolvency remoteness follows from the same fact. If FairWins — the software provider — were to disappear tomorrow, the assets would not be entangled in its estate, because they were never in its possession. There is no omnibus account to unwind, no creditor claim to litigate, no administrator deciding the order of the queue. The network keeps running; the keys keep working. That is a materially stronger form of insolvency remoteness than most custodial structures can offer, and it is worth stating plainly because it is one of the genuine advantages.
+
+What does *not* vanish is operational responsibility. Someone must hold the keys, control access, and make sure the right people — and only the right people — can move funds. In a custodial model, the custodian's operations team does this. In self-custody, it is you. This is where most of the traditional custody value actually sat, and it is the part self-custody hands back to the owner. The interesting question is therefore not "is self-custody safer?" but "can the key-management and access controls be made institution-grade?"
+
+## Passkey-based smart accounts as a controls story
+
+This is where the account design matters more than the custody label. A FairWins account is not a private key written on paper. It is a small program on the blockchain — a smart account — whose authority to move funds is defined by a list of owners and a set of rules the account itself enforces. The controls a treasurer cares about are expressed in that program rather than in a service-level agreement.
+
+Start with the keys. Each owner can be a passkey — the same hardware-backed, biometric credential (WebAuthn, the standard behind Face ID and fingerprint sign-in) that already protects enterprise logins and payments. The private key is generated inside a tamper-resistant chip, never leaves the device, and will only sign after a biometric check. It cannot be exported, emailed, or pasted into a fake support chat. Compared with a seed phrase on paper — the classic self-custody failure mode — this is a categorical improvement in the operational risk that most worries a controls reviewer: key exfiltration and social engineering.
+
+Now the access model. Ownership of the account is a list, not a single secret. That list can hold more than one credential, and the account refuses to remove its last owner, so it cannot lock itself out. This is the on-chain analogue of controls a treasury team already runs: no single point of failure, redundant signers, and a recovery path that does not depend on one fragile artifact. For higher-value balances, the same building blocks extend to multi-signature arrangements, where several independent approvals are required before funds move — structurally similar to the dual-authorization and quorum controls you would demand of any corporate treasury account, but enforced by code rather than by a bank's back office.
+
+Two further properties are worth a risk officer's attention. First, upgrades to the account's logic can only be authorized by the account's own owners; the software provider holds no override switch over anyone's funds. That is what makes this self-custody without scare quotes — nobody but the owner can move or freeze the owner's assets. Second, because the rules live in an open, auditable program deployed identically across networks, the control environment is inspectable in a way a proprietary custodial black box is not.
+
+## Risk and controls: an honest ledger
+
+Self-custody removes custodian counterparty risk and delivers strong segregation and insolvency remoteness. In exchange, it concentrates a different risk set that a professional must own explicitly.
+
+- **Key and access risk.** There is no custodian help desk and, for on-chain transfers, no reversal. Passkeys and multi-owner accounts sharply reduce the classic loss modes, but device loss, recovery design, and owner-list governance now sit inside *your* control framework, not a vendor's. Recovery must be planned before it is needed, not after.
+- **Operational and process risk.** Reconciliation, authorization workflows, and segregation of duties do not disappear; they move in-house. The upside is that on-chain balances are continuously and independently verifiable against the public ledger — a stronger reconciliation primitive than a custodial statement — but someone has to run the process.
+- **Smart-contract risk.** The account is code, and code can carry bugs. FairWins' mitigation is to build on a widely deployed, professionally audited smart-account design and adopt it unmodified, so external audits keep applying, rather than forking it into something un-reviewed. Reused audited components are a control; bespoke unaudited ones are a risk.
+- **Compliance and classification risk.** Self-custody does not change your KYC/AML, sanctions-screening, or record-keeping obligations, and the regulatory treatment of custody-technology arrangements varies by jurisdiction and is still evolving. Nothing here substitutes for your own legal and regulatory analysis.
+
+The through-line: self-custody is not the absence of controls. It is a different *placement* of controls, and passkey-based smart accounts are what make that placement defensible to an institutional reviewer.
+
+## How FairWins approaches this
+
+FairWins never takes custody of user funds. Assets sit in self-custodial smart accounts controlled by passkeys, with multi-owner and multi-signature options for higher-value balances, upgrade authority that belongs solely to the account owner, and audited, unmodified account logic underneath. Operational responsibilities that a custodian would traditionally absorb are handed back to the owner deliberately — and the account design exists to make carrying them realistic rather than reckless.
+
+*This briefing is educational and informational only. It is not investment, legal, tax, custody, or regulatory advice. Custody arrangements and their regulatory treatment vary by jurisdiction and are evolving; assess your own obligations with qualified advisors before acting.*
+
+## Related deep-dive
+
+For the engineering details, see [Passkey Smart Accounts](../../posts/04-passkey-smart-accounts/blog.md).
+
+## Further reading
+
+- SEC Custody Rule (Investment Advisers Act, Rule 206(4)-2) overview — Investopedia: <https://www.investopedia.com/terms/c/custodian.asp>
+- SOC 2 and service-organization controls (AICPA): <https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2>
+- WebAuthn / passkeys (W3C standard): <https://www.w3.org/TR/webauthn-2/>
+- FIDO Alliance — what passkeys are: <https://fidoalliance.org/passkeys/>
+- ERC-4337 account abstraction (smart-contract wallets): <https://eips.ethereum.org/EIPS/eip-4337>
+- BIS/CPMI–IOSCO Principles for Financial Market Infrastructures (custody and segregation context): <https://www.bis.org/cpmi/publ/d101a.pdf>

--- a/docs/blog/finance/01-self-custody-vs-qualified-custodians/social.md
+++ b/docs/blog/finance/01-self-custody-vs-qualified-custodians/social.md
@@ -1,0 +1,25 @@
+# Social & Image — Custody Without a Custodian
+
+## X (Twitter)
+Self-custody doesn't delete the three custody questions — segregation, insolvency remoteness, operational responsibility. It relocates them. Segregation becomes structural, insolvency remoteness near-absolute, ops your job. Passkey smart accounts make that trade defensible. 🔗 <link> #custody #selfcustody #fintech
+
+## LinkedIn
+Every custody due-diligence review is really answering three questions: Are the assets segregated? Are they insolvency-remote? Who owns the operational burden? A qualified custodian lets you answer "yes, yes, them."
+
+Self-custody doesn't remove those questions — it relocates them, and whether that's an upgrade depends entirely on the controls that replace the custodian.
+
+This intermediate briefing for finance professionals covers:
+
+- Why on-chain segregation is structural (one address, one owner) rather than contractual, and why insolvency remoteness becomes near-absolute when assets were never on anyone's balance sheet
+- How operational responsibility — the part you were really paying a custodian for — comes home to the asset owner
+- Passkey-based smart accounts as an institution-grade controls story: hardware-backed keys, multi-owner and multi-signature access, owner-only upgrade authority
+- An honest risk ledger: key, operational, smart-contract, and compliance risk
+
+Read the full piece: <link>
+
+For custody and treasury professionals: where would you want code-enforced controls, and where do you still want a human in the loop?
+
+#Custody #SelfCustody #TreasuryManagement #OperationalRisk #DigitalAssets
+
+## Image prompt (Gemini / Nano Banana)
+A restrained, institutional editorial illustration for a 16:9 banner: a heavy vault door rendered not as a bank safe but as an abstract geometric mechanism, its locking bolts formed from interlocking gears that a single fingerprint motif quietly activates at the center — suggesting keys held by the owner, not a third party. Deep navy and teal base palette with a single warm amber accent on the fingerprint and the active bolt. Clean modern lines, soft directional lighting, generous negative space, sophisticated and understated — not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/02-trustless-escrow-counterparty-risk/blog.md
+++ b/docs/blog/finance/02-trustless-escrow-counterparty-risk/blog.md
@@ -1,0 +1,74 @@
+# Trustless Escrow and the End of "Will They Pay?"
+
+*How code-enforced escrow removes the counterparty risk that clearinghouses and escrow agents have traditionally been paid to intermediate*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Custody & Settlement |
+| **Level** | Intermediate |
+| **Audience** | Risk managers, operations and clearing specialists, treasury leads, fintech product managers |
+| **Tags** | `escrow`, `counterparty-risk`, `clearing`, `settlement`, `collateral`, `operational-risk` |
+| **Reading time** | ~8 minutes |
+
+## The oldest question in finance
+
+Two parties agree on a transaction. One question hangs over it before anything else: *will the other side actually perform?* Almost the entire apparatus of clearing, escrow, margin, and settlement exists to answer that question — or, more precisely, to move it off the two principals and onto an institution engineered to absorb it. A clearinghouse novates trades and stands in the middle. An escrow agent holds the money until conditions are met. A settlement bank guarantees the leg. Each is a paid intermediary whose product is, at bottom, *credit assurance*: the promise that you will get what you are owed even if your counterparty falters.
+
+Code-enforced escrow proposes something that sounds almost too neat to a risk professional: remove the "will they pay?" question entirely by making non-performance mechanically impossible for the party that already put money in. Not "reduce the probability." Eliminate the failure mode. That is a strong claim, and it deserves the same scrutiny you would apply to any novel risk-transfer structure. Let us take it apart.
+
+## The traditional model: intermediated trust
+
+In a bilateral, uncollateralized arrangement — a handshake deal, an invoice, an over-the-counter contract without margin — each side carries the other's credit risk directly. Everyone in markets knows how that ends when incentives sour: the losing side goes quiet, disputes the terms, delays, or simply cannot pay.
+
+To tame this, finance interposes trusted third parties:
+
+- An **escrow agent** takes possession of the funds or the asset and releases them only when agreed conditions are satisfied — common in real estate, M&A, and marketplace transactions.
+- A **central counterparty (CCP)**, or clearinghouse, novates each trade so that it becomes the buyer to every seller and the seller to every buyer, backing the guarantee with margin and a default waterfall.
+- **Collateral and margin** convert a promise into pre-funded assurance, so that performance no longer depends on the counterparty's continued willingness or solvency.
+
+These mechanisms work, and they are indispensable at scale. But each carries its own costs and its own risks. You pay fees and post margin. You take on the intermediary itself as a new, concentrated counterparty — a clearinghouse is systemically important precisely because so much risk pools there. You accept operational latency, dispute processes, and the possibility that the agent misbehaves, errs, or is compelled by outside pressure to freeze or misdirect funds. The trust was never eliminated; it was relocated to an entity you judged more reliable than your counterparty.
+
+## What changes on-chain: the escrow is a program, not an agent
+
+Code-enforced escrow keeps the escrow *function* and removes the escrow *agent*. When two parties enter a wager on FairWins, the stakes are transferred into a program on the blockchain — a smart contract — that holds them under fixed, pre-agreed rules. No employee, no company, and no administrator has discretion over those funds. The program will release them in exactly the ways its rules permit and in no other way.
+
+The critical move is *pre-funding by construction*. A wager does not become live until both stakes are actually inside the escrow. There is no window in which one party is exposed to the other's willingness to pay later, because "later" never exists — the money is already locked before the contest matters. This is the on-chain equivalent of a fully margined, pre-collateralized position, except that the collateral *is* the settlement asset and it is already in the box. The counterparty's future solvency, mood, or whereabouts become irrelevant to whether the winner gets paid.
+
+Just as important is what happens when things do *not* go to plan, because that is where traditional escrow generates disputes. The FairWins escrow is designed so that every state holding money has an exit that needs no cooperation from the other side. If a counterparty never funds their side, the offer expires and the proposer's stake returns. If the outcome never resolves by its deadline, each side's own stake is returned. If both agree the contest tied, each stake goes home. And a neutral party — even an automated helper — can trigger these return paths, but the rules force the money back to its rightful owners regardless of who pushes the button. No one can redirect a single unit. There is, deliberately, no dead end where funds sit stuck forever.
+
+## Where it genuinely differs — better, worse, and just different
+
+**Genuinely better: performance risk on the funded leg is gone.** Once both stakes are escrowed, the "will they pay?" question is answered mechanically. There is no chasing, no dispute over willingness, no reliance on a counterparty's balance sheet. For the classic bilateral-credit failure mode, this is a real elimination, not a mitigation.
+
+**Genuinely better: no intermediary to trust, freeze, or fail.** There is no escrow agent to become insolvent, no clearinghouse to concentrate risk in, no back office to misprocess a release. The rules are open and inspectable rather than a private black box.
+
+**Just different: the trust moves, it does not vanish.** You no longer trust your counterparty or an agent — but you now trust *the code* and *the source of truth that resolves the contest*. That is a genuinely different risk surface, and pretending otherwise would be dishonest. The right question shifts from "is my counterparty good for it?" to "is this contract correct, and is the outcome determined cleanly?"
+
+**Potentially worse: irreversibility and the outcome oracle.** On-chain settlement is final; there is no chargeback and no ombudsman. And for contests settled by an external source of truth — a data feed or market outcome, an "oracle" in on-chain terms — the integrity of that source becomes the load-bearing assumption. A CCP can exercise judgment in a messy edge case; correctly designed code applies its rules without discretion, which is a feature for predictability and a limitation when reality is genuinely ambiguous.
+
+## Risk and controls: a professional read
+
+- **Smart-contract risk.** The escrow's guarantees are only as good as its code. FairWins' discipline is to record state changes *before* releasing funds — the standard defense against the re-entrancy class of attack — to escrow only an approved list of stable, well-understood tokens, and to run on audited building blocks. This is auditable in a way an escrow agent's internal procedures rarely are.
+- **Oracle / resolution risk.** For externally settled contests, the resolution source is the key dependency. Where a human decider is used instead, the deciding authority is fixed at creation and cannot be quietly changed — removing the "who gets to call it?" ambiguity that is the usual root of escrow disputes.
+- **Settlement finality risk.** Irreversibility is a strength for eliminating reversal games and a risk for operational error. It raises the premium on correct instructions and pre-trade controls, since there is no unwind.
+- **Liquidity risk.** Because stakes are pre-funded and locked for the contest's duration, capital is committed up front. That is the price of removing performance risk, and it is a familiar trade to anyone who posts margin.
+- **Compliance risk.** Removing an intermediary does not remove obligations. Sanctions screening and eligibility checks run before funds move, and participants remain subject to applicable law. Regulatory classification of these arrangements varies by jurisdiction and is still evolving.
+
+## How FairWins approaches this
+
+FairWins treats escrow as a small, legible set of states with a hard clock on every step and no place to get stuck. Both stakes are locked before a wager is live, every money-holding state has a no-cooperation-required exit, the deciding authority is chosen up front and cannot drift, and return paths always pay the rightful owner no matter who triggers them. The result is escrow that answers "will they pay?" structurally — while being honest that the trust has moved to code and to a clean resolution source, not disappeared.
+
+*This briefing is educational and informational only. It is not investment, legal, tax, or regulatory advice. Prediction and wager mechanisms and their regulatory treatment vary by jurisdiction and are evolving; assess your own obligations with qualified advisors. Wagers described here are peer-to-peer forecasts on public information; participants remain subject to applicable law.*
+
+## Related deep-dive
+
+For the engineering details, see [The Wager Lifecycle](../../posts/14-wager-lifecycle-contract/blog.md).
+
+## Further reading
+
+- CPMI–IOSCO Principles for Financial Market Infrastructures (central counterparties and clearing): <https://www.bis.org/cpmi/publ/d101a.pdf>
+- Central counterparty clearing — Investopedia: <https://www.investopedia.com/terms/c/ccp.asp>
+- Escrow — Investopedia: <https://www.investopedia.com/terms/e/escrow.asp>
+- Reentrancy and checks-effects-interactions (the attack class the escrow defends against): <https://en.wikipedia.org/wiki/Reentrancy_(computing)>
+- CFTC on event contracts and prediction markets (evolving U.S. treatment): <https://www.cftc.gov/>

--- a/docs/blog/finance/02-trustless-escrow-counterparty-risk/social.md
+++ b/docs/blog/finance/02-trustless-escrow-counterparty-risk/social.md
@@ -1,0 +1,25 @@
+# Social & Image — Trustless Escrow and the End of "Will They Pay?"
+
+## X (Twitter)
+Clearinghouses and escrow agents exist to answer one question: will the other side perform? Code-enforced escrow removes the question — both stakes are locked before the contest matters. The trust doesn't vanish, it moves to code. Honest read inside. 🔗 <link> #clearing #counterpartyrisk #settlement
+
+## LinkedIn
+Almost the entire apparatus of clearing, escrow, and margin exists to answer one question: will your counterparty actually perform? Traditionally we don't eliminate that risk — we relocate it onto an intermediary engineered to absorb it, and pay for the privilege.
+
+Code-enforced escrow makes a stronger claim: remove the "will they pay?" failure mode entirely by pre-funding both sides before the contest matters. This intermediate briefing for risk and operations professionals examines whether that claim holds up.
+
+Covered:
+
+- How pre-funding by construction turns escrow from a trusted agent into an inspectable program — no CCP to concentrate risk in, no agent to freeze or fail
+- Why every money-holding state has a no-cooperation-required exit, closing the disputes traditional escrow generates
+- The honest part: the trust moves to code and to a clean resolution source — it doesn't disappear
+- A full risk read: smart-contract, oracle, finality, liquidity, and compliance risk
+
+Read the full piece: <link>
+
+For clearing and risk professionals: where is eliminating intermediary discretion an upgrade, and where do you still want human judgment in the loop?
+
+#CounterpartyRisk #Clearing #Settlement #RiskManagement #DigitalAssets
+
+## Image prompt (Gemini / Nano Banana)
+A restrained institutional editorial illustration for a 16:9 banner: two identical balanced weights suspended over a central locked chamber, connected by a clean mechanical linkage that only releases once both weights are seated — evoking pre-funded, code-enforced escrow where neither side pays until both have staked. Abstract, geometric, architectural. Deep navy and teal base palette with a single warm amber accent on the central lock. Soft directional lighting, generous negative space, sophisticated and understated — not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/03-atomic-settlement-dvp/blog.md
+++ b/docs/blog/finance/03-atomic-settlement-dvp/blog.md
@@ -1,0 +1,76 @@
+# Atomic Settlement and DvP at T+0
+
+*Settlement finality, the elimination of Herstatt and principal risk, and the real trade-offs against netted T+2 settlement*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Custody & Settlement |
+| **Level** | Advanced |
+| **Audience** | Settlement and clearing specialists, risk managers, treasury and collateral leads, market-structure analysts |
+| **Tags** | `settlement`, `DvP`, `settlement-finality`, `principal-risk`, `netting`, `market-structure` |
+| **Reading time** | ~9 minutes |
+
+## A settlement risk officer reads the timeline
+
+Ask a settlement risk officer what keeps the function honest and you will hear a familiar vocabulary: delivery-versus-payment (DvP), settlement finality, principal risk, Herstatt risk, netting, and the trade date-plus-*n* convention (T+2, now T+1 in several markets) that governs when obligations actually extinguish. Every one of those concepts exists to manage a single uncomfortable fact: in traditional settlement, the two legs of a trade do not complete at the same instant, and the gap between them is where risk lives.
+
+Atomic on-chain settlement collapses that gap to zero. Both legs either complete together or neither does, in a single indivisible step, at T+0. For a professional trained to manage the gap, the natural reaction is a mix of interest and suspicion — because removing the gap removes some risks outright while introducing others, and changes the economics of netting in ways worth thinking through carefully. This briefing works through what genuinely improves, what is merely different, and what a settlement risk team should watch.
+
+## The traditional model: managed gaps and mutualized guarantees
+
+Traditional settlement is a triumph of risk management built around unavoidable delay. Consider its core devices.
+
+**DvP** ensures that delivery of the asset occurs *if and only if* payment occurs, so that neither party delivers without receiving. Central securities depositories and settlement systems implement DvP precisely to remove *principal risk* — the risk of delivering your side and never receiving the other. But DvP as traditionally implemented still runs over a settlement cycle; it guarantees the linkage, not instantaneity.
+
+**Netting** is the reason the cycle exists at all. Rather than settle every trade gross, a clearinghouse nets many offsetting obligations into small end-of-cycle transfers, dramatically reducing the volume and the liquidity that must actually move. Netting is enormously capital-efficient, and the multi-day cycle is partly what makes deep multilateral netting possible.
+
+**Settlement finality** is the legally defined moment an obligation becomes irrevocable — protected in major jurisdictions by settlement-finality law so that a participant's insolvency cannot claw back completed settlements. Until finality, exposure persists.
+
+The most infamous consequence of the gap is **Herstatt risk** — named for the 1974 failure of Bankhaus Herstatt, whose counterparties had paid the Deutsche Mark leg before the bank failed and never received the dollar leg. It is the foreign-exchange face of principal risk: a timing gap across systems or time zones in which one leg settles and the other does not. An entire piece of market infrastructure exists mainly to close that specific gap through payment-versus-payment settlement. That such infrastructure had to be built at all tells you how expensive the gap is.
+
+## What changes on-chain: atomicity as the primitive
+
+On a public blockchain, a transaction is *atomic*: every state change inside it either happens together or the whole transaction reverts and nothing happens. That property, applied to settlement, is what "atomic settlement" means. When a FairWins wager resolves, the winner's claim moves both escrowed stakes in one indivisible action. There is no interval in which one leg has moved and the other has not. Either the payout completes in full or the ledger is unchanged.
+
+Map this onto the traditional devices:
+
+- **DvP becomes structural and instantaneous.** The linkage between legs is not a rule enforced by a settlement system across a cycle; it is a property of the single transaction. The two legs cannot separate because they are not two events — they are one.
+- **Settlement occurs at T+0** and, once the transaction is confirmed to finality on the network, the transfer is irrevocable. Because the assets were pre-funded into escrow, there is no post-trade credit exposure waiting to be settled at all — the only thing left to determine is the outcome, not whether the funds exist.
+- **Principal risk on the settlement leg is eliminated, not mitigated.** There is no state of the world in which the winner surrenders a claim and fails to receive the stakes, because the claim and the transfer are the same atomic step. The Herstatt-style timing gap has no place to occur.
+
+For settlements denominated in the same on-chain asset — a stablecoin such as USDC on both sides — this is genuinely gap-free. The device built to defeat Herstatt risk is, in this narrow context, made unnecessary by the settlement primitive itself.
+
+## Where it genuinely differs — and the trade-off nobody should skip
+
+Atomic T+0 settlement is not free lunch; it is a different point on the risk-efficiency frontier. Two consequences deserve honest attention.
+
+**The netting trade-off.** Netting's efficiency comes precisely from delay: batching many obligations over a cycle so that only small residual amounts move, minimizing the liquidity that must be on hand. Pure atomic gross settlement gives that up. Every settlement moves the full amount, at the moment it occurs, from pre-funded balances. You buy the elimination of the settlement gap by *pre-funding* — committing the full principal up front rather than economizing on liquidity through multilateral netting. For a bilateral, pre-collateralized wager this is exactly the right trade: there is no portfolio of offsetting exposures to net, and the capital was going to be locked anyway. For a high-volume trading book, the calculus is entirely different, and it would be dishonest to pretend atomic gross settlement dominates netted settlement in every context. It does not. It dominates when the value of eliminating principal and finality risk exceeds the liquidity cost of pre-funding — which is precisely the case for the escrowed, bilateral contests FairWins settles.
+
+**Finality cuts both ways.** Irrevocable T+0 settlement removes reversal games, failed-trade queues, and the credit exposure of the settlement window. It also removes the unwind. There is no fail, no buy-in, no chargeback, no settlement-system judgment call in an edge case. That raises the premium on correct pre-trade controls and on the integrity of the process that determines the outcome, because once the atomic step fires there is nothing to reverse.
+
+## Risk and controls: the advanced read
+
+- **Settlement finality risk (probabilistic vs. legal).** On-chain finality is achieved when a transaction is confirmed deeply enough that reversal is economically implausible — a probabilistic finality that hardens quickly on modern networks, as opposed to the statutory finality of traditional systems. A settlement team should understand its chosen network's finality characteristics and confirmation policy, and treat "confirmed to finality" as the moment exposure ends.
+- **Resolution / oracle risk.** Atomicity guarantees the *transfer* is clean; it does not guarantee the *outcome* fed into it is correct. Where an external source of truth resolves the contest, that source is the load-bearing dependency. FairWins fixes the deciding authority at creation so it cannot be quietly swapped, and refuses to open a contest on an already-decided question.
+- **Liquidity and pre-funding cost.** The counterpart to zero settlement gap is full up-front commitment. That is capital locked for the contest's life — a familiar cost to anyone who posts margin, and the explicit price of removing principal risk.
+- **Smart-contract and operational risk.** The atomic step is only as sound as the code executing it and the instruction that triggers it. State is recorded before value moves (the standard re-entrancy defense), only approved settlement assets are used, and — because there is no unwind — pre-trade correctness matters more, not less.
+- **Compliance.** Faster, final settlement does not shorten your obligations. Sanctions and eligibility checks run before value moves; classification and treatment of these arrangements vary by jurisdiction and are evolving.
+
+## How FairWins approaches this
+
+FairWins settles bilateral, pre-funded contests atomically at T+0: both escrowed stakes move to the winner in one indivisible, irrevocable step, so DvP is structural rather than procedural and the Herstatt-style gap has nowhere to open. It deliberately trades the liquidity efficiency of netting — which offers little to a pair of fully collateralized principals — for the elimination of principal and settlement-window risk, while being explicit that finality means no unwind and that the outcome source, not the transfer, is the assumption to guard.
+
+*This briefing is educational and informational only. It is not investment, legal, tax, or regulatory advice. Settlement mechanisms and their regulatory treatment vary by jurisdiction and are evolving; assess your own obligations with qualified advisors.*
+
+## Related deep-dive
+
+For the engineering details, see [The Wager Lifecycle](../../posts/14-wager-lifecycle-contract/blog.md).
+
+## Further reading
+
+- CPMI–IOSCO Principles for Financial Market Infrastructures (DvP and settlement finality): <https://www.bis.org/cpmi/publ/d101a.pdf>
+- BIS on the Herstatt case and settlement risk in FX: <https://www.bis.org/publ/cpss17.htm>
+- Delivery versus payment (DvP) — Investopedia: <https://www.investopedia.com/terms/d/deliveryversuspayment.asp>
+- Settlement finality and the move to shorter cycles (T+1) — DTCC: <https://www.dtcc.com/ust>
+- Atomic settlement and tokenization — BIS working material: <https://www.bis.org/publ/work1178.htm>

--- a/docs/blog/finance/03-atomic-settlement-dvp/social.md
+++ b/docs/blog/finance/03-atomic-settlement-dvp/social.md
@@ -1,0 +1,23 @@
+# Social & Image — Atomic Settlement and DvP at T+0
+
+## X (Twitter)
+An entire piece of market infrastructure exists to close the FX timing gap that killed Bankhaus Herstatt in 1974. Atomic on-chain settlement collapses that gap to zero: both legs settle together at T+0 or neither does. The netting trade-off, honestly. 🔗 <link> #settlement #DvP #marketstructure
+
+## LinkedIn
+Traditional settlement is a triumph of risk management built around an unavoidable delay: the two legs of a trade don't complete at the same instant, and the gap between them is where principal risk — and Herstatt risk — lives. DvP, settlement finality law, and payment-versus-payment infrastructure all exist to manage that gap.
+
+Atomic on-chain settlement collapses it to zero. This advanced briefing for settlement and risk professionals works through what that actually changes:
+
+- Why DvP becomes structural and instantaneous — one indivisible transaction, not a rule enforced across a cycle
+- How principal and Herstatt-style timing risk are eliminated rather than mitigated when both legs are one atomic step
+- The trade-off nobody should skip: atomic gross settlement gives up the liquidity efficiency of multilateral netting — a good trade for pre-funded bilateral contests, not a universal win
+- Why finality cuts both ways: no reversal games, but also no unwind
+
+Read the full piece: <link>
+
+For settlement and clearing professionals: where does eliminating the gap justify the pre-funding cost, and where does netting still win?
+
+#Settlement #DvP #MarketStructure #RiskManagement #DigitalAssets
+
+## Image prompt (Gemini / Nano Banana)
+A restrained institutional editorial illustration for a 16:9 banner: two settlement rails converging into a single synchronized junction where two tokens lock into place at the exact same instant — one indivisible motion, evoking delivery-versus-payment at T+0 with no timing gap. Abstract, geometric, architectural; a subtle sense of two clocks reading the same moment. Deep navy and teal base palette with a single warm amber accent at the synchronized junction. Soft directional lighting, generous negative space, sophisticated and understated — not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/04-institutional-controls-multisig/blog.md
+++ b/docs/blog/finance/04-institutional-controls-multisig/blog.md
@@ -1,0 +1,72 @@
+# Segregation of Duties, Enforced by Code: Multisig as Institutional Custody Control
+
+*How maker-checker, four-eyes authorization, and M-of-N approval map onto a Safe-based on-chain treasury — and where the control model is genuinely stronger, weaker, or simply different*
+
+---
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Custody & Settlement |
+| **Level** | Intermediate |
+| **Audience** | Treasury operations, custody and controls leads, internal audit, compliance officers |
+| **Tags** | `custody`, `segregation-of-duties`, `maker-checker`, `treasury-governance`, `multisig` |
+| **Reading time** | ~8 minutes |
+
+---
+
+## The control question, restated
+
+Every treasury or operations lead has answered some version of the same audit question: *who can move the money, and what stops any one of them from moving it alone?* In a traditional shop the answer is a stack of controls you know cold — dual authorization on wire releases, a maker who initiates and a checker who approves, approval matrices that scale with amount, an authorized-signatory list at the bank, and a segregation of duties that keeps the person who initiates a payment away from the person who releases it. None of this is exotic. It is the ordinary machinery of not losing money to error or fraud.
+
+The interesting thing about moving a treasury on-chain is not that these controls disappear. It is that they change *substrate* — from bank procedure and internal policy enforced by people, to authorization logic enforced by the settlement rail itself. That shift is worth understanding precisely, because it improves some failure modes, worsens others, and leaves a few exactly where they were.
+
+## The traditional model
+
+In a conventional corporate treasury, control over cash rests on layered, mostly procedural defenses. The bank holds an authorized-signatory list and a set of mandates: below one threshold a single signer suffices, above it two are required, above another the transaction routes to a named officer. Inside the company, a payments workflow enforces maker-checker — one clerk keys the payment, a second reviews and releases it — and segregation of duties keeps vendor-master maintenance, payment initiation, and reconciliation in separate hands so no single person controls a transaction end to end.
+
+Two things are worth naming about this model. First, the controls are real but *soft*: they are policy and workflow, and a determined insider who compromises the workflow — or a bank that fails to enforce the mandate — can bypass them. Second, the ultimate custodian is the bank. You are trusting an institution's balance sheet, its operational controls, and its willingness to reverse an error. That trust is usually well-placed, and it comes with genuine benefits (fraud reversal, regulatory recourse) that on-chain custody does not replicate.
+
+## What changes on-chain
+
+An on-chain multisig — the most widely used is Safe, an audited smart-contract wallet deployed across Ethereum, Polygon, and their relatives — turns the authorization rule into a property of the account itself. A multisig is configured as **M-of-N**: N owners hold keys, and any transaction requires M of them to authorize before it will execute. Two-of-three, three-of-five: the same approval-matrix logic a bank mandate expresses, except the *account will not move funds* unless the threshold is met. There is no workflow to bypass and no operator to socially engineer into releasing early. The threshold is not a policy about the account; it *is* the account.
+
+The proposal-and-approval flow maps cleanly to maker-checker. One owner constructs the exact transaction — recipient, asset, amount — and submits it. The other owners each review those details and register approval. Only when M approvals exist can anyone execute. The maker cannot also be the sole checker, because one signature is below threshold by construction. Four-eyes is not a procedure layered on top; it is the minimum the account enforces.
+
+A well-designed integration adds one discipline the raw mechanism lacks: making sure each approver actually knows what they are approving. When an owner is asked to sign, the underlying data can look like an opaque code. A serious setup shows each approver the full, human-readable transaction and re-derives the fingerprint locally, so an owner never blind-signs and a tampered proposal fails verification inside the approver's own device rather than at the bank's discretion. That is the on-chain analogue of a checker actually reading the payment, not rubber-stamping it.
+
+## Where it genuinely differs
+
+**Stronger.** The authorization rule is cryptographically binding and continuously enforced, not periodically audited. There is no privileged operator who can release a sub-threshold payment "just this once," and no central workflow whose compromise defeats every control at once. The ledger of who approved what is public and immutable — a built-in, tamper-evident audit trail that a traditional approval log has to be trusted to preserve. Key material is distributed by design, so a single stolen laptop or phished credential does not equal a lost treasury.
+
+**Weaker or different.** There is no bank to reverse a mistaken or fraudulent transfer; settlement is final, the way a cash handover is final. Segregation of duties protects against a *minority* of compromised signers, but M colluding or simultaneously-phished owners can move funds exactly as the account permits — the same residual risk a bank mandate carries, made explicit. Key management becomes your operational burden: lost keys, unavailable signers, and succession planning are now custody risks you own rather than the bank's. And a threshold set too high against too few reachable signers can strand the treasury — an availability risk with no customer-service line behind it.
+
+## Risk and controls
+
+A professional risk read on a multisig treasury covers several distinct exposures:
+
+- **Signer key risk.** Each owner key is a credential to protect. Hardware wallets, separated custody of keys, and geographic and organizational distribution of signers reduce single-point compromise. The control objective is that no single failure — and ideally no single insider — reaches threshold.
+- **Threshold and availability risk.** M and N are a governance trade-off: higher M resists collusion but raises the chance that enough signers are unavailable when a legitimate, time-sensitive payment must move. Document the rationale, keep backup signers, and rehearse the signing process the way you would test a disaster-recovery plan.
+- **Operational and key-lifecycle risk.** Onboarding and offboarding signers, rotating keys after a departure, and maintaining current recovery documentation are recurring controls, not one-time setup. Review the owner set on a schedule the way you review an authorized-signatory list.
+- **Smart-contract risk.** You are trusting the wallet's code. Using a long-audited, widely-deployed implementation rather than a bespoke build is the risk-management choice here; verifying that the expected contracts are actually deployed at the expected addresses on each network is a control worth performing rather than assuming.
+- **Settlement finality risk.** No reversal, no chargeback. The compensating controls are all *pre-execution*: verified recipients, human-readable review, and — as the companion piece explores — programmable policy that can block an in-policy-violating transaction even after it clears the signature threshold.
+
+## How FairWins approaches this
+
+FairWins treats a shared vault as a standard Safe multisig, not a proprietary custody product — so it interoperates with the wider Safe ecosystem and an existing organizational Safe can be used as-is. The design deliberately avoids a company-run coordination server: approvals are registered on-chain, which means the account's own state is the single source of truth and no participant can be locked out of their own funds if any FairWins infrastructure were to disappear. Every approver's software re-verifies the full transaction against its fingerprint locally, so four-eyes review is real review rather than blind approval. Recorded backups store addresses and labels, never key material. And a vault can be governed by more than threshold alone — a policy layer, covered in the companion briefing, constrains what an already-approved transaction is permitted to do.
+
+The result maps recognizably onto the controls you already run — segregation of duties, dual authorization, an approval matrix, a tamper-evident audit trail — with the authorization rule moved from procedure the bank enforces into logic the settlement rail enforces, and with the honest trade-off that finality and key custody become your responsibility rather than an institution's.
+
+*This is educational information for finance professionals, not investment, legal, tax, or regulatory advice. On-chain custody and its treatment vary by jurisdiction and are evolving; evaluate any custody arrangement against your own control framework and obligations.*
+
+## Related deep-dive
+
+For the engineering details, see [Shared Vaults Where No One Person Can Move the Money](../../posts/07-safe-multisig-custody/blog.md).
+
+## Further reading
+
+- [Safe — the smart-account multisig referenced here](https://safe.global)
+- [BIS Principles for Financial Market Infrastructures (PFMI)](https://www.bis.org/cpmi/publ/d101.htm) — settlement, custody, and operational-risk principles
+- [COSO Internal Control — Integrated Framework](https://www.coso.org/guidance-on-ic) — segregation of duties and control-activity concepts
+- [Investopedia — Maker-Checker (dual control)](https://www.investopedia.com/terms/t/two-man-rule.asp)
+- [SOC 2 / Trust Services Criteria (AICPA)](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2) — control-assurance context for custody operations

--- a/docs/blog/finance/04-institutional-controls-multisig/social.md
+++ b/docs/blog/finance/04-institutional-controls-multisig/social.md
@@ -1,0 +1,30 @@
+# Social & Image — Segregation of Duties, Enforced by Code
+
+## X (Twitter)
+
+Maker-checker, four-eyes, M-of-N approval matrices — the controls your treasury already runs, moved from bank procedure into the settlement rail itself. What a multisig custody model gets right, and where finality bites. 🔗 <link>
+
+#Treasury #Custody #DigitalAssets
+
+## LinkedIn
+
+Every custody control review answers one question: who can move the money, and what stops any one of them from moving it alone? In a traditional treasury that answer is a stack of soft controls — dual authorization, maker-checker, approval matrices, an authorized-signatory list. On-chain, the same authorization logic becomes a property of the account itself.
+
+A new Finance Professional Series briefing maps institutional custody controls onto a Safe-based multisig:
+
+- M-of-N authorization as an approval matrix the account will not override
+- Propose-and-approve as maker-checker, with real (not blind) four-eyes review
+- A public, tamper-evident approval trail as a built-in audit log
+- The honest trade-offs: settlement finality, key custody, and availability risk become yours, not a bank's
+
+Written for treasury operations, custody leads, internal audit, and compliance — starting from the controls you already run.
+
+🔗 <link>
+
+How does your control framework treat finality and key-lifecycle risk when there's no institution to reverse a transfer?
+
+#Treasury #Custody #DigitalAssets #InternalAudit #RiskManagement
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration for a 16:9 banner: a heavy institutional vault door whose locking mechanism requires several separate keys turned at once, rendered as interlocking concentric rings that only align when multiple hands act together — a visual metaphor for M-of-N authorization and segregation of duties. Deep navy and teal base palette with a single warm amber accent on the aligned locking ring, soft directional lighting, restrained and sophisticated, understated corporate-finance mood, not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/05-programmable-spending-policy/blog.md
+++ b/docs/blog/finance/05-programmable-spending-policy/blog.md
@@ -1,0 +1,81 @@
+# The Transaction That Had Every Signature It Needed: Programmable Spending Policy as a Pre-Settlement Control
+
+*On-chain limits, allowlists, and timelocks that can block an already-authorized transfer — read as a pre-trade compliance engine for treasury*
+
+---
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Custody & Settlement |
+| **Level** | Advanced |
+| **Audience** | Compliance officers, risk managers, treasury controls leads, fintech product managers |
+| **Tags** | `pre-trade-controls`, `spending-policy`, `investment-mandate`, `treasury-governance`, `compliance` |
+| **Reading time** | ~8 minutes |
+
+---
+
+## A transaction with nothing wrong with it, except everything
+
+A three-owner treasury runs two-of-three authorization. A proposal appears: send 180,000 in stablecoin to an address that matches the quarterly market-maker payment, description and all. One owner approves from a phone between meetings. An hour later a second owner approves for the same reason. Threshold met; the transfer executes. The address belonged to whoever phished the first owner and quietly queued the proposal.
+
+Nothing in the authorization model failed. That is the uncomfortable part, and it is the whole subject of this briefing. Multi-party approval answers *who* may move funds. It says nothing about *what* the approved transaction is permitted to do. Once the threshold clears, a bare multisig will send any amount, to any destination, at any time. Everything else — "we vet destinations," "we never approve big transfers on mobile," "anything over a threshold gets a call first" — is procedure living in people's heads, and people approve things between meetings.
+
+The traditional world solved this long ago, in a different layer: the **pre-trade compliance check** and the **spending-policy engine**. This is the on-chain version of that layer, and it is worth understanding as a distinct control from authorization, because it catches a distinct class of failure.
+
+## The traditional model: rules that fire before the money moves
+
+Finance professionals already work with three closely related instances of the same idea.
+
+- **Corporate-card and payment policy engines.** A card that is authenticated and within its credit line will still decline at a prohibited merchant category, above a per-transaction cap, or outside a spending window. The cardholder is legitimate; the *transaction* violates policy, so it never settles.
+- **Investment mandates.** A fund's mandate encodes what the portfolio may hold — asset-class limits, issuer concentration caps, prohibited names, counterparty allowlists. A trader with full authority still cannot put on a position the mandate forbids; the order-management system blocks it pre-trade.
+- **Pre-trade compliance and DvP controls.** Before an order reaches the market, restricted-list, credit-limit, and best-execution checks run automatically. The check sits between authorization and settlement, and it can veto a fully authorized instruction.
+
+The common shape: an automated rule, evaluated *before* execution, that can block an action the actor was otherwise entitled to take. Authorization and policy are two separate gates. You can be perfectly authorized and still be stopped — and that separation is the point.
+
+## What changes on-chain
+
+The on-chain analogue is a **transaction guard**: a small contract the multisig consults immediately before it executes anything. The account hands the guard the full details of the about-to-run transaction — asset, amount, destination, shape — and if the guard objects, the transaction does not run, no matter how many valid signatures it carries.
+
+This is the crucial architectural fact: the check lives at the *settlement rail*, not in the app and not on a company server. A rule inside a user interface is advisory — anyone can talk to the account directly and bypass it. A rules service on a vendor's server is one more party to trust and one more thing to breach. A guard the account itself is obligated to call is binding in the only place that matters: between "approved" and "settled."
+
+The rules themselves are the classic treasury controls, each independently switchable:
+
+- **Per-transaction limits**, per asset — no single outflow exceeds a ceiling.
+- **Rolling daily limits**, per asset — a velocity cap over a time window, the on-chain cousin of a daily payment limit.
+- **Recipient allowlists** — funds may leave only to pre-approved destinations, exactly like a counterparty or approved-payee list.
+- **Cooldowns / timelocks** — a minimum interval between money-moving transactions, so a rapid drain is impossible and there is time to react.
+
+The phished 180,000 transfer above dies at the guard against a per-transaction limit or an allowlist that never contained the attacker's address — after every signature was collected, before a cent moved.
+
+## Where it genuinely differs
+
+**Stronger.** The policy is enforced by the same rail that settles, so it cannot be bypassed by going around the app, and it applies uniformly to every path into the account. A well-built guard also offers a *preview* that runs the exact same check the real enforcement uses, so what the interface warns you about cannot drift from what actually gets enforced — the perennial gap between a compliance system's simulation and its production behavior, closed by construction. And critically, the policy binds *even a quorum of compromised signers*: authorization and policy being separate gates means clearing one does not clear the other.
+
+**Weaker or different.** On-chain rules are only as expressive as what the guard can interpret. Native transfers and standard token movements are legible; an exotic instruction the guard cannot decode may pass the *value* limits unmeasured (though a hard-lockdown allowlist still constrains where it can reach). The daily window is typically a fixed reset rather than a perfectly continuous rolling window, which in a worst case straddling the reset can permit up to twice the intended limit — a small, bounded, disclosable weakening. And a rule set too tight against reality — a cooldown of a year, an allowlist whose only address is now defunct — could brick the treasury, which is why the ability to *loosen* rules must itself be a governed, always-available action.
+
+## Risk and controls
+
+- **Policy-coverage risk.** Know what your guard measures and what it waves through. Treat uninterpreted-transaction handling explicitly: for high-assurance vaults, an allowlist provides a hard backstop regardless of whether the guard can value the transaction.
+- **Lock-out / availability risk.** The escape hatch is a control, not a loophole: changing policy — and managing the account itself — must remain possible under the normal approval threshold, so a too-strict policy can always be relaxed by the same group consent that set it. Verify this carve-out exists before relying on strict rules.
+- **Governance-of-the-rules risk.** Who can change the policy is the real control surface. The strongest design gives *no* admin or upgrade key authority to waive enforcement — policy changes clear the vault's own threshold and nothing else — so there is no master backdoor over the controls. Confirm there is no privileged party who can silently disable the guard.
+- **Ordering / reentrancy risk.** A guard that evaluates, then records totals, then never calls out to untrusted code avoids the reentrancy failure mode that plagues contracts moving money. This is an assurance question for any guard you adopt.
+- **Accounting-direction risk.** Conservative guards count a spend before execution, so a quietly-failed inner action still counts — over-restricting, never over-permitting. Erring toward restriction is the correct direction for a control.
+
+## How FairWins approaches this
+
+FairWins can govern a shared vault with a policy layer that sits above threshold approval: per-transaction and rolling daily limits, recipient allowlists, and cooldowns, each switchable per vault. The guard is deliberately restriction-only — it can block a transaction but can never initiate, approve, or execute one, and it holds no funds. It is intentionally not upgradeable, because an upgrade key over enforcement would be a backdoor over every vault; improvements ship as a new guard each vault chooses to adopt through its own approval. A vault is the sole authority over its own rules, and loosening them is always available under the normal threshold, so no vault can be locked out by its own policy. The interface previews the exact check the chain enforces, and the rules can be wired in from a vault's very first transaction rather than leaving an early unpoliced window. It is, in the reader's terms, a pre-settlement compliance engine that binds even when the signers themselves are compromised.
+
+*This is educational information for finance professionals, not investment, legal, tax, or compliance advice. Programmable controls reduce specific risks; they are not a substitute for a complete compliance program, and their treatment varies by jurisdiction and is evolving.*
+
+## Related deep-dive
+
+For the engineering details, see [Enough Signatures Is Not Enough: Adding Real Rules to a Shared Vault](../../posts/08-multisig-policy-engine/blog.md).
+
+## Further reading
+
+- [IOSCO Principles for Financial Market Infrastructures / market-conduct guidance](https://www.iosco.org/) — pre-trade control and market-integrity context
+- [MiFID II pre-trade controls and best-execution obligations (ESMA)](https://www.esma.europa.eu/) — the regulated analogue of pre-execution checks
+- [Safe transaction guards — the enforcement mechanism referenced here](https://docs.safe.global/advanced/smart-account-guards)
+- [Investopedia — Investment Mandate](https://www.investopedia.com/terms/m/mandate.asp)
+- [COSO Enterprise Risk Management framework](https://www.coso.org/guidance-erm) — control-activity design for preventive controls

--- a/docs/blog/finance/05-programmable-spending-policy/social.md
+++ b/docs/blog/finance/05-programmable-spending-policy/social.md
@@ -1,0 +1,30 @@
+# Social & Image — Programmable Spending Policy as a Pre-Settlement Control
+
+## X (Twitter)
+
+The phished transfer had every signature it needed. Authorization says WHO may move funds; it says nothing about WHAT the transaction may do. On-chain spending policy is the pre-trade compliance layer for treasury — limits, allowlists, timelocks that block even an approved transfer. 🔗 <link>
+
+#Compliance #Treasury #RiskManagement
+
+## LinkedIn
+
+Multi-party approval answers who may move funds. It says nothing about what the approved transaction is permitted to do — which is exactly how a fully-authorized, fully-signed transfer still ends up in an attacker's wallet.
+
+Traditional finance solved this in a separate layer decades ago: the pre-trade compliance check, the investment mandate, the corporate-card policy engine. A new Finance Professional Series briefing maps that layer onto on-chain treasury:
+
+- A transaction guard as a pre-settlement check the account itself must consult
+- Per-transaction limits, rolling velocity caps, recipient allowlists, and timelocks
+- Why enforcement at the settlement rail binds even a quorum of compromised signers
+- Honest limits: policy coverage, fixed vs. rolling windows, and lock-out risk
+
+Written for compliance officers, risk managers, and treasury controls leads — starting from mandates and pre-trade controls you already know.
+
+🔗 <link>
+
+Where in your stack does an authorized-but-non-compliant instruction get stopped — and is that check advisory or binding?
+
+#Compliance #Treasury #RiskManagement #FinTech #InternalControls
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration for a 16:9 banner: a settlement rail or pipeline where an approved payment token approaches a precise mechanical gate that has swung shut to intercept it just before the endpoint — a single object stopped mid-transit while others pass, evoking a pre-settlement policy check. Deep navy and teal base palette with one warm amber accent on the closed gate, soft directional lighting, restrained institutional-finance aesthetic, sophisticated and understated, not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/06-stablecoins-settlement-asset/blog.md
+++ b/docs/blog/finance/06-stablecoins-settlement-asset/blog.md
@@ -1,0 +1,72 @@
+# Tokenized Cash as the Unit of Settlement: What a Stablecoin Actually Is on the Books
+
+*Stablecoins versus e-money and bank deposits, peg mechanics and reserve attestation, and why an app settles in them — with an honest read on de-peg and issuer risk*
+
+---
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Money, Yield & Markets |
+| **Level** | Intermediate |
+| **Audience** | Treasury and payments leads, product managers, risk and compliance officers, allocators |
+| **Tags** | `stablecoins`, `settlement-asset`, `tokenized-cash`, `e-money`, `payments` |
+| **Reading time** | ~8 minutes |
+
+---
+
+## Which dollar is it, exactly?
+
+When an app tells you a balance is "200 dollars," a finance professional's next question is the right one: *a claim on what, held by whom, redeemable how?* A bank deposit is an unsecured claim on a commercial bank, insured to a limit, settling through the banking system. E-money is a claim on a licensed issuer that must hold safeguarded funds against it. A money-market fund share is a claim on a pool of short-dated instruments, redeemable at (or very near) par. These are different instruments with different risk, different settlement, and different legal treatment — even though each *reads* as a dollar on a screen.
+
+A dollar-pegged stablecoin is another such instrument, and the point of this briefing is to place it precisely among the ones you already know: what it structurally resembles, where the analogy breaks, and why an application would choose it as its unit of settlement despite carrying risks a bank deposit does not.
+
+## The traditional model: how "cash" settles today
+
+In conventional finance, the settlement asset varies by rail. Retail payments settle across bank deposits and card networks; wholesale settles in central-bank reserves; securities settle delivery-versus-payment through infrastructures that exchange the asset and the cash simultaneously to eliminate principal risk. Each rail has an operator, a settlement window (often T+1 or T+2), business hours, and a legal framework governing finality and reversal.
+
+E-money regimes and money-market funds are the closest reference points for what a stablecoin is trying to be. E-money is prepaid value: you hand a licensed issuer fiat, they issue redeemable digital value one-for-one, and regulation requires the fiat be safeguarded — segregated, held in secure assets — so it is there when you redeem. A money-market fund takes cash, holds short-term government and high-quality paper, and lets you redeem shares at approximately par on demand. Both are "dollar-shaped claims backed by conservative assets, redeemable near par." Hold that thought.
+
+## What changes with a stablecoin
+
+A reserve-backed stablecoin — USDC, issued by the regulated firm Circle, is the most common reference — is tokenized cash: a digital bearer-style instrument on a public blockchain, intended to always be redeemable for one dollar. Structurally it is *analogous* to e-money backed by a conservative reserve: the issuer creates a coin when a real dollar arrives, holds reserves against outstanding coins (typically cash and short-dated US government debt), and burns the coin on redemption. Reputable issuers publish regular third-party attestations confirming the reserves exist and match supply.
+
+Note the careful word: *analogous*. A stablecoin is not, by that fact, a regulated e-money instrument or a fund — its legal classification is unsettled and varies by jurisdiction, and this briefing makes no claim of regulatory equivalence. What it shares with those instruments is the *structure*: a redeemable claim backed by a reserve, whose price is pinned by that redeemability.
+
+The peg mechanics are worth stating plainly, because they are what a risk officer actually underwrites. The anchor is arbitrage against redemption. If the token trades at 99 cents on an exchange while remaining redeemable for a full dollar, arbitrageurs buy the cheap token and redeem it for par, and that buying pressure pushes the market price back toward a dollar. The peg holds *because* redemption is credible. Which means the peg is exactly as strong as the reserve behind it and the redemption channel in front of it — and no stronger.
+
+Two properties change everything else. First, settlement is **near-instant, final, and continuous** — no T+2, no business hours, no operator queue. That is a genuine operational upgrade for a payments or escrow application: the moment the transfer confirms, value has moved and cannot be clawed back. Second, it is **programmable** — it can be escrowed by code, released against conditions, and settled inside an application without a bank in the loop. For a real-money app, those two properties are the entire reason to settle in a stablecoin rather than in a volatile crypto asset (whose price won't sit still) or in bank rails (which can't ride the same programmable settlement layer).
+
+## Where it genuinely differs
+
+**Better.** Continuous, near-instant, final settlement; native programmability; global reach without correspondent-banking friction; a transparent, publicly auditable supply. For escrow and cross-border use, these are real advantages over multi-day, business-hours rails.
+
+**Worse or different.** No deposit insurance and no chargeback: settlement is final the way cash is final, so an error or a payment to the wrong address has no reversal mechanism. You take **issuer credit and reserve risk** directly — the token is a claim on the issuer's reserve management, not on an insured bank. And you inherit the peg's failure mode: it is maintained, not guaranteed.
+
+## Risk and controls
+
+- **Issuer and reserve risk.** The token is only as good as the reserve behind it and the issuer running it. Favor issuers with conservative, transparent reserves (cash and short-dated government paper), regular attestations from credible auditors, and clear redemption rights. Treat the attestation cadence and reserve composition as ongoing diligence, not a one-time check. Avoid algorithmic designs that attempt to hold a peg through trading mechanics rather than real reserves — several have collapsed, and the label "stablecoin" alone guarantees nothing.
+- **De-peg risk.** In stressed markets a fully-reserved stablecoin can briefly trade below a dollar; the notable historical episodes tied to reserve concentration have generally recovered, but "generally recovered" is not "cannot fail." Size exposure and concentration accordingly, and monitor the peg the way you would monitor a money-market fund's shadow price.
+- **Settlement-finality and operational risk.** Irreversibility raises the stakes on payment operations: address verification, transaction review, and the custody controls covered elsewhere in this series matter more, not less, than on a reversible rail. There is no back office to unwind a mistake.
+- **Custody and counterparty risk.** How the token is held (self-custody versus a third party) reintroduces custody risk on top of issuer risk — two distinct layers to assess separately.
+- **Compliance risk.** Transfers are pseudonymous but permanently public. Sanctions screening and applicable AML obligations — including travel-rule considerations where they apply — remain fully in force; the rail's transparency is a tool here, not an exemption. Regulatory classification of stablecoins is evolving and jurisdiction-specific.
+
+## How FairWins approaches this
+
+FairWins uses stablecoins as its unit of settlement precisely for the reasons above: a stake, a group pot, or a payment is denominated and settled in a dollar-pegged token, so every figure a member sees is a plain dollar amount rather than "whatever this coin is worth on payout day." The platform deliberately handles only a short, vetted list of reserve-backed, dollar-pegged tokens — not volatile assets — so the amount agreed is the amount that changes hands. Escrowed stakes are held in stablecoins and payouts arrive in stablecoins, with the finality that makes a code-held escrow trustworthy: once resolved, the winner can claim and no one can strand the funds. Movements pass the same sanctions and membership checks as any other action, on-chain transparency notwithstanding. And where any fee applies, FairWins discloses the exact cost, in dollars, before a member approves — the settlement asset's transparency extended to the platform's own economics. (The core wager escrow itself is denominated and settled in these tokens; it is not a yield product, and no return is implied by holding a stake.)
+
+The honest summary for this reader: a reserve-backed stablecoin is structurally analogous to conservatively-backed tokenized cash, with settlement properties that genuinely beat traditional rails, in exchange for taking issuer, reserve, and finality risk directly and giving up insurance and reversibility. It is the right unit of settlement for a real-money application *because* of those trade-offs, not in spite of your needing to understand them.
+
+*This is educational information for finance professionals, not investment, legal, tax, or regulatory advice. Stablecoins carry issuer, reserve, de-peg, and operational risk; a peg is maintained, not guaranteed, and regulatory treatment varies by jurisdiction and is evolving. Assess any settlement asset against your own risk framework.*
+
+## Related deep-dive
+
+For the engineering details, see [The Wager Lifecycle: How a Handshake Bet Becomes a Payout Nobody Can Strand](../../posts/14-wager-lifecycle-contract/blog.md).
+
+## Further reading
+
+- [Circle — USDC transparency and reserve reporting](https://www.circle.com/usdc) — issuer attestations and reserve composition
+- [BIS — Stablecoins and the future of money / cross-border payments](https://www.bis.org/) — central-bank perspective on tokenized settlement
+- [IOSCO / FSB recommendations on global stablecoin arrangements](https://www.fsb.org/) — international regulatory framing
+- [FATF guidance on virtual assets and the travel rule](https://www.fatf-gafi.org/) — AML/CFT obligations for token transfers
+- [Investopedia — Stablecoin](https://www.investopedia.com/terms/s/stablecoin.asp) — plain-English overview of designs and risks

--- a/docs/blog/finance/06-stablecoins-settlement-asset/social.md
+++ b/docs/blog/finance/06-stablecoins-settlement-asset/social.md
@@ -1,0 +1,30 @@
+# Social & Image — Tokenized Cash as the Unit of Settlement
+
+## X (Twitter)
+
+An app says the balance is "200 dollars." A claim on what, held by whom, redeemable how? Placing a stablecoin among the instruments you know — e-money, bank deposits, money-market shares — with an honest read on de-peg and issuer risk. 🔗 <link>
+
+#Stablecoins #Payments #Treasury
+
+## LinkedIn
+
+When an application settles in "dollars," a finance professional asks the right question: a claim on what, held by whom, redeemable how? A bank deposit, e-money, a money-market share, and a stablecoin all read as a dollar on a screen — and are four different instruments.
+
+A new Finance Professional Series briefing places the stablecoin precisely among them:
+
+- Structurally analogous to conservatively-backed tokenized cash — not a regulated fund or e-money by that fact
+- Peg mechanics: redemption arbitrage is the anchor, and it is only as strong as the reserve behind it
+- Why continuous, final, programmable settlement is a genuine upgrade over T+2 rails
+- Honest risk read: issuer and reserve risk, de-peg, no insurance, no chargeback
+
+Written for treasury, payments, product, and risk professionals — starting from the settlement assets you already underwrite.
+
+🔗 <link>
+
+How are you sizing issuer and reserve risk when the settlement asset is a direct claim on a reserve rather than an insured deposit?
+
+#Stablecoins #Payments #Treasury #RiskManagement #FinTech
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration for a 16:9 banner: a precise balance scale where one pan holds a stack of tokenized digital coins and the other holds a reserve of conservative dollar assets, the two resting in exact equilibrium — a metaphor for a reserve-backed peg pinned one-for-one. Deep navy and teal base palette with a single warm amber accent glowing at the scale's fulcrum, soft directional lighting, restrained institutional-finance aesthetic, sophisticated and understated, not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/07-onchain-lending-vs-money-markets/blog.md
+++ b/docs/blog/finance/07-onchain-lending-vs-money-markets/blog.md
@@ -1,0 +1,78 @@
+# On-Chain Lending Against Money Markets, Repo, and Securities Lending
+
+*Where the yield actually comes from when you lend digital dollars into an over-collateralized pool — and how that engine compares to the short-term instruments you already run*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Money, Yield & Markets |
+| **Level** | Advanced |
+| **Audience** | Treasury and liquidity managers, allocators, credit and money-market analysts, risk officers |
+| **Tags** | on-chain lending, money markets, repo, securities lending, collateral, utilization, yield |
+| **Reading time** | ~9 minutes |
+
+---
+
+## The allocation question
+
+A treasury desk has a slug of dollars it does not need this week. The familiar menu is short and well understood: a government money-market fund yielding roughly the policy rate less a management fee; overnight repo against Treasuries; a bank sweep; or a securities-lending program that squeezes a few extra basis points out of assets already on the book. Each has a known yield source, a known counterparty profile, and a known settlement mechanic.
+
+Now a colleague points at an on-chain lending vault quoting a variable annual rate on USDC — a fully-reserved dollar stablecoin — and asks the only question that matters: *where is that yield coming from, and what am I actually holding?* This piece answers that in the vocabulary you already use, and is candid about where the analogy holds and where it breaks.
+
+**Informational, not advice.** Nothing here is investment, legal, tax, or regulatory guidance. On-chain yield is variable, never guaranteed, is not a deposit, is not insured, and can result in loss of principal.
+
+## The traditional model
+
+Your short-term yield instruments resolve into two archetypes.
+
+A **money-market fund** is a pooled vehicle holding short-dated, high-quality paper — Treasury bills, agency discount notes, commercial paper, repo. Investors buy shares; the fund's yield is the blended coupon on the portfolio net of fees; and daily liquidity is a structural promise backed by the maturity ladder, not a contractual guarantee (2008 and 2020 both reminded the market of the difference). Yield ultimately tracks the central-bank policy rate, because that is what short government paper prices off.
+
+**Repo** is secured overnight financing: you lend cash against securities delivered as collateral, with an agreed repurchase price the next day. The rate is a money-market rate; the security is your protection; a haircut absorbs mark-to-market moves. It is delivery-versus-payment in spirit — cash and collateral change hands together — and the counterparty's credit matters far less because you are holding their bonds.
+
+**Securities lending** inverts the flow: you lend a security to a short-seller or market-maker, take cash or securities as collateral, reinvest that collateral, and split the spread. Your yield is manufactured from collateral reinvestment plus any specials premium, and your risk sits squarely in that reinvestment book.
+
+In every case the yield has a nameable source and the collateral has a nameable owner.
+
+## What changes on-chain
+
+An over-collateralized on-chain lending market is, structurally, a **secured lending book with a transparent, algorithmic rate.** Borrowers post collateral — say, a volatile crypto asset — worth materially more than they draw, and borrow a stablecoin against it. There is no unsecured tenor and no credit underwriting of the borrower as an entity; the collateral, continuously priced and enforceable by code, *is* the underwriting. In that respect it rhymes far more with repo and margin lending than with the unsecured commercial paper inside a prime money fund.
+
+The yield you receive as a lender comes from exactly one place: **borrower-paid interest, scaled by utilization.** A pool holds deposited dollars; borrowers draw some fraction of them; the ratio drawn is the utilization rate; and an interest-rate curve maps utilization to a borrow rate. Lenders receive the borrow interest, pro-rata, net of whatever the market reserves. When demand to borrow rises, utilization climbs, the rate curve steepens, and lender yield rises with it. When borrowers repay and utilization falls, yield compresses. There is no policy committee — the "central bank" of this system is live borrowing demand, arbitraged against off-chain rates by anyone who can move capital between the two worlds.
+
+Two practical consequences follow. First, the quoted APY (annual percentage yield) is a **live, backward-and-forward-looking estimate**, not a declared coupon; it moves continuously and can be sharply lower — or higher — tomorrow. Second, the position is **non-custodial**: you hold a claim on the pool directly in your own wallet, redeemable on demand up to available liquidity, with no fund administrator or custodian standing between you and the assets.
+
+## Where it genuinely differs
+
+**Better, honestly:** transparency and settlement. The collateral backing every loan, the total borrowed, the utilization, and the rate curve are all publicly readable in real time — a level of look-through that money-fund shadow-NAV disclosures and tri-party repo reporting only approximate, and only periodically. Settlement is atomic and effectively instant: no T+2, no failed deliveries, no rehypothecation chain to unwind. Redemption is not a next-day process but a single transaction, subject only to available liquidity.
+
+**Worse or simply different:** the guardrails you take for granted are absent. There is no sponsor with a balance sheet to support the "buck," no SIPC or deposit insurance, no lender of last resort, and no regulator supervising liquidity buckets or stress tests. A government money fund's yield rests on sovereign credit; an on-chain lending yield rests on continued borrower demand *and* on the integrity of the stablecoin, the collateral pricing, and the code. Your counterparty is not a rated institution — it is a pool of pseudonymous over-collateralized borrowers plus the smart contract itself. That is a genuinely different risk object, not a worse or better version of the same one.
+
+## Risk and controls
+
+A professional read should price several distinct exposures, none of which nets to zero:
+
+- **Smart-contract risk.** The pool is software. A flaw can impair or freeze funds regardless of how sound the credit is. Audits and battle-tested, widely-used protocols reduce but never eliminate this. It is the closest analogue to operational/technology risk in a custodian, except the failure mode is code, not process.
+- **Collateral and liquidation risk.** Over-collateralization only protects lenders if liquidations clear *fast enough* during a sharp move. Gap risk, thin liquidity, and oracle latency can leave a pool under-collateralized — the on-chain equivalent of a repo book where the collateral gapped through the haircut before you could sell.
+- **Oracle risk.** The system prices collateral from a price feed. A manipulated, stale, or wrong feed mis-triggers or fails to trigger liquidations. Treat feed design and independence as you would a valuation-agent dependency.
+- **Liquidity and redemption risk.** If utilization is very high, idle dollars available to withdraw shrink; you may have to wait for borrowers to repay or new deposits to arrive. This is the on-chain twin of a gated fund or a crowded exit — the yield was compensation for exactly this.
+- **Stablecoin risk.** Your "dollar" is an issuer's liability or an on-chain construct. A de-peg is a principal event that no amount of lending-side over-collateralization offsets.
+- **Curator/counterparty risk.** In curated systems a professional manager chooses which collateral and markets the pool touches. That is a real, named discretionary counterparty whose judgment you are underwriting — analogous to the portfolio manager of the fund, but without the regulatory wrapper.
+
+The controls that matter are diligence-side: prefer audited, long-lived protocols; understand the collateral set and liquidation parameters; size to what you can afford to lose; and treat the APY as a variable rate to be monitored, not a locked coupon.
+
+## How FairWins approaches this
+
+FairWins does not run a lending book, take custody, or manufacture yield. Its Earn surface is a **non-custodial conduit** into third-party curated lending vaults on established protocols — deposits move straight from the member's own wallet into vaults the underlying protocol itself has listed, and the position is held by the member, not FairWins. Yield is whatever the vault earns from borrower demand; APY is displayed live from the protocol's own data, and when that data cannot be fetched the deposit path is disabled rather than showing a stale number. FairWins currently charges **no platform fee** on Earn, and the interface says so; the vault's own fees, already reflected in the displayed rate, and network gas still apply. Withdrawals return principal plus accrued return to the member's wallet, bounded only by the vault's available liquidity. The platform's role is plumbing and honest disclosure — not asset management, and not a yield promise.
+
+## Related deep-dive
+
+For the engineering details, see [Earn Without Surprises: Putting Idle Funds to Work](../../posts/23-earn-erc4626-vaults/blog.md).
+
+## Further reading
+
+- [IOSCO — Policy Recommendations for Money Market Funds](https://www.iosco.org/)
+- [BIS / CGFS — Repo market functioning](https://www.bis.org/)
+- [Investopedia — Securities Lending](https://www.investopedia.com/terms/s/securitieslending.asp)
+- [Investopedia — Repurchase Agreement (Repo)](https://www.investopedia.com/terms/r/repurchaseagreement.asp)
+- [ERC-4626: Tokenized Vault Standard](https://eips.ethereum.org/EIPS/eip-4626)
+- [Morpho documentation](https://docs.morpho.org/)

--- a/docs/blog/finance/07-onchain-lending-vs-money-markets/social.md
+++ b/docs/blog/finance/07-onchain-lending-vs-money-markets/social.md
@@ -1,0 +1,25 @@
+# Social & Image — On-Chain Lending Against Money Markets, Repo, and Securities Lending
+
+## X (Twitter)
+Where does on-chain lending yield actually come from? Borrower demand × utilization — a secured book that rhymes with repo, not with a prime money fund. Our advanced briefing maps it to the instruments you already run. Variable, not a deposit. 🔗 <link> #DeFi #Treasury
+
+## LinkedIn
+Your short-term yield menu is well understood: government money funds, overnight repo, securities lending — each with a nameable yield source and a nameable collateral owner. So when a colleague points at an on-chain vault quoting a variable APY on USDC, the right question is the treasury question: where is that yield coming from, and what am I actually holding?
+
+Our latest Finance Professional Series briefing (Advanced) answers it in TradFi vocabulary:
+
+- Why over-collateralized on-chain lending is structurally closer to repo and margin lending than to a prime money fund
+- The single yield source — borrower-paid interest scaled by utilization — and why there's no policy committee, only live demand
+- Where it's genuinely better (transparency, atomic settlement, on-demand redemption) and genuinely worse (no sponsor, no insurance, no lender of last resort)
+- A practitioner's risk read: smart-contract, collateral/liquidation, oracle, liquidity, stablecoin, and curator risk
+
+Yield here is variable, never guaranteed, and is not a deposit. Informational, not advice.
+
+🔗 <link>
+
+How are you framing on-chain yield against your existing repo and money-market book?
+
+#DeFi #Treasury #MoneyMarkets #Repo #RiskManagement
+
+## Image prompt (Gemini / Nano Banana)
+A restrained, institutional editorial illustration for a 16:9 banner: two interlocking mechanical systems rendered as a single elegant clearing mechanism — on one side a classic money-market ledger and repo settlement rail, on the other an abstract lending pool depicted as balanced reservoirs connected by precise pipework, joined by interlocking brass gears at the center to suggest a shared engine of secured lending. Deep navy and teal base palette with a single warm amber accent highlighting the point of connection, soft directional lighting, clean modern lines, sophisticated and understated, not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/08-tokenized-vaults-fund-structures/blog.md
+++ b/docs/blog/finance/08-tokenized-vaults-fund-structures/blog.md
@@ -1,0 +1,74 @@
+# Tokenized Vaults as Fund Structures
+
+*The ERC-4626 standard read as a share-and-NAV accounting model: deposits as subscriptions, withdrawals as redemptions, and the curator as a risk manager — structurally analogous to a fund, not legally equivalent to one*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Money, Yield & Markets |
+| **Level** | Advanced |
+| **Audience** | Fund operations and administration leads, allocators, product managers, compliance and risk officers |
+| **Tags** | ERC-4626, tokenized vaults, NAV, fund accounting, subscriptions, redemptions, curator |
+| **Reading time** | ~9 minutes |
+
+---
+
+## A due-diligence lens you already own
+
+An allocator sits down to evaluate a new pooled vehicle. The questions are reflexive: How are shares priced? What is the NAV mechanism? How do subscriptions and redemptions settle, and on what cycle? Who is the manager, what discretion do they hold, and where is the fee? Who administers the book and strikes the price?
+
+Point that same lens at a **tokenized vault** — a pool built to the ERC-4626 standard, the common template for on-chain yield-bearing pools — and something useful happens: most of the questions have clean answers, several of the mechanics are unusually transparent, and a few of your instincts need adjusting. This briefing reads a tokenized vault as a fund operations professional would read a fund, and is deliberate about the one thing it is *not* claiming: legal equivalence.
+
+**Informational, not advice.** This is educational material, not investment, legal, tax, or regulatory guidance, and not a legal opinion on any instrument's classification. On-chain yield is variable, never guaranteed, is not a deposit, and can lose value. Regulatory treatment of tokenized vehicles varies by jurisdiction and is unsettled and evolving.
+
+## The traditional model
+
+A pooled fund is, at its core, a **share-and-NAV accounting machine.** Investors subscribe by delivering cash; the administrator issues units at the prevailing net asset value per share; the manager invests the pool; income and gains accrue; and the NAV per share rises (or falls) to reflect them. Redemptions run the machine in reverse — units are cancelled and the investor receives their proportional slice of NAV, on the dealing cycle the offering documents specify. A transfer agent maintains the register, an administrator strikes the NAV and reconciles, a custodian holds the assets, and an auditor checks the whole apparatus once a year. Fees — management, sometimes performance — are accrued into or deducted from NAV.
+
+Every one of those roles exists to answer a trust question: *can I rely on the share price, and can I get my money back at it?*
+
+## What changes on-chain
+
+ERC-4626 is, in effect, a **standardized fund-accounting interface expressed in code.** A vault issues share units when assets are deposited and burns them on withdrawal, and it exposes a canonical conversion between shares and underlying assets. That conversion *is* a NAV-per-share: total assets held by the vault divided by shares outstanding. Map the roles directly:
+
+- **A deposit is a subscription.** Assets in, shares issued at the current share-to-asset ratio.
+- **A withdrawal is a redemption.** Shares burned, assets out at that same ratio, up to available liquidity.
+- **The share balance is the register entry.** It lives in the investor's own wallet — the holder is their own transfer-agent record, and ownership is settled, not merely recorded on a manager's books.
+- **The conversion function is the NAV strike.** But rather than a once-a-day price struck by an administrator, it is computed continuously and readable by anyone at any moment.
+- **Yield accrues into the share price.** As the vault's assets grow, each share converts to more underlying — the on-chain analogue of an accumulating NAV, no distribution event required.
+
+Because the interface is standardized, any application can subscribe to, value, and redeem from any compliant vault the same way — the operational equivalent of every fund in the market speaking one dealing protocol. The **curator** (the vault's risk manager) plays the portfolio-manager role: choosing where the pooled assets are deployed, setting concentration and risk limits, and, where applicable, setting the vault's own fee — which, exactly like a fund, is reflected in the price the investor ultimately receives.
+
+## Where it genuinely differs
+
+**Better, honestly:** the accounting is glass-boxed. There is no dealing lag and no stale-price uncertainty — the share-to-asset ratio is verifiable on demand, so an investor never subscribes or redeems at a NAV they cannot independently reconstruct. Settlement is atomic: units and assets change hands in the same transaction, eliminating the subscription-in-limbo and failed-redemption states that fund operations teams manage around. The register is self-custodied, removing an entire layer of transfer-agent and omnibus-account reconciliation. And *composability* has no fund analogue: a vault share is itself a standard token that other systems can hold, price, or build on.
+
+**Worse or simply different:** the assurance scaffolding is thinner and differently shaped. There is no independent administrator striking and reconciling NAV, no custodian segregating assets under a regulated mandate, and typically no statutory audit of financial statements — the "administrator" is the contract's own arithmetic, which is transparent but unsupervised. Redemption is not a contractual right honored by a sponsor; it is a mechanical function bounded by whatever liquidity the vault holds at that instant. And critically, **structural analogy is not legal status.** A tokenized vault that looks and accounts like a fund is not thereby a regulated fund, does not carry a prospectus or the investor protections that attach to one, and its classification — as a security, a collective investment scheme, or something else — varies by jurisdiction and remains unsettled. Read the resemblance as intuition, never as a claim.
+
+## Risk and controls
+
+The fund-operations checklist translates cleanly, and should be applied:
+
+- **NAV integrity / valuation risk.** The share price is only as sound as the vault's asset valuation. If underlying positions are mispriced — by a bad oracle or an illiquid, hard-to-value holding — the conversion misprices subscriptions and redemptions. This is your fair-value and pricing-source diligence, unchanged in spirit.
+- **Liquidity and redemption risk.** Continuous redeemability is bounded by on-hand liquidity. A vault deploying into less-liquid strategies can leave redemptions partially available — the on-chain cousin of a gate or side-pocket. Understand the maturity and liquidity profile of what the curator holds.
+- **Curator/manager risk.** The curator holds real discretion over strategy, concentration, and fees. That is a named counterparty whose competence and incentives you are underwriting, without the regulatory wrapper you may be used to. Diligence the curator as you would a sub-advisor.
+- **Smart-contract and operational risk.** The accounting machine is code; a defect can impair the share price or freeze redemptions irrespective of portfolio quality. Favor audited, long-established implementations and standard building blocks.
+- **Fee transparency.** Vault fees are embedded in the price. Confirm what the quoted yield is net of, and remember that any additional platform layer must be disclosed as its own cost, not buried in the rate.
+
+The overarching control is the same one a good administrator provides: *be able to reconstruct the price and the redemption terms independently.* On-chain, you often can — which is the point.
+
+## How FairWins approaches this
+
+FairWins does not operate a vault, act as administrator, or take custody. Its Earn surface lets a member subscribe to and redeem from **third-party curated tokenized vaults** on established protocols, with the share units held in the member's own wallet throughout — the member is their own register entry, and FairWins never sits in the asset path. The vault's share-to-asset value and live APY are read directly from the protocol's data and shown honestly; when that data is unavailable, deposits are disabled rather than displaying a stale price. The curator — a third party — is the risk manager; FairWins neither selects strategies nor guarantees a return. FairWins currently charges **no platform fee** on Earn and says so plainly; the vault's own fee is already reflected in the displayed rate, and network gas applies. The role is honest disclosure and clean plumbing into someone else's fund-like structure — never a promise about its price.
+
+## Related deep-dive
+
+For the engineering details, see [Earn Without Surprises: Putting Idle Funds to Work](../../posts/23-earn-erc4626-vaults/blog.md).
+
+## Further reading
+
+- [ERC-4626: Tokenized Vault Standard](https://eips.ethereum.org/EIPS/eip-4626)
+- [IOSCO — Principles for the Valuation of Collective Investment Schemes](https://www.iosco.org/)
+- [Investopedia — Net Asset Value (NAV)](https://www.investopedia.com/terms/n/nav.asp)
+- [Investopedia — Open-End Fund](https://www.investopedia.com/terms/o/open-endfund.asp)
+- [Morpho documentation](https://docs.morpho.org/)

--- a/docs/blog/finance/08-tokenized-vaults-fund-structures/social.md
+++ b/docs/blog/finance/08-tokenized-vaults-fund-structures/social.md
@@ -1,0 +1,25 @@
+# Social & Image — Tokenized Vaults as Fund Structures
+
+## X (Twitter)
+A tokenized (ERC-4626) vault is a share-and-NAV machine: deposits are subscriptions, withdrawals are redemptions, the curator is the risk manager. Structurally like a fund — NOT legally one. Our advanced briefing reads it as a fund-ops pro would. 🔗 <link> #ERC4626 #FundOps
+
+## LinkedIn
+Every allocator has the same reflexes evaluating a pooled vehicle: How are shares priced? What's the NAV mechanism? How do subscriptions and redemptions settle? Who's the manager, and where's the fee?
+
+Point that lens at a tokenized (ERC-4626) vault and most of the questions have clean — and unusually transparent — answers. Our latest Finance Professional Series briefing (Advanced) reads the vault as a fund operations professional would:
+
+- Deposits as subscriptions, withdrawals as redemptions, the share-to-asset conversion as a continuously-struck NAV
+- The curator as the portfolio manager / risk manager, with real discretion you underwrite
+- Where it's genuinely better (glass-box accounting, atomic settlement, self-custodied register) and where the assurance scaffolding is thinner
+- Why "structurally analogous to a fund" is never "is a regulated fund" — classification varies by jurisdiction and is unsettled
+
+Yield is variable, never guaranteed, and is not a deposit. Informational, not advice — not a legal opinion on any instrument's status.
+
+🔗 <link>
+
+Which parts of your fund-diligence checklist translate cleanly on-chain, and which don't?
+
+#ERC4626 #FundOperations #NAV #DeFi #RiskManagement
+
+## Image prompt (Gemini / Nano Banana)
+A restrained, institutional editorial illustration for a 16:9 banner: an elegant balance scale where one pan holds a classic bound fund prospectus and share certificate and the other holds an abstract geometric "vault share" token, the fulcrum rendered as a precise NAV-strike mechanism with fine engraved gradations. Behind it, a subtle vault door motif suggesting structure and safekeeping. Deep navy and teal base palette with a single warm gold accent on the fulcrum, soft museum lighting, clean modern lines, sophisticated and understated, not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/09-defi-yield-risk-framework/blog.md
+++ b/docs/blog/finance/09-defi-yield-risk-framework/blog.md
@@ -1,0 +1,72 @@
+# A Practitioner's Risk Framework for DeFi Yield
+
+*Seven exposures to price before you underwrite an on-chain yield, and a diligence discipline that treats the quoted APY as the last thing you look at, not the first*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Money, Yield & Markets |
+| **Level** | Advanced |
+| **Audience** | Risk officers, allocators, treasury and credit analysts, compliance and operational-risk leads |
+| **Tags** | risk framework, smart-contract risk, oracle risk, liquidity risk, de-peg, curator risk, diligence |
+| **Reading time** | ~10 minutes |
+
+---
+
+## Start with the risk, not the rate
+
+An allocator is handed two on-chain vaults. One quotes 4%, the other 9%. The instinct — reach for the 9% and ask why later — is exactly backwards. In on-chain yield, the headline APY (annual percentage yield) is not a coupon; it is a variable output of an engine you have not yet inspected, and the spread between the two vaults is usually *risk you cannot see priced by a market that can*. The professional move is to build the risk stack first and read the rate last.
+
+This briefing lays out a seven-part risk taxonomy for DeFi yield in the language of counterparty, liquidity, valuation, and operational risk you already use, then sketches a diligence discipline. It is deliberately protocol-agnostic.
+
+**Informational, not advice.** Educational material only — not investment, legal, tax, or regulatory guidance. On-chain yield is variable, never guaranteed, is not a deposit, is not insured, and can result in total loss of principal. Regulatory treatment varies by jurisdiction and is evolving.
+
+## Why the usual framework needs extending
+
+A money-market or repo risk model concentrates on credit, duration, and liquidity, backstopped by an assumption that the plumbing — custody, settlement, valuation, the legal wrapper — works and is supervised. On-chain, that assumption is the exposure. The plumbing is software and market microstructure with no supervisor, and several risks that TradFi externalizes to custodians, administrators, and central banks are pulled directly onto your book. The seven categories below are the ones that repeatedly explain why an on-chain yield is what it is.
+
+## The seven exposures
+
+**1. Smart-contract risk.** The vault, the lending market, and every contract they touch are code, and code can contain flaws that drain, freeze, or mis-account funds regardless of how sound the underlying credit is. This is technology and operational risk with an unusually sharp tail: failures are often sudden, total, and irreversible. Mitigants are real but partial — independent audits, formal verification, bug-bounty programs, and above all *time-in-market* at scale (a protocol that has held billions through multiple stress events has survived a test a new fork has not). Treat an unaudited or freshly-deployed contract as an unpriced binary risk.
+
+**2. Oracle risk.** On-chain systems price collateral and assets from external data feeds. A feed that is manipulated (via a flash-funded price move), stale (not updated through a fast market), or simply wrong will mistrigger or fail to trigger the liquidations that protect lenders, and will misprice the vault's own NAV. This is your valuation-agent and pricing-source dependency, concentrated into a single technical component. Diligence the feed's sources, update cadence, and manipulation resistance as you would a critical vendor.
+
+**3. Liquidity and redemption risk.** On-chain redeemability is bounded by on-hand liquidity, not by a sponsor's promise. In a lending pool, high utilization shrinks the withdrawable balance until borrowers repay or new deposits arrive; in a vault holding less-liquid strategies, redemptions can be partial. This is the gate/side-pocket risk you know, minus the disclosure documents — and it tends to bind precisely when everyone wants out at once. Part of any elevated yield is compensation for exactly this.
+
+**4. Collateral and liquidation risk.** Over-collateralization protects lenders only if liquidations clear *fast enough and deep enough* during a sharp move. Gap risk, thin market depth, cascading liquidations, and oracle latency can leave a pool under-collateralized — a bad-debt event borne by lenders. This is repo haircut risk with the collateral gapping through the cushion before it can be sold. Read the collateral set, the loan-to-value limits, and the liquidation mechanics, not just the yield.
+
+**5. Stablecoin de-peg risk.** When the yield and the principal are denominated in a stablecoin, the peg is a load-bearing assumption. A de-peg — whether an asset-backed token's reserve is questioned or an algorithmic design unwinds — is a principal-loss event that no amount of lending-side over-collateralization offsets. Understand what backs the specific stablecoin (fully-reserved cash and short government paper is a different object from crypto-collateralized or algorithmic designs), and remember 2022 taught this lesson at scale.
+
+**6. Curator / counterparty risk.** In curated systems a professional manager chooses collateral, sets limits, and may set fees. That discretion is a named counterparty you are underwriting — competence, incentives, and governance keys included. If the curator can change strategy or parameters, you hold *manager risk* without a regulatory wrapper. Diligence them as a sub-advisor: track record, alignment, and the scope and control of their admin powers.
+
+**7. Governance and admin-key risk.** Many protocols retain privileged controls — upgradeable contracts, pausing, parameter changes, treasury keys. Those powers are necessary for maintenance and dangerous if compromised or misused. Ask who holds the keys, whether changes pass through a timelock (a mandatory delay that gives you a window to exit), and how decentralized and accountable the governance actually is. This is the on-chain analogue of key-person and change-control risk.
+
+These do not net. A vault can be flawless on six axes and fail on the seventh, and the loss is often the whole position. Underwrite the maximum, not the average.
+
+## A diligence discipline
+
+Turning the taxonomy into a repeatable process:
+
+- **Read the rate last.** Build the seven-part risk stack first; only then ask whether the yield compensates it. An unexplained spread over a comparable vault is a question, not a gift.
+- **Prefer time-tested infrastructure.** Longevity at scale through real stress is the single most informative signal about smart-contract and economic robustness. Favor it over novelty and headline APY.
+- **Insist on transparency you can act on.** Look-through into collateral, utilization, oracle sources, and admin controls is a genuine on-chain advantage — use it. If you cannot reconstruct the position and its risks from public data, treat the opacity as a risk in itself.
+- **Size for the tail.** Because failure modes are often sudden and total, position sizing — not clever hedging — is the primary control. Only deploy what you can afford to lose, and diversify across independent protocols so a single code or curator failure is survivable.
+- **Monitor as a variable, not a fixture.** APY, utilization, and peg status move continuously. Treat an on-chain position as a live exposure requiring ongoing surveillance, not a set-and-forget coupon.
+- **Keep the compliance lens.** Classification of tokens and yields, and their treatment for tax and regulatory purposes, is unsettled and jurisdiction-specific. Keep records, and do not assume any regulated-product protections apply.
+
+## How FairWins approaches this
+
+FairWins' posture toward its Earn surface is an applied version of this framework: it does not manufacture yield, take custody, or promise a return. Members deposit directly from their own wallets into **third-party curated vaults** on established, long-lived protocols, and hold the positions themselves. The design leans on the framework's honesty principles — live APY read from the protocol's own data, with the deposit path disabled rather than showing a stale or invented number when that data is unavailable; explicit unavailable states instead of silent assumptions; and only vaults the underlying protocol itself lists surfaced to members. FairWins currently charges **no platform fee** on Earn and discloses that plainly; the vault's own fee is already reflected in the displayed rate, and network gas applies. Every risk in this taxonomy still belongs to the member — smart-contract, oracle, liquidity, collateral, de-peg, curator, and governance risk are all real and named in the product's own risk disclosure. The platform's contribution is transparency and honest failure states, which is exactly what a risk framework asks the infrastructure to provide; it is not a substitute for the member's own diligence.
+
+## Related deep-dive
+
+For the engineering details, see [Earn Without Surprises: Putting Idle Funds to Work](../../posts/23-earn-erc4626-vaults/blog.md).
+
+## Further reading
+
+- [BIS — The financial stability risks of decentralised finance](https://www.bis.org/)
+- [IOSCO — Policy Recommendations for Decentralized Finance (DeFi)](https://www.iosco.org/)
+- [FSB — Assessment of Risks to Financial Stability from Crypto-assets](https://www.fsb.org/)
+- [Investopedia — Stablecoin](https://www.investopedia.com/terms/s/stablecoin.asp)
+- [ERC-4626: Tokenized Vault Standard](https://eips.ethereum.org/EIPS/eip-4626)
+- [Morpho documentation](https://docs.morpho.org/)

--- a/docs/blog/finance/09-defi-yield-risk-framework/social.md
+++ b/docs/blog/finance/09-defi-yield-risk-framework/social.md
@@ -1,0 +1,25 @@
+# Social & Image — A Practitioner's Risk Framework for DeFi Yield
+
+## X (Twitter)
+Two vaults: one quotes 4%, one 9%. Reaching for the 9% and asking why later is backwards. The spread is usually risk you can't see, priced by a market that can. Our advanced briefing: read the rate LAST. Seven exposures to price first. 🔗 <link> #DeFi #RiskManagement
+
+## LinkedIn
+In on-chain yield, the headline APY is not a coupon — it's a variable output of an engine you haven't inspected yet, and the spread between two vaults is usually risk you can't see, priced by a market that can. The professional move is to build the risk stack first and read the rate last.
+
+Our latest Finance Professional Series briefing (Advanced) lays out a seven-part risk taxonomy for DeFi yield in the language of counterparty, valuation, and operational risk you already use:
+
+- Smart-contract and oracle risk — technology and pricing-source exposure with a sharp tail
+- Liquidity/redemption and collateral/liquidation risk — gates and haircuts, minus the disclosure docs
+- Stablecoin de-peg, curator/counterparty, and governance/admin-key risk
+- A diligence discipline: read the rate last, prefer time-tested infrastructure, size for the tail, monitor continuously
+
+These exposures don't net — underwrite the maximum, not the average. Yield is variable, never guaranteed, and is not a deposit. Informational, not advice.
+
+🔗 <link>
+
+Which of these seven do you find hardest to diligence with the data available?
+
+#DeFi #RiskManagement #Yield #OperationalRisk #Diligence
+
+## Image prompt (Gemini / Nano Banana)
+A restrained, institutional editorial illustration for a 16:9 banner: seven precise interlocking gears of varying sizes arranged as a single risk-assessment mechanism, each gear subtly distinct to suggest distinct exposures, driving one central balance indicator that reads the system's overall integrity. The composition should feel like the inner workings of a clearing house or a fine instrument. Deep navy and teal base palette with a single warm amber accent on the central indicator, soft directional lighting, clean modern lines, sophisticated and understated, not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/10-oracles-reference-data-integrity/blog.md
+++ b/docs/blog/finance/10-oracles-reference-data-integrity/blog.md
@@ -1,0 +1,78 @@
+# Oracles as Reference-Data Infrastructure: Sourcing Outside Truth With Integrity
+
+*Price feeds and event-resolution oracles are the on-chain analogue of your market-data vendors and benchmark administrators — with a different, and in some ways more auditable, integrity model*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Money, Yield & Markets |
+| **Level** | Advanced |
+| **Audience** | Risk managers, data-governance leads, benchmark and valuation officers, fintech product managers |
+| **Tags** | `oracles`, `reference-data`, `benchmarks`, `market-data`, `integrity-controls` |
+| **Reading time** | ~9 minutes |
+
+---
+
+## A familiar control question, in an unfamiliar place
+
+Every valuation, margin call, and structured-product coupon in your firm depends on a number your firm did not generate. A closing price from an exchange feed. A reference rate from an administrator. A settlement level scraped from a screen at a fixed cut-off. You know the discipline this demands: vendor due diligence, redundant sources, stale-data checks, a documented waterfall for when the primary source fails, and — since the LIBOR episode — an acute institutional memory of what happens when the input to a contract can be nudged.
+
+A smart contract that settles a wager, pays a coupon, or liquidates collateral faces exactly the same problem: it must import a fact from the outside world and act on it irreversibly. The component that supplies that fact is called an **oracle**. This briefing maps the oracle problem onto the reference-data and benchmark-administration disciplines you already run, and is honest about where the on-chain version is stronger, weaker, or simply different.
+
+## The traditional model: vendors and benchmark administrators
+
+In traditional finance, outside truth arrives through two broad channels. **Market-data vendors** redistribute observed prices — exchange feeds, consolidated tapes, evaluated pricing for illiquid instruments. **Benchmark administrators** construct a number from inputs according to a published methodology and governance framework; post-reform, they operate under regimes such as the EU Benchmarks Regulation and the IOSCO Principles for Financial Benchmarks, which demand methodology transparency, conflict-of-interest controls, and submitter oversight.
+
+Your controls around both are mature. You assess the source's governance, you hold contractual SLAs, you run tolerance checks against a secondary source, and you keep a fallback waterfall. The integrity model is fundamentally **institutional**: you trust the administrator's controls and the regulator behind them, and you retain evidence to challenge a bad print after the fact.
+
+## What changes on-chain
+
+A blockchain is a closed system: it cannot reach out to a web service or an exchange API on its own. Every external fact must be *pushed in* by a specific mechanism, and once a contract acts on that fact, the action typically cannot be reversed. That single property — irreversible settlement on imported data — is why oracle design is treated as a first-order risk rather than plumbing. There is no unwind desk and no chargeback.
+
+In practice, imported truth arrives in a few structurally distinct shapes, and the differences matter more than the branding:
+
+- **Live price feeds.** A network of independent operators observes prices from many venues, aggregates them (typically a trimmed median to blunt any single outlier), and publishes the result on-chain on a schedule. Chainlink's data feeds are the widely used example. Structurally this is your consolidated tape plus an evaluated-pricing layer — with the aggregation methodology and the operator set publicly inspectable rather than proprietary.
+- **On-demand data lookups.** Rather than a continuously published number, a contract poses a specific question and a decentralized network fetches the answer from a defined source and returns it. This is closer to a bespoke data pull against a named vendor endpoint, with the request specification pinned in advance.
+- **Optimistic / dispute-based resolution.** For facts that require human judgment — did a merger close, did an event occur — no feed is authoritative. Here the model inverts: someone *asserts* the answer and posts a bond; the assertion stands as truth unless challenged within a defined window, and a challenge escalates to a broader adjudication that the loser's bond funds. UMA's optimistic oracle is the reference implementation. The nearest traditional analogue is a **calculation-agent-plus-dispute** clause in an ISDA confirmation: an agent determines a value, and the counterparty has a defined window to dispute it.
+
+The recurring on-chain convention is worth flagging for a controls audience: a well-designed oracle interface always permits a clean *"not resolved yet"* answer. An undecidable or unavailable outcome routes to a refund or a wait — never to a guessed result. That is the settlement analogue of failing a trade to "unmatched" rather than forcing it through on a bad price.
+
+## Where it genuinely differs
+
+**Better: transparency and auditability of the input.** A benchmark's submitter panel and a vendor's evaluated-pricing model are often proprietary; you audit the administrator, not the arithmetic. On-chain, the aggregation logic, the operator set, and the exact printed value at each block are public and independently verifiable. You can reconstruct precisely what number a contract saw and when — a forensic capability that the LIBOR investigations had to build painstakingly after the fact.
+
+**Different: the trust anchor moves from institutions to cryptoeconomics.** A benchmark's integrity rests on regulated governance and legal accountability. An oracle's integrity often rests on economic incentives: enough independent reporters that collusion is expensive, or a dispute bond large enough that lying does not pay. This is a real substitution, not a free lunch — you are trading a legal-accountability model for a game-theoretic one, and each fails differently.
+
+**Worse / genuinely hard: the last mile of trust.** An on-demand lookup is only as good as the single web source it queries; an optimistic oracle assumes someone is watching to dispute a false assertion. Neither eliminates trust — they relocate and make it explicit. That explicitness is an advantage for a risk officer, but it is not the same as removing the exposure.
+
+## Risk & controls
+
+A professional risk lens on oracle dependence:
+
+- **Manipulation risk.** The canonical on-chain failure is a manipulated spot price — often an attacker distorting a thin liquidity pool for a single block to trigger a favorable liquidation. The mitigations parallel benchmark reform: aggregate across many venues, use medians over means to reject outliers, and prefer time-averaged or multi-source readings for thin instruments. When you evaluate a protocol, ask the same question a benchmark regulator asks — *how manipulable is the input, and at what cost?*
+- **Staleness and liveness.** A feed can stop updating. Robust designs stamp each reading and reject data older than a tolerance, refusing to settle on a stale print rather than acting on last week's number. This is your stale-data control, enforced mechanically at the point of settlement.
+- **Source and methodology risk.** For lookups and disputes, concentration in a single data source or a thin set of adjudicators is the exposure. Diversification and a documented fallback are the answer — the same waterfall discipline you already apply to primary/secondary vendors.
+- **Governance and change risk.** Who can add or reconfigure an oracle, and under what controls? A reference-data source you cannot see being swapped is an operational risk. Prefer arrangements where curation of *which* oracle answers a question is a controlled, logged admin action while triggering settlement is open and permissionless — trusted curation, untrusted execution.
+- **Finality risk.** Because settlement is irreversible, an erroneous input is not a break to be re-papered — it is a realized loss. That raises the bar on input quality relative to a world where you can dispute and unwind.
+
+The relevant external benchmarks for this discipline are the **IOSCO Principles for Financial Benchmarks** and the BIS/CPMI-IOSCO principles for financial-market infrastructures; both translate cleanly into questions you can put to an oracle design.
+
+## How FairWins approaches this
+
+FairWins settles wagers from external truth and treats the referee as a pluggable component: the escrow that holds the stakes does not contain source-specific logic. It consults a configured oracle at two moments — when a wager is created (to confirm the question is valid and not already decided) and when settlement is triggered (to read the outcome). The supported shapes span the spectrum above — reading a resolved public prediction market, thresholding a live price feed with a freshness check, on-demand lookups, and optimistic dispute-based resolution — but only well-understood options are exposed to members, with the rest behind configuration.
+
+Two integrity choices are worth naming for this audience. First, an undecidable outcome — a disputed or invalid market result, a failed lookup, a stale feed — resolves to a refund or an unresolved state, never a coin-flip payout. Second, curating which oracle answers a question is a controlled action, while *triggering* settlement is open to anyone, since the outcome is a public fact. That separation — trusted curation, untrusted, permissionless execution — is the same control philosophy a benchmark regime encodes, expressed in code.
+
+> *Informational only.* This briefing is educational and is not investment, legal, tax, or regulatory advice. Oracle mechanisms and their treatment vary by design and by jurisdiction; evaluate any specific integration against your own controls and obligations.
+
+## Related deep-dive
+
+For the engineering details, see [Three Kinds of Truth, One Referee Slot](../../posts/15-oracle-adapter-abstraction/blog.md).
+
+## Further reading
+
+- [IOSCO Principles for Financial Benchmarks](https://www.iosco.org/library/pubdocs/pdf/IOSCOPD415.pdf) — the post-LIBOR governance standard for benchmark administration
+- [CPMI-IOSCO Principles for Financial Market Infrastructures](https://www.bis.org/cpmi/publ/d101.htm) — integrity and operational-resilience principles for settlement systems
+- [Chainlink Data Feeds documentation](https://docs.chain.link/data-feeds) — aggregated on-chain price feeds
+- [UMA Optimistic Oracle documentation](https://docs.uma.xyz/) — dispute-based resolution with a challenge window and bonds
+- [Investopedia: Benchmark](https://www.investopedia.com/terms/b/benchmark.asp) — primer on reference rates and their role in contracts

--- a/docs/blog/finance/10-oracles-reference-data-integrity/social.md
+++ b/docs/blog/finance/10-oracles-reference-data-integrity/social.md
@@ -1,0 +1,30 @@
+# Social & Image — Oracles as Reference-Data Infrastructure
+
+## X (Twitter)
+
+Every valuation depends on a number your firm didn't generate. On-chain contracts face the same problem — and solve it with oracles: price feeds, on-demand lookups, and dispute-based resolution. A risk-and-controls read for data-governance pros. 🔗 <link> #ReferenceData #Oracles #RiskManagement
+
+## LinkedIn
+
+Every margin call and structured coupon in your firm relies on a number imported from outside — a closing price, a reference rate, a settlement level. Your controls around that are mature: vendor due diligence, redundant sources, stale-data checks, a documented fallback waterfall. Since LIBOR, you know exactly what's at stake when a contract's input can be nudged.
+
+Smart contracts face the identical problem. The component that imports outside truth is called an oracle, and it settles irreversibly — no unwind desk, no chargeback. This briefing maps the oracle problem onto the reference-data and benchmark-administration disciplines you already run.
+
+It covers:
+
+- The three structural shapes of imported truth: aggregated price feeds, on-demand lookups, and optimistic/dispute-based resolution (Chainlink and UMA as examples)
+- Where on-chain is genuinely stronger — public, reconstructable inputs — and where the trust model just moves, from institutional accountability to cryptoeconomics
+- Manipulation, staleness, source-concentration, and governance risk, mapped to IOSCO benchmark principles
+- Why "not resolved yet" routing to a refund is the settlement analogue of failing a trade to unmatched
+
+Educational only — not investment, legal, or regulatory advice.
+
+How would your benchmark-integrity controls translate to an input you can't dispute after the fact?
+
+🔗 <link>
+
+#ReferenceData #Benchmarks #RiskManagement #MarketData #Oracles
+
+## Image prompt (Gemini / Nano Banana)
+
+A restrained, institutional editorial illustration for a 16:9 banner: a single luminous data conduit feeding into the center of a stylized clearing-house vault, with three distinct inflow channels converging into one — suggesting multiple sources of truth reconciled into a single verified value. Deep navy and teal base palette with one warm amber accent marking the verified input. Clean modern lines, subtle geometric precision evoking benchmark integrity and settlement infrastructure, soft directional lighting, generous negative space, sophisticated and understated — not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/11-prediction-markets-event-derivatives/blog.md
+++ b/docs/blog/finance/11-prediction-markets-event-derivatives/blog.md
@@ -1,0 +1,77 @@
+# Prediction Markets as Information Machines: Event Contracts, Read Honestly
+
+*How staking on outcomes aggregates dispersed information into a price — and why the resemblance to event contracts is an analogy, not a claim of regulated-derivative status*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Money, Yield & Markets |
+| **Level** | Intermediate |
+| **Audience** | Portfolio strategists, research and risk analysts, fintech product managers, allocators |
+| **Tags** | `prediction-markets`, `event-contracts`, `information-aggregation`, `forecasting` |
+| **Reading time** | ~8 minutes |
+
+---
+
+> **Responsible-use note.** This briefing describes prediction markets based on publicly available information and legitimate, skill-based forecasting. These markets are not a mechanism for trading on material non-public information or for circumventing securities, commodities, or gaming regulation. All participants remain fully subject to applicable law and to any platform-level regional restrictions in their jurisdiction.
+
+---
+
+## A question your research desk already asks
+
+Your firm spends heavily to answer forward-looking questions. Will the central bank cut at the next meeting? Will this deal clear antitrust review before quarter-end? Will a named macro figure print above consensus? You buy sell-side research, run internal models, and poll experts — and you know the frustration of a survey that averages confident-but-stale opinions with no cost to being wrong.
+
+A prediction market answers the same class of question with a different instrument: it lets people **stake capital on a yes-or-no outcome**, and the price at which those stakes clear becomes a probability estimate. This briefing is about what that price is worth as an input to your process, how the instrument structurally resembles an event contract, and — importantly — the lines you should not cross when reading that resemblance.
+
+## The traditional model: surveys, models, and event contracts
+
+You already have three tools for the same job. **Surveys** (consensus estimates) aggregate opinion but attach no cost to a bad answer, so they drift toward the safe and the herd-like. **Models** are disciplined but only as good as their assumptions and data. And **event contracts** — instruments that pay a fixed amount if a specified event occurs — let participants express a probabilistic view with real money on the line. In the United States, certain event contracts trade on venues regulated by the Commodity Futures Trading Commission (CFTC); binary options are a close structural cousin, paying a fixed sum on a yes outcome and zero otherwise.
+
+The distinguishing virtue of the money-on-the-line instruments is **skin in the game**. A forecaster who is confident and correct is rewarded; one who is loud and wrong pays. That incentive is what makes a market price more than an opinion poll.
+
+## What changes on-chain
+
+An on-chain prediction market keeps that incentive structure and changes the plumbing. Participants take positions on a defined outcome; the market clears to a price between 0 and 1 that reads directly as an implied probability. When the event resolves, an oracle imports the real-world result and the contract pays the winning side. Polymarket is the widely known example; settlement typically leans on a dispute-based oracle for outcomes that require human judgment.
+
+Two structural features are worth a professional's attention:
+
+- **The price is a live, capital-weighted probability.** A market sitting at 0.68 says the marginal dollar prices the event at roughly a 68% chance. Unlike a monthly survey, it updates continuously as new information arrives, and unlike a model, it aggregates the private information of everyone willing to back a view.
+- **Resolution is mechanical and public.** The payout is a function of an imported outcome, not a discretionary determination by an issuer. That reduces one kind of counterparty ambiguity — but relocates trust onto the oracle and its dispute process (a subject in its own right).
+
+## Where it genuinely differs
+
+**The forecasting value is real and measurable.** A deep, liquid prediction market has repeatedly proven a competitive forecaster — often matching or beating polls and pundits — precisely because it prices in incentives and updates in real time. As a *research input*, a market probability is a genuinely useful cross-check against your consensus estimate and your own model. Treat it as one signal among several, not as an oracle of truth.
+
+**But the resemblance to a regulated event contract is a structural analogy — not a legal equivalence.** This is the line to hold firmly. A prediction market that pays a fixed sum on a yes outcome *looks like* a binary option or a CFTC-style event contract. It does not follow that any given on-chain market **is** a regulated derivative, or that trading it carries the protections — or the permissions — of one. Classification of these instruments is genuinely unsettled and varies by jurisdiction; the same market may be treated as an event contract, a swap, a form of gaming, or something else entirely depending on where you sit and how it is offered. Use the analogy to build intuition about payoff and pricing; do not use it to infer regulatory status.
+
+**Liquidity and thinness are the practical caveat.** A market's probability is only as informative as its depth. A thin market moves on a single large stake, and its price then reflects one participant's conviction more than a genuine consensus. The same skepticism you apply to a price discovered in an illiquid instrument applies here.
+
+## Risk & controls
+
+A professional lens on treating prediction-market data as an input, and on any participation:
+
+- **Interpretation risk.** An implied probability is a market's view, not a fact. Read it as you would a forward curve — informative about expectations, not a guarantee of outcomes. Weight it against liquidity: a probability from a deep market carries more signal than the same number from a thin one.
+- **Oracle and settlement risk.** The payout depends on an external resolution. A disputed, ambiguous, or invalid outcome is a real scenario; well-designed markets route these to a draw or refund rather than an arbitrary winner. Understand the resolution mechanism before relying on a market's expected payoff.
+- **Regulatory and eligibility risk.** Access is often gated by region and by platform policy, and the legal characterization of both the instrument and the activity varies widely. A participant remains responsible for their own eligibility and compliance; a platform surfacing and enforcing regional restrictions is doing the right thing, and those restrictions should never be bypassed.
+- **Conduct risk.** These markets are for forecasting on public information. Staking on the basis of material non-public information, or on outcomes one can improperly influence, raises exactly the legal and ethical exposures you already police elsewhere. The responsible-use framing at the top of this piece is not boilerplate — it is the operative constraint.
+- **Behavioral risk.** Skin in the game sharpens forecasts in aggregate but can concentrate individual risk. Position sizing and the usual discipline apply.
+
+## How FairWins approaches this
+
+FairWins treats prediction-market outcomes primarily as a *source of truth* for settling peer-to-peer wagers: it can read a resolved public prediction market and map the result to a plain yes-or-no, with undecidable or invalid outcomes routed to a refund rather than a guessed winner. Separately, FairWins offers a way to browse and trade on a major public prediction market directly, without taking custody of a member's funds or standing between them and the venue — the member's own wallet is the only signer, and regional eligibility is surfaced and respected rather than circumvented.
+
+The through-line is honesty about what the instrument is and is not: a useful information machine and a defined-payoff position, described in those terms — never dressed up as a regulated derivative or a guaranteed return.
+
+> *Informational only.* This briefing is educational and is not investment, legal, tax, or regulatory advice, and is not a recommendation to participate in any market. Prediction-market instruments and their legal treatment vary by jurisdiction and are evolving; assess any specific market against your own obligations and eligibility.
+
+## Related deep-dive
+
+For the engineering details, see [Three Kinds of Truth, One Referee Slot](../../posts/15-oracle-adapter-abstraction/blog.md).
+
+## Further reading
+
+- [CFTC: Event Contracts](https://www.cftc.gov/) — the U.S. regulator's materials on event-contract oversight
+- [Investopedia: Binary Option](https://www.investopedia.com/terms/b/binary-option.asp) — the fixed-payoff instrument a prediction market structurally resembles
+- [Wolfers & Zitzewitz, "Prediction Markets" (Journal of Economic Perspectives)](https://www.aeaweb.org/articles?id=10.1257/0895330041371321) — foundational work on information aggregation in these markets
+- [Polymarket documentation](https://docs.polymarket.com/) — a widely used on-chain prediction market and its resolution model
+- [Prediction market (overview)](https://en.wikipedia.org/wiki/Prediction_market) — general background

--- a/docs/blog/finance/11-prediction-markets-event-derivatives/social.md
+++ b/docs/blog/finance/11-prediction-markets-event-derivatives/social.md
@@ -1,0 +1,30 @@
+# Social & Image — Prediction Markets as Information Machines
+
+## X (Twitter)
+
+A prediction market at 0.68 is a live, capital-weighted forecast that people paid to be right about. It structurally resembles an event contract — an analogy, NOT a claim of regulated status. What that price is worth to your research desk, read honestly. 🔗 <link> #PredictionMarkets #Forecasting
+
+## LinkedIn
+
+Your research desk spends heavily to answer forward-looking questions — rate decisions, deal approvals, macro prints. Surveys average confident-but-stale opinions with no cost to being wrong. Models are only as good as their assumptions. Prediction markets take a different approach: people stake capital on a yes-or-no outcome, and the clearing price reads directly as an implied probability.
+
+This intermediate briefing looks at what that price is worth as an input to your process — and, importantly, at the line you should not cross when reading it.
+
+It covers:
+
+- Why skin-in-the-game pricing often out-forecasts polls and pundits
+- The structural resemblance to binary options and CFTC-style event contracts — as an analogy for intuition, never a claim of regulated-derivative status
+- Liquidity, oracle/settlement, regulatory-eligibility, and conduct risk
+- Why classification of these instruments is genuinely unsettled and varies by jurisdiction
+
+Responsible use is the operative constraint: forecasting on public information, subject to applicable law — not a route around it. Educational only; not investment, legal, or regulatory advice.
+
+Where would a live market probability add the most value as a cross-check in your process?
+
+🔗 <link>
+
+#PredictionMarkets #EventContracts #Forecasting #MarketStructure #RiskManagement
+
+## Image prompt (Gemini / Nano Banana)
+
+A restrained, institutional editorial illustration for a 16:9 banner: many fine converging lines flowing into a single elegant dial or gauge whose needle rests between two poles — evoking dispersed information aggregating into one probability reading. Deep navy and teal base palette with a single warm amber accent on the needle and its resting point. Clean modern geometry, a sense of balance and measurement, soft directional lighting, generous negative space, sophisticated and understated — not flashy crypto art, no casino or gambling imagery. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/12-builder-codes-best-execution/blog.md
+++ b/docs/blog/finance/12-builder-codes-best-execution/blog.md
@@ -1,0 +1,81 @@
+# Builder Codes and Best Execution: An Honest Look at a Disclosed, Additive Fee
+
+*What a builder fee is, how it compares to payment for order flow, and why the only defensible version is the one the client sees before they sign*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Money, Yield & Markets |
+| **Level** | Advanced |
+| **Audience** | Best-execution and compliance officers, brokerage product managers, cost-transparency and MiFID leads |
+| **Tags** | `builder-codes`, `best-execution`, `PFOF`, `cost-disclosure`, `conflicts-of-interest` |
+| **Reading time** | ~9 minutes |
+
+---
+
+> **Responsible-use note.** This briefing describes an order-routing referral mechanism on a public prediction market, used for legitimate, skill-based trading on publicly available information. It is not a way to trade on non-public information or to circumvent applicable market rules or regional restrictions. Participants remain fully subject to the law and to the venue's own policies in their jurisdiction.
+
+---
+
+## A conflict you already know how to police
+
+You have spent a career on a specific tension: the venue or intermediary that routes a client's order often earns money in a way the client cannot see, and that revenue can — sometimes subtly — pull against the duty to get the client the best result. Payment for order flow (PFOF) is the canonical case. A broker routes retail orders to a market maker, the market maker pays the broker for that flow, and the debate that has run for years is whether the client's execution quality is quietly compromised to fund a "free" trade. Regulators on both sides of the Atlantic have circled it; some jurisdictions restrict or ban it outright.
+
+The relevant frameworks are familiar: **best execution** obligations that require an intermediary to act in the client's interest across price, cost, speed, and likelihood of execution; and **cost-disclosure** regimes — MiFID II's ex-ante and ex-post cost transparency being the sharpest example — that insist the client can see what they are paying. This briefing takes a newer, on-chain construct — the **builder code** — and holds it up against exactly these frameworks.
+
+## The traditional model: where the money hides
+
+In the PFOF arrangement, the defining feature for a compliance officer is that the intermediary's revenue is **embedded and invisible**. The client sees "commission-free." The payment happens behind the quote, in the spread the market maker captures. Whether or not any individual execution is worse for it, the *structure* buries the intermediary's incentive where the client cannot weigh it — which is precisely why it draws best-execution scrutiny and why disclosure of routing practices became a regulatory demand.
+
+Hold that property in mind — *embedded, invisible, potentially in tension with best execution* — because it is the exact benchmark against which a builder code should be judged.
+
+## What a builder code is
+
+On some public trading venues, an application that helps a user place an order can attach a **builder code** to that order: a public identifier that credits the referring app and entitles it to a **builder fee**, a small share of the trade. It is the venue's official, sanctioned way for an interface to earn from the volume it originates. Polymarket's program is the example relevant here.
+
+Mechanically, three properties define it:
+
+- **It is additive.** The builder fee stacks *on top of* the venue's own trading fee. It is not carved out of a spread the client was paying anyway — it is an extra, real cost to the trader on a taker order. (Common designs charge it only to takers, not to makers who post resting liquidity.)
+- **It is attribution, not intermediation.** The referring app does not stand between the client and the venue, does not take custody, and need not touch the order's economics. It attaches a tag; the client's own wallet signs and submits the trade to the venue directly.
+- **It is capped and configurable.** The venue sets a hard ceiling on the fee, and the rate is a published setting rather than a buried constant.
+
+## The honest comparison to PFOF
+
+It is tempting to wave a builder code through as "better than PFOF because it's on a public venue." Resist that. The right comparison is structural, and it cuts both ways.
+
+**Where a builder code is genuinely more defensible:** it can be made **fully visible**. Because the fee is a discrete, known amount rather than value captured inside a spread, it can be shown to the client as its own line item *before* they authorize the trade. That is the opposite of PFOF's defining flaw. And because the model is attribution rather than intermediation, the referring app has no lever over the client's *execution* — it cannot route to a worse venue for a kickback, because it isn't routing at all; the client trades directly with the venue.
+
+**Where it is not automatically better — and the honesty this demands:** an additive fee is a *real, additional cost*. A builder fee makes the client's all-in cost higher than trading without it, full stop. Calling it "free," folding it into a blended total, or crediting it silently would reproduce the precise sin that makes PFOF objectionable — an intermediary earning from the client in a way the client cannot see and weigh. The mechanism does not earn its defensibility automatically; it earns it *only if disclosed*. A hidden builder fee is arguably worse than PFOF, because it is additive rather than spread-embedded — it takes more from the client, not less.
+
+So the compliance conclusion is precise: the builder code is not virtuous because of what it is, but because of how it is presented. Same conflict, different — and, done right, better — disclosure.
+
+## Risk & controls
+
+A best-execution and cost-transparency lens:
+
+- **Disclosure as the primary control.** The fee must appear as its own clearly labeled line, in the currency and amount (or exact rate) the client will pay, *before* authorization — the ex-ante cost transparency MiFID II demands. "What you see is what you're charged" is the standard; a blended total is a red flag.
+- **Separating controlled from uncontrolled costs.** The referring app controls its own builder fee and should disclose it exactly. The venue's own execution-time fee varies with price and size and is not the app's to promise; the honest treatment is to disclose it as a separate, clearly-flagged estimate or note rather than invent a precise figure the app cannot guarantee.
+- **A cap enforced early, loudly.** A misconfigured fee above the venue's ceiling should fail fast — ideally a service refusing to start rather than quietly overcharging. A fat-fingered rate ought to be an outage you catch in seconds, not a fee incident surfacing in complaints weeks later.
+- **Conflict transparency.** The client should understand the referring app earns from their volume. That is not disqualifying — venues explicitly sanction it — but an undisclosed conflict is. The whole point is to make the incentive legible.
+- **Best-execution posture.** Because attribution does not alter routing or execution, the app is not exercising execution discretion for a kickback. Preserve that separation: the moment a referral fee could influence *where or how* a client's order executes, you are back in classic best-execution territory and the analysis hardens considerably.
+- **Never-stranded principle.** Attribution should be best-effort: if the referral component is unavailable, the client's trade should still go through — unattributed — rather than be blocked. A client must never be prevented from trading merely to protect the intermediary's fee.
+
+## How FairWins approaches this
+
+FairWins participates in a public prediction market's builder-code program and treats the resulting fee as a first-class disclosure obligation, not a footnote. The member's own wallet is the only signer; FairWins takes no custody and does not intermediate the trade — it attaches attribution alongside an order the member submits directly to the venue. Because the builder fee is additive and real, it is shown as its own labeled line before the member approves — never described as free, never folded into a total. The venue's own execution-time fee, which FairWins does not control, is disclosed separately and honestly rather than guessed at. The rate is a capped configuration setting, and a value above the program's ceiling is designed to fail loudly rather than silently overcharge. And if the attribution component is unavailable, the trade still proceeds unattributed — the member is never stranded to protect a referral fee.
+
+The design principle worth taking away is transferable well beyond crypto: *disclose what you control exactly, admit what you don't, and never let your own revenue mechanism sit invisibly against the client's interest.* That is the standard best execution has always asked for.
+
+> *Informational only.* This briefing is educational and is not investment, legal, tax, or regulatory advice. Fee structures, best-execution obligations, and the treatment of referral arrangements vary by jurisdiction and are evolving; assess any specific arrangement against your own regulatory obligations.
+
+## Related deep-dive
+
+For the engineering details, see [Predict: Earning From Prediction-Market Trades Without Ever Touching One](../../posts/24-predict-polymarket-builder-codes/blog.md).
+
+## Further reading
+
+- [SEC: Payment for Order Flow](https://www.sec.gov/) — U.S. regulator materials on PFOF and order-routing disclosure
+- [ESMA / MiFID II cost and charges disclosure](https://www.esma.europa.eu/) — the ex-ante and ex-post cost-transparency regime
+- [Investopedia: Payment for Order Flow (PFOF)](https://www.investopedia.com/terms/p/paymentoforderflow.asp) — primer on the arrangement and its criticisms
+- [Investopedia: Best Execution](https://www.investopedia.com/terms/b/bestexecution.asp) — the duty and its components
+- [Polymarket documentation](https://docs.polymarket.com/) — the venue and its builder-code referral program

--- a/docs/blog/finance/12-builder-codes-best-execution/social.md
+++ b/docs/blog/finance/12-builder-codes-best-execution/social.md
@@ -1,0 +1,30 @@
+# Social & Image — Builder Codes and Best Execution
+
+## X (Twitter)
+
+A builder fee is a real, additive cost — it stacks on top of the venue's fee. That makes it MORE demanding of disclosure than PFOF, not less. The mechanism isn't virtuous because of what it is, but because of how it's shown. A best-execution read. 🔗 <link> #BestExecution #PFOF
+
+## LinkedIn
+
+You've spent a career policing one tension: the intermediary earns in a way the client can't see, and that revenue can pull against best execution. Payment for order flow is the canonical case — commission-free trades funded by a payment buried behind the quote.
+
+Builder codes are a newer, on-chain version of the same question. When an app helps place a trade on a public venue, it can attach a code that earns a builder fee. This advanced briefing holds that construct up against best-execution and MiFID-style cost-disclosure frameworks — honestly.
+
+It covers:
+
+- What a builder fee is: additive, attribution-not-intermediation, capped
+- The honest PFOF comparison — and why a hidden builder fee would be worse, because it's additive rather than spread-embedded
+- Why the mechanism earns its defensibility only through disclosure, shown as its own line before the client signs
+- Controls: disclose what you control exactly, admit what you don't, fail loud on a misconfigured cap, never strand the client to protect a fee
+
+Educational only; not investment, legal, or regulatory advice.
+
+Where should the line sit between sanctioned attribution and a conflict that compromises best execution?
+
+🔗 <link>
+
+#BestExecution #PFOF #CostTransparency #MiFID #Compliance
+
+## Image prompt (Gemini / Nano Banana)
+
+A restrained, institutional editorial illustration for a 16:9 banner: a precise balance scale where one pan holds a single clearly-illuminated coin sitting fully in the open — nothing hidden — evoking a fee disclosed in plain sight rather than buried. Deep navy and teal base palette with one warm amber accent on the illuminated coin. Clean modern geometry, a sense of transparency and fair measurement, soft directional lighting, generous negative space, sophisticated and understated — not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/13-programmatic-compliance-travel-rule/blog.md
+++ b/docs/blog/finance/13-programmatic-compliance-travel-rule/blog.md
@@ -1,0 +1,73 @@
+# Compliance as Code: On-Chain Screening, KYC/AML Programs, and the Travel Rule
+
+*What a contract-level sanctions gate can and cannot do — and where it fits inside a real compliance program*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Compliance, Disclosure & Governance |
+| **Level** | Advanced |
+| **Audience** | Compliance officers, BSA/AML program leads, fintech risk and product managers, general counsel |
+| **Tags** | `sanctions`, `KYC-AML`, `travel-rule`, `screening`, `controls` |
+| **Reading time** | ~9 minutes |
+
+> **Informational, not advice.** This briefing is educational. It is not legal, regulatory, or compliance advice, and it does not describe a regulated money-services program. Sanctions and AML obligations vary by jurisdiction and are evolving; consult qualified counsel for your own facts.
+
+## The control that lived in the wrong place
+
+Imagine reviewing a peer-to-peer platform's compliance posture. On paper it screens users: when a customer connects, the interface checks their wallet address against the sanctions list and refuses to proceed if there's a hit. The Terms of Service describe this as a control. The screen even renders a tidy "blocked" state. As a compliance reviewer, you ask the question that decides whether this is a control or a decoration: *what happens if a sanctioned party never loads your interface?*
+
+On a public blockchain, the settlement logic is directly reachable. Anyone with a script can call the contracts without ever touching the website. A screen-only check is a suggestion, not an enforcement point. And US sanctions exposure is effectively **strict liability** — intent and interface design don't rescue you if prohibited property was accepted. So the compliance-relevant question is never "does the app screen?" It is "where does enforcement actually bind, and can it be routed around?"
+
+This is the lens for understanding *programmatic compliance*: pushing a specific, narrow control — sanctions and blocklist screening — down to the layer where value actually moves, so it cannot be bypassed. It is powerful and genuinely useful. It is also frequently oversold. The honest version distinguishes carefully between what address screening does and what a full KYC/AML program does, because they are not substitutes.
+
+## The traditional model
+
+In a regulated financial institution, sanctions screening is one component of a broader Bank Secrecy Act / anti-money-laundering (BSA/AML) program. That program rests on several pillars: a written program with board-level ownership; **Customer Identification and Customer Due Diligence** (CIP/CDD) — you verify *who* the customer is; ongoing transaction monitoring; sanctions screening of parties and transactions against lists such as OFAC's Specially Designated Nationals; suspicious-activity reporting; recordkeeping; and independent testing. Screening is the gate; identity verification, monitoring, and reporting are the rest of the house.
+
+Layered on top for value transfers is the **FATF travel rule** (FATF Recommendation 16). It requires that originator and beneficiary information — names, account identifiers, and often address or identifier details — travel *with* a qualifying transfer between the institutions on each end. It exists so that the sending and receiving institutions can each screen the counterparty and reconstruct a payment's parties after the fact. Crucially, the travel rule is an obligation on **regulated intermediaries** (banks, and, in the crypto context, "virtual asset service providers"). It presumes there is an intermediary who takes custody and holds identity data to pass along.
+
+## What changes on-chain
+
+A contract-level screening control collapses the gate into the settlement path itself. Instead of a website consulting a list and *asking* the system to stop, the settlement logic consults a shared screening component on every entry point where money moves in — and simply refuses to complete a transaction from a listed address. Because the check lives with the money, skipping the interface skips nothing.
+
+Three properties are worth a compliance reader's attention.
+
+**Fail-closed by design.** A well-built on-chain gate treats an unavailable or malformed answer from its screening source the same as a hit: it blocks. If the sanctions data source can't give a clean, well-formed "yes" or "no," the safe posture is to deny rather than wave everyone through. This is the on-chain analogue of a control that defaults to "hold" when the screening system is down — the opposite of the fail-open behavior that quietly creates exposure.
+
+**A built-in, immutable audit trail.** The screening source combines a public on-chain sanctions oracle (a service that answers, for any address, whether it appears on the US Treasury list) with a discretionary operator blocklist for addresses tied to illicit finance beyond the official set. Every blocklist change — who made it, which address, in which direction, and a human-readable reason — is written permanently to the chain. There is no separate compliance database to reconcile or lose; the event log *is* the record. For anyone who has assembled evidence for an exam or a lookback, an immutable, timestamped change history is a real operational advantage.
+
+**Gate entry, never exit.** A deliberate and defensible line: entry paths (putting value in, creating or accepting a position) are screened; exit paths (claiming a refund or a payout already owed) are not. If an address is listed *after* its stake is already in escrow, screening the exit would trap those funds — converting a screening control into a *de facto* asset freeze, a heavier and legally distinct act that would make the contract a custodian of blocked property. Refusing new business is not the same as freezing existing property, and conflating the two is a common design error.
+
+## Where it genuinely differs — address screening is not identity KYC
+
+Here is the distinction a compliance professional must hold firmly, because marketing language routinely blurs it.
+
+**Address screening answers "is this address on a list?" It does not answer "who is this person?"** A contract gate checks a wallet against sanctions and blocklists. It performs no identity verification, no beneficial-ownership analysis, no CDD, no sanctions screening of a *name* behind the address, and no ongoing behavioral monitoring. A newly created wallet with no listing history passes trivially — it is clean *as an address* while being completely unknown *as a person*. Address screening is necessary but nowhere near sufficient for a program that must actually know its customer.
+
+This also reframes the **travel rule** honestly. The travel rule is about intermediaries exchanging identity data about the parties to a transfer. A non-custodial, peer-to-peer settlement layer where users hold their own keys and the platform never takes custody sits differently from a custodial VASP in most current frameworks — but "differently" is not "exempt," classification is jurisdiction-specific and unsettled, and regulators are actively extending travel-rule expectations into crypto. The correct posture is not to claim the rule doesn't apply; it is to recognize that a screening gate does not *satisfy* the travel rule, because the gate transmits no originator/beneficiary identity information at all. These are different controls addressing different obligations.
+
+## Risk & controls
+
+- **Oracle/data-source risk.** The on-chain sanctions oracle is a centralized, permissioned feed taken as ground truth. Mitigations are structural, not trustless: the gate only reads from it, the source can be replaced if compromised or retired, and the operator blocklist keeps working even if the oracle is unset. No decentralized sanctions feed exists; pretending otherwise helps no one.
+- **List-coverage risk.** Sanctions lists change; on-chain oracles update on their own cadence; addresses are added faster than any list captures. Screening reduces exposure to *known* listed addresses. It does nothing about a sanctioned party operating through a fresh, unlisted wallet — the residual risk that only real identity diligence addresses.
+- **Availability vs. exposure.** Fail-closed means a screening-source outage can halt entry across the platform until an operator restores or reconfigures it. That downtime is the accepted cost: a recoverable outage beats a strict-liability violation.
+- **Program completeness.** The largest risk is treating the gate as the whole program. Address screening is one layer among many a serious operation still needs — jurisdictional geo-controls, versioned legal terms with recorded consent, and, where the activity and jurisdiction require it, actual identity verification and monitoring. Defense in depth, not defense in one place.
+
+## How FairWins approaches this
+
+FairWins treats sanctions screening as a shared, fail-closed building block enforced inside the contracts rather than in the interface. A single screening component — the public sanctions oracle plus an operator-maintained, fully audit-logged blocklist — is consulted at every entry point where value moves: creating and accepting wagers (both sides are re-screened at acceptance), buying or extending memberships, joining pools, and issuing tokens. The interface still checks first for fast feedback, but the enforcement layer is the one no one can route around. Exit paths are intentionally never gated, so a mid-position listing can't strand funds. FairWins is explicit that this is *address* screening, not identity KYC, and that participants remain fully subject to applicable law — the gate is a genuine control, not a complete compliance program.
+
+> **Informational, not advice.** Nothing here is a determination that any particular activity is or isn't subject to the travel rule, VASP registration, or any AML obligation. Those are facts-and-jurisdiction questions for qualified counsel.
+
+## Related deep-dive
+
+For the engineering details, see [Sanctions Screening as a Shared Building Block](../../posts/03-sanctions-compliance-gating/blog.md).
+
+## Further reading
+
+- FATF Recommendations and the travel rule (Recommendation 16): https://www.fatf-gafi.org/en/publications/Fatfrecommendations/Fatf-recommendations.html
+- FATF guidance on virtual assets and VASPs: https://www.fatf-gafi.org/en/publications/Fatfrecommendations/Guidance-rba-virtual-assets-2021.html
+- US Treasury OFAC sanctions programs and the SDN List: https://ofac.treasury.gov/sanctions-list-service
+- FFIEC BSA/AML Examination Manual (program pillars, CDD, sanctions): https://bsaaml.ffiec.gov/manual
+- Investopedia, "Know Your Client (KYC)": https://www.investopedia.com/terms/k/knowyourclient.asp

--- a/docs/blog/finance/13-programmatic-compliance-travel-rule/social.md
+++ b/docs/blog/finance/13-programmatic-compliance-travel-rule/social.md
@@ -1,0 +1,26 @@
+# Social & Image — Compliance as Code: On-Chain Screening, KYC/AML Programs, and the Travel Rule
+
+## X (Twitter)
+A screen-only sanctions check on a public chain is a suggestion, not a control — anyone can call the contract directly. But address screening still isn't identity KYC, and it doesn't satisfy the FATF travel rule. What each control actually does 👇 🔗 <link>
+#Compliance #AML #SanctionsScreening
+
+## LinkedIn
+Sanctions screening is one pillar of a BSA/AML program — not the whole house. On a public blockchain, that distinction gets sharp fast: if your screening check lives only in the website, a sanctioned party who never loads your interface walks right past it, because the settlement contracts are directly callable. US sanctions exposure is effectively strict liability, so "where does enforcement actually bind?" is the only question that matters.
+
+This Advanced briefing works through the compliance reality of on-chain screening:
+
+- Why a contract-level gate must be fail-closed — deny when the data source can't give a clean answer
+- Why entry is screened but exit never is (screening a held position becomes a de facto asset freeze)
+- The distinction professionals must hold: address screening answers "is this address listed?", not "who is this person?" — it is not identity KYC
+- Why a screening gate does not satisfy the FATF travel rule, which is about intermediaries exchanging originator/beneficiary identity data
+
+Honest throughout about limits, and explicitly not legal advice.
+
+🔗 <link>
+
+How are you drawing the line between address screening and true CDD in your own crypto risk framework?
+
+#Compliance #AML #KYC #TravelRule #RegTech
+
+## Image prompt (Gemini / Nano Banana)
+A restrained, institutional editorial illustration for a 16:9 banner: a single secure gate or turnstile set into a long transparent glass wall, symbolizing a control that binds at the settlement layer rather than the surface — figures and value flows can only pass through the one gate, none around it. Deep navy and teal base palette with a single warm amber accent light on the gate mechanism, clean modern vector style, soft directional lighting, sophisticated and understated, not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/14-fee-transparency-cost-disclosure/blog.md
+++ b/docs/blog/finance/14-fee-transparency-cost-disclosure/blog.md
@@ -1,0 +1,66 @@
+# Ex-Ante Cost Disclosure, Made Mechanical: A MiFID-II Lens on On-Chain Fees
+
+*One auditable rate source, hard caps, and the exact cost shown before you approve — cost transparency as an enforced property rather than a policy*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Compliance, Disclosure & Governance |
+| **Level** | Intermediate |
+| **Audience** | Compliance officers, product managers, cost-transparency and best-execution leads, fintech operators |
+| **Tags** | `fees`, `cost-disclosure`, `MiFID-II`, `transparency`, `governance` |
+| **Reading time** | ~7 minutes |
+
+> **Informational, not advice.** This briefing is educational, not legal, regulatory, or investment advice, and it does not assert that any FairWins mechanism is a MiFID-regulated service. Fees are real costs; regulatory treatment varies by jurisdiction.
+
+## The review that fees usually fail
+
+Picture a product or compliance review of a fee schedule. You ask three questions that any cost-disclosure regime — and any honest one — should be able to answer. First: *where does the number the customer sees actually come from, and is it the same number the system charges?* Second: *can the fee change between the moment we quote it and the moment we execute?* Third: *what stops the rate from being raised without limit or without a record?*
+
+In a lot of systems, the honest answers are uncomfortable. The quoted rate is a constant hardcoded in the app; the charged rate lives in a server config; and a third copy sits in the billing code. Three copies of one number, three owners, three release cadences. Someone updates one and forgets the others, and a customer approves a screen reading 0.50% while the system bills 0.60%. That isn't a cosmetic bug — it is the exact failure mode cost-transparency rules were written to prevent.
+
+## The traditional model: MiFID-II ex-ante disclosure
+
+European investment-services regulation — the second Markets in Financial Instruments Directive, **MiFID II** — codified a principle worth borrowing regardless of where you operate: **ex-ante cost disclosure**. Before a client is bound, the firm must disclose the *aggregated* costs and charges of the service and the product, in cash and percentage terms, so the client sees the full cost of the transaction *before* deciding — not reconstructed from a statement weeks later. The regime also pushes against **hidden costs**: charges buried in a spread, embedded in a "free" product, or disclosed only in aggregate where a line item was warranted. The spirit is simple and demanding: the customer should see the real, all-in cost, itemized, up front.
+
+Most fee disclosure is a *policy* — a commitment, honored by process and goodwill, that the number shown matches the number charged. The interesting question for an on-chain system is whether that policy can be made a *property*: something the mechanism itself enforces, so the shown number and the charged number cannot drift apart even if someone wanted them to.
+
+## What changes on-chain
+
+Three moves turn the disclosure policy into an enforced property.
+
+**One auditable rate source.** Every fee the platform can charge lives as a single entry on one on-chain price list, labeled by what it is for. That list is the *only* place any rate lives. The application reads the live rate directly from it to render the disclosure; the charging step reads the same entry to bill. There is no second copy in a server config or a client constant to fall out of sync. When the single source of truth is also the source the interface quotes and the source the charge honors, the "three copies" failure mode simply cannot occur.
+
+**Hard caps, fixed at creation.** Each entry carries not just a current rate but a permanent ceiling set when the entry is created — a maximum no one, including an administrator, can raise. An admin can move the current rate up and down beneath the ceiling; the ceiling itself is immutable. For fees the platform charges directly there is also an absolute company-wide limit (a low single-digit percentage) that no entry can exceed. A cap that can't be lifted is a very different promise from a cap written in a policy document.
+
+**A consent ceiling that closes the timing gap.** This is the elegant part, and it maps directly onto a best-execution instinct. Before a customer signs, the app reads the live rate and shows it. When the customer approves, *that exact rate they saw* travels with the transaction as a ceiling. If an administrator raises the rate while the transaction is in flight, the customer either pays no more than what the screen showed, or the transaction stops and they review again. The confirmation screen stops being a courtesy or a best guess and becomes a limit the system enforces. The disclosure is no longer a statement about the price — it *is* the price ceiling.
+
+## Where it genuinely differs
+
+**Better:** the number-you-see-equals-the-number-you-pay guarantee is mechanical, not procedural. In a conventional stack, "we always show the real cost" depends on three teams keeping three numbers aligned; here, there is one number, and the act of charging re-reads and re-checks it. The rate-change history is a permanent, public event log — who changed what, when — so the audit trail is a byproduct of the system rather than a separate report that can be edited or lost. And a rate that rounds down to nothing on a small amount is charged as zero: rounding is biased, deliberately, toward the customer.
+
+**Different, and worth stating plainly:** the immutable cap cuts both ways. Because a ceiling can never be raised, a ceiling set wrong can't be edited — only abandoned in favor of a fresh entry. That rigidity is precisely the price of a ceiling a customer can rely on. And an on-chain price list governs *the platform's own* fee. It does not, and cannot, absorb every cost a transaction bears — network gas, or a third-party venue's own fee, are separate costs that must be disclosed on their own terms rather than folded silently into one figure. Honest aggregation means showing each real cost as its own line, not collapsing distinct costs into a single friendly percentage.
+
+## Risk & controls
+
+- **Governance risk (rate changes).** The power to move rates beneath the cap is an administrative privilege. The controls that fence it: a permanent per-entry ceiling, an absolute company-wide cap, role separation between who can change a rate and who can register a new entry, and a public change log. The admin gets one convenient screen; the customer gets guarantees anyone can verify.
+- **Configuration / availability risk.** Two safe-by-default behaviors matter. If a network was never set up with a treasury to receive fees, the system skips the fee and completes the transaction — a setup mistake costs the platform revenue, never the customer their funds. And if the live rate can't be read on a network that *should* have one, the fee-bearing action stops rather than proceeding on a possibly understated rate. Fail safe, not fail open. Exit paths (withdrawals) are never gated by a fee lookup.
+- **Atomicity risk.** For fees charged directly, the fee and the delivery of value happen in one all-or-nothing transaction: if any leg fails, the whole thing reverts, so the treasury can never keep a fee for a transaction that didn't complete.
+- **Disclosure-completeness risk.** The residual risk is treating the platform-fee line as the *whole* cost. Where other real costs exist, honest ex-ante disclosure requires each to appear as its own line — never one figure standing in for several.
+
+## How FairWins approaches this
+
+FairWins routes every configurable platform fee through a single on-chain price list — one source of truth, each entry carrying a permanent cap and a low absolute company-wide ceiling for fees it charges directly. Every fee-bearing confirmation shows a clearly named platform-fee line with the live percentage, the absolute amount, and the net amount reaching the service, before any signature; a zero rate shows no fee line and behaves exactly as the pre-fee flow did. The quoted rate travels with the transaction as an enforced ceiling, so a customer can never be charged above what they saw. Where a cost is genuinely additive and separate — a third-party trading venue's own fee, for instance — FairWins discloses it as its own line rather than hiding it or calling it "free." One important, honest note: the platform's yield-earning feature currently charges no FairWins platform fee at all — so it shows no fee line, and no fee is taken.
+
+> **Informational, not advice.** Cost disclosure here is a design property, not a representation of regulatory compliance with MiFID II or any other regime; those obligations depend on your jurisdiction and activity.
+
+## Related deep-dive
+
+For the engineering details, see [One Place for Every Fee](../../posts/22-fee-router/blog.md).
+
+## Further reading
+
+- ESMA on MiFID II costs and charges disclosure: https://www.esma.europa.eu/policy-rules/mifid-ii-and-investor-protection
+- Investopedia, "MiFID II": https://www.investopedia.com/terms/m/mifid-ii.asp
+- Investopedia, "Total Expense Ratio (TER)" — an example of aggregated cost disclosure: https://www.investopedia.com/terms/t/ter.asp
+- ERC-4626: Tokenized Vaults — the shared standard behind the yield feature referenced above: https://eips.ethereum.org/EIPS/eip-4626

--- a/docs/blog/finance/14-fee-transparency-cost-disclosure/social.md
+++ b/docs/blog/finance/14-fee-transparency-cost-disclosure/social.md
@@ -1,0 +1,26 @@
+# Social & Image — Ex-Ante Cost Disclosure, Made Mechanical: A MiFID-II Lens on On-Chain Fees
+
+## X (Twitter)
+MiFID-II asks you to show the all-in cost before a client is bound. Most fee stacks keep 3 copies of the number — app, server, billing — and let them drift. What if the quoted rate IS the enforced ceiling, and the charge re-reads the same source? 🔗 <link>
+#CostDisclosure #MiFIDII #Fintech
+
+## LinkedIn
+MiFID II codified a principle worth borrowing everywhere: ex-ante cost disclosure — the client sees the real, all-in cost before being bound, not reconstructed from a statement weeks later. The hard part isn't the policy; it's making the number you show equal the number you charge, every time.
+
+Most systems keep three copies of a fee rate — in the app, in a server config, in the billing code — owned by three teams on three release cadences. One drifts, and a customer approves 0.50% while the system bills 0.60%.
+
+This Intermediate briefing looks at turning cost disclosure from a policy into an enforced property:
+
+- One auditable, on-chain rate source — the same entry the app quotes and the charge honors
+- Hard caps fixed at creation that no admin can raise, plus a company-wide ceiling
+- A consent ceiling: the rate you saw travels with the transaction, so you can never be charged above it
+- Honest aggregation — additive third-party costs shown as their own line, never called "free"
+
+🔗 <link>
+
+How do you keep quoted and charged costs from drifting in your own product?
+
+#CostDisclosure #MiFIDII #Compliance #Fintech #Transparency
+
+## Image prompt (Gemini / Nano Banana)
+A restrained, institutional editorial illustration for a 16:9 banner: a single elegant price tag or ledger line locked behind a transparent glass panel with a fixed ceiling bar above it that cannot be pushed higher — conveying one source of truth and an immovable cap. Deep navy and teal base palette with a single warm amber accent on the ceiling bar, clean modern vector style, soft directional lighting, sophisticated and understated, not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/15-confidentiality-public-ledger-mnpi/blog.md
+++ b/docs/blog/finance/15-confidentiality-public-ledger-mnpi/blog.md
@@ -1,0 +1,86 @@
+# Confidential Terms, Transparent Settlement: Privacy on a Public Ledger
+
+*Protecting legitimate competitive intelligence while settling on an open chain — compared with bilateral OTC and dark pools, and where the information-barrier line sits*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Compliance, Disclosure & Governance |
+| **Level** | Advanced |
+| **Audience** | Compliance officers, buy-side risk and desk heads, general counsel, market-structure and product leads |
+| **Tags** | `confidentiality`, `market-structure`, `MNPI`, `information-barriers`, `settlement` |
+| **Reading time** | ~9 minutes |
+
+> **Informational, not advice.** Educational only — not legal, compliance, or investment advice. Confidentiality protects legitimate competitive intelligence, not misconduct. Participants remain fully subject to securities laws, insider-trading rules, and their firms' policies. Regulatory treatment varies by jurisdiction and is unsettled.
+
+## A wager two competitors can't make in public
+
+Two professionals — say a derivatives desk head at one fund and a structured-products lead at a competitor — have known each other for years. Reviewing the same public filings and analyst reports everyone else can see, they land on opposite convictions about whether a widely covered merger clears regulatory review before quarter-end. Both want to back their view with real money.
+
+A public prediction market is out instantly. One side's position would signal her fund's broader pharma-consolidation thesis; the other can't broadcast a view to his own trading floor; neither wants the reputational exposure of a named bet between competitors. The concern isn't hiding anything improper — it's protecting legitimate competitive intelligence, exactly the way a desk protects its positioning from being read off a public tape. They could paper a bilateral agreement, but that means lawyers, an escrow arrangement, and the uncomfortable question of what happens if the loser simply refuses to pay.
+
+What they want is a familiar thing in an unfamiliar venue: **a private agreement with public enforceability.** Terms only they can see; settlement neither can escape. The tension is that public blockchains are radically transparent — the property that makes settlement trustless is the same property that would broadcast their thesis to every competitor watching the chain.
+
+## The traditional model: how markets already hide size and intent
+
+Financial markets have spent decades engineering *confidentiality without abandoning enforceability*. Two reference points matter here.
+
+**Bilateral OTC.** Over-the-counter trades — swaps, forwards, negotiated blocks — are struck privately between two parties, typically under master agreements (an ISDA framework, for instance). Terms are confidential to the counterparties. The cost is precisely what our two professionals want to avoid: **counterparty credit risk**. A private promise is only as good as the loser's willingness and ability to pay, which is why OTC relationships lean on collateral, netting, and legal recourse.
+
+**Dark pools.** Venues that let institutions execute large orders without displaying pre-trade quotes to the public book, so a big order doesn't move the price against the trader before it fills. The trade prints *after* execution; pre-trade intent stays dark. **Suppressing pre-trade information to protect a large or sensitive position** is a recognized, legitimate market-structure tool, not an inherently suspect one.
+
+Both show the same idea our professionals need: confidentiality of *terms and intent* is a normal, lawful feature of institutional markets. What's been hard is combining that confidentiality with *guaranteed* settlement — without a trusted intermediary holding either the secret or the money.
+
+## What changes on-chain
+
+On a transparent chain, confidentiality is engineered rather than assumed, and the technique is one treasury and security professionals already know by name: **envelope encryption**, the same pattern enterprise cloud and secure-messaging systems use.
+
+The mechanics, in the reader's terms: the agreement's terms are encrypted once with a single random key. That key is then separately re-wrapped for each participant using a keypair derived from their own wallet — so each party can open the terms independently, and no central service ever holds a master key. The encrypted bundle lives off-chain on decentralized storage; the chain holds only a small pointer to it plus the enforcement essentials — who the parties are, how much is escrowed, timing. Escrow and automatic settlement handle the money.
+
+The result splits cleanly into what the world sees and what only the counterparties know:
+
+- **Public on-chain:** two wallet addresses, the stake amounts, the status and timestamps, and a reference to the encrypted terms. Enough to enforce, and no more.
+- **Private to the participants:** the actual question, the resolution criteria, the deadline, any custom terms. A competitor watching the chain sees a locked position between two addresses — not the thesis behind it.
+
+This is dark-pool logic generalized: pre-settlement *intent and terms* are dark, while settlement itself is public and guaranteed. And it removes the OTC weakness in the same stroke — because both stakes are escrowed the moment the agreement binds, there is no counterparty credit risk left to manage. Settlement becomes a question of outcome, not of the loser's goodwill.
+
+## Where it genuinely differs
+
+**Better than bilateral OTC on credit risk.** The classic OTC exposure — will the loser pay? — is eliminated by pre-funded escrow, not merely mitigated by collateral schedules and legal recourse.
+
+**Different from dark pools in what stays hidden.** A dark pool hides pre-trade quotes but still reports the executed trade to the market and its regulator. Here, the *terms* stay encrypted indefinitely, while the *fact* of a position, its size, and its parties' addresses are permanently public. That is a different confidentiality profile — arguably more private on content, arguably less private on the existence and counterparties of the position — and professionals should understand the trade rather than assume it maps onto either reference point exactly.
+
+**Durability of the secret.** Because the encrypted terms may stay sensitive for years, a serious implementation defends against "harvest now, decrypt later" — an adversary recording ciphertext today to break with a future quantum computer — by using a hybrid scheme pairing today's proven encryption with a quantum-resistant one. Competitive intelligence doesn't always expire on schedule; the encryption shouldn't either.
+
+## The line that matters: confidentiality is not a cover for misconduct
+
+This is the section a compliance reader should weigh most carefully, because the same privacy that protects a legitimate desk position could be *imagined* as cover for something it must never be.
+
+**Information barriers exist to keep material non-public information (MNPI) from crossing into trading decisions.** MNPI is information that is both material and not public — earnings ahead of release, a deal not yet announced, anything a reasonable investor would want that the market doesn't yet have. Trading on it, or passing it to someone who does, is insider dealing. Firms build "Chinese walls" — information barriers between, say, an advisory team that holds MNPI and a trading desk that must not.
+
+Confidential settlement does nothing to change that line, and it is essential to say so plainly. Encrypting the *terms of a bet made on public information* protects competitive intelligence — a legitimate interest. It does not launder a bet made on *non-public* information into something permissible. The two professionals in the scenario are on opposite sides of a public, well-covered question, reasoning from filings anyone can read; that is skill-based forecasting, not trading on a secret. Privacy protects the analysis, not the existence of a legal basis for the trade. A participant sitting on MNPI is in exactly the same legal jeopardy encrypted or not — the encryption is irrelevant to the violation, and no honest description of this technology should suggest otherwise.
+
+## Risk & controls
+
+- **Compliance / conduct risk.** The dominant risk is not technical. A confidential-terms venue must be used to protect legitimate competitive intelligence only; participants remain fully subject to insider-trading law and firm policy. This is a use-governance question, not an encryption one.
+- **Key-management risk.** Access is derived from each participant's own wallet, and the platform never holds a master key. That removes central-key-custody risk but places the burden on wallet security: lose control of the wallet and you lose control of the confidential access. Standard key-hygiene and recovery discipline apply.
+- **Metadata leakage.** Terms are encrypted, but the *existence* of a position, its size, its timing, and the parties' addresses are permanently public. Observers can sometimes infer meaning from metadata and timing alone — confidentiality of content is not anonymity of activity.
+- **Resolution and durability.** A private agreement still needs a trustworthy way to settle: pegging to an independent public market or a designated neutral arbitrator removes reliance on either party's self-attestation, but inherits that source's own risk. And the off-chain encrypted data must remain retrievable for the life of the agreement — the on-chain pointer is only useful if the referenced content persists.
+
+## How FairWins approaches this
+
+FairWins lets counterparties keep the *terms* of a peer-to-peer agreement confidential while settling on a public chain. Terms are encrypted once and re-wrapped per participant from wallet-derived keys, so no central service ever holds a master key; the encrypted bundle sits off-chain with only a small reference and the enforcement essentials on-chain. Stakes are escrowed on binding, removing counterparty credit risk, and settlement can be pegged to an independent public outcome or a neutral arbitrator rather than either party's word. The encryption uses a post-quantum hybrid scheme against harvest-now-decrypt-later exposure. FairWins is explicit on the boundary: this protects competitive intelligence and trading strategy, never material non-public information or any circumvention of securities law — participants remain fully subject to applicable law and their own professional obligations.
+
+> **Informational, not advice.** Nothing here endorses using confidentiality to trade on MNPI or evade disclosure or reporting duties, and none of it is legal or compliance advice.
+
+## Related deep-dive
+
+For the engineering details, see [Private Prediction Markets: Confidential Terms with Trustless Settlement](../../posts/18-envelope-encryption/blog.md).
+
+## Further reading
+
+- Investopedia, "Dark Pool": https://www.investopedia.com/terms/d/dark-pool.asp
+- Investopedia, "Over-the-Counter (OTC)": https://www.investopedia.com/terms/o/otc.asp
+- Investopedia, "Material Nonpublic Information (MNPI)": https://www.investopedia.com/terms/m/materialinsiderinformation.asp
+- IOSCO principles on dark liquidity: https://www.iosco.org/library/pubdocs/pdf/IOSCOPD353.pdf
+- NIST post-quantum cryptography standards (ML-KEM): https://csrc.nist.gov/projects/post-quantum-cryptography

--- a/docs/blog/finance/15-confidentiality-public-ledger-mnpi/social.md
+++ b/docs/blog/finance/15-confidentiality-public-ledger-mnpi/social.md
@@ -1,0 +1,24 @@
+# Social & Image — Confidential Terms, Transparent Settlement: Privacy on a Public Ledger
+
+## X (Twitter)
+Dark pools hide pre-trade intent. OTC hides terms but keeps counterparty credit risk. What if you could hide the terms AND escrow settlement on a public chain — while the MNPI line stays exactly where it was? 🔗 <link>
+#MarketStructure #Compliance #Privacy
+
+## LinkedIn
+Institutional markets have hidden size and intent for decades — dark pools suppress pre-trade quotes; bilateral OTC keeps terms confidential to the counterparties. The unsolved part was combining that confidentiality with guaranteed settlement, without a trusted intermediary holding either the secret or the money.
+
+On a radically transparent public chain, confidentiality has to be engineered — via envelope encryption, the same pattern enterprise cloud systems use. This Advanced briefing maps it onto the market structure professionals already know:
+
+- What stays public (addresses, size, timing) vs. private (question, criteria, terms)
+- Why pre-funded escrow removes the OTC counterparty-credit-risk weakness entirely
+- How the confidentiality profile differs from a dark pool — more private on content, less on the position's existence
+- The line that matters most: privacy protects legitimate competitive intelligence, never MNPI — the information-barrier boundary is unchanged, and encryption is irrelevant to an insider-trading violation
+
+🔗 <link>
+
+Where would confidential-but-enforceable settlement fit — or not fit — in your market-structure thinking?
+
+#MarketStructure #Compliance #MNPI #Privacy #Settlement
+
+## Image prompt (Gemini / Nano Banana)
+A restrained, institutional editorial illustration for a 16:9 banner: a sealed wax-stamped envelope resting on a transparent glass settlement rail, the envelope opaque while the rail beneath it is clear and lit — confidential content above, transparent settlement below. Deep navy and teal base palette with a single warm amber accent on the wax seal, clean modern vector style, soft directional lighting, sophisticated and understated, not flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/16-operational-risk-upgradeable-systems/blog.md
+++ b/docs/blog/finance/16-operational-risk-upgradeable-systems/blog.md
@@ -1,0 +1,70 @@
+# Who Can Change the Rules: Operational Risk in Upgradeable Systems
+
+*Change-management, key governance, and the trade-off between immutability and the ability to fix — read as operational and governance risk*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Compliance, Disclosure & Governance |
+| **Level** | Advanced |
+| **Audience** | Risk managers, operations and compliance leads, allocators conducting operational due diligence |
+| **Tags** | `operational-risk`, `governance`, `change-management`, `key-management`, `upgradeability` |
+| **Reading time** | ~9 minutes |
+
+---
+
+You are running operational due diligence on a platform that holds client value in a set of smart contracts. The investment thesis is fine. Your job is the boring, decisive part: **who can change the rules after you have committed capital, by what process, and what stops them from doing it badly?** In a traditional operational-risk review this is familiar terrain — you would ask about the change-advisory board, segregation of duties, the four-eyes principle on production releases, privileged-access management, and the vendor's SOC 2 report. On-chain, the same questions have sharper, more literal answers, because "change the rules" can mean "replace the exact code that holds the escrow." This briefing maps that terrain in the vocabulary you already use.
+
+## The traditional model
+
+In a conventional financial system, the ledger and the software that runs it are two different things, and both are mutable. Balances are database rows an administrator with sufficient privilege can edit. The code is deployed and re-deployed on a release cadence. Control does not come from the technology being unchangeable — it comes from **layered process**: a change-advisory board that approves releases, separation between the person who writes a change and the person who deploys it, immutable audit logs, privileged-access management with break-glass procedures, and an external auditor who tests that those controls actually operated over a period (the substance of a SOC 2 Type II report). The risk you are underwriting is process risk: that a privileged insider, or someone who compromised a privileged credential, pushes a harmful change and the controls fail to catch it.
+
+## What changes on-chain
+
+Two things invert. First, the ledger becomes genuinely immutable — no administrator can edit a balance or reverse a settled transaction. That removes a whole category of insider risk at the record-keeping layer. Second, the *code* was historically immutable too, which sounds like a control paradise until you need to fix a bug. A contract you cannot change is a contract you cannot patch: a discovered flaw is permanent, and the only "fix" is to deploy a brand-new contract at a new address and somehow migrate everyone — abandoning the old one, which is still sitting there holding real money.
+
+So most serious platforms adopt **upgradeability**: a permanent public address (a "proxy") that never changes, sitting in front of swappable logic behind it. The address your users, your app, and the block explorer all reference stays fixed; the code executing behind it can be replaced. This is the single most important governance fact about any such system, and it is where your due-diligence attention belongs. Immutability at the record layer is a genuine improvement over an editable database. Mutability at the *code* layer reintroduces exactly the insider/change-management risk you know from TradFi — now concentrated into a specific, auditable question: **who holds the upgrade key, and what governs its use?**
+
+## Where it genuinely differs
+
+Three differences are worth stating honestly — some better, some worse, some just different.
+
+**Better: the powers are enumerable and the record is public.** In a bank you infer the control environment from an auditor's attestation. On-chain, the privileged roles are declared in the code and every use of them emits a public, timestamped event anyone can inspect forever. You are not taking the operator's word that a pause happened or that the treasury address changed — the chain is the log, and it cannot be quietly rewritten. That is a stronger evidentiary position than most operational-risk reviewers ever get.
+
+**Worse (or at least starker): key compromise is more consequential and less reversible.** If the credential controlling upgrades is stolen, an attacker can replace the logic that holds the escrow, and there is no clearing house, no chargeback, no regulator to unwind the trade. The blast radius of a single compromised privileged key is larger and the recovery options are thinner than in a system with settlement finality you can litigate. This is the central operational risk of any upgradeable on-chain system, and no amount of clever architecture eliminates it — it can only be *bounded* and *governed*.
+
+**Different: "immutable" and "upgradeable" are opposite promises, chosen deliberately per component.** A well-run platform does not treat this as one global switch. Some components are intentionally left un-upgradeable because permanence is the feature; others are made upgradeable because the ability to ship a security fix outweighs the promise of frozen code. Expect the operator to tell you, component by component, which choice they made and why.
+
+## Risk & controls: what a professional should check
+
+Read an upgradeable system the way you would read a privileged-access and change-management review. The controls that matter:
+
+**Segregation of duties across roles.** The mature pattern splits privileged power into several narrow roles so no single key carries blanket authority. In FairWins' case, for example, the ability to *pause* new activity in an incident, the ability to *freeze* an individual account under a moderation policy, the ability to *grant memberships*, the ability to *configure parameters* (prices, allowed tokens, the treasury address), and the ability to *replace contract logic* are five different roles held by different custodians. A guardian can halt the protocol but cannot seize an account; a moderator can freeze an account but cannot move funds or ship code; the upgrade key can ship code but holds no other privilege. This is the on-chain form of the four-eyes principle and least-privilege access — and critically, **no role can move escrowed stakes or redirect a payout.** That last constraint is the one to verify hardest: privileged power over *policy* is very different from privileged power over *client money*.
+
+**Key custody and signing discipline.** Ask where each key lives. The strong answer separates day-to-day configuration keys from the upgrade key, and holds the upgrade key on air-gapped, offline storage with multi-signature approval — the equivalent of requiring multiple officers and a hardware security module for a production release, not a single admin with a password. A single-signer hot key controlling upgrades is a red flag.
+
+**Change-safety gating.** The most dangerous upgrade error is not malice — it is a botched release that silently corrupts stored records (imagine a code change that shifts where balances are read from). The control is an automated compatibility check that runs before any upgrade can be merged *and* again at the moment of deployment, rejecting any change that would rearrange existing storage. This is your automated change-advisory gate; confirm it exists, that it is mandatory rather than advisory, and that it fails the build loudly rather than being waved through.
+
+**Non-brickability and roll-forward.** A subtle but important property: the upgrade mechanism should be unable to configure itself into a state that permanently locks out *future* upgrades. There is no "undo" for a bad release on-chain — the fix is to upgrade *again* to a corrected version — so the ability to keep fixing must be preserved. The flip side is the honest trade-off: lose the upgrade key and the contract runs forever but can never be patched again.
+
+**The decentralization trajectory.** Finally, ask where governance is *going*. The credible direction is to move admin and upgrade authority behind a **timelock** (a mandatory public delay between an upgrade being announced and taking effect) and/or a broader multisig, so changes carry a public notice window in which users can react or exit. A timelock is the on-chain analogue of a published change freeze and advance notice — it converts "the operator can change the code" into "the operator can change the code, but you will see it coming and can act first." Whether this is live today or a stated roadmap materially changes your risk read; get it in writing.
+
+## How FairWins approaches this
+
+FairWins is a peer-to-peer wager protocol with **no token, no DAO, and no on-chain voting** — its "governance" is precisely the bounded set of operator roles above. Its two core value-bearing contracts sit behind permanent addresses with swappable logic; upgrade authority is a dedicated, air-gapped, offline-signed key held separately from ordinary configuration; storage-compatibility is checked automatically and gates the build; and the upgrade path is non-brickable and roll-forward-only. Powers are split so that a pause halts new activity without freezing settlement — already-active wagers still resolve and remain refundable while a fix ships — and no role, including the upgrade role, can move escrowed stakes or forge a result. The stated trajectory is to place admin and upgrade authority behind a timelock and/or broader multisig before scaling. That is the shape of a defensible answer to "who can change the rules, and how" — and the shape of the answer you should demand from any upgradeable system holding value.
+
+---
+
+*This briefing is educational and informational only. It is not investment, legal, tax, or regulatory advice, and it does not assert that any FairWins mechanism is a regulated product or carries any particular legal status. Regulatory treatment of on-chain systems varies by jurisdiction and is evolving.*
+
+## Related deep-dive
+
+For the engineering details, see [Renovating a Contract Without Changing Its Address](../../posts/11-uups-upgrades-storage-safety/blog.md).
+
+## Further reading
+
+- [BIS/CPMI–IOSCO Principles for Financial Market Infrastructures](https://www.bis.org/cpmi/publ/d101.htm) — governance, operational risk, and access controls for systems that hold value
+- [ISACA / COBIT change-management and privileged-access control guidance](https://www.isaca.org/) — the traditional change-advisory and segregation-of-duties baseline
+- [AICPA SOC 2 overview](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2) — what a third-party controls attestation does and does not cover
+- [OpenZeppelin: upgradeable smart contracts and proxy patterns](https://docs.openzeppelin.com/upgrades-plugins/) — the public tooling behind fixed-address, swappable-logic designs
+- [Timelock controllers, explained](https://docs.openzeppelin.com/contracts/5.x/api/governance#TimelockController) — the delay-and-notice mechanism for privileged changes

--- a/docs/blog/finance/16-operational-risk-upgradeable-systems/social.md
+++ b/docs/blog/finance/16-operational-risk-upgradeable-systems/social.md
@@ -1,0 +1,28 @@
+# Social & Image — Who Can Change the Rules: Operational Risk in Upgradeable Systems
+
+## X (Twitter)
+
+"Who can change the rules after you commit capital?" Upgradeable smart contracts reintroduce classic change-management risk in on-chain form. How to run OpDD on the upgrade key, segregation of duties, and timelocks. 🔗 <link> #OperationalRisk #Governance #DeFi
+
+## LinkedIn
+
+Operational due diligence has always turned on one question: who can change the production system after you've committed, and what governs how? On-chain, that question gets sharper — because "change the rules" can mean "replace the exact code that holds the escrow."
+
+This Advanced briefing reads upgradeable smart contracts through a traditional operational-risk lens:
+
+- Why an immutable ledger is a genuine control win, while mutable *code* reintroduces the insider/change-management risk you already know
+- Segregation of duties on-chain: splitting pause, freeze, configuration, and upgrade authority so no single key holds blanket power — and why "no role can move client funds" is the line to verify hardest
+- Key custody and signing discipline: multisig, air-gapped, offline-signed upgrade keys vs. a single hot key
+- Automated change-safety gating, non-brickability, and the role of timelocks as public advance notice
+
+A clear map from the change-advisory board and four-eyes principle you know to their on-chain equivalents.
+
+🔗 <link>
+
+When you assess an upgradeable on-chain system, what evidence do you require before you're comfortable that the upgrade key is governed, not just held?
+
+#OperationalRisk #Governance #ChangeManagement #DigitalAssets #Compliance
+
+## Image prompt (Gemini / Nano Banana)
+
+A restrained, institutional editorial illustration for a 16:9 banner: a heavy bank-vault door standing slightly ajar, but the door itself is composed of interlocking mechanical gears and a multi-position key mechanism requiring several keys turned at once, suggesting controlled, multi-party change rather than a single lock. Deep navy and teal base palette with a single warm amber accent on the key mechanism catching soft directional light. Clean, modern, sophisticated and understated — not flashy crypto art, no neon. Subtle depth of field, calm and authoritative mood. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/17-assurance-audits-formal-verification/blog.md
+++ b/docs/blog/finance/17-assurance-audits-formal-verification/blog.md
@@ -1,0 +1,74 @@
+# How to Read "Audited": Assurance for Smart Contracts
+
+*What audits, automated analysis, and formal verification actually assure — and what they don't — read alongside SOC 2, model validation, and third-party assurance*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Compliance, Disclosure & Governance |
+| **Level** | Intermediate |
+| **Audience** | Compliance officers, risk managers, allocators, and product leads assessing third-party assurance |
+| **Tags** | `assurance`, `audit`, `formal-verification`, `due-diligence`, `smart-contracts` |
+| **Reading time** | ~8 minutes |
+
+---
+
+A protocol's landing page says "audited." A due-diligence questionnaire comes back with a link to a PDF. You have read a great many assurance artifacts in your career — SOC 2 reports, ISAE 3402 controls attestations, model-validation memos, external audit opinions — and you know the discipline they require: *what was in scope, what standard was applied, who signed it, over what period, and what the exceptions were.* The word "audited," used about a smart contract, deserves exactly that scrutiny. This briefing is about how to apply it — how to read the assurance stack behind on-chain code the way you would read any third-party attestation, and what each layer genuinely tells you.
+
+## The traditional model
+
+In traditional finance, "assurance" is a layered, well-understood stack, and every layer has a defined scope. A financial-statement audit gives an opinion on whether statements are fairly presented — not a guarantee the business won't fail. A SOC 2 Type II report tests whether a service organization's controls *operated effectively over a period* — not that the system is bug-free. Model validation, in the sense your model-risk-management function uses it, independently checks that a model is conceptually sound, correctly implemented, and used within its limits. Penetration testing probes for exploitable weaknesses at a point in time. No competent professional confuses these. You would never accept "we passed our SOC 2" as evidence that a specific calculation is mathematically correct, and you would never accept a pen-test as proof that internal controls operate over a year. **Scope and standard are everything**, and the maturity of the field is precisely that everyone agrees on what each artifact does and does not cover.
+
+## What changes on-chain
+
+Smart-contract assurance has a parallel stack, and the single most useful thing you can do is stop treating "audited" as one thing and start reading it as *several distinct activities with very different guarantees.* There are broadly four layers.
+
+**Automated static analysis** reads the code without running it — the way a spell-checker reads a document without understanding the plot. It is fast and cheap, so it runs on every code change, and it is genuinely good at catching known *dangerous shapes*: a payment sent before the internal record is updated (the classic re-entrancy trap), a missing check for an empty address, an ownership change with no lock. Its hard limit: it sees grammar, not meaning. It cannot tell you whether a payout *amount* is correct, because "add both stakes" and "use just one stake" look almost identical to it.
+
+**Fuzzing** stands up a realistic copy of the whole system and throws long, random sequences of real actions at it — hundreds of operations in wild combinations — checking after every step whether a set of stated rules still holds. The most important such rule is solvency: does the contract always hold at least enough to cover everything it still owes? Fuzzing is superb at finding bugs that *no single action causes but some order of actions does*. Its honest limit is the mirror image of its strength: it is random, not exhaustive. A clean run means "no counterexample found this time," never "no counterexample exists."
+
+**Formal verification** (in the smart-contract world, often via symbolic execution) is the layer most worth understanding, because it is the closest thing on offer to a mathematical *proof*. Instead of testing with a chosen number, it feeds the code an unknown value and reasons across *every possible value at once*, following every branch. That lets it prove statements a test never can: that a sum can never overflow into a wrong number across the entire range of inputs, or that there is no code path that skips a required safety check. This is genuinely stronger than testing — but only within a scope, and the scope is narrow: it excels at one contract at a time with a bounded number of steps, and it drowns if asked to reason about many interacting operations in arbitrary order.
+
+**Third-party audit** is a human expert engagement: reviewers read the code, model attacker behavior, and produce a report with findings graded by severity, remediation notes, and — the part professionals actually read — the *scope*, the *commit* that was reviewed, and the *disclaimer*. A reputable audit report is explicit that it is a point-in-time review of a specific version, not a warranty that the code is safe forever.
+
+## Where it genuinely differs
+
+Two differences from TradFi assurance are worth stating plainly.
+
+**Better: some of these layers deliver a strength no financial-statement audit can — actual proof over all inputs.** Formal verification, where it applies, is categorically stronger than sampling or testing. And because the code and the on-chain record are public, an assurance claim is unusually falsifiable: anyone can inspect the deployed code and the audit's stated scope and check they match.
+
+**Worse / just different: the field is younger and less standardized.** There is no single universally-accepted "smart-contract audit standard" with the settled authority of a financial-statement audit or a SOC 2 framework. Audit quality varies widely between firms; an "audit" can mean a two-week engagement or a deep multi-month effort. The burden of reading scope critically falls more heavily on *you* than it does with a standardized attestation.
+
+## Risk & controls: how to read "audited"
+
+Apply the same discipline you apply to any assurance artifact.
+
+**Insist on scope and version.** *What* was audited (which contracts), *which exact version* (code moves; an audit of last quarter's version says nothing about today's), and *what was explicitly out of scope*. An audit of the escrow logic tells you nothing about the oracle it trusts or the off-chain infrastructure around it.
+
+**Read the findings, not the badge.** A serious report lists issues by severity and their remediation status. "Audited" with no accessible report is a marketing claim, not assurance. Look for high/critical findings and confirmation they were fixed and re-reviewed.
+
+**Check that automated assurance is continuous and mandatory.** A one-time audit ages the moment code changes. The stronger signal is that static analysis and fuzzing run automatically on *every* change and *block* a merge on failure — the on-chain analogue of controls that operate continuously rather than being tested once. Ask whether these gates can be bypassed; a gate that can be waved through under deadline pressure is not a control.
+
+**Beware the silent tool — the assurance-theater failure.** The most dangerous state for any verification tool is to report "green" while actually examining nothing. It is a real failure mode: a tool that cannot assemble the code, fails, and has that failure miscounted as a pass — manufacturing confidence no one earned. The professional analogue is a control that is documented but never actually operated. The mitigation is the same in both worlds: verify that the tool is genuinely exercising the real, as-deployed system, not a stripped-down stand-in, and that a non-run is treated as a failure, not a pass.
+
+**Understand what none of it covers.** No audit or verification addresses governance risk (who can change the code afterward), key-compromise risk, oracle risk, or economic-design risk. "Audited" is a statement about code correctness within a scope — not about whether the overall arrangement is safe, sound, or suitable. Treat it as one input among several, exactly as you would treat a SOC 2 report as necessary but not sufficient.
+
+## How FairWins approaches this
+
+FairWins layers its assurance deliberately rather than relying on any single artifact. Fast automated static analysis runs on every change and blocks a merge on failure; fuzzing pressure-tests the real, as-deployed system — same setup, same memberships, not a toy — against explicit solvency and state-progression rules; and the highest-risk money-moving logic is additionally checked by symbolic-execution proofs, on purpose overlapping with the fuzzer so payout correctness is both *proven over all inputs* and *stress-tested over all orderings*. The team treats a silent or non-running tool as a failure rather than a pass — an explicit design lesson from experience. None of this makes bugs impossible, and FairWins says so; what it does is make whole *categories* of them very hard to ship. That posture — continuous, mandatory, overlapping, honest about limits — is what a professional should want to see behind the word "audited."
+
+---
+
+*This briefing is educational and informational only. It is not investment, legal, tax, or regulatory advice. An audit or verification is not a warranty of safety, and no assurance activity guarantees a system is free of defects or suitable for any particular use.*
+
+## Related deep-dive
+
+For the engineering details, see [Three Ways to Break an Escrow: How We Stress-Test the Code That Holds the Money](../../posts/31-symbolic-execution-fuzzing/blog.md).
+
+## Further reading
+
+- [AICPA SOC 2 overview](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2) — what a controls attestation covers, and its period-of-time basis
+- [US Federal Reserve / OCC SR 11-7: Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/sr1107.htm) — the discipline of independent validation, conceptual soundness, and use limits
+- [Smart Contract Weakness Registry](https://swcregistry.io/) — a catalog of known contract bug classes assurance tools target
+- [Symbolic execution](https://en.wikipedia.org/wiki/Symbolic_execution) and [fuzz testing](https://en.wikipedia.org/wiki/Fuzzing) — plain introductions to the two heavy assurance techniques
+- [Ethereum smart-contract security best practices](https://consensys.github.io/smart-contract-best-practices/) — the practitioner baseline for what audits look for

--- a/docs/blog/finance/17-assurance-audits-formal-verification/social.md
+++ b/docs/blog/finance/17-assurance-audits-formal-verification/social.md
@@ -1,0 +1,27 @@
+# Social & Image — How to Read "Audited": Assurance for Smart Contracts
+
+## X (Twitter)
+
+"Audited" deserves the same scrutiny you give a SOC 2 report: what scope, what standard, what version, what exceptions? A field guide to the four layers of smart-contract assurance — and what each one genuinely proves. 🔗 <link> #Assurance #RiskManagement #DueDiligence
+
+## LinkedIn
+
+You would never accept "we passed our SOC 2" as proof that a specific calculation is correct — scope and standard are everything. The word "audited," applied to a smart contract, deserves exactly that discipline.
+
+This Intermediate briefing reads the on-chain assurance stack the way a professional reads any third-party attestation:
+
+- The four distinct layers — static analysis, fuzzing, formal verification, human audit — and the very different guarantee each provides
+- Why formal verification can *prove* things a financial-statement audit never could, but only within a narrow scope
+- How to read an audit report: scope, version, findings by severity, and the disclaimer that actually matters
+- The "silent tool" failure — assurance theater that reports green while examining nothing — and its analogue in a control documented but never operated
+- What no audit covers: governance, key-compromise, oracle, and economic-design risk
+
+🔗 <link>
+
+When a vendor tells you their contracts are "audited," what do you require to see before you treat that as assurance rather than marketing?
+
+#Assurance #Audit #ModelRisk #DigitalAssets #Compliance
+
+## Image prompt (Gemini / Nano Banana)
+
+A restrained, institutional editorial illustration for a 16:9 banner: a precise brass balance scale on a clean surface, but rendered so the two pans hold contrasting symbols of assurance — one a magnifying glass over a document, the other a geometric proof-like lattice of interlocking lines — suggesting inspection versus proof. Deep navy and teal base palette with a single warm amber accent illuminating the scale's fulcrum. Soft directional lighting, subtle depth of field, sophisticated and understated, editorial not decorative — no neon, no flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/18-daos-member-owned-governance/blog.md
+++ b/docs/blog/finance/18-daos-member-owned-governance/blog.md
@@ -1,0 +1,70 @@
+# Member-Owned, On-Chain: What DAOs Borrow From Mutuals and Cooperatives
+
+*On-chain coordination compared to mutuals, cooperatives, and member-owned structures — governance rights, participation, and the honest limits of voting on a blockchain*
+
+| | |
+|---|---|
+| **Series** | Finance Professional Series |
+| **Track** | Compliance, Disclosure & Governance |
+| **Level** | Intermediate |
+| **Audience** | Compliance officers, product leads, allocators, and advisors evaluating member-governed on-chain structures |
+| **Tags** | `dao`, `governance`, `member-owned`, `cooperatives`, `participation` |
+| **Reading time** | ~8 minutes |
+
+---
+
+A client — or a product team — asks you to make sense of a "DAO." They hold a governance position in one on-chain organization, a delegation in another, and membership in a third, across two different networks, and they want to understand what those rights actually are. You have a useful anchor already, and it is not crypto: the **member-owned structures** you know from traditional finance. A mutual insurer owned by its policyholders. A credit union owned by its depositors. An agricultural or retail cooperative owned by its members. A mutual fund whose shareholders vote on certain matters. A DAO — a "decentralized autonomous organization," an on-chain group whose members vote on proposals enforced by a governance smart contract rather than by a company — is best understood as a member-owned structure implemented in code. That framing gets you most of the way, and it also makes the honest limits easy to see.
+
+## The traditional model
+
+Member-owned organizations share a few defining properties. Ownership and governance are tied to *membership* rather than to outside shareholders. Members have defined **governance rights** — typically to vote on directors, major transactions, or bylaw changes. Decisions run through a chartered process: notice, quorum, a vote, and an outcome the organization is legally bound to honor. Crucially, that process is backstopped by *law and enforcement*: a cooperative's bylaws are enforceable in court, a mutual's board owes fiduciary duties, and a regulator supervises the whole arrangement. Participation is also famously imperfect — most members never vote, proxy advisors carry outsized influence, and control concentrates among the engaged few. None of this is new; it is the well-documented reality of member democracy, and it is the right baseline for judging what a DAO does and does not change.
+
+## What changes on-chain
+
+A DAO takes the member-governance idea and moves the *mechanics* onto a public blockchain. Membership and voting power are represented by tokens or roles recorded on-chain. Proposals are submitted, voted on, and — this is the genuinely novel part — *executed automatically* by the governance contract when they pass. There is no corporate secretary who transcribes the resolution and no operations team who implements it; the smart contract that counts the votes is the same contract that carries out the decision. The rules of the process (who may propose, the voting period, the threshold to pass, any delay before execution) are written into that contract and visible to all. Different DAOs use different governance frameworks — the widely-used OpenZeppelin Governor design is one; Compound-style governance is another — but the shape is common: on-chain proposal, on-chain vote, on-chain execution.
+
+For a professional, three properties stand out. **Transparency**: every proposal, every vote, and every execution is a public, permanent record — a level of process visibility most member organizations never approach. **Automatic execution**: a passed proposal is not a promise to act but the act itself, removing a layer of implementation discretion. **Composability of tooling**: because the rules are public and standardized, third parties can build dashboards that let a member see and act on positions across many DAOs and networks from one place — without those tools needing to take custody of anything.
+
+## Where it genuinely differs
+
+Be honest in both directions.
+
+**Better: transparency and tamper-evidence.** You do not have to trust a report that a vote happened and was counted correctly — the chain *is* the record, and it cannot be quietly revised. Execution is not subject to an implementer's discretion. For anyone who has chased down whether a corporate action was actually carried out as resolved, this is a real improvement.
+
+**Worse or genuinely unsettled: legal standing and enforcement.** A cooperative's governance rights are backed by charter, statute, and courts. A DAO's on-chain vote is self-executing on-chain, but its *legal* status is unsettled and varies sharply by jurisdiction — whether a DAO is a partnership, an unincorporated association, a registered entity, or something else, and what liability its members bear, is exactly the kind of question with no settled answer yet. On-chain enforceability and *legal* enforceability are not the same thing, and the gap is the single most important limit to convey.
+
+**Just different: how participation and power actually distribute.** DAOs were meant to democratize governance, but token-weighted voting can concentrate power in large holders as surely as share-weighted voting does, delegation recreates the proxy-advisor dynamic, and voter apathy is at least as severe on-chain as off. The mechanism is more transparent; it is not obviously more *equitable*. Treat claims of "decentralized" governance as a question to investigate, not a property to assume.
+
+## Risk & controls: reading an on-chain governance arrangement
+
+Assess a DAO the way you would assess any member-governed structure, plus a few on-chain-specific checks.
+
+**Governance-rights mapping.** What can members actually decide, and what is reserved? Read the on-chain rules for who may propose, the voting threshold, the quorum, and — importantly — whether there is a *timelock* (a mandatory delay between a vote passing and taking effect) that gives members notice and a chance to exit before a change lands. A timelock is the on-chain analogue of advance notice on a bylaw change.
+
+**Power concentration.** Look at the actual distribution of voting weight and delegation. A DAO where a handful of addresses can pass anything is member-owned in form but not in substance — the same critique you would apply to a cooperative captured by an insider bloc.
+
+**Custody and authority of any tooling.** If a dashboard or aggregator sits between the member and the DAO, ask the decisive question: does it *take custody or voting authority*, or does it only *display and relay*? A tool that asks members to delegate voting power to it becomes a new party to trust and a new thing to attack. The safer design records only that a DAO exists and what kind of governance it runs — like a phone book listing a business — while every actual vote or proposal is signed by the member and sent to the DAO's own contract, judged by the DAO's own rules. That distinction — *describe, don't embody* — is the heart of a trustworthy governance tool.
+
+**Data integrity.** On-chain governance data can be read from a fast index or directly from the contract; a good tool degrades honestly when a source is unreachable — showing an explicit empty, partial, or error state rather than a plausible-looking but fabricated one. "Never show a confident lie" is a control worth confirming.
+
+**Legal and regulatory posture.** Because classification is unsettled, do not assume a DAO membership carries the protections of a regulated member structure, and do not assume it doesn't. This is precisely where a professional pauses and gets jurisdiction-specific advice rather than reasoning by analogy.
+
+## How FairWins approaches this
+
+Two honest clarifications matter here. First, **FairWins itself is not a DAO.** It is a peer-to-peer wager protocol with no governance token, no proposal-and-voting process, and no on-chain treasury governed by members; its only "governance" is a small set of bounded operator roles, none of which can move user funds. (The project began as research into DAO-style governance, but that design is archived, not deployed — a useful reminder that "started as a DAO experiment" and "is governed as a DAO" are different claims.) Second, where FairWins *touches* DAOs, it does so strictly as a **describe-don't-embody** layer: members can see and act on governance positions they hold in external DAOs — across different networks and frameworks — from one place, with every vote or proposal signed by the member and sent to that DAO's own contract. The tooling records that a DAO exists and what framework it runs; it holds no keys, no funds, and no voting authority, takes no delegation, and never sits in the path of a member's decision. When it cannot reach a network, it says so rather than inventing data. That is the model to prefer in any member-governed on-chain arrangement: transparent mechanics, member-signed actions, no custodial middleman — and clear eyes about where on-chain execution ends and legal enforceability begins.
+
+---
+
+*This briefing is educational and informational only. It is not investment, legal, tax, or regulatory advice. The legal classification and treatment of DAOs and on-chain governance rights are unsettled and vary by jurisdiction; nothing here asserts that a DAO membership is legally equivalent to any regulated member-owned structure.*
+
+## Related deep-dive
+
+For the engineering details, see [ClearPath: A Registry That Owns Nothing](../../posts/26-clearpath-dao-registry/blog.md).
+
+## Further reading
+
+- [International Cooperative Alliance — cooperative identity and principles](https://www.ica.coop/en/cooperatives/cooperative-identity) — the member-ownership baseline DAOs echo
+- [OECD — the role of mutuals and cooperatives in finance](https://www.oecd.org/) — governance and member-participation dynamics in traditional member-owned structures
+- [OpenZeppelin Governance (Governor framework)](https://docs.openzeppelin.com/contracts/5.x/api/governance) — a widely-used on-chain governance design
+- [Compound Governance](https://docs.compound.finance/) — an alternative on-chain governance model
+- [Investopedia: Decentralized Autonomous Organization (DAO)](https://www.investopedia.com/tech/what-dao/) — a plain-language primer on DAOs and their limits

--- a/docs/blog/finance/18-daos-member-owned-governance/social.md
+++ b/docs/blog/finance/18-daos-member-owned-governance/social.md
@@ -1,0 +1,27 @@
+# Social & Image — Member-Owned, On-Chain: What DAOs Borrow From Mutuals and Cooperatives
+
+## X (Twitter)
+
+A DAO is best understood as a member-owned structure — like a mutual or credit union — implemented in code. What that borrows, what it improves, and where on-chain execution stops and legal enforceability begins. 🔗 <link> #DAO #Governance #Cooperatives
+
+## LinkedIn
+
+The clearest anchor for understanding a DAO isn't crypto — it's the member-owned structures you already know: mutual insurers, credit unions, cooperatives. A DAO is member governance implemented in code, and that framing makes both its strengths and its honest limits easy to see.
+
+This Intermediate briefing maps the comparison for a finance professional:
+
+- What transfers cleanly: membership-based governance rights, notice, quorum, votes
+- What's genuinely better on-chain: tamper-evident records and automatic execution of passed proposals
+- What's unsettled: the gap between on-chain execution and *legal* enforceability, which varies sharply by jurisdiction
+- What doesn't change: voter apathy and power concentration, in token-weighted form
+- The controls that matter: timelocks, power distribution, and whether any tooling takes custody/voting authority or merely displays and relays
+
+🔗 <link>
+
+When you evaluate an on-chain governance arrangement, how do you weigh transparent, self-executing mechanics against unsettled legal standing?
+
+#DAO #Governance #MemberOwned #DigitalAssets #Compliance
+
+## Image prompt (Gemini / Nano Banana)
+
+A restrained, institutional editorial illustration for a 16:9 banner: a circular arrangement of identical small brass tokens or seats around a shared central table, evoking a member assembly or cooperative council, with fine connecting lines suggesting a distributed but linked network. Deep navy and teal base palette with a single warm amber accent on the central point where the connections meet. Soft, even lighting, subtle depth of field, sophisticated and understated, editorial rather than decorative — no neon, no flashy crypto art. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/finance/README.md
+++ b/docs/blog/finance/README.md
@@ -1,0 +1,53 @@
+# FairWins Finance Professional Series
+
+Intermediate and advanced briefings for readers with a **financial-services
+background** — asset management, treasury, operations, compliance, risk,
+advisory, and fintech product — who are fluent in traditional finance but not
+in code.
+
+Each briefing bridges: it starts from a concept you already know (custody,
+settlement, counterparty risk, NAV, KYC/AML, best execution, cost disclosure),
+maps it onto the on-chain mechanism, and gives an honest read on where the two
+genuinely differ, with a real **Risk & controls** section. No Solidity, no
+implementation detail — the register is finance, not engineering.
+
+> **Informational, not advice.** These are educational pieces — not investment,
+> legal, tax, or regulatory advice. Analogies to regulated products build
+> intuition; they are not claims of legal equivalence. Regulatory treatment
+> varies by jurisdiction and is evolving; yield carries risk and is never
+> guaranteed.
+
+The full topic list, levels, and suggested "Finance Desk" cadence are in the
+**[Finance Professional Series inventory](../finance-professional-inventory.md)**.
+For the plain-language versions of these ideas, see the
+**[Knowledge Base](../knowledge/README.md)**; for how the systems are built, the
+**[Engineering Blog](../posts/README.md)**.
+
+## Index
+
+### Custody & Settlement
+- [Self-custody vs. qualified custodians](01-self-custody-vs-qualified-custodians/blog.md) · Intermediate
+- [Trustless escrow and the end of counterparty risk](02-trustless-escrow-counterparty-risk/blog.md) · Intermediate
+- [Atomic settlement: delivery-versus-payment at T+0](03-atomic-settlement-dvp/blog.md) · Advanced
+- [Institutional controls on-chain: multisig & segregation of duties](04-institutional-controls-multisig/blog.md) · Intermediate
+- [Programmable spending policy as pre-trade controls](05-programmable-spending-policy/blog.md) · Advanced
+
+### Money, Yield & Markets
+- [Stablecoins as a settlement asset](06-stablecoins-settlement-asset/blog.md) · Intermediate
+- [On-chain lending vs. money markets & repo](07-onchain-lending-vs-money-markets/blog.md) · Advanced
+- [Tokenized vaults as fund structures](08-tokenized-vaults-fund-structures/blog.md) · Advanced
+- [A practitioner's risk framework for DeFi yield](09-defi-yield-risk-framework/blog.md) · Advanced
+- [Oracles as reference-data and benchmark infrastructure](10-oracles-reference-data-integrity/blog.md) · Advanced
+- [Prediction markets as information markets & event contracts](11-prediction-markets-event-derivatives/blog.md) · Intermediate
+- [Builder codes and best execution](12-builder-codes-best-execution/blog.md) · Advanced
+
+### Compliance, Disclosure & Governance
+- [Programmatic compliance: screening, KYC/AML & the travel rule](13-programmatic-compliance-travel-rule/blog.md) · Advanced
+- [Fee transparency and cost disclosure](14-fee-transparency-cost-disclosure/blog.md) · Intermediate
+- [Confidentiality on a public ledger](15-confidentiality-public-ledger-mnpi/blog.md) · Advanced
+- [Operational risk in upgradeable systems](16-operational-risk-upgradeable-systems/blog.md) · Advanced
+- [Assurance for smart contracts: audits & formal verification](17-assurance-audits-formal-verification/blog.md) · Intermediate
+- [DAOs and member-owned governance](18-daos-member-owned-governance/blog.md) · Intermediate
+
+Each folder also contains a `social.md` with X and LinkedIn copy and a banner
+image prompt.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -237,11 +237,36 @@ nav:
     - Standalone:
       - CallsignRegistry (ENS-Style Naming): blog/posts/33-callsign-registry/blog.md
       - TokenFactory (Templated Minting): blog/posts/34-token-factory/blog.md
+  - Finance Professional Series:
+    - Overview: blog/finance/README.md
+    - Series Inventory: blog/finance-professional-inventory.md
+    - Custody & Settlement:
+      - Self-Custody vs. Qualified Custodians: blog/finance/01-self-custody-vs-qualified-custodians/blog.md
+      - Trustless Escrow & Counterparty Risk: blog/finance/02-trustless-escrow-counterparty-risk/blog.md
+      - Atomic Settlement (DvP at T+0): blog/finance/03-atomic-settlement-dvp/blog.md
+      - Institutional Controls & Multisig: blog/finance/04-institutional-controls-multisig/blog.md
+      - Programmable Spending Policy: blog/finance/05-programmable-spending-policy/blog.md
+    - Money, Yield & Markets:
+      - Stablecoins as a Settlement Asset: blog/finance/06-stablecoins-settlement-asset/blog.md
+      - On-Chain Lending vs. Money Markets: blog/finance/07-onchain-lending-vs-money-markets/blog.md
+      - Tokenized Vaults as Fund Structures: blog/finance/08-tokenized-vaults-fund-structures/blog.md
+      - A Risk Framework for DeFi Yield: blog/finance/09-defi-yield-risk-framework/blog.md
+      - Oracles & Reference-Data Integrity: blog/finance/10-oracles-reference-data-integrity/blog.md
+      - Prediction Markets as Event Contracts: blog/finance/11-prediction-markets-event-derivatives/blog.md
+      - Builder Codes & Best Execution: blog/finance/12-builder-codes-best-execution/blog.md
+    - Compliance, Disclosure & Governance:
+      - Programmatic Compliance & the Travel Rule: blog/finance/13-programmatic-compliance-travel-rule/blog.md
+      - Fee Transparency & Cost Disclosure: blog/finance/14-fee-transparency-cost-disclosure/blog.md
+      - Confidentiality on a Public Ledger: blog/finance/15-confidentiality-public-ledger-mnpi/blog.md
+      - Operational Risk in Upgradeable Systems: blog/finance/16-operational-risk-upgradeable-systems/blog.md
+      - "Assurance: Audits & Formal Verification": blog/finance/17-assurance-audits-formal-verification/blog.md
+      - DAOs & Member-Owned Governance: blog/finance/18-daos-member-owned-governance/blog.md
 
 # Companion social/image-prompt assets live beside each post but are not nav pages.
 not_in_nav: |
   /blog/posts/*/social.md
   /blog/knowledge/*/social.md
+  /blog/finance/*/social.md
   /blog/private-prediction-markets-envelope-encryption.md
 
 extra:


### PR DESCRIPTION
## Summary

Adds a **Finance Professional Series** — an intermediate/advanced content layer for a fourth, distinct reader: the **non-technical finance professional** (asset management, treasury, operations, compliance, risk, advisory, fintech product) who is fluent in traditional finance but not in code.

Each briefing **bridges**: it starts from a concept the reader already knows, maps it to the on-chain mechanism, is honest about where the two genuinely differ, and includes a real **Risk & controls** section.

The program now has four layers:

| Layer | Reader | Depth |
|-------|--------|-------|
| User Guide | app users | how-to |
| Knowledge Base | crypto-curious beginners | beginner |
| Engineering Blog | semi-technical | how it's built |
| **Finance Professional Series** (new) | **finance pros, non-technical** | **intermediate / advanced** |

## What's included

**18 briefings** (1,100–1,600 words each), every one with a social kit, in three tracks:

- **Custody & Settlement** — self-custody vs. qualified custodians · trustless escrow & counterparty risk · atomic settlement (DvP at T+0) · institutional controls & multisig · programmable spending policy
- **Money, Yield & Markets** — stablecoins as a settlement asset · on-chain lending vs. money markets & repo · tokenized vaults as fund structures · a risk framework for DeFi yield · oracles & reference-data integrity · prediction markets as event contracts · builder codes & best execution
- **Compliance, Disclosure & Governance** — programmatic compliance & the travel rule · fee transparency & cost disclosure · confidentiality on a public ledger · operational risk in upgradeable systems · assurance (audits & formal verification) · DAOs & member-owned governance

Plus a **series inventory** with TradFi anchors and a parallel monthly "Finance Desk" cadence, an **index README**, and **mkdocs nav** wiring.

## Editorial guardrails (important for this audience)

- **Informational, not advice** disclaimer in every briefing (verified 18/18) — not investment, legal, tax, or regulatory advice.
- **No claims of legal equivalence** to regulated products — analogies are labeled "structurally analogous," and classification is framed as jurisdiction-varying and unsettled.
- Yield is framed as variable, never guaranteed, and not a deposit; fees as real costs disclosed before approval; Earn's current no-fee status is respected.
- Responsible-use notes on the prediction-market briefings.
- One factual correction the research surfaced: FairWins is **not itself a DAO** (bounded operator roles, no token/voting), so the DAO briefing frames its role as a tracking layer rather than overclaiming.

## Validation

- All 18 directories present with both files; scanned clean for spec numbers, FRs, code fences, function-name soup, and repo paths.
- Every briefing has a Risk & controls section and the not-advice disclaimer; all "Related deep-dive" cross-links resolve.
- mkdocs config parses; all 18 pages wired into the nav (72 blog pages total across the four layers) with `social.md` companions excluded via `not_in_nav`.
- Docs-only; scope limited to `docs/blog/finance/**`, the inventory doc, and `mkdocs.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjwYbKV9hUFKjuKrqprmoi)_