### PR TITLE
feat(recovery): legacy account recovery — encrypted import, all-asset sweep, address book, backup & audit

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/061-bitcoin-transactions"
+  "feature_directory": "specs/062-legacy-account-recovery"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,5 +167,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/061-bitcoin-transactions/plan.md
+at specs/062-legacy-account-recovery/plan.md
 <!-- SPECKIT END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,21 @@ artifacts live under `specs/<feature>/`.
   (`services/relay-gateway/src/bitcoin/`, `BTC_*` env) is optional — unset/disabled ⇒ every
   Bitcoin surface hides/degrades honestly. See `docs/developer-guide/bitcoin.md` +
   `docs/runbooks/bitcoin-operations.md` + `specs/061-bitcoin-transactions/`.
+- **Legacy account recovery (spec 062) is FRONTEND-ONLY** — the **Recovery** section (renamed from
+  "Backup & Security"; tab id `security` + `backup` alias unchanged). Members import an old EOA
+  **private key** or **BIP-39 word list**; the secret is encrypted at rest (AES-GCM under a
+  PBKDF2-650k passphrase key) and **NEVER** persisted in the clear, transmitted, or logged — only the
+  ciphertext blob is stored/backed up. `legacyKeyVault(account)` (in
+  `frontend/src/lib/recovery/legacyKeys.js`) is a per-account CRUD facade over
+  `legacyRecoveredKeysStore.js` (userStorage key `legacy_recovered_keys`, the single source of truth);
+  it rides the spec-032 backup via the non-network-scoped `legacyRecoveredKeys` synced object. Storing
+  completes recovery; **moving funds is OPTIONAL** — `sweepAllAssets` moves ALL supported fungible
+  assets (native + every `getPortfolioRegistry` ERC-20, ERC-20s first / native last with a gas
+  reserve) with **per-asset outcomes** (one failure never aborts the rest; NFTs excluded + disclosed).
+  Recovered accounts save to the address book via `useAddressBook()` (usable platform-wide) and the
+  recovery is audited via `captureLegacyRecovery` (client-ledger `legacy_account_recovered`, address +
+  type only, stable/idempotent entryId, **never** key material). See
+  `docs/developer-guide/legacy-account-recovery.md` + `specs/062-legacy-account-recovery/`.
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,

--- a/docs/developer-guide/legacy-account-recovery.md
+++ b/docs/developer-guide/legacy-account-recovery.md
@@ -1,0 +1,49 @@
+# Legacy account recovery (spec 062)
+
+The **Recovery** section (formerly "Backup & Security") lets a member bring an older account into
+FairWins from a raw **EOA private key** or a **BIP-39 word list**, store it encrypted on-device, and
+optionally move its funds to a smart account. It is a **frontend-only** feature — no contracts, no
+gateway — that composes existing subsystems.
+
+## Where it lives
+
+| Concern | Module |
+|---|---|
+| Classify / encrypt / decrypt / vault / sweep | `frontend/src/lib/recovery/legacyKeys.js` |
+| Backup-synced encrypted store (ciphertext only) | `frontend/src/lib/recovery/legacyRecoveredKeysStore.js` |
+| BIP-39 word suggestions (typo help) | `frontend/src/lib/recovery/bip39Suggest.js` |
+| Audit ledger record (no secrets) | `frontend/src/data/ledger/sources/legacyRecoverySource.js` |
+| UI (guided bottom sheets) | `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` |
+| Backup domain registration | `frontend/src/lib/backup/syncedObjects.js` (`legacyRecoveredKeys`) |
+
+## Rules to keep
+
+- **Secrets are encrypted at rest, never in the clear, never transmitted, never logged.** The raw
+  private key / mnemonic is wrapped with AES-GCM under a PBKDF2-SHA256 (650k) key stretched from a
+  member-chosen passphrase. A wrong passphrase fails the GCM tag — never fall through to substitute
+  material. Only the **ciphertext blob** (`{ v, kind, address, salt, iv, ct, iterations, importedAt }`)
+  is persisted or backed up.
+- **The vault is per-account.** `legacyKeyVault(account)` is a CRUD facade over
+  `legacyRecoveredKeysStore` (userStorage key `legacy_recovered_keys`). The store owns the key + shape;
+  do not read/write that key from anywhere else.
+- **Moving funds is OPTIONAL.** Storing the encrypted secret completes recovery (the SAVED screen).
+  The sweep (`sweepAllAssets`) moves **all supported fungible assets** — native + every supported
+  ERC-20 from `getPortfolioRegistry(chainId)` — ERC-20s first, native last (leaving a gas reserve).
+  It returns a **per-asset outcome** array; one asset failing never aborts the rest, and nothing is
+  silently dropped. NFTs/collectibles are out of scope and disclosed as such.
+- **Recovered accounts are first-class.** Saving to the address book uses `useAddressBook()`
+  (`findByAddress` → `addContact`/`updateContact`) so the account is usable on every picker. The
+  encrypted records ride the spec-032 backup via the `legacyRecoveredKeys` synced object (not
+  network-scoped — a legacy EOA address is the same across EVM chains).
+- **Audit without leakage.** `captureLegacyRecovery(account, chainId, { recoveredAddress, source })`
+  appends one client-ledger record (`kind: 'legacy_account_recovered'`, `refs` = address + type only)
+  with a **stable entryId**, so it is idempotent and never carries key material.
+
+## Testing note
+
+Under vitest+jsdom, Node's `Buffer` leaks in and ethers' default sha256 returns a `Buffer` its own
+`hexlify` rejects, breaking BIP-39 parsing. Any suite that exercises mnemonics calls
+`registerEthersCrypto()` (`frontend/src/test/recovery/registerEthersCrypto.js`) to register
+`@noble/hashes`. Real browsers have no `Buffer` and use the pure-JS path — production is unaffected.
+
+See `specs/062-legacy-account-recovery/` for the spec, plan, and task breakdown.

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.css
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.css
@@ -1,0 +1,161 @@
+/* Legacy key & word-list recovery. The bottom-sheet shell (ActionSheet.css) and
+   the per-step layout (.recover-step*, RecoverAccountPanel.css) are shared; this
+   file styles only the entry card, the stored-key list, and the secret/quote
+   inputs unique to this panel. Theme tokens (src/theme.css) with light-mode
+   fallbacks so text stays readable in both themes. */
+
+.legacy-recovery__start {
+  margin-top: 8px;
+}
+
+/* --- Stored keys --- */
+.lkr-stored {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lkr-stored__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 10px;
+  background: var(--bg-primary, #f7f9fa);
+}
+
+.lkr-stored__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.lkr-stored__addr {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  color: var(--text-primary, #1f2933);
+  font-size: 0.9rem;
+}
+
+.lkr-stored__sub {
+  font-size: 0.78rem;
+  color: var(--text-muted, #8a959e);
+}
+
+.lkr-stored__actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.lkr-stored__remove {
+  color: var(--danger-color, #dc2626);
+}
+
+/* --- Secret entry --- */
+.lkr-secret-input {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 64px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 8px;
+  background: var(--bg-primary, #f7f9fa);
+  color: var(--text-primary, #1f2933);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.9rem;
+  line-height: 1.4;
+  margin-bottom: 10px;
+}
+
+.lkr-secret-input:focus {
+  outline: none;
+  border-color: var(--brand-primary, #36b37e);
+}
+
+/* --- Passphrase fields --- */
+.lkr-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.lkr-field span {
+  font-size: 0.82rem;
+  color: var(--text-secondary, #5a6772);
+}
+
+.lkr-field input {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 8px;
+  background: var(--bg-primary, #f7f9fa);
+  color: var(--text-primary, #1f2933);
+  font-size: 0.95rem;
+}
+
+.lkr-field input:focus {
+  outline: none;
+  border-color: var(--brand-primary, #36b37e);
+}
+
+/* --- Notices --- */
+.lkr-notice {
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 0.86rem;
+  margin: 0 0 12px;
+}
+
+.lkr-notice--error {
+  border: 1px solid var(--danger-color, #dc2626);
+  color: var(--danger-color, #dc2626);
+  background: color-mix(in srgb, var(--danger-color, #dc2626) 10%, transparent);
+}
+
+.lkr-notice--warn {
+  border: 1px solid var(--warning-color, #f59e0b);
+  color: var(--text-primary, #1f2933);
+  background: color-mix(in srgb, var(--warning-color, #f59e0b) 12%, transparent);
+}
+
+/* --- Balance quote --- */
+.lkr-quote {
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 10px;
+  padding: 10px 12px;
+  margin: 12px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lkr-quote > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.88rem;
+}
+
+.lkr-quote span {
+  color: var(--text-secondary, #5a6772);
+}
+
+.lkr-quote strong {
+  color: var(--text-primary, #1f2933);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.lkr-quote__empty {
+  color: var(--warning-color, #b7791f) !important;
+  font-size: 0.82rem !important;
+  margin: 4px 0 0 !important;
+}

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.css
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.css
@@ -79,6 +79,30 @@
   border-color: var(--brand-primary, #36b37e);
 }
 
+/* --- BIP-39 word suggestions --- */
+.lkr-suggest {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 10px;
+}
+
+.lkr-suggest__chip {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.82rem;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color, #e3e7eb);
+  background: var(--bg-primary, #f7f9fa);
+  color: var(--text-primary, #1f2933);
+  cursor: pointer;
+}
+
+.lkr-suggest__chip:hover {
+  border-color: var(--brand-primary, #36b37e);
+  color: var(--brand-primary, #36b37e);
+}
+
 /* --- Passphrase fields --- */
 .lkr-field {
   display: flex;
@@ -158,4 +182,83 @@
   color: var(--warning-color, #b7791f) !important;
   font-size: 0.82rem !important;
   margin: 4px 0 0 !important;
+}
+
+/* --- SAVED screen optional actions --- */
+.lkr-saved-action {
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 10px;
+  padding: 10px 12px;
+  margin: 10px 0;
+}
+
+.lkr-saved-action__title {
+  margin: 0 0 2px !important;
+  font-weight: 600;
+  color: var(--text-primary, #1f2933) !important;
+  font-size: 0.9rem !important;
+}
+
+.lkr-saved-action__hint {
+  margin: 0 !important;
+  color: var(--text-secondary, #5a6772) !important;
+  font-size: 0.82rem !important;
+}
+
+.lkr-book-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.lkr-book-name {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 8px;
+  background: var(--bg-primary, #f7f9fa);
+  color: var(--text-primary, #1f2933);
+  font-size: 0.9rem;
+}
+
+.lkr-book-name:focus {
+  outline: none;
+  border-color: var(--brand-primary, #36b37e);
+}
+
+/* --- Per-asset transfer outcomes --- */
+.lkr-outcomes {
+  list-style: none;
+  margin: 12px 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.lkr-outcome {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.86rem;
+  padding: 4px 0;
+}
+
+.lkr-outcome__sym {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  color: var(--text-primary, #1f2933);
+}
+
+.lkr-outcome--sent .lkr-outcome__status {
+  color: var(--brand-primary, #36b37e);
+}
+
+.lkr-outcome--skipped .lkr-outcome__status {
+  color: var(--text-muted, #8a959e);
+}
+
+.lkr-outcome--failed .lkr-outcome__status {
+  color: var(--danger-color, #dc2626);
 }

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.css
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.css
@@ -184,6 +184,16 @@
   margin: 4px 0 0 !important;
 }
 
+.lkr-quote__fee {
+  border-top: 1px solid var(--border-color, #e3e7eb);
+  padding-top: 6px;
+  margin-top: 2px;
+}
+
+.lkr-quote__fee span {
+  color: var(--text-muted, #8a959e);
+}
+
 /* --- SAVED screen optional actions --- */
 .lkr-saved-action {
   border: 1px solid var(--border-color, #e3e7eb);

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
@@ -1,0 +1,509 @@
+/**
+ * Legacy key & word-list recovery (Recovery section).
+ *
+ * Members who arrive with an *old* secret — a raw EOA private key or a BIP-39
+ * word list — use this to bring that account under FairWins. The flow is a
+ * guided series of informational bottom sheets (shared ActionSheet, mirroring
+ * RecoverAccountPanel) because handling a raw secret is high-stakes:
+ *
+ *   intro → enter the key/word list → set a passphrase (encrypt at rest) →
+ *   move the funds to a smart account → done.
+ *
+ * The secret is encrypted on-device with a passphrase-derived key
+ * (lib/recovery/legacyKeys.js) and never leaves the browser. The headline
+ * outcome is sweeping the funds onto a passkey smart account — a legacy EOA is
+ * treated as something to move off of, not a place to keep money.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
+import { ethers } from 'ethers'
+import { useWallet } from '../../hooks/useWalletManagement'
+import { getNetwork } from '../../config/networks'
+import AddressInput from '../ui/AddressInput'
+import AddressBookButton from '../ui/AddressBookButton'
+import ActionSheet from './ActionSheet'
+import {
+  classifySecret,
+  encryptLegacySecret,
+  decryptLegacySecret,
+  legacyKeyVault,
+  quoteNativeSweep,
+  sweepNativeToSmartAccount,
+} from '../../lib/recovery/legacyKeys'
+import './LegacyKeyRecoveryPanel.css'
+
+const shortAddr = (a) => (a ? `${a.substring(0, 6)}…${a.substring(a.length - 4)}` : '')
+const KIND_LABEL = { privateKey: 'private key', mnemonic: 'word list' }
+
+const STEP_TITLES = {
+  intro: 'Recover a legacy account',
+  enter: 'Enter your key or word list',
+  secure: 'Secure this key on your device',
+  transfer: 'Move your funds to a smart account',
+  unlock: 'Unlock this key',
+  done: 'Recovery complete',
+}
+
+function LegacyKeyRecoveryPanel({ deps = {} }) {
+  const { address: sessionAddress, provider, loginMethod, chainId, isConnected } = useWallet()
+  const vault = useMemo(() => (deps.vault ?? legacyKeyVault)(), [deps.vault])
+
+  const [open, setOpen] = useState(false)
+  const [step, setStep] = useState('intro')
+  const [phase, setPhase] = useState('idle') // idle | encrypting | quoting | sweeping
+  const [notice, setNotice] = useState(null)
+  const [stored, setStored] = useState(() => vault.list())
+
+  // Import working state.
+  const [rawSecret, setRawSecret] = useState('')
+  const [passphrase, setPassphrase] = useState('')
+  const [passphrase2, setPassphrase2] = useState('')
+  // The classified secret currently in memory (from import OR after unlock).
+  const [active, setActive] = useState(null) // { kind, address, secret }
+
+  // Transfer working state.
+  const [destInput, setDestInput] = useState('')
+  const [destResolved, setDestResolved] = useState('')
+  const [quote, setQuote] = useState(null)
+  const [txHash, setTxHash] = useState(null)
+
+  const network = useMemo(() => getNetwork(chainId), [chainId])
+  const networkName = network?.name || 'this network'
+  const nativeSymbol = network?.nativeCurrency?.symbol || 'the native token'
+
+  const detected = useMemo(() => classifySecret(rawSecret), [rawSecret])
+  const alreadyStored = detected.address ? vault.has(detected.address) : false
+
+  const destTarget = useMemo(() => {
+    const r = (destResolved || '').trim()
+    if (ethers.isAddress(r)) return r
+    const i = destInput.trim()
+    return ethers.isAddress(i) ? i : ''
+  }, [destResolved, destInput])
+
+  const refreshStored = useCallback(() => setStored(vault.list()), [vault])
+
+  const resetWizard = useCallback(() => {
+    setStep('intro')
+    setPhase('idle')
+    setNotice(null)
+    setRawSecret('')
+    setPassphrase('')
+    setPassphrase2('')
+    setActive(null)
+    setQuote(null)
+    setTxHash(null)
+    // Default the destination to the current session account when it is a
+    // passkey smart account — that is exactly where we want the funds to land.
+    const suggest = loginMethod === 'passkey' && sessionAddress ? sessionAddress : ''
+    setDestInput(suggest)
+    setDestResolved(suggest)
+  }, [loginMethod, sessionAddress])
+
+  const openWizard = useCallback(() => {
+    resetWizard()
+    setOpen(true)
+  }, [resetWizard])
+
+  const closeWizard = useCallback(() => {
+    if (phase === 'encrypting' || phase === 'sweeping') return // never yank mid-write
+    setOpen(false)
+  }, [phase])
+
+  // Clear any secret material from memory when the sheet fully closes.
+  useEffect(() => {
+    if (!open) {
+      setRawSecret('')
+      setPassphrase('')
+      setPassphrase2('')
+      setActive(null)
+    }
+  }, [open])
+
+  // Step 1→2 handoff: capture the classified secret so later steps don't
+  // re-parse the textarea.
+  const goSecure = useCallback(() => {
+    const c = classifySecret(rawSecret)
+    if (c.kind !== 'privateKey' && c.kind !== 'mnemonic') {
+      setNotice({ kind: 'error', text: "That doesn't look like a private key or a valid word list. Check for typos or missing words." })
+      return
+    }
+    setActive({ kind: c.kind, address: c.address, secret: c.secret })
+    setNotice(null)
+    setStep('secure')
+  }, [rawSecret])
+
+  const storeAndContinue = useCallback(async () => {
+    if (!active) return
+    if (passphrase !== passphrase2) {
+      setNotice({ kind: 'error', text: 'The two passphrases do not match.' })
+      return
+    }
+    setNotice(null)
+    setPhase('encrypting')
+    try {
+      const entry = await encryptLegacySecret({
+        secret: active.secret,
+        kind: active.kind,
+        address: active.address,
+        passphrase,
+        deps,
+      })
+      vault.set(entry)
+      refreshStored()
+      setPassphrase('')
+      setPassphrase2('')
+      setPhase('idle')
+      setStep('transfer')
+    } catch (e) {
+      setPhase('idle')
+      setNotice({ kind: 'error', text: e.message })
+    }
+  }, [active, passphrase, passphrase2, deps, vault, refreshStored])
+
+  const checkBalance = useCallback(async () => {
+    if (!active) return
+    setNotice(null)
+    setPhase('quoting')
+    try {
+      const q = await quoteNativeSweep({ kind: active.kind, secret: active.secret, provider: deps.provider ?? provider })
+      setQuote(q)
+      setPhase('idle')
+    } catch (e) {
+      setPhase('idle')
+      setNotice({ kind: 'error', text: `Could not read the balance on ${networkName}: ${e.reason || e.shortMessage || e.message}` })
+    }
+  }, [active, provider, deps.provider, networkName])
+
+  const doSweep = useCallback(async () => {
+    if (!active || !destTarget) return
+    setNotice(null)
+    setPhase('sweeping')
+    try {
+      const tx = await sweepNativeToSmartAccount({
+        kind: active.kind,
+        secret: active.secret,
+        to: destTarget,
+        provider: deps.provider ?? provider,
+      })
+      const receipt = await tx.wait()
+      if (receipt?.status === 0) throw new Error('the transfer reverted on-chain')
+      setTxHash(tx.hash)
+      setPhase('idle')
+      setStep('done')
+    } catch (e) {
+      setPhase('idle')
+      setNotice({ kind: 'error', text: `The transfer did not go through: ${e.reason || e.shortMessage || e.message}` })
+    }
+  }, [active, destTarget, provider, deps.provider])
+
+  // Stored-entry actions.
+  const [unlockEntry, setUnlockEntry] = useState(null)
+  const [unlockPass, setUnlockPass] = useState('')
+
+  const startTransferStored = useCallback((entry) => {
+    resetWizard()
+    setUnlockEntry(entry)
+    setUnlockPass('')
+    setStep('unlock')
+    setOpen(true)
+  }, [resetWizard])
+
+  const doUnlock = useCallback(async () => {
+    if (!unlockEntry) return
+    setNotice(null)
+    setPhase('encrypting')
+    try {
+      const secret = await decryptLegacySecret({ entry: unlockEntry, passphrase: unlockPass, deps })
+      setActive({ kind: unlockEntry.kind, address: unlockEntry.address, secret })
+      setUnlockPass('')
+      setPhase('idle')
+      setStep('transfer')
+    } catch (e) {
+      setPhase('idle')
+      setNotice({ kind: 'error', text: e.message })
+    }
+  }, [unlockEntry, unlockPass, deps])
+
+  const removeStored = useCallback((address) => {
+    vault.delete(address)
+    refreshStored()
+  }, [vault, refreshStored])
+
+  if (!isConnected) return null
+
+  const busy = phase === 'encrypting' || phase === 'sweeping'
+  const noticeEl = notice && (
+    <p role="alert" className={`lkr-notice lkr-notice--${notice.kind}`}>{notice.text}</p>
+  )
+
+  return (
+    <section className="legacy-recovery section" aria-label="Recover a legacy key or word list">
+      <h3>Legacy key & word-list recovery</h3>
+      <p className="section-description">
+        Moving from an older wallet? Bring in a legacy <strong>private key</strong> or <strong>word list</strong>{' '}
+        (recovery phrase). FairWins stores it encrypted on this device and helps you move the funds to a modern
+        smart account — the safer place to keep them.
+      </p>
+      <button type="button" className="btn btn-primary legacy-recovery__start" onClick={openWizard}>
+        Recover a legacy key
+      </button>
+
+      {stored.length > 0 && (
+        <ul className="lkr-stored" aria-label="Recovered legacy keys stored on this device">
+          {stored.map((e) => (
+            <li key={e.address} className="lkr-stored__item">
+              <div className="lkr-stored__meta">
+                <code className="lkr-stored__addr" title={e.address}>{shortAddr(e.address)}</code>
+                <span className="lkr-stored__sub">
+                  {KIND_LABEL[e.kind] || 'key'}
+                  {e.importedAt ? ` · saved ${new Date(e.importedAt).toLocaleDateString()}` : ''}
+                </span>
+              </div>
+              <div className="lkr-stored__actions">
+                <button type="button" className="btn btn-small" onClick={() => startTransferStored(e)}>
+                  Move funds
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-small lkr-stored__remove"
+                  onClick={() => removeStored(e.address)}
+                  aria-label={`Remove stored key ${shortAddr(e.address)}`}
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ActionSheet open={open} onClose={closeWizard} title={STEP_TITLES[step]} closeDisabled={busy}>
+        {/* Step 1 — what this does + the honest warning. */}
+        {step === 'intro' && (
+          <div className="recover-step">
+            <p>
+              Recover an account from a legacy <strong>private key</strong> or <strong>word list</strong>. This
+              lets you move any funds it holds onto a smart account you control here.
+            </p>
+            <ol className="recover-step__list">
+              <li>Paste the private key or word list — we detect which it is.</li>
+              <li>Choose a passphrase so we can store it encrypted on this device.</li>
+              <li>Move its funds to your smart account in one transaction.</li>
+            </ol>
+            <p className="recover-step__warn" role="note">
+              ⚠ Only paste a key you own. Anyone with this secret controls that account — treat it like cash. We
+              never send it anywhere; it stays encrypted on this device.
+            </p>
+            <div className="recover-step__actions">
+              <button type="button" className="btn" onClick={closeWizard}>Cancel</button>
+              <button type="button" className="btn btn-primary" onClick={() => { setNotice(null); setStep('enter') }}>
+                Get started
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 2 — enter + live detection. */}
+        {step === 'enter' && (
+          <div className="recover-step">
+            <p>Paste your private key (starts with <code>0x</code>) or your recovery word list (12–24 words).</p>
+            <textarea
+              className="lkr-secret-input"
+              value={rawSecret}
+              onChange={(e) => { setRawSecret(e.target.value); setNotice(null) }}
+              placeholder="0x… private key, or your 12–24 recovery words separated by spaces"
+              rows={3}
+              spellCheck={false}
+              autoComplete="off"
+              autoCapitalize="off"
+              aria-label="Private key or recovery word list"
+            />
+            {detected.kind === 'privateKey' || detected.kind === 'mnemonic' ? (
+              <p className="recover-step__ok" role="status" data-testid="lkr-detected">
+                ✓ Detected a {KIND_LABEL[detected.kind]} for account <code>{shortAddr(detected.address)}</code>.
+                {alreadyStored && ' This account is already stored — continuing will replace it.'}
+              </p>
+            ) : detected.kind === 'invalid' ? (
+              <p className="lkr-notice lkr-notice--warn" role="status">
+                Not a recognizable key yet — keep typing, or check for a missing/mistyped word.
+              </p>
+            ) : null}
+            {noticeEl}
+            <div className="recover-step__actions">
+              <button type="button" className="btn" onClick={() => setStep('intro')}>Back</button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={detected.kind !== 'privateKey' && detected.kind !== 'mnemonic'}
+                onClick={goSecure}
+              >
+                Continue
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 3 — passphrase → encrypt at rest. */}
+        {step === 'secure' && (
+          <div className="recover-step">
+            <p>
+              Choose a passphrase to encrypt this {active ? KIND_LABEL[active.kind] : 'key'} on this device. You
+              will need it to move funds later. <strong>We can&apos;t reset it</strong> — if you forget it, the
+              stored copy is unrecoverable (your original key still works).
+            </p>
+            <label className="lkr-field">
+              <span>Passphrase</span>
+              <input
+                type="password"
+                value={passphrase}
+                onChange={(e) => { setPassphrase(e.target.value); setNotice(null) }}
+                placeholder="At least 8 characters"
+                autoComplete="new-password"
+              />
+            </label>
+            <label className="lkr-field">
+              <span>Confirm passphrase</span>
+              <input
+                type="password"
+                value={passphrase2}
+                onChange={(e) => { setPassphrase2(e.target.value); setNotice(null) }}
+                autoComplete="new-password"
+              />
+            </label>
+            {noticeEl}
+            <div className="recover-step__actions">
+              <button type="button" className="btn" onClick={() => setStep('enter')} disabled={busy}>Back</button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={busy || passphrase.length < 8 || passphrase !== passphrase2}
+                onClick={storeAndContinue}
+              >
+                {phase === 'encrypting' ? 'Encrypting…' : 'Encrypt & continue'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 3b — unlock a previously stored key before moving funds. */}
+        {step === 'unlock' && (
+          <div className="recover-step">
+            <p>
+              Enter the passphrase for <code>{shortAddr(unlockEntry?.address)}</code> to move its funds.
+            </p>
+            <label className="lkr-field">
+              <span>Passphrase</span>
+              <input
+                type="password"
+                value={unlockPass}
+                onChange={(e) => { setUnlockPass(e.target.value); setNotice(null) }}
+                autoComplete="off"
+                aria-label="Passphrase"
+              />
+            </label>
+            {noticeEl}
+            <div className="recover-step__actions">
+              <button type="button" className="btn" onClick={closeWizard} disabled={busy}>Cancel</button>
+              <button type="button" className="btn btn-primary" disabled={busy || !unlockPass} onClick={doUnlock}>
+                {phase === 'encrypting' ? 'Unlocking…' : 'Unlock'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 4 — recommend + sweep to a smart account. */}
+        {step === 'transfer' && (
+          <div className="recover-step">
+            <p role="status" className="recover-step__ok">
+              ✓ Key for <code>{shortAddr(active?.address)}</code> is stored encrypted on this device.
+            </p>
+            <p>
+              We recommend moving the funds to a <strong>smart account</strong> — it supports passkeys, recovery,
+              and gasless actions. Send the {nativeSymbol} balance to the account below.
+            </p>
+            <div className="recover-step__address-row">
+              <div className="recover-step__address-wrap">
+                <AddressInput
+                  id="lkr-destination"
+                  label="Destination smart account"
+                  value={destInput}
+                  onChange={(e) => { setDestInput(e.target.value); setNotice(null) }}
+                  onResolvedChange={(addr) => setDestResolved(addr || '')}
+                  chainId={chainId}
+                  placeholder="0x… smart account to receive funds"
+                  disabled={busy}
+                />
+              </div>
+              <AddressBookButton disabled={busy} onSelect={(entry) => { setDestInput(entry.address); setDestResolved(entry.address) }} />
+            </div>
+
+            <div className="recover-step__actions">
+              <button type="button" className="btn" onClick={checkBalance} disabled={phase !== 'idle'}>
+                {phase === 'quoting' ? 'Checking…' : 'Check balance'}
+              </button>
+            </div>
+
+            {quote && (
+              <div className="lkr-quote" role="status">
+                <div><span>Balance</span><strong>{ethers.formatEther(quote.balance)} {nativeSymbol}</strong></div>
+                <div><span>Network fee (reserved)</span><strong>~{ethers.formatEther(quote.gasReserve)} {nativeSymbol}</strong></div>
+                <div><span>Will transfer</span><strong>{ethers.formatEther(quote.sendable)} {nativeSymbol}</strong></div>
+                {quote.sendable <= 0n && (
+                  <p className="lkr-quote__empty">Not enough to cover the network fee — add a little {nativeSymbol} to this account first, or there is nothing to move.</p>
+                )}
+              </div>
+            )}
+
+            <p className="recover-step__meta-line">
+              Only the {nativeSymbol} balance moves. Tokens (USDC, etc.) on this key stay put — move those from Pay
+              &amp; Transfer after you sign in. Checked on {networkName}.
+            </p>
+
+            {noticeEl}
+
+            <div className="recover-step__actions">
+              <button type="button" className="btn" onClick={closeWizard} disabled={busy}>Do this later</button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={busy || !destTarget || !quote || quote.sendable <= 0n}
+                onClick={doSweep}
+              >
+                {phase === 'sweeping' ? 'Transferring…' : 'Transfer funds'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 5 — done. */}
+        {step === 'done' && (
+          <div className="recover-step">
+            <p role="status" className="recover-step__ok">✓ Funds sent to your smart account.</p>
+            <p>
+              The transfer is confirmed. Your legacy key stays encrypted on this device in case you need it again —
+              remove it from the Recovery list once you&apos;re sure it&apos;s empty.
+            </p>
+            {txHash && network?.explorer?.baseUrl && (
+              <p className="recover-step__hint">
+                <a href={`${network.explorer.baseUrl}/tx/${txHash}`} target="_blank" rel="noopener noreferrer">
+                  View transaction →
+                </a>
+              </p>
+            )}
+            <div className="recover-step__actions">
+              <button type="button" className="btn btn-primary" onClick={closeWizard}>Done</button>
+            </div>
+          </div>
+        )}
+      </ActionSheet>
+    </section>
+  )
+}
+
+LegacyKeyRecoveryPanel.propTypes = {
+  deps: PropTypes.object,
+}
+
+export default LegacyKeyRecoveryPanel

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
@@ -87,6 +87,7 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
   const network = useMemo(() => getNetwork(chainId), [chainId])
   const networkName = network?.name || 'this network'
   const nativeSymbol = network?.nativeCurrency?.symbol || 'the native token'
+  const nativeDecimals = network?.nativeCurrency?.decimals ?? 18
 
   const detected = useMemo(() => classifySecret(rawSecret), [rawSecret])
   const alreadyStored = detected.address ? vault.has(detected.address) : false
@@ -236,14 +237,16 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
     setNotice(null)
     setPhase('quoting')
     try {
-      const q = await quoteAllAssets({ kind: active.kind, secret: active.secret, chainId, provider: deps.provider ?? provider })
+      // Pass the destination so the native-leg fee is estimated against it (a
+      // smart-account recipient needs more than the 21k EOA baseline).
+      const q = await quoteAllAssets({ kind: active.kind, secret: active.secret, chainId, provider: deps.provider ?? provider, to: destTarget || undefined })
       setQuote(q)
       setPhase('idle')
     } catch (e) {
       setPhase('idle')
       setNotice({ kind: 'error', text: `Could not read balances on ${networkName}: ${e.reason || e.shortMessage || e.message}` })
     }
-  }, [active, chainId, provider, deps.provider, networkName])
+  }, [active, chainId, provider, deps.provider, networkName, destTarget])
 
   const doSweep = useCallback(async () => {
     if (!active || !destTarget) return
@@ -303,6 +306,9 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
   const noticeEl = notice && (
     <p role="alert" className={`lkr-notice lkr-notice--${notice.kind}`}>{notice.text}</p>
   )
+
+  // Tokens present but no native to pay gas ⇒ nothing can be moved from here.
+  const noNativeForGas = Boolean(quote && !quote.hasNative && quote.holdings.length > 0)
 
   const renderOutcomes = () =>
     outcomes && outcomes.length > 0 && (
@@ -574,7 +580,7 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
             </div>
 
             <div className="recover-step__actions">
-              <button type="button" className="btn" onClick={checkBalances} disabled={phase !== 'idle'}>
+              <button type="button" className="btn" onClick={checkBalances} disabled={phase !== 'idle' || !destTarget}>
                 {phase === 'quoting' ? 'Checking…' : 'Check balances'}
               </button>
             </div>
@@ -584,12 +590,26 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
                 {quote.holdings.length === 0 ? (
                   <p className="lkr-quote__empty">No supported-asset balances found on {networkName} for this account.</p>
                 ) : (
-                  quote.holdings.map((h) => (
-                    <div key={h.asset.id || h.asset.symbol}>
-                      <span>{h.asset.symbol}</span>
-                      <strong>{ethers.formatUnits(h.balance, h.asset.decimals ?? 18)}</strong>
-                    </div>
-                  ))
+                  <>
+                    {quote.holdings.map((h) => (
+                      <div key={h.asset.id || h.asset.symbol}>
+                        <span>{h.asset.symbol}</span>
+                        <strong>{ethers.formatUnits(h.balance, h.asset.decimals ?? 18)}</strong>
+                      </div>
+                    ))}
+                    {quote.hasNative && (
+                      <div className="lkr-quote__fee">
+                        <span>Estimated network fee</span>
+                        <strong>≈ {ethers.formatUnits(quote.nativeGasReserve ?? 0n, nativeDecimals)} {nativeSymbol}</strong>
+                      </div>
+                    )}
+                  </>
+                )}
+                {noNativeForGas && (
+                  <p className="lkr-quote__empty">
+                    This account has no {nativeSymbol} to pay network fees, so its tokens can&apos;t be moved from here.
+                    Send a little {nativeSymbol} to <code>{shortAddr(active?.address)}</code> first, then check balances again.
+                  </p>
                 )}
               </div>
             )}
@@ -609,7 +629,7 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
               <button
                 type="button"
                 className="btn btn-primary"
-                disabled={busy || !destTarget || !quote || quote.holdings.length === 0}
+                disabled={busy || !destTarget || !quote || quote.holdings.length === 0 || noNativeForGas}
                 onClick={doSweep}
               >
                 {phase === 'sweeping' ? 'Transferring…' : 'Transfer all'}

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
@@ -1,25 +1,28 @@
 /**
- * Legacy key & word-list recovery (Recovery section).
+ * Legacy key & word-list recovery (Recovery section, spec 062).
  *
  * Members who arrive with an *old* secret — a raw EOA private key or a BIP-39
  * word list — use this to bring that account under FairWins. The flow is a
  * guided series of informational bottom sheets (shared ActionSheet, mirroring
  * RecoverAccountPanel) because handling a raw secret is high-stakes:
  *
- *   intro → enter the key/word list → set a passphrase (encrypt at rest) →
- *   move the funds to a smart account → done.
+ *   intro → enter the key/word list → set a passphrase → SAVED
  *
- * The secret is encrypted on-device with a passphrase-derived key
- * (lib/recovery/legacyKeys.js) and never leaves the browser. The headline
- * outcome is sweeping the funds onto a passkey smart account — a legacy EOA is
- * treated as something to move off of, not a place to keep money.
+ * Storing the encrypted secret COMPLETES recovery (the SAVED screen); the secret
+ * is encrypted on-device with a passphrase-derived key (lib/recovery/legacyKeys)
+ * and never leaves the browser, and the recovery is written to the audit ledger
+ * with no key material. From the SAVED screen (or later, from a stored-key row)
+ * the member may OPTIONALLY move all supported assets to a smart account and/or
+ * save the account to their address book so it is usable across the platform.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import { ethers } from 'ethers'
 import { useWallet } from '../../hooks/useWalletManagement'
+import { useAddressBook } from '../../hooks/useAddressBook'
 import { getNetwork } from '../../config/networks'
+import { captureLegacyRecovery } from '../../data/ledger/sources/legacyRecoverySource'
 import AddressInput from '../ui/AddressInput'
 import AddressBookButton from '../ui/AddressBookButton'
 import ActionSheet from './ActionSheet'
@@ -28,26 +31,32 @@ import {
   encryptLegacySecret,
   decryptLegacySecret,
   legacyKeyVault,
-  quoteNativeSweep,
-  sweepNativeToSmartAccount,
+  quoteAllAssets,
+  sweepAllAssets,
 } from '../../lib/recovery/legacyKeys'
+import { suggestWords, applySuggestion, currentWord, unknownWordsIn } from '../../lib/recovery/bip39Suggest'
 import './LegacyKeyRecoveryPanel.css'
 
 const shortAddr = (a) => (a ? `${a.substring(0, 6)}…${a.substring(a.length - 4)}` : '')
 const KIND_LABEL = { privateKey: 'private key', mnemonic: 'word list' }
+const kindNoun = (kind) => (kind === 'mnemonic' ? 'word list' : 'private key')
 
 const STEP_TITLES = {
   intro: 'Recover a legacy account',
   enter: 'Enter your key or word list',
   secure: 'Secure this key on your device',
+  saved: 'Recovery complete',
   transfer: 'Move your funds to a smart account',
   unlock: 'Unlock this key',
-  done: 'Recovery complete',
+  done: 'Funds moved',
 }
 
 function LegacyKeyRecoveryPanel({ deps = {} }) {
   const { address: sessionAddress, provider, loginMethod, chainId, isConnected } = useWallet()
-  const vault = useMemo(() => (deps.vault ?? legacyKeyVault)(), [deps.vault])
+  const { findByAddress, addContact, updateContact } = useAddressBook()
+  // Stable module import ⇒ the memo is preservable and re-derives only when the
+  // signed-in account changes. Tests inject a fake vault via the module mock.
+  const vault = useMemo(() => legacyKeyVault(sessionAddress), [sessionAddress])
 
   const [open, setOpen] = useState(false)
   const [step, setStep] = useState('intro')
@@ -59,14 +68,21 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
   const [rawSecret, setRawSecret] = useState('')
   const [passphrase, setPassphrase] = useState('')
   const [passphrase2, setPassphrase2] = useState('')
-  // The classified secret currently in memory (from import OR after unlock).
   const [active, setActive] = useState(null) // { kind, address, secret }
+
+  // Save-to-address-book state (on the SAVED screen).
+  const [bookName, setBookName] = useState('')
+  const [bookSaved, setBookSaved] = useState(false)
 
   // Transfer working state.
   const [destInput, setDestInput] = useState('')
   const [destResolved, setDestResolved] = useState('')
   const [quote, setQuote] = useState(null)
-  const [txHash, setTxHash] = useState(null)
+  const [outcomes, setOutcomes] = useState(null)
+
+  // Unlock (stored-key → move funds later).
+  const [unlockEntry, setUnlockEntry] = useState(null)
+  const [unlockPass, setUnlockPass] = useState('')
 
   const network = useMemo(() => getNetwork(chainId), [chainId])
   const networkName = network?.name || 'this network'
@@ -74,6 +90,21 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
 
   const detected = useMemo(() => classifySecret(rawSecret), [rawSecret])
   const alreadyStored = detected.address ? vault.has(detected.address) : false
+
+  // BIP-39 help: only when the input looks like a word list (not a 0x key).
+  const looksLikeWords = rawSecret.trim().length > 0 && !rawSecret.trim().toLowerCase().startsWith('0x')
+  const wordSuggestions = useMemo(
+    () => (looksLikeWords ? suggestWords(currentWord(rawSecret)) : []),
+    [looksLikeWords, rawSecret]
+  )
+  const unknownWords = useMemo(
+    () => (looksLikeWords ? unknownWordsIn(rawSecret) : []),
+    [looksLikeWords, rawSecret]
+  )
+  const pickSuggestion = useCallback((word) => {
+    setRawSecret((prev) => applySuggestion(prev, word))
+    setNotice(null)
+  }, [])
 
   const destTarget = useMemo(() => {
     const r = (destResolved || '').trim()
@@ -83,6 +114,12 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
   }, [destResolved, destInput])
 
   const refreshStored = useCallback(() => setStored(vault.list()), [vault])
+  useEffect(() => { refreshStored() }, [refreshStored])
+
+  const suggestedDest = useCallback(
+    () => (loginMethod === 'passkey' && sessionAddress ? sessionAddress : ''),
+    [loginMethod, sessionAddress]
+  )
 
   const resetWizard = useCallback(() => {
     setStep('intro')
@@ -92,37 +129,35 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
     setPassphrase('')
     setPassphrase2('')
     setActive(null)
+    setBookName('')
+    setBookSaved(false)
     setQuote(null)
-    setTxHash(null)
-    // Default the destination to the current session account when it is a
-    // passkey smart account — that is exactly where we want the funds to land.
-    const suggest = loginMethod === 'passkey' && sessionAddress ? sessionAddress : ''
+    setOutcomes(null)
+    setUnlockEntry(null)
+    setUnlockPass('')
+    const suggest = suggestedDest()
     setDestInput(suggest)
     setDestResolved(suggest)
-  }, [loginMethod, sessionAddress])
+  }, [suggestedDest])
 
   const openWizard = useCallback(() => {
     resetWizard()
     setOpen(true)
   }, [resetWizard])
 
+  const busy = phase === 'encrypting' || phase === 'sweeping'
+
   const closeWizard = useCallback(() => {
     if (phase === 'encrypting' || phase === 'sweeping') return // never yank mid-write
+    // Clear any secret material from memory as the sheet closes.
+    setRawSecret('')
+    setPassphrase('')
+    setPassphrase2('')
+    setActive(null)
+    setUnlockPass('')
     setOpen(false)
   }, [phase])
 
-  // Clear any secret material from memory when the sheet fully closes.
-  useEffect(() => {
-    if (!open) {
-      setRawSecret('')
-      setPassphrase('')
-      setPassphrase2('')
-      setActive(null)
-    }
-  }, [open])
-
-  // Step 1→2 handoff: capture the classified secret so later steps don't
-  // re-parse the textarea.
   const goSecure = useCallback(() => {
     const c = classifySecret(rawSecret)
     if (c.kind !== 'privateKey' && c.kind !== 'mnemonic') {
@@ -130,10 +165,12 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
       return
     }
     setActive({ kind: c.kind, address: c.address, secret: c.secret })
+    setBookName('Recovered account')
     setNotice(null)
     setStep('secure')
   }, [rawSecret])
 
+  // Encrypt + store, write the audit record, land on SAVED (recovery is now complete).
   const storeAndContinue = useCallback(async () => {
     if (!active) return
     if (passphrase !== passphrase2) {
@@ -152,55 +189,85 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
       })
       vault.set(entry)
       refreshStored()
+      // Audit WITHOUT key material (address/time/type only). Never breaks recovery.
+      try {
+        captureLegacyRecovery(sessionAddress, chainId, { recoveredAddress: active.address, source: active.kind })
+      } catch { /* audit is best-effort */ }
       setPassphrase('')
       setPassphrase2('')
+      setBookSaved(false)
       setPhase('idle')
-      setStep('transfer')
+      setStep('saved')
     } catch (e) {
       setPhase('idle')
       setNotice({ kind: 'error', text: e.message })
     }
-  }, [active, passphrase, passphrase2, deps, vault, refreshStored])
+  }, [active, passphrase, passphrase2, deps, vault, refreshStored, sessionAddress, chainId])
 
-  const checkBalance = useCallback(async () => {
+  // Save the recovered account to the address book (upsert; usable platform-wide).
+  const saveToBook = useCallback(() => {
+    if (!active) return
+    const notes = `Recovered from legacy ${kindNoun(active.kind)}`
+    try {
+      const found = findByAddress(active.address, chainId)
+      if (found) {
+        updateContact(found.contact.id, { nickname: bookName || found.contact.nickname })
+      } else {
+        addContact({ nickname: bookName || 'Recovered account', addresses: [{ address: active.address, chainId, notes }] })
+      }
+      setBookSaved(true)
+    } catch (e) {
+      setNotice({ kind: 'error', text: `Could not save to the address book: ${e.message}` })
+    }
+  }, [active, bookName, chainId, findByAddress, addContact, updateContact])
+
+  const openTransfer = useCallback(() => {
+    setNotice(null)
+    setQuote(null)
+    setOutcomes(null)
+    const suggest = suggestedDest()
+    setDestInput(suggest)
+    setDestResolved(suggest)
+    setStep('transfer')
+  }, [suggestedDest])
+
+  const checkBalances = useCallback(async () => {
     if (!active) return
     setNotice(null)
     setPhase('quoting')
     try {
-      const q = await quoteNativeSweep({ kind: active.kind, secret: active.secret, provider: deps.provider ?? provider })
+      const q = await quoteAllAssets({ kind: active.kind, secret: active.secret, chainId, provider: deps.provider ?? provider })
       setQuote(q)
       setPhase('idle')
     } catch (e) {
       setPhase('idle')
-      setNotice({ kind: 'error', text: `Could not read the balance on ${networkName}: ${e.reason || e.shortMessage || e.message}` })
+      setNotice({ kind: 'error', text: `Could not read balances on ${networkName}: ${e.reason || e.shortMessage || e.message}` })
     }
-  }, [active, provider, deps.provider, networkName])
+  }, [active, chainId, provider, deps.provider, networkName])
 
   const doSweep = useCallback(async () => {
     if (!active || !destTarget) return
     setNotice(null)
     setPhase('sweeping')
+    setOutcomes([])
     try {
-      const tx = await sweepNativeToSmartAccount({
+      const results = await sweepAllAssets({
         kind: active.kind,
         secret: active.secret,
         to: destTarget,
+        chainId,
         provider: deps.provider ?? provider,
+        onProgress: (o) => setOutcomes((prev) => [...(prev || []), o]),
       })
-      const receipt = await tx.wait()
-      if (receipt?.status === 0) throw new Error('the transfer reverted on-chain')
-      setTxHash(tx.hash)
+      setOutcomes(results)
       setPhase('idle')
-      setStep('done')
+      const anyFail = results.some((r) => r.status === 'failed')
+      if (!anyFail) setStep('done')
     } catch (e) {
       setPhase('idle')
-      setNotice({ kind: 'error', text: `The transfer did not go through: ${e.reason || e.shortMessage || e.message}` })
+      setNotice({ kind: 'error', text: `The transfer could not start: ${e.reason || e.shortMessage || e.message}` })
     }
-  }, [active, destTarget, provider, deps.provider])
-
-  // Stored-entry actions.
-  const [unlockEntry, setUnlockEntry] = useState(null)
-  const [unlockPass, setUnlockPass] = useState('')
+  }, [active, destTarget, chainId, provider, deps.provider])
 
   const startTransferStored = useCallback((entry) => {
     resetWizard()
@@ -219,12 +286,12 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
       setActive({ kind: unlockEntry.kind, address: unlockEntry.address, secret })
       setUnlockPass('')
       setPhase('idle')
-      setStep('transfer')
+      openTransfer()
     } catch (e) {
       setPhase('idle')
       setNotice({ kind: 'error', text: e.message })
     }
-  }, [unlockEntry, unlockPass, deps])
+  }, [unlockEntry, unlockPass, deps, openTransfer])
 
   const removeStored = useCallback((address) => {
     vault.delete(address)
@@ -233,18 +300,31 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
 
   if (!isConnected) return null
 
-  const busy = phase === 'encrypting' || phase === 'sweeping'
   const noticeEl = notice && (
     <p role="alert" className={`lkr-notice lkr-notice--${notice.kind}`}>{notice.text}</p>
   )
 
+  const renderOutcomes = () =>
+    outcomes && outcomes.length > 0 && (
+      <ul className="lkr-outcomes" aria-label="Transfer results">
+        {outcomes.map((o, i) => (
+          <li key={`${o.asset.symbol}-${i}`} className={`lkr-outcome lkr-outcome--${o.status}`}>
+            <span className="lkr-outcome__sym">{o.asset.symbol}</span>
+            <span className="lkr-outcome__status">
+              {o.status === 'sent' ? '✓ sent' : o.status === 'skipped' ? 'skipped' : `failed${o.error ? ` — ${o.error}` : ''}`}
+            </span>
+          </li>
+        ))}
+      </ul>
+    )
+
   return (
     <section className="legacy-recovery section" aria-label="Recover a legacy key or word list">
-      <h3>Legacy key & word-list recovery</h3>
+      <h3>Legacy key &amp; word-list recovery</h3>
       <p className="section-description">
         Moving from an older wallet? Bring in a legacy <strong>private key</strong> or <strong>word list</strong>{' '}
-        (recovery phrase). FairWins stores it encrypted on this device and helps you move the funds to a modern
-        smart account — the safer place to keep them.
+        (recovery phrase). FairWins stores it encrypted on this device; you can then optionally move its funds to
+        a smart account and save it to your address book.
       </p>
       <button type="button" className="btn btn-primary legacy-recovery__start" onClick={openWizard}>
         Recover a legacy key
@@ -284,13 +364,13 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
         {step === 'intro' && (
           <div className="recover-step">
             <p>
-              Recover an account from a legacy <strong>private key</strong> or <strong>word list</strong>. This
-              lets you move any funds it holds onto a smart account you control here.
+              Recover an account from a legacy <strong>private key</strong> or <strong>word list</strong>. FairWins
+              stores it encrypted on this device; moving its funds to a smart account is an optional next step.
             </p>
             <ol className="recover-step__list">
               <li>Paste the private key or word list — we detect which it is.</li>
               <li>Choose a passphrase so we can store it encrypted on this device.</li>
-              <li>Move its funds to your smart account in one transaction.</li>
+              <li>Optionally move its funds to a smart account and save it to your address book.</li>
             </ol>
             <p className="recover-step__warn" role="note">
               ⚠ Only paste a key you own. Anyone with this secret controls that account — treat it like cash. We
@@ -320,6 +400,20 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
               autoCapitalize="off"
               aria-label="Private key or recovery word list"
             />
+            {wordSuggestions.length > 0 && (
+              <div className="lkr-suggest" role="group" aria-label="Word suggestions">
+                {wordSuggestions.map((w) => (
+                  <button key={w} type="button" className="lkr-suggest__chip" onClick={() => pickSuggestion(w)}>
+                    {w}
+                  </button>
+                ))}
+              </div>
+            )}
+            {unknownWords.length > 0 && detected.kind !== 'mnemonic' && (
+              <p className="lkr-notice lkr-notice--warn" role="status">
+                Not in the recovery word list: <strong>{unknownWords.join(', ')}</strong>. Check for a typo.
+              </p>
+            )}
             {detected.kind === 'privateKey' || detected.kind === 'mnemonic' ? (
               <p className="recover-step__ok" role="status" data-testid="lkr-detected">
                 ✓ Detected a {KIND_LABEL[detected.kind]} for account <code>{shortAddr(detected.address)}</code>.
@@ -381,8 +475,53 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
                 disabled={busy || passphrase.length < 8 || passphrase !== passphrase2}
                 onClick={storeAndContinue}
               >
-                {phase === 'encrypting' ? 'Encrypting…' : 'Encrypt & continue'}
+                {phase === 'encrypting' ? 'Encrypting…' : 'Encrypt & save'}
               </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 4 — SAVED: recovery is complete. Optional follow-ups only. */}
+        {step === 'saved' && (
+          <div className="recover-step">
+            <p role="status" className="recover-step__ok" data-testid="lkr-saved">
+              ✓ Recovered. <code>{shortAddr(active?.address)}</code> is stored encrypted on this device.
+            </p>
+            <p>Recovery is complete. These next steps are optional.</p>
+
+            <div className="lkr-saved-action">
+              <p className="lkr-saved-action__title">Save to your address book</p>
+              <p className="lkr-saved-action__hint">Makes this account available everywhere you pick an address.</p>
+              {bookSaved ? (
+                <p className="recover-step__ok" role="status">✓ Saved to your address book.</p>
+              ) : (
+                <div className="lkr-book-row">
+                  <input
+                    type="text"
+                    className="lkr-book-name"
+                    value={bookName}
+                    onChange={(e) => setBookName(e.target.value)}
+                    aria-label="Address book name"
+                    placeholder="Name for this account"
+                  />
+                  <button type="button" className="btn" onClick={saveToBook}>Save to address book</button>
+                </div>
+              )}
+            </div>
+
+            <div className="lkr-saved-action">
+              <p className="lkr-saved-action__title">Move funds to a smart account</p>
+              <p className="lkr-saved-action__hint">
+                Recommended — a smart account supports passkeys, recovery, and gasless actions. Moves all supported
+                assets ({nativeSymbol} and tokens).
+              </p>
+            </div>
+
+            {noticeEl}
+
+            <div className="recover-step__actions">
+              <button type="button" className="btn" onClick={closeWizard}>Done</button>
+              <button type="button" className="btn btn-primary" onClick={openTransfer}>Move funds</button>
             </div>
           </div>
         )}
@@ -390,9 +529,7 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
         {/* Step 3b — unlock a previously stored key before moving funds. */}
         {step === 'unlock' && (
           <div className="recover-step">
-            <p>
-              Enter the passphrase for <code>{shortAddr(unlockEntry?.address)}</code> to move its funds.
-            </p>
+            <p>Enter the passphrase for <code>{shortAddr(unlockEntry?.address)}</code> to move its funds.</p>
             <label className="lkr-field">
               <span>Passphrase</span>
               <input
@@ -413,15 +550,12 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
           </div>
         )}
 
-        {/* Step 4 — recommend + sweep to a smart account. */}
+        {/* Step 5 — move ALL supported assets to a smart account (optional). */}
         {step === 'transfer' && (
           <div className="recover-step">
-            <p role="status" className="recover-step__ok">
-              ✓ Key for <code>{shortAddr(active?.address)}</code> is stored encrypted on this device.
-            </p>
             <p>
-              We recommend moving the funds to a <strong>smart account</strong> — it supports passkeys, recovery,
-              and gasless actions. Send the {nativeSymbol} balance to the account below.
+              Move the supported assets held by <code>{shortAddr(active?.address)}</code> to a smart account. Send
+              them to the account below.
             </p>
             <div className="recover-step__address-row">
               <div className="recover-step__address-wrap">
@@ -440,58 +574,59 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
             </div>
 
             <div className="recover-step__actions">
-              <button type="button" className="btn" onClick={checkBalance} disabled={phase !== 'idle'}>
-                {phase === 'quoting' ? 'Checking…' : 'Check balance'}
+              <button type="button" className="btn" onClick={checkBalances} disabled={phase !== 'idle'}>
+                {phase === 'quoting' ? 'Checking…' : 'Check balances'}
               </button>
             </div>
 
             {quote && (
               <div className="lkr-quote" role="status">
-                <div><span>Balance</span><strong>{ethers.formatEther(quote.balance)} {nativeSymbol}</strong></div>
-                <div><span>Network fee (reserved)</span><strong>~{ethers.formatEther(quote.gasReserve)} {nativeSymbol}</strong></div>
-                <div><span>Will transfer</span><strong>{ethers.formatEther(quote.sendable)} {nativeSymbol}</strong></div>
-                {quote.sendable <= 0n && (
-                  <p className="lkr-quote__empty">Not enough to cover the network fee — add a little {nativeSymbol} to this account first, or there is nothing to move.</p>
+                {quote.holdings.length === 0 ? (
+                  <p className="lkr-quote__empty">No supported-asset balances found on {networkName} for this account.</p>
+                ) : (
+                  quote.holdings.map((h) => (
+                    <div key={h.asset.id || h.asset.symbol}>
+                      <span>{h.asset.symbol}</span>
+                      <strong>{ethers.formatUnits(h.balance, h.asset.decimals ?? 18)}</strong>
+                    </div>
+                  ))
                 )}
               </div>
             )}
 
             <p className="recover-step__meta-line">
-              Only the {nativeSymbol} balance moves. Tokens (USDC, etc.) on this key stay put — move those from Pay
-              &amp; Transfer after you sign in. Checked on {networkName}.
+              Only platform-supported assets ({nativeSymbol} + supported tokens) are moved — collectibles/NFTs are
+              not. The legacy key pays the network fee from its {nativeSymbol}. Checked on {networkName}.
             </p>
 
+            {renderOutcomes()}
             {noticeEl}
 
             <div className="recover-step__actions">
-              <button type="button" className="btn" onClick={closeWizard} disabled={busy}>Do this later</button>
+              <button type="button" className="btn" onClick={closeWizard} disabled={busy}>
+                {outcomes && outcomes.length ? 'Close' : 'Do this later'}
+              </button>
               <button
                 type="button"
                 className="btn btn-primary"
-                disabled={busy || !destTarget || !quote || quote.sendable <= 0n}
+                disabled={busy || !destTarget || !quote || quote.holdings.length === 0}
                 onClick={doSweep}
               >
-                {phase === 'sweeping' ? 'Transferring…' : 'Transfer funds'}
+                {phase === 'sweeping' ? 'Transferring…' : 'Transfer all'}
               </button>
             </div>
           </div>
         )}
 
-        {/* Step 5 — done. */}
+        {/* Step 6 — done (all assets moved with no failure). */}
         {step === 'done' && (
           <div className="recover-step">
-            <p role="status" className="recover-step__ok">✓ Funds sent to your smart account.</p>
+            <p role="status" className="recover-step__ok">✓ Funds moved to your smart account.</p>
+            {renderOutcomes()}
             <p>
-              The transfer is confirmed. Your legacy key stays encrypted on this device in case you need it again —
-              remove it from the Recovery list once you&apos;re sure it&apos;s empty.
+              Your legacy key stays encrypted on this device in case you need it again — remove it from the Recovery
+              list once you&apos;re sure it&apos;s empty.
             </p>
-            {txHash && network?.explorer?.baseUrl && (
-              <p className="recover-step__hint">
-                <a href={`${network.explorer.baseUrl}/tx/${txHash}`} target="_blank" rel="noopener noreferrer">
-                  View transaction →
-                </a>
-              </p>
-            )}
             <div className="recover-step__actions">
               <button type="button" className="btn btn-primary" onClick={closeWizard}>Done</button>
             </div>

--- a/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
@@ -1,19 +1,20 @@
 /**
- * Legacy key & word-list recovery panel (Recovery section).
+ * Legacy key & word-list recovery panel (Recovery section, spec 062).
  *
- * Covers: session gating, the guided bottom-sheet flow (intro → enter → secure
- * → transfer → done), live key/word-list detection, at-rest encryption on
- * continue, the recommend-and-sweep step (balance quote → transfer to a smart
- * account), and the stored-key list (unlock-to-move + remove). The recovery
- * library is mocked so the test drives the component's orchestration; the
- * library's crypto/ethers behavior is covered in test/recovery/legacyKeys.test.js.
+ * Covers: session gating, the guided flow ending at SAVED (recovery completes
+ * with no transfer), the audit call on save, the optional save-to-address-book
+ * upsert, the optional all-asset sweep (balances → per-asset outcomes, partial
+ * failure), and the stored-key list (unlock-to-move + remove). The recovery
+ * library, address book, and audit source are mocked so the test drives the
+ * component's orchestration; their internals are covered in their own suites.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { axe } from 'vitest-axe'
 
 const mockWallet = {
-  address: '0x' + 'a'.repeat(40), // a passkey smart account → suggested destination
+  address: '0x' + 'a'.repeat(40), // passkey smart account → suggested destination
   provider: {},
   loginMethod: 'passkey',
   chainId: 137,
@@ -25,29 +26,34 @@ vi.mock('../../../config/networks', () => ({
   getNetwork: () => ({ name: 'Polygon', nativeCurrency: { symbol: 'MATIC' }, explorer: { baseUrl: 'https://polygonscan.com' } }),
 }))
 
-// Lightweight address inputs so the test isn't coupled to ENS/wagmi wiring.
 vi.mock('../../ui/AddressInput', () => ({
-  default: ({ id, value, onChange, label }) => (
-    <input aria-label={label} id={id} value={value} onChange={onChange} />
-  ),
+  default: ({ id, value, onChange, label }) => <input aria-label={label} id={id} value={value} onChange={onChange} />,
 }))
 vi.mock('../../ui/AddressBookButton', () => ({ default: () => <button type="button">Book</button> }))
 
-// The recovery library — fully controlled per test.
+// Address book hook — controlled.
+const book = vi.hoisted(() => ({ findByAddress: vi.fn(), addContact: vi.fn(), updateContact: vi.fn() }))
+vi.mock('../../../hooks/useAddressBook', () => ({ useAddressBook: () => book }))
+
+// Audit source — spy.
+const audit = vi.hoisted(() => ({ captureLegacyRecovery: vi.fn() }))
+vi.mock('../../../data/ledger/sources/legacyRecoverySource', () => ({ captureLegacyRecovery: audit.captureLegacyRecovery }))
+
+// Recovery library — fully controlled per test.
 const lib = vi.hoisted(() => ({
   classifySecret: vi.fn(),
   encryptLegacySecret: vi.fn(),
   decryptLegacySecret: vi.fn(),
-  quoteNativeSweep: vi.fn(),
-  sweepNativeToSmartAccount: vi.fn(),
+  quoteAllAssets: vi.fn(),
+  sweepAllAssets: vi.fn(),
   store: new Map(),
 }))
 vi.mock('../../../lib/recovery/legacyKeys', () => ({
   classifySecret: lib.classifySecret,
   encryptLegacySecret: lib.encryptLegacySecret,
   decryptLegacySecret: lib.decryptLegacySecret,
-  quoteNativeSweep: lib.quoteNativeSweep,
-  sweepNativeToSmartAccount: lib.sweepNativeToSmartAccount,
+  quoteAllAssets: lib.quoteAllAssets,
+  sweepAllAssets: lib.sweepAllAssets,
   legacyKeyVault: () => ({
     list: () => Array.from(lib.store.values()).sort((a, b) => (b.importedAt || 0) - (a.importedAt || 0)),
     get: (a) => lib.store.get(String(a).toLowerCase()) ?? null,
@@ -68,9 +74,16 @@ beforeEach(() => {
   lib.classifySecret.mockReturnValue({ kind: 'empty' })
 })
 
-async function openToEnter(user) {
+async function importToSaved(user, kind = 'privateKey') {
   await user.click(screen.getByRole('button', { name: 'Recover a legacy key' }))
   await user.click(screen.getByRole('button', { name: 'Get started' }))
+  lib.classifySecret.mockReturnValue({ kind, address: LEGACY_ADDR, secret: '0xkey' })
+  await user.type(screen.getByLabelText('Private key or recovery word list'), '0xkey')
+  await user.click(screen.getByRole('button', { name: 'Continue' }))
+  await user.type(screen.getByLabelText('Passphrase'), 'longenough')
+  await user.type(screen.getByLabelText('Confirm passphrase'), 'longenough')
+  await user.click(screen.getByRole('button', { name: 'Encrypt & save' }))
+  await screen.findByTestId('lkr-saved')
 }
 
 describe('LegacyKeyRecoveryPanel', () => {
@@ -81,74 +94,132 @@ describe('LegacyKeyRecoveryPanel', () => {
     mockWallet.isConnected = true
   })
 
-  it('detects a key, encrypts it, then sweeps funds to the smart account', async () => {
+  it('completes recovery at SAVED without any transfer, and writes the audit record', async () => {
     const user = userEvent.setup()
-    lib.encryptLegacySecret.mockResolvedValue({ v: 1, kind: 'privateKey', address: LEGACY_ADDR, importedAt: 1 })
-    lib.quoteNativeSweep.mockResolvedValue({ from: LEGACY_ADDR, balance: 5n, gasReserve: 1n, sendable: 4n })
-    lib.sweepNativeToSmartAccount.mockResolvedValue({ hash: '0xdead', wait: async () => ({ status: 1 }) })
-
+    lib.encryptLegacySecret.mockResolvedValue({ v: 1, kind: 'privateKey', address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
     render(<LegacyKeyRecoveryPanel />)
-    await openToEnter(user)
+    await importToSaved(user)
 
-    // Live detection appears once classifySecret recognizes the input.
-    lib.classifySecret.mockReturnValue({ kind: 'privateKey', address: LEGACY_ADDR, secret: '0xkey' })
-    await user.type(screen.getByLabelText('Private key or recovery word list'), '0xkey')
-    expect(await screen.findByTestId('lkr-detected')).toHaveTextContent(/private key/i)
-    await user.click(screen.getByRole('button', { name: 'Continue' }))
-
-    // Passphrase step — must match and clear the min length before encrypting.
-    await user.type(screen.getByLabelText('Passphrase'), 'longenough')
-    await user.type(screen.getByLabelText('Confirm passphrase'), 'longenough')
-    await user.click(screen.getByRole('button', { name: 'Encrypt & continue' }))
-    await waitFor(() => expect(lib.encryptLegacySecret).toHaveBeenCalledWith(expect.objectContaining({ passphrase: 'longenough', kind: 'privateKey' })))
-
-    // Transfer step — destination pre-filled with the passkey smart account.
-    expect(screen.getByLabelText('Destination smart account')).toHaveValue(DEST)
-    await user.click(screen.getByRole('button', { name: 'Check balance' }))
-    await waitFor(() => expect(screen.getByText(/Will transfer/i)).toBeInTheDocument())
-
-    await user.click(screen.getByRole('button', { name: 'Transfer funds' }))
-    await waitFor(() =>
-      expect(lib.sweepNativeToSmartAccount).toHaveBeenCalledWith(expect.objectContaining({ to: DEST }))
+    // Recovery is complete on its own — the SAVED screen, no transfer required.
+    expect(screen.getByTestId('lkr-saved')).toHaveTextContent(/stored encrypted/i)
+    expect(lib.encryptLegacySecret).toHaveBeenCalledWith(expect.objectContaining({ passphrase: 'longenough' }))
+    // Audit written with address + type, never a secret.
+    expect(audit.captureLegacyRecovery).toHaveBeenCalledWith(
+      DEST, 137, { recoveredAddress: LEGACY_ADDR, source: 'privateKey' }
     )
-    expect(await screen.findByText(/Funds sent to your smart account/i)).toBeInTheDocument()
+    // Closing here (Done) leaves recovery complete without moving funds.
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+  })
+
+  it('suggests BIP-39 completions while typing a word list', async () => {
+    const user = userEvent.setup()
+    render(<LegacyKeyRecoveryPanel />)
+    await user.click(screen.getByRole('button', { name: 'Recover a legacy key' }))
+    await user.click(screen.getByRole('button', { name: 'Get started' }))
+    lib.classifySecret.mockReturnValue({ kind: 'invalid' })
+    await user.type(screen.getByLabelText('Private key or recovery word list'), 'legal winner aban')
+    // A completion chip for the partial word appears; clicking it completes the word.
+    const chip = await screen.findByRole('button', { name: 'abandon' })
+    await user.click(chip)
+    expect(screen.getByLabelText('Private key or recovery word list')).toHaveValue('legal winner abandon ')
   })
 
   it('blocks continuing when passphrases do not match', async () => {
     const user = userEvent.setup()
     render(<LegacyKeyRecoveryPanel />)
-    await openToEnter(user)
+    await user.click(screen.getByRole('button', { name: 'Recover a legacy key' }))
+    await user.click(screen.getByRole('button', { name: 'Get started' }))
     lib.classifySecret.mockReturnValue({ kind: 'mnemonic', address: LEGACY_ADDR, secret: 'a b c' })
     await user.type(screen.getByLabelText('Private key or recovery word list'), 'a b c')
     await user.click(screen.getByRole('button', { name: 'Continue' }))
-
     await user.type(screen.getByLabelText('Passphrase'), 'longenough')
     await user.type(screen.getByLabelText('Confirm passphrase'), 'different1')
-    // Mismatch keeps the button disabled and never calls encrypt.
-    expect(screen.getByRole('button', { name: 'Encrypt & continue' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Encrypt & save' })).toBeDisabled()
     expect(lib.encryptLegacySecret).not.toHaveBeenCalled()
   })
 
-  it('lists a stored key and unlocks it before moving funds', async () => {
-    lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'mnemonic', address: LEGACY_ADDR, importedAt: 42, v: 1, ct: 'x', iv: 'y', salt: 'z' })
+  it('saves the recovered account to the address book (upsert)', async () => {
+    const user = userEvent.setup()
+    lib.encryptLegacySecret.mockResolvedValue({ v: 1, address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
+    book.findByAddress.mockReturnValue(null) // not yet in book → addContact
+    render(<LegacyKeyRecoveryPanel />)
+    await importToSaved(user)
+
+    await user.click(screen.getByRole('button', { name: 'Save to address book' }))
+    expect(book.addContact).toHaveBeenCalledWith(
+      expect.objectContaining({ addresses: [expect.objectContaining({ address: LEGACY_ADDR, chainId: 137 })] })
+    )
+    expect(await screen.findByText(/Saved to your address book/i)).toBeInTheDocument()
+  })
+
+  it('moves all supported assets to the smart account and shows per-asset outcomes', async () => {
+    const user = userEvent.setup()
+    lib.encryptLegacySecret.mockResolvedValue({ v: 1, address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
+    lib.quoteAllAssets.mockResolvedValue({
+      from: LEGACY_ADDR,
+      holdings: [
+        { asset: { id: 'usdc', symbol: 'USDC', decimals: 6 }, balance: 5_000_000n },
+        { asset: { id: 'native', symbol: 'MATIC', decimals: 18 }, balance: 10n ** 17n },
+      ],
+      nativeGasReserve: 1n,
+      hasNative: true,
+    })
+    lib.sweepAllAssets.mockResolvedValue([
+      { asset: { symbol: 'USDC' }, status: 'sent', txHash: '0x1' },
+      { asset: { symbol: 'MATIC' }, status: 'sent', txHash: '0x2' },
+    ])
+    render(<LegacyKeyRecoveryPanel />)
+    await importToSaved(user)
+
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move funds' }))
+    expect(screen.getByLabelText('Destination smart account')).toHaveValue(DEST)
+    await user.click(screen.getByRole('button', { name: 'Check balances' }))
+    await waitFor(() => expect(screen.getByText('USDC')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Transfer all' }))
+    await waitFor(() => expect(lib.sweepAllAssets).toHaveBeenCalledWith(expect.objectContaining({ to: DEST, chainId: 137 })))
+    expect(await screen.findByText(/Funds moved to your smart account/i)).toBeInTheDocument()
+  })
+
+  it('keeps a partial failure visible instead of declaring success', async () => {
+    const user = userEvent.setup()
+    lib.encryptLegacySecret.mockResolvedValue({ v: 1, address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
+    lib.quoteAllAssets.mockResolvedValue({
+      from: LEGACY_ADDR,
+      holdings: [{ asset: { id: 'usdc', symbol: 'USDC', decimals: 6 }, balance: 5_000_000n }],
+      nativeGasReserve: 1n,
+      hasNative: false,
+    })
+    lib.sweepAllAssets.mockResolvedValue([{ asset: { symbol: 'USDC' }, status: 'failed', error: 'reverted' }])
+    render(<LegacyKeyRecoveryPanel />)
+    await importToSaved(user)
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move funds' }))
+    await user.click(screen.getByRole('button', { name: 'Check balances' }))
+    await waitFor(() => expect(screen.getByText('USDC')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: 'Transfer all' }))
+    // Failure is shown; we do NOT advance to the success screen.
+    expect(await screen.findByText(/failed — reverted/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Funds moved to your smart account/i)).not.toBeInTheDocument()
+  })
+
+  it('unlocks a stored key before moving funds', async () => {
+    lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'mnemonic', address: LEGACY_ADDR, importedAt: 42, ct: 'x' })
     lib.decryptLegacySecret.mockResolvedValue('word list secret')
-    lib.quoteNativeSweep.mockResolvedValue({ from: LEGACY_ADDR, balance: 5n, gasReserve: 1n, sendable: 4n })
+    lib.quoteAllAssets.mockResolvedValue({ from: LEGACY_ADDR, holdings: [], nativeGasReserve: 1n, hasNative: false })
     const user = userEvent.setup()
     render(<LegacyKeyRecoveryPanel />)
 
     const item = screen.getByRole('listitem')
     expect(within(item).getByText(/word list/i)).toBeInTheDocument()
     await user.click(within(item).getByRole('button', { name: 'Move funds' }))
-
     await user.type(screen.getByLabelText('Passphrase'), 'unlockme1')
     await user.click(screen.getByRole('button', { name: 'Unlock' }))
     await waitFor(() => expect(lib.decryptLegacySecret).toHaveBeenCalled())
-    // Lands on the transfer step for that key.
-    expect(await screen.findByText(/is stored encrypted on this device/i)).toBeInTheDocument()
+    expect(await screen.findByLabelText('Destination smart account')).toBeInTheDocument()
   })
 
-  it('removes a stored key from the list', async () => {
-    lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'privateKey', address: LEGACY_ADDR, importedAt: 42 })
+  it('removes a stored key', async () => {
+    lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'privateKey', address: LEGACY_ADDR, importedAt: 42, ct: 'x' })
     const user = userEvent.setup()
     render(<LegacyKeyRecoveryPanel />)
     expect(screen.getByRole('listitem')).toBeInTheDocument()
@@ -156,8 +227,17 @@ describe('LegacyKeyRecoveryPanel', () => {
     await waitFor(() => expect(screen.queryByRole('listitem')).not.toBeInTheDocument())
   })
 
+  it('has no accessibility violations on the entry and SAVED screens', async () => {
+    const user = userEvent.setup()
+    lib.encryptLegacySecret.mockResolvedValue({ v: 1, address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
+    const { container } = render(<LegacyKeyRecoveryPanel />)
+    expect(await axe(container)).toHaveNoViolations()
+    await importToSaved(user)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
   it('surfaces a decryption failure on unlock', async () => {
-    lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'privateKey', address: LEGACY_ADDR, importedAt: 42 })
+    lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'privateKey', address: LEGACY_ADDR, importedAt: 42, ct: 'x' })
     lib.decryptLegacySecret.mockRejectedValue(new Error('That passphrase did not unlock this key.'))
     const user = userEvent.setup()
     render(<LegacyKeyRecoveryPanel />)

--- a/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
@@ -186,11 +186,17 @@ describe('LegacyKeyRecoveryPanel', () => {
     lib.encryptLegacySecret.mockResolvedValue({ v: 1, address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
     lib.quoteAllAssets.mockResolvedValue({
       from: LEGACY_ADDR,
-      holdings: [{ asset: { id: 'usdc', symbol: 'USDC', decimals: 6 }, balance: 5_000_000n }],
+      holdings: [
+        { asset: { id: 'usdc', symbol: 'USDC', decimals: 6 }, balance: 5_000_000n },
+        { asset: { id: 'native', symbol: 'MATIC', decimals: 18 }, balance: 10n ** 17n },
+      ],
       nativeGasReserve: 1n,
-      hasNative: false,
+      hasNative: true,
     })
-    lib.sweepAllAssets.mockResolvedValue([{ asset: { symbol: 'USDC' }, status: 'failed', error: 'reverted' }])
+    lib.sweepAllAssets.mockResolvedValue([
+      { asset: { symbol: 'USDC' }, status: 'failed', error: 'reverted' },
+      { asset: { symbol: 'MATIC' }, status: 'sent', txHash: '0x2' },
+    ])
     render(<LegacyKeyRecoveryPanel />)
     await importToSaved(user)
     await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move funds' }))
@@ -200,6 +206,44 @@ describe('LegacyKeyRecoveryPanel', () => {
     // Failure is shown; we do NOT advance to the success screen.
     expect(await screen.findByText(/failed — reverted/i)).toBeInTheDocument()
     expect(screen.queryByText(/Funds moved to your smart account/i)).not.toBeInTheDocument()
+  })
+
+  it('discloses the estimated fee and blocks transfer when there is no native for gas', async () => {
+    const user = userEvent.setup()
+    lib.encryptLegacySecret.mockResolvedValue({ v: 1, address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
+    // Tokens present but zero native ⇒ cannot pay gas ⇒ transfer must be blocked.
+    lib.quoteAllAssets.mockResolvedValue({
+      from: LEGACY_ADDR,
+      holdings: [{ asset: { id: 'usdc', symbol: 'USDC', decimals: 6 }, balance: 5_000_000n }],
+      nativeGasReserve: 0n,
+      hasNative: false,
+    })
+    render(<LegacyKeyRecoveryPanel />)
+    await importToSaved(user)
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move funds' }))
+    await user.click(screen.getByRole('button', { name: 'Check balances' }))
+    await waitFor(() => expect(screen.getByText('USDC')).toBeInTheDocument())
+    expect(screen.getByText(/no MATIC to pay network fees/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Transfer all' })).toBeDisabled()
+    expect(lib.sweepAllAssets).not.toHaveBeenCalled()
+  })
+
+  it('discloses the estimated network fee before signing', async () => {
+    const user = userEvent.setup()
+    lib.encryptLegacySecret.mockResolvedValue({ v: 1, address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
+    lib.quoteAllAssets.mockResolvedValue({
+      from: LEGACY_ADDR,
+      holdings: [{ asset: { id: 'native', symbol: 'MATIC', decimals: 18 }, balance: 10n ** 18n }],
+      nativeGasReserve: 5n * 10n ** 16n, // 0.05 MATIC
+      nativeGasLimit: 25200n,
+      hasNative: true,
+    })
+    render(<LegacyKeyRecoveryPanel />)
+    await importToSaved(user)
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move funds' }))
+    await user.click(screen.getByRole('button', { name: 'Check balances' }))
+    expect(await screen.findByText(/Estimated network fee/i)).toBeInTheDocument()
+    expect(screen.getByText(/≈ 0.05 MATIC/)).toBeInTheDocument()
   })
 
   it('unlocks a stored key before moving funds', async () => {

--- a/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
@@ -1,0 +1,169 @@
+/**
+ * Legacy key & word-list recovery panel (Recovery section).
+ *
+ * Covers: session gating, the guided bottom-sheet flow (intro → enter → secure
+ * → transfer → done), live key/word-list detection, at-rest encryption on
+ * continue, the recommend-and-sweep step (balance quote → transfer to a smart
+ * account), and the stored-key list (unlock-to-move + remove). The recovery
+ * library is mocked so the test drives the component's orchestration; the
+ * library's crypto/ethers behavior is covered in test/recovery/legacyKeys.test.js.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockWallet = {
+  address: '0x' + 'a'.repeat(40), // a passkey smart account → suggested destination
+  provider: {},
+  loginMethod: 'passkey',
+  chainId: 137,
+  isConnected: true,
+}
+vi.mock('../../../hooks/useWalletManagement', () => ({ useWallet: () => mockWallet }))
+
+vi.mock('../../../config/networks', () => ({
+  getNetwork: () => ({ name: 'Polygon', nativeCurrency: { symbol: 'MATIC' }, explorer: { baseUrl: 'https://polygonscan.com' } }),
+}))
+
+// Lightweight address inputs so the test isn't coupled to ENS/wagmi wiring.
+vi.mock('../../ui/AddressInput', () => ({
+  default: ({ id, value, onChange, label }) => (
+    <input aria-label={label} id={id} value={value} onChange={onChange} />
+  ),
+}))
+vi.mock('../../ui/AddressBookButton', () => ({ default: () => <button type="button">Book</button> }))
+
+// The recovery library — fully controlled per test.
+const lib = vi.hoisted(() => ({
+  classifySecret: vi.fn(),
+  encryptLegacySecret: vi.fn(),
+  decryptLegacySecret: vi.fn(),
+  quoteNativeSweep: vi.fn(),
+  sweepNativeToSmartAccount: vi.fn(),
+  store: new Map(),
+}))
+vi.mock('../../../lib/recovery/legacyKeys', () => ({
+  classifySecret: lib.classifySecret,
+  encryptLegacySecret: lib.encryptLegacySecret,
+  decryptLegacySecret: lib.decryptLegacySecret,
+  quoteNativeSweep: lib.quoteNativeSweep,
+  sweepNativeToSmartAccount: lib.sweepNativeToSmartAccount,
+  legacyKeyVault: () => ({
+    list: () => Array.from(lib.store.values()).sort((a, b) => (b.importedAt || 0) - (a.importedAt || 0)),
+    get: (a) => lib.store.get(String(a).toLowerCase()) ?? null,
+    has: (a) => lib.store.has(String(a).toLowerCase()),
+    set: (e) => lib.store.set(String(e.address).toLowerCase(), e),
+    delete: (a) => lib.store.delete(String(a).toLowerCase()),
+  }),
+}))
+
+import LegacyKeyRecoveryPanel from '../LegacyKeyRecoveryPanel'
+
+const LEGACY_ADDR = '0x' + 'f'.repeat(40)
+const DEST = mockWallet.address
+
+beforeEach(() => {
+  lib.store.clear()
+  vi.clearAllMocks()
+  lib.classifySecret.mockReturnValue({ kind: 'empty' })
+})
+
+async function openToEnter(user) {
+  await user.click(screen.getByRole('button', { name: 'Recover a legacy key' }))
+  await user.click(screen.getByRole('button', { name: 'Get started' }))
+}
+
+describe('LegacyKeyRecoveryPanel', () => {
+  it('renders nothing when disconnected', () => {
+    mockWallet.isConnected = false
+    const { container } = render(<LegacyKeyRecoveryPanel />)
+    expect(container).toBeEmptyDOMElement()
+    mockWallet.isConnected = true
+  })
+
+  it('detects a key, encrypts it, then sweeps funds to the smart account', async () => {
+    const user = userEvent.setup()
+    lib.encryptLegacySecret.mockResolvedValue({ v: 1, kind: 'privateKey', address: LEGACY_ADDR, importedAt: 1 })
+    lib.quoteNativeSweep.mockResolvedValue({ from: LEGACY_ADDR, balance: 5n, gasReserve: 1n, sendable: 4n })
+    lib.sweepNativeToSmartAccount.mockResolvedValue({ hash: '0xdead', wait: async () => ({ status: 1 }) })
+
+    render(<LegacyKeyRecoveryPanel />)
+    await openToEnter(user)
+
+    // Live detection appears once classifySecret recognizes the input.
+    lib.classifySecret.mockReturnValue({ kind: 'privateKey', address: LEGACY_ADDR, secret: '0xkey' })
+    await user.type(screen.getByLabelText('Private key or recovery word list'), '0xkey')
+    expect(await screen.findByTestId('lkr-detected')).toHaveTextContent(/private key/i)
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    // Passphrase step — must match and clear the min length before encrypting.
+    await user.type(screen.getByLabelText('Passphrase'), 'longenough')
+    await user.type(screen.getByLabelText('Confirm passphrase'), 'longenough')
+    await user.click(screen.getByRole('button', { name: 'Encrypt & continue' }))
+    await waitFor(() => expect(lib.encryptLegacySecret).toHaveBeenCalledWith(expect.objectContaining({ passphrase: 'longenough', kind: 'privateKey' })))
+
+    // Transfer step — destination pre-filled with the passkey smart account.
+    expect(screen.getByLabelText('Destination smart account')).toHaveValue(DEST)
+    await user.click(screen.getByRole('button', { name: 'Check balance' }))
+    await waitFor(() => expect(screen.getByText(/Will transfer/i)).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Transfer funds' }))
+    await waitFor(() =>
+      expect(lib.sweepNativeToSmartAccount).toHaveBeenCalledWith(expect.objectContaining({ to: DEST }))
+    )
+    expect(await screen.findByText(/Funds sent to your smart account/i)).toBeInTheDocument()
+  })
+
+  it('blocks continuing when passphrases do not match', async () => {
+    const user = userEvent.setup()
+    render(<LegacyKeyRecoveryPanel />)
+    await openToEnter(user)
+    lib.classifySecret.mockReturnValue({ kind: 'mnemonic', address: LEGACY_ADDR, secret: 'a b c' })
+    await user.type(screen.getByLabelText('Private key or recovery word list'), 'a b c')
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await user.type(screen.getByLabelText('Passphrase'), 'longenough')
+    await user.type(screen.getByLabelText('Confirm passphrase'), 'different1')
+    // Mismatch keeps the button disabled and never calls encrypt.
+    expect(screen.getByRole('button', { name: 'Encrypt & continue' })).toBeDisabled()
+    expect(lib.encryptLegacySecret).not.toHaveBeenCalled()
+  })
+
+  it('lists a stored key and unlocks it before moving funds', async () => {
+    lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'mnemonic', address: LEGACY_ADDR, importedAt: 42, v: 1, ct: 'x', iv: 'y', salt: 'z' })
+    lib.decryptLegacySecret.mockResolvedValue('word list secret')
+    lib.quoteNativeSweep.mockResolvedValue({ from: LEGACY_ADDR, balance: 5n, gasReserve: 1n, sendable: 4n })
+    const user = userEvent.setup()
+    render(<LegacyKeyRecoveryPanel />)
+
+    const item = screen.getByRole('listitem')
+    expect(within(item).getByText(/word list/i)).toBeInTheDocument()
+    await user.click(within(item).getByRole('button', { name: 'Move funds' }))
+
+    await user.type(screen.getByLabelText('Passphrase'), 'unlockme1')
+    await user.click(screen.getByRole('button', { name: 'Unlock' }))
+    await waitFor(() => expect(lib.decryptLegacySecret).toHaveBeenCalled())
+    // Lands on the transfer step for that key.
+    expect(await screen.findByText(/is stored encrypted on this device/i)).toBeInTheDocument()
+  })
+
+  it('removes a stored key from the list', async () => {
+    lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'privateKey', address: LEGACY_ADDR, importedAt: 42 })
+    const user = userEvent.setup()
+    render(<LegacyKeyRecoveryPanel />)
+    expect(screen.getByRole('listitem')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /Remove stored key/i }))
+    await waitFor(() => expect(screen.queryByRole('listitem')).not.toBeInTheDocument())
+  })
+
+  it('surfaces a decryption failure on unlock', async () => {
+    lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'privateKey', address: LEGACY_ADDR, importedAt: 42 })
+    lib.decryptLegacySecret.mockRejectedValue(new Error('That passphrase did not unlock this key.'))
+    const user = userEvent.setup()
+    render(<LegacyKeyRecoveryPanel />)
+    await user.click(screen.getByRole('button', { name: 'Move funds' }))
+    await user.type(screen.getByLabelText('Passphrase'), 'wrongpass1')
+    await user.click(screen.getByRole('button', { name: 'Unlock' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/did not unlock/i)
+  })
+})

--- a/frontend/src/config/appNav.js
+++ b/frontend/src/config/appNav.js
@@ -53,9 +53,11 @@ export const NAV_GROUPS = [
     label: 'Tools',
     items: [
       { id: 'addressbook', label: 'Address Book', icon: 'addressbook' },
-      // Backup + Security combined into one panel (tab id 'security'); the old
-      // 'backup' tab id is kept as a deep-link alias (see WalletPage TAB_ALIASES).
-      { id: 'security', label: 'Backup & Security', icon: 'lock' },
+      // Recovery — data backup, account controllers, legacy key/word-list
+      // recovery, and encryption keys, combined into one panel (tab id
+      // 'security', kept stable). The old 'backup' tab id is a deep-link alias
+      // (see WalletPage TAB_ALIASES).
+      { id: 'security', label: 'Recovery', icon: 'lock' },
       { id: 'reports', label: 'Reporting', icon: 'reports' },
       { id: 'network', label: 'Network', icon: 'globe' },
     ],

--- a/frontend/src/data/ledger/sources/legacyRecoverySource.js
+++ b/frontend/src/data/ledger/sources/legacyRecoverySource.js
@@ -1,0 +1,45 @@
+/**
+ * Spec 062 — legacy-account-recovery audit record.
+ *
+ * A recovery must be auditable (there is a durable record that a legacy account
+ * was brought in) WITHOUT ever leaking key material. This helper appends one
+ * client-ledger record carrying only the recovered address, the time, and the
+ * recovery type — never the private key or mnemonic. It rides the encrypted
+ * spec-032 backup like any other client-ledger entry (the ledger is the
+ * `activityLedger` synced object).
+ *
+ * The entryId is STABLE (derived from chain + address), so re-recovering the
+ * same account is idempotent: `appendClientRecord` no-ops on an existing id and
+ * the activity-ledger backup domain unions by entryId — no misleading duplicate.
+ */
+
+import { appendClientRecord } from '../ledgerClientStore'
+import { clientEntryId } from '../identity'
+import { LEDGER_CLASS, LEDGER_STATUS, LEDGER_DIRECTION, PROVENANCE, TS_PROVENANCE } from '../constants'
+
+/**
+ * Record that a legacy account was recovered. Metadata only — NEVER a secret.
+ *
+ * @param {string} account - the signed-in account whose ledger owns the record
+ * @param {number} chainId - active chain
+ * @param {{ recoveredAddress: string, source: 'privateKey'|'mnemonic' }} info
+ */
+export function captureLegacyRecovery(account, chainId, info = {}) {
+  const recoveredAddress = info.recoveredAddress ? String(info.recoveredAddress).toLowerCase() : null
+  if (!account || !recoveredAddress) return
+  const source = info.source === 'mnemonic' ? 'mnemonic' : 'privateKey'
+  appendClientRecord(account, {
+    entryId: clientEntryId(`legacy-recovered:${Number(chainId)}:${recoveredAddress}`),
+    chainId: Number(chainId),
+    account: String(account).toLowerCase(),
+    class: LEDGER_CLASS.MEMBERSHIP,
+    kind: 'legacy_account_recovered',
+    direction: LEDGER_DIRECTION.NONE,
+    status: LEDGER_STATUS.SETTLED,
+    provenance: PROVENANCE.CLIENT,
+    timestamp: Date.now(),
+    timestampProvenance: TS_PROVENANCE.DEVICE,
+    // Metadata ONLY — address + type. No key material ever enters the ledger.
+    refs: { recoveredAddress, source },
+  })
+}

--- a/frontend/src/lib/backup/syncedObjects.js
+++ b/frontend/src/lib/backup/syncedObjects.js
@@ -14,6 +14,11 @@ import {
   mergeClientRecordsAllChains,
 } from '../../data/ledger/ledgerClientStore'
 import { readVaultEnvelope, writeVaultEnvelope, hasVault } from '../openChallenge/codeVault'
+import {
+  loadLegacyRecoveredKeys,
+  saveLegacyRecoveredKeys,
+  mergeLegacyRecoveredKeys,
+} from '../recovery/legacyRecoveredKeysStore'
 
 const PREF_KEYS = {
   recentSearches: 'recent_searches',
@@ -124,6 +129,27 @@ export const syncedObjects = [
       return { conflicts: [] }
     },
     merge: (current, incoming) => ({ value: current || incoming || null, conflicts: [] }),
+  },
+  {
+    // Spec 062 — recovered legacy accounts. The value is a map of
+    // passphrase-ENCRYPTED vault entries (ciphertext blobs only; no plaintext
+    // key material), so it is safe to place in the backup. Not network-scoped:
+    // a legacy EOA address is the same across every EVM chain, so entries are
+    // keyed by address alone.
+    key: 'legacyRecoveredKeys',
+    label: 'Recovered accounts',
+    networkScoped: false,
+    load: (account) => loadLegacyRecoveredKeys(account),
+    apply: (account, value, mode) => {
+      if (mode === 'replace') {
+        saveLegacyRecoveredKeys(account, value)
+        return { conflicts: [] }
+      }
+      const { value: merged, conflicts } = mergeLegacyRecoveredKeys(loadLegacyRecoveredKeys(account), value)
+      saveLegacyRecoveredKeys(account, merged)
+      return { conflicts }
+    },
+    merge: (current, incoming) => mergeLegacyRecoveredKeys(current, incoming),
   },
 ]
 

--- a/frontend/src/lib/passkey/__tests__/encryption.test.js
+++ b/frontend/src/lib/passkey/__tests__/encryption.test.js
@@ -93,7 +93,7 @@ describe('ensurePasskeyEncryptionKeys', () => {
     await resolveMasterSeed({ account: ACCOUNT, credentialId: CRED_B, deps: { store, getAssertion: makeAssertion(9) } })
       .catch((e) => {
         expect(e.message).not.toMatch(/Account → Controllers/)
-        expect(e.message).toMatch(/Backup & Security/)
+        expect(e.message).toMatch(/Recovery/)
       })
   })
 

--- a/frontend/src/lib/passkey/encryption.js
+++ b/frontend/src/lib/passkey/encryption.js
@@ -58,7 +58,7 @@ export async function resolveMasterSeed({ account, credentialId, allowInit = fal
     return initMasterSeedForCredential({ account, credentialId, deps })
   }
   throw new EncryptionUnavailable(
-    'this passkey has no encryption key material on this account yet — register your encryption key under Backup & Security, ' +
+    'this passkey has no encryption key material on this account yet — register your encryption key under Recovery, ' +
     'or open FairWins on the device where you first enabled encryption (or restore your encrypted backup) to use it here'
   )
 }

--- a/frontend/src/lib/passkey/prfKeys.js
+++ b/frontend/src/lib/passkey/prfKeys.js
@@ -202,6 +202,6 @@ export function capability({ account, credentialId, prfCapable, deps = {} }) {
   if (store.get(account, credentialId)) return { state: 'available' }
   return {
     state: 'unavailable',
-    reason: 'This passkey has no key material yet — register your encryption key under Backup & Security, or open FairWins on the device where you first enabled encryption.',
+    reason: 'This passkey has no key material yet — register your encryption key under Recovery, or open FairWins on the device where you first enabled encryption.',
   }
 }

--- a/frontend/src/lib/recovery/bip39Suggest.js
+++ b/frontend/src/lib/recovery/bip39Suggest.js
@@ -1,0 +1,97 @@
+/**
+ * BIP-39 word suggestions for the recovery word-list input (spec 062).
+ *
+ * As a member types their recovery phrase, we (a) suggest completions for the
+ * word currently being typed and (b) flag already-typed words that aren't valid
+ * BIP-39 words, so typos surface immediately instead of only at final
+ * validation. English list only (recovery targets English phrases; the ZK-pool
+ * multi-language registry is a separate concern). Sourced from ethers'
+ * bundled wordlist — no extra 2048-word asset shipped.
+ */
+import { wordlists } from 'ethers'
+
+let cachedWords = null
+let cachedSet = null
+
+/** The 2048 English BIP-39 words (cached). */
+export function bip39Words() {
+  if (cachedWords) return cachedWords
+  const en = wordlists?.en
+  const out = []
+  if (en && typeof en.getWord === 'function') {
+    for (let i = 0; i < 2048; i += 1) {
+      try {
+        out.push(en.getWord(i))
+      } catch {
+        break
+      }
+    }
+  }
+  cachedWords = out
+  cachedSet = new Set(out)
+  return cachedWords
+}
+
+function wordSet() {
+  if (!cachedSet) bip39Words()
+  return cachedSet
+}
+
+/** True iff `word` is a valid BIP-39 English word. */
+export function isBip39Word(word) {
+  return wordSet().has(String(word || '').trim().toLowerCase())
+}
+
+/**
+ * Suggest completions for a partial word. Returns up to `limit` words that start
+ * with `prefix` (case-insensitive), excluding an exact full match (nothing to
+ * suggest once the word is complete and unique).
+ */
+export function suggestWords(prefix, limit = 6) {
+  const p = String(prefix || '').trim().toLowerCase()
+  if (!p) return []
+  const out = []
+  for (const w of bip39Words()) {
+    if (w.startsWith(p) && w !== p) {
+      out.push(w)
+      if (out.length >= limit) break
+    }
+  }
+  return out
+}
+
+/** The word currently being typed = the last whitespace-delimited token. */
+export function currentWord(text) {
+  const t = String(text || '')
+  if (!t || /\s$/.test(t)) return '' // trailing space ⇒ starting a new word
+  const parts = t.split(/\s+/)
+  return parts[parts.length - 1] || ''
+}
+
+/**
+ * Replace the word currently being typed with `word` (adding a trailing space so
+ * the member can continue). If the text ends in whitespace, append instead.
+ */
+export function applySuggestion(text, word) {
+  const t = String(text || '')
+  if (!t || /\s$/.test(t)) return `${t}${word} `
+  const idx = t.search(/\S+$/)
+  return `${t.slice(0, idx)}${word} `
+}
+
+/**
+ * The already-completed words that aren't valid BIP-39 words (typo detection).
+ * The final token is excluded while it's still being typed (no trailing space),
+ * so we don't flag a half-typed word as invalid.
+ */
+export function unknownWordsIn(text) {
+  const t = String(text || '')
+  if (!t.trim()) return []
+  const tokens = t.trim().split(/\s+/)
+  const stillTyping = !/\s$/.test(t)
+  const complete = stillTyping ? tokens.slice(0, -1) : tokens
+  const seen = new Set()
+  return complete
+    .map((w) => w.toLowerCase())
+    .filter((w) => w && !isBip39Word(w) && !seen.has(w) && seen.add(w))
+}

--- a/frontend/src/lib/recovery/legacyKeys.js
+++ b/frontend/src/lib/recovery/legacyKeys.js
@@ -14,16 +14,16 @@
  *  - a wrong passphrase fails the AES-GCM tag — we never fall through to a
  *    different/empty secret.
  *
- * A legacy EOA is a liability, not a destination: the module deliberately makes
- * "sweep the funds to a smart account" the headline action and stores the key
- * only so the member can finish that move (and retry if gas was short).
+ * A legacy EOA is a liability, not a destination: the module makes "move the
+ * funds to a smart account" the recommended follow-up, but it is OPTIONAL —
+ * storing the key completes recovery on its own. When chosen, the move sweeps
+ * ALL supported assets (native + supported ERC-20s), not just the native coin.
  */
 
 import { ethers } from 'ethers'
-
-// Versioned localStorage key for the encrypted legacy-key vault. Bumping the
-// version is a migration, never an in-place reformat.
-const VAULT_KEY = 'fairwins.recovery.legacyKeys.v1'
+import { getPortfolioRegistry } from '../../config/assetTaxonomy'
+import { TRANSFER_ABI } from '../transfer/eip3009Transfer'
+import { loadLegacyRecoveredKeys, saveLegacyRecoveredKeys } from './legacyRecoveredKeysStore'
 
 // PBKDF2 work factor. OWASP's 2023 floor for PBKDF2-HMAC-SHA256 is 600k; we sit
 // above it. Stored per-entry so a future bump stays backward-compatible.
@@ -148,18 +148,21 @@ export async function decryptLegacySecret({ entry, passphrase, deps = {} }) {
 }
 
 /**
- * Device-local vault of encrypted legacy keys, keyed by lowercased address so a
- * given legacy account is stored once. Mirrors lib/passkey/prfKeys.js#blobStore.
+ * Per-account, device-local vault of encrypted legacy keys, keyed by lowercased
+ * address so a given legacy account is stored once. Backed by the same
+ * per-account storage the spec-032 backup reads (legacyRecoveredKeysStore), so
+ * recovered accounts ride the encrypted backup — the CRUD facade and the backup
+ * domain share one source of truth. `deps.load`/`deps.save` are injectable for
+ * tests.
+ *
+ * @param {string} account - the signed-in account that owns this vault
+ * @param {{ load?: Function, save?: Function }} [deps]
  */
-export function legacyKeyVault(storage = globalThis.localStorage) {
-  const read = () => {
-    try {
-      return JSON.parse(storage.getItem(VAULT_KEY) || '{}')
-    } catch {
-      return {}
-    }
-  }
-  const write = (all) => storage.setItem(VAULT_KEY, JSON.stringify(all))
+export function legacyKeyVault(account, deps = {}) {
+  const load = deps.load ?? loadLegacyRecoveredKeys
+  const save = deps.save ?? saveLegacyRecoveredKeys
+  const read = () => load(account)
+  const write = (all) => save(account, all)
   return {
     list() {
       return Object.values(read()).sort((a, b) => (b.importedAt || 0) - (a.importedAt || 0))
@@ -221,4 +224,108 @@ export async function sweepNativeToSmartAccount({ kind, secret, to, provider }) 
   }
   const wallet = walletFromSecret({ kind, secret }, provider)
   return wallet.sendTransaction({ to, value: quote.sendable, gasLimit: quote.gasLimit })
+}
+
+// Minimal ABI for reading an arbitrary account's ERC-20 balance.
+const BALANCE_OF_ABI = ['function balanceOf(address) view returns (uint256)']
+
+/** The platform-supported fungible assets on a chain (native + ERC-20; NFTs excluded). */
+export function supportedAssetsForChain(chainId, registry) {
+  const all = registry ?? getPortfolioRegistry(chainId)
+  return (all || []).filter((a) => a && (a.kind === 'native' || a.kind === 'erc20'))
+}
+
+/**
+ * Quote a full-portfolio sweep: enumerate every platform-supported asset on the
+ * active chain and read the legacy account's balance for each. Only non-zero
+ * balances are returned (native listed last). Read-only — no signing.
+ *
+ * @returns {Promise<{ from: string, holdings: Array<{ asset: object, balance: bigint }>,
+ *   nativeGasReserve: bigint, hasNative: boolean }>}
+ */
+export async function quoteAllAssets({ kind, secret, chainId, provider, registry }) {
+  if (!provider) throw new Error('No network connection to read balances.')
+  const from = walletFromSecret({ kind, secret }).address
+  const assets = supportedAssetsForChain(chainId, registry)
+
+  const reads = await Promise.all(
+    assets.map(async (asset) => {
+      try {
+        if (asset.kind === 'native') {
+          return { asset, balance: await provider.getBalance(from) }
+        }
+        const erc20 = new ethers.Contract(asset.address, BALANCE_OF_ABI, provider)
+        return { asset, balance: await erc20.balanceOf(from) }
+      } catch {
+        // A single unreadable token must not fail the whole quote — treat as zero.
+        return { asset, balance: 0n }
+      }
+    })
+  )
+
+  const erc20Holdings = reads.filter((h) => h.asset.kind === 'erc20' && h.balance > 0n)
+  const nativeRead = reads.find((h) => h.asset.kind === 'native')
+  const hasNative = Boolean(nativeRead && nativeRead.balance > 0n)
+
+  const feeData = await provider.getFeeData()
+  const gasPrice = feeData.maxFeePerGas ?? feeData.gasPrice ?? 0n
+  const nativeGasReserve = (TRANSFER_GAS_LIMIT * gasPrice * GAS_BUFFER_NUM) / GAS_BUFFER_DEN
+
+  // ERC-20s first, native last (native pays the gas for every transfer).
+  const holdings = [...erc20Holdings]
+  if (hasNative) holdings.push(nativeRead)
+  return { from, holdings, nativeGasReserve, hasNative }
+}
+
+/**
+ * Sweep ALL supported assets held by the legacy key to `to`. Transfers each
+ * ERC-20 first, then the native currency last (leaving a gas reserve so the
+ * transaction pays for itself). A single asset failing NEVER aborts the rest —
+ * every asset gets an honest outcome, so nothing is silently dropped and funds
+ * are never stranded.
+ *
+ * @param {(outcome: object) => void} [onProgress] - called after each asset
+ * @returns {Promise<Array<{ asset: object, status: 'sent'|'skipped'|'failed',
+ *   txHash?: string, error?: string }>>}
+ */
+export async function sweepAllAssets({ kind, secret, to, chainId, provider, registry, onProgress }) {
+  if (!ethers.isAddress(to)) throw new Error('Enter a valid destination address.')
+  const quote = await quoteAllAssets({ kind, secret, chainId, provider, registry })
+  if (to.toLowerCase() === quote.from.toLowerCase()) {
+    throw new Error('Choose a destination other than the legacy account.')
+  }
+  const signer = walletFromSecret({ kind, secret }, provider)
+  const outcomes = []
+  const record = (o) => {
+    outcomes.push(o)
+    if (onProgress) onProgress(o)
+  }
+
+  for (const { asset, balance } of quote.holdings) {
+    if (asset.kind === 'native') {
+      const sendable = balance > quote.nativeGasReserve ? balance - quote.nativeGasReserve : 0n
+      if (sendable <= 0n) {
+        record({ asset, status: 'skipped', error: 'Not enough to cover the network fee.' })
+        continue
+      }
+      try {
+        const tx = await signer.sendTransaction({ to, value: sendable, gasLimit: TRANSFER_GAS_LIMIT })
+        await tx.wait()
+        record({ asset, status: 'sent', txHash: tx.hash })
+      } catch (e) {
+        record({ asset, status: 'failed', error: e.reason || e.shortMessage || e.message })
+      }
+      continue
+    }
+    try {
+      const erc20 = new ethers.Contract(asset.address, TRANSFER_ABI, signer)
+      const tx = await erc20.transfer(to, balance)
+      await tx.wait()
+      record({ asset, status: 'sent', txHash: tx.hash })
+    } catch (e) {
+      record({ asset, status: 'failed', error: e.reason || e.shortMessage || e.message })
+    }
+  }
+
+  return outcomes
 }

--- a/frontend/src/lib/recovery/legacyKeys.js
+++ b/frontend/src/lib/recovery/legacyKeys.js
@@ -1,0 +1,224 @@
+/**
+ * Legacy key & word-list recovery (Recovery section).
+ *
+ * Many members arrive holding an *old* secret: a raw EOA private key, or a
+ * BIP-39 word list (12/15/18/21/24 words) from a previous wallet. FairWins can
+ * take custody of that secret ONLY on this device, encrypted at rest, and — the
+ * important part — help the member move the funds off that legacy key onto a
+ * modern passkey smart account, which is what the rest of the app protects.
+ *
+ * Security posture (mirrors the passkey blob approach in lib/passkey/prfKeys.js):
+ *  - the raw secret is NEVER persisted in the clear and never leaves the device;
+ *  - at rest it is wrapped with AES-GCM under a key stretched from a
+ *    member-chosen passphrase (PBKDF2-SHA256), so localStorage alone is useless;
+ *  - a wrong passphrase fails the AES-GCM tag — we never fall through to a
+ *    different/empty secret.
+ *
+ * A legacy EOA is a liability, not a destination: the module deliberately makes
+ * "sweep the funds to a smart account" the headline action and stores the key
+ * only so the member can finish that move (and retry if gas was short).
+ */
+
+import { ethers } from 'ethers'
+
+// Versioned localStorage key for the encrypted legacy-key vault. Bumping the
+// version is a migration, never an in-place reformat.
+const VAULT_KEY = 'fairwins.recovery.legacyKeys.v1'
+
+// PBKDF2 work factor. OWASP's 2023 floor for PBKDF2-HMAC-SHA256 is 600k; we sit
+// above it. Stored per-entry so a future bump stays backward-compatible.
+export const PBKDF2_ITERATIONS = 650000
+const MIN_PASSPHRASE_LEN = 8
+
+// BIP-39 word lists come in these lengths only.
+const VALID_WORD_COUNTS = [12, 15, 18, 21, 24]
+const PRIVATE_KEY_RE = /^0x[0-9a-fA-F]{64}$/
+
+const subtleOf = (deps = {}) => deps.subtle ?? globalThis.crypto?.subtle
+const randomBytes = (n) => globalThis.crypto.getRandomValues(new Uint8Array(n))
+const toB64 = (u8) => btoa(String.fromCharCode(...u8))
+const fromB64 = (s) => Uint8Array.from(atob(s), (c) => c.charCodeAt(0))
+
+/**
+ * Classify a pasted secret without persisting anything. Recognizes a raw
+ * private key (64 hex chars, optional 0x) or a valid BIP-39 mnemonic, and
+ * returns the address it controls so the member can confirm it's the right one
+ * before we ever store it.
+ *
+ * @param {string} input
+ * @returns {{ kind: 'privateKey'|'mnemonic', address: string, secret: string, wordCount: number }
+ *          | { kind: 'empty'|'invalid' }}
+ */
+export function classifySecret(input) {
+  const raw = (input || '').trim()
+  if (!raw) return { kind: 'empty' }
+
+  // Private key — accept with or without the 0x prefix.
+  const hex = raw.startsWith('0x') ? raw : `0x${raw}`
+  if (PRIVATE_KEY_RE.test(hex)) {
+    try {
+      const wallet = new ethers.Wallet(hex)
+      return { kind: 'privateKey', address: wallet.address, secret: hex.toLowerCase(), wordCount: 0 }
+    } catch {
+      /* not a usable key — fall through to invalid */
+    }
+  }
+
+  // Word list — normalize whitespace/case the way BIP-39 expects.
+  const words = raw.split(/\s+/).filter(Boolean)
+  if (VALID_WORD_COUNTS.includes(words.length)) {
+    const phrase = words.join(' ').toLowerCase()
+    try {
+      if (ethers.Mnemonic.isValidMnemonic(phrase)) {
+        const wallet = ethers.HDNodeWallet.fromPhrase(phrase)
+        return { kind: 'mnemonic', address: wallet.address, secret: phrase, wordCount: words.length }
+      }
+    } catch {
+      /* invalid checksum / word — fall through */
+    }
+  }
+
+  return { kind: 'invalid' }
+}
+
+/** Build an (optionally provider-connected) signer from a classified secret. */
+export function walletFromSecret({ kind, secret }, provider = null) {
+  const wallet = kind === 'mnemonic' ? ethers.HDNodeWallet.fromPhrase(secret) : new ethers.Wallet(secret)
+  return provider ? wallet.connect(provider) : wallet
+}
+
+async function deriveWrapKey(passphrase, salt, iterations, subtle) {
+  const baseKey = await subtle.importKey('raw', new TextEncoder().encode(passphrase), 'PBKDF2', false, ['deriveKey'])
+  return subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+
+/**
+ * Encrypt a classified secret at rest under a passphrase-derived key. The
+ * returned entry is a plain JSON blob safe to keep in localStorage — it reveals
+ * the address (so the member can recognize it) but nothing about the secret.
+ *
+ * @returns {Promise<object>} vault entry
+ */
+export async function encryptLegacySecret({ secret, kind, address, passphrase, deps = {} }) {
+  if (!secret) throw new Error('Nothing to encrypt.')
+  if (!passphrase || passphrase.length < MIN_PASSPHRASE_LEN) {
+    throw new Error(`Choose a passphrase of at least ${MIN_PASSPHRASE_LEN} characters.`)
+  }
+  const subtle = subtleOf(deps)
+  const salt = randomBytes(16)
+  const iv = randomBytes(12)
+  const key = await deriveWrapKey(passphrase, salt, PBKDF2_ITERATIONS, subtle)
+  const ct = new Uint8Array(await subtle.encrypt({ name: 'AES-GCM', iv }, key, new TextEncoder().encode(secret)))
+  return {
+    v: 1,
+    kind,
+    address,
+    salt: toB64(salt),
+    iv: toB64(iv),
+    ct: toB64(ct),
+    iterations: PBKDF2_ITERATIONS,
+    importedAt: deps.now ?? Date.now(),
+  }
+}
+
+/**
+ * Recover the raw secret from a vault entry. A wrong passphrase (or a tampered
+ * blob) fails the AES-GCM tag and raises — we never return partial/other data.
+ *
+ * @returns {Promise<string>} the private key (0x…) or mnemonic phrase
+ */
+export async function decryptLegacySecret({ entry, passphrase, deps = {} }) {
+  if (!entry) throw new Error('No stored key to unlock.')
+  const subtle = subtleOf(deps)
+  const salt = fromB64(entry.salt)
+  const iv = fromB64(entry.iv)
+  const key = await deriveWrapKey(passphrase, salt, entry.iterations ?? PBKDF2_ITERATIONS, subtle)
+  try {
+    const pt = await subtle.decrypt({ name: 'AES-GCM', iv }, key, fromB64(entry.ct))
+    return new TextDecoder().decode(pt)
+  } catch {
+    throw new Error('That passphrase did not unlock this key. Check it and try again.')
+  }
+}
+
+/**
+ * Device-local vault of encrypted legacy keys, keyed by lowercased address so a
+ * given legacy account is stored once. Mirrors lib/passkey/prfKeys.js#blobStore.
+ */
+export function legacyKeyVault(storage = globalThis.localStorage) {
+  const read = () => {
+    try {
+      return JSON.parse(storage.getItem(VAULT_KEY) || '{}')
+    } catch {
+      return {}
+    }
+  }
+  const write = (all) => storage.setItem(VAULT_KEY, JSON.stringify(all))
+  return {
+    list() {
+      return Object.values(read()).sort((a, b) => (b.importedAt || 0) - (a.importedAt || 0))
+    },
+    get(address) {
+      return read()[String(address).toLowerCase()] ?? null
+    },
+    has(address) {
+      return Boolean(this.get(address))
+    },
+    set(entry) {
+      const all = read()
+      all[String(entry.address).toLowerCase()] = entry
+      write(all)
+    },
+    delete(address) {
+      const all = read()
+      delete all[String(address).toLowerCase()]
+      write(all)
+    },
+  }
+}
+
+// Pad the estimated fee by 20% so a small gas-price bump between quote and send
+// doesn't strand the sweep — the leftover dust stays on the legacy key.
+const GAS_BUFFER_NUM = 12n
+const GAS_BUFFER_DEN = 10n
+const TRANSFER_GAS_LIMIT = 21000n
+
+/**
+ * Quote a native-currency sweep from a legacy key to a destination: how much is
+ * on it, the reserved gas, and the sendable remainder. Read-only.
+ *
+ * @returns {Promise<{ from: string, balance: bigint, gasReserve: bigint,
+ *   sendable: bigint, gasLimit: bigint, gasPrice: bigint }>}
+ */
+export async function quoteNativeSweep({ kind, secret, provider }) {
+  if (!provider) throw new Error('No network connection to check the balance.')
+  const from = walletFromSecret({ kind, secret }).address
+  const [balance, feeData] = await Promise.all([provider.getBalance(from), provider.getFeeData()])
+  const gasPrice = feeData.maxFeePerGas ?? feeData.gasPrice ?? 0n
+  const gasReserve = (TRANSFER_GAS_LIMIT * gasPrice * GAS_BUFFER_NUM) / GAS_BUFFER_DEN
+  const sendable = balance > gasReserve ? balance - gasReserve : 0n
+  return { from, balance, gasReserve, sendable, gasLimit: TRANSFER_GAS_LIMIT, gasPrice }
+}
+
+/**
+ * Sweep the sendable native balance of a legacy key to `to`. Leaves the gas
+ * reserve behind so the transaction can pay for itself. Native currency only —
+ * ERC-20 balances are not moved (disclosed in the UI).
+ *
+ * @returns {Promise<object>} the sent transaction (already broadcast)
+ */
+export async function sweepNativeToSmartAccount({ kind, secret, to, provider }) {
+  if (!ethers.isAddress(to)) throw new Error('Enter a valid destination address.')
+  const quote = await quoteNativeSweep({ kind, secret, provider })
+  if (quote.sendable <= 0n) {
+    throw new Error('This key does not hold enough to cover the network fee — there is nothing to transfer.')
+  }
+  const wallet = walletFromSecret({ kind, secret }, provider)
+  return wallet.sendTransaction({ to, value: quote.sendable, gasLimit: quote.gasLimit })
+}

--- a/frontend/src/lib/recovery/legacyKeys.js
+++ b/frontend/src/lib/recovery/legacyKeys.js
@@ -240,10 +240,15 @@ export function supportedAssetsForChain(chainId, registry) {
  * active chain and read the legacy account's balance for each. Only non-zero
  * balances are returned (native listed last). Read-only — no signing.
  *
+ * When `to` is a valid address, the native leg's gas is estimated against that
+ * exact destination (a smart-account recipient with a `receive()`/fallback needs
+ * more than the 21k EOA baseline), and both the reserved fee and the gas limit
+ * used at send time are sized from that estimate.
+ *
  * @returns {Promise<{ from: string, holdings: Array<{ asset: object, balance: bigint }>,
- *   nativeGasReserve: bigint, hasNative: boolean }>}
+ *   nativeGasReserve: bigint, nativeGasLimit: bigint, gasPrice: bigint, hasNative: boolean }>}
  */
-export async function quoteAllAssets({ kind, secret, chainId, provider, registry }) {
+export async function quoteAllAssets({ kind, secret, chainId, provider, registry, to }) {
   if (!provider) throw new Error('No network connection to read balances.')
   const from = walletFromSecret({ kind, secret }).address
   const assets = supportedAssetsForChain(chainId, registry)
@@ -269,12 +274,26 @@ export async function quoteAllAssets({ kind, secret, chainId, provider, registry
 
   const feeData = await provider.getFeeData()
   const gasPrice = feeData.maxFeePerGas ?? feeData.gasPrice ?? 0n
-  const nativeGasReserve = (TRANSFER_GAS_LIMIT * gasPrice * GAS_BUFFER_NUM) / GAS_BUFFER_DEN
+
+  // Estimate the native-transfer gas against the real destination so a smart
+  // account (contract) recipient is funded for its receive()/fallback; fall back
+  // to the EOA baseline if estimation is unavailable. Buffer the gas units by 20%
+  // and derive the reserve from the SAME buffered limit, so `value + gas ≤ balance`.
+  let estimatedGas = TRANSFER_GAS_LIMIT
+  if (hasNative && to && ethers.isAddress(to) && typeof provider.estimateGas === 'function') {
+    try {
+      estimatedGas = await provider.estimateGas({ from, to, value: 1n })
+    } catch {
+      estimatedGas = TRANSFER_GAS_LIMIT
+    }
+  }
+  const nativeGasLimit = (estimatedGas * GAS_BUFFER_NUM) / GAS_BUFFER_DEN
+  const nativeGasReserve = nativeGasLimit * gasPrice
 
   // ERC-20s first, native last (native pays the gas for every transfer).
   const holdings = [...erc20Holdings]
   if (hasNative) holdings.push(nativeRead)
-  return { from, holdings, nativeGasReserve, hasNative }
+  return { from, holdings, nativeGasReserve, nativeGasLimit, gasPrice, hasNative }
 }
 
 /**
@@ -290,7 +309,7 @@ export async function quoteAllAssets({ kind, secret, chainId, provider, registry
  */
 export async function sweepAllAssets({ kind, secret, to, chainId, provider, registry, onProgress }) {
   if (!ethers.isAddress(to)) throw new Error('Enter a valid destination address.')
-  const quote = await quoteAllAssets({ kind, secret, chainId, provider, registry })
+  const quote = await quoteAllAssets({ kind, secret, chainId, provider, registry, to })
   if (to.toLowerCase() === quote.from.toLowerCase()) {
     throw new Error('Choose a destination other than the legacy account.')
   }
@@ -309,7 +328,7 @@ export async function sweepAllAssets({ kind, secret, to, chainId, provider, regi
         continue
       }
       try {
-        const tx = await signer.sendTransaction({ to, value: sendable, gasLimit: TRANSFER_GAS_LIMIT })
+        const tx = await signer.sendTransaction({ to, value: sendable, gasLimit: quote.nativeGasLimit })
         await tx.wait()
         record({ asset, status: 'sent', txHash: tx.hash })
       } catch (e) {

--- a/frontend/src/lib/recovery/legacyRecoveredKeysStore.js
+++ b/frontend/src/lib/recovery/legacyRecoveredKeysStore.js
@@ -1,0 +1,64 @@
+// Spec 062 — the backup-synced store of a member's recovered legacy accounts. It holds ONLY the
+// passphrase-encrypted vault entries (ciphertext blobs), never plaintext key material, so it is safe
+// to place in the app-wide encrypted backup (spec 032). Per-account, keyed by lowercased address so a
+// given legacy account is stored once. This module owns the storage key + value shape; the imperative
+// CRUD facade (`legacyKeyVault` in legacyKeys.js) reads/writes through the same key, so there is a
+// single source of truth.
+
+import { getUserPreference, saveUserPreference } from '../../utils/userStorage'
+
+// Per-account userStorage key (resolves to fw_user_<owner>_legacy_recovered_keys).
+export const LEGACY_KEYS_STORAGE_KEY = 'legacy_recovered_keys'
+
+const isEntry = (e) => e && typeof e === 'object' && typeof e.address === 'string' && typeof e.ct === 'string'
+const lower = (a) => String(a).toLowerCase()
+
+/**
+ * Load the recovered-keys map for an account: { [lowerAddress]: VaultEntry }.
+ * Tolerates a legacy/global array shape by ignoring anything that isn't a well-formed entry map.
+ */
+export function loadLegacyRecoveredKeys(account) {
+  const raw = getUserPreference(account, LEGACY_KEYS_STORAGE_KEY, {}, true)
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out = {}
+  for (const [k, v] of Object.entries(raw)) {
+    if (isEntry(v)) out[lower(k)] = v
+  }
+  return out
+}
+
+/** Persist the full map (replaces). */
+export function saveLegacyRecoveredKeys(account, map) {
+  const clean = {}
+  for (const [k, v] of Object.entries(map || {})) {
+    if (isEntry(v)) clean[lower(k)] = v
+  }
+  saveUserPreference(account, LEGACY_KEYS_STORAGE_KEY, clean, true)
+  return clean
+}
+
+/**
+ * Merge two recovered-keys maps (backup restore "merge" mode). Union by lowercased address; on the
+ * same address the entry with the newer `importedAt` wins. `conflicts` lists addresses present on both
+ * sides whose ciphertext differs (informational — the newer import is kept). Pure; touches no storage.
+ * @returns {{ value: Record<string, object>, conflicts: Array<{ address: string }> }}
+ */
+export function mergeLegacyRecoveredKeys(current, incoming) {
+  const out = {}
+  const conflicts = []
+  for (const [k, v] of Object.entries(current || {})) {
+    if (isEntry(v)) out[lower(k)] = v
+  }
+  for (const [k, v] of Object.entries(incoming || {})) {
+    if (!isEntry(v)) continue
+    const key = lower(k)
+    const existing = out[key]
+    if (!existing) {
+      out[key] = v
+      continue
+    }
+    if (existing.ct !== v.ct) conflicts.push({ address: key })
+    out[key] = (v.importedAt || 0) >= (existing.importedAt || 0) ? v : existing
+  }
+  return { value: out, conflicts }
+}

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -21,6 +21,7 @@ import ClearPathPanel from '../components/clearpath/ClearPathPanel'
 import AccountDashboard from '../components/account/AccountDashboard'
 import ControllersPanel from '../components/account/ControllersPanel'
 import RecoverAccountPanel from '../components/account/RecoverAccountPanel'
+import LegacyKeyRecoveryPanel from '../components/account/LegacyKeyRecoveryPanel'
 import NotificationProfilesPanel from '../components/account/NotificationProfilesPanel'
 import HomePreferencesPanel from '../components/account/HomePreferencesPanel'
 import WalletDisplayPreferencesPanel from '../components/account/WalletDisplayPreferencesPanel'
@@ -50,7 +51,7 @@ const WALLET_TABS = [
   { id: 'membership', label: 'Membership' },
   { id: 'network', label: 'Network' },
   { id: 'preferences', label: 'Preferences' },
-  { id: 'security', label: 'Backup & Security' },
+  { id: 'security', label: 'Recovery' },
   { id: 'portfolio', label: 'Portfolio' },
   { id: 'earn', label: 'Earn' },
   { id: 'trade', label: 'Trade' },
@@ -65,7 +66,7 @@ const WALLET_TABS = [
 ]
 
 // Legacy deep-link aliases → canonical tab ids (the Swap tab is now "Trade"; the
-// old standalone Backup tab is now part of the combined "Backup & Security" panel).
+// old standalone Backup tab is now part of the combined "Recovery" panel).
 const TAB_ALIASES = { swap: 'trade', backup: 'security' }
 
 // Canonical Polymarket category slugs — kept here to keep WalletPage
@@ -390,6 +391,10 @@ function WalletPage() {
                         access using a linked wallet). Each self-gates. */}
                     <ControllersPanel />
                     <RecoverAccountPanel />
+                    {/* Recover an account from a legacy private key or word
+                        list, store it encrypted on-device, and move its funds
+                        to a smart account. Self-gates to connected sessions. */}
+                    <LegacyKeyRecoveryPanel />
                     <div className="section">
                       <h3>Encryption Key</h3>
                       <p className="section-description">

--- a/frontend/src/test/AppNavDrawer.test.jsx
+++ b/frontend/src/test/AppNavDrawer.test.jsx
@@ -45,9 +45,9 @@ describe('AppNavDrawer (global nav drawer)', () => {
     // semantics with aria-current — not tablist/tab.
     expect(screen.getByRole('button', { name: /home/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Trade' })).toBeInTheDocument()
-    // Custody is surfaced as "Protect"; Security relocated into Tools.
+    // Custody is surfaced as "Protect"; the Backup & Security section is now "Recovery".
     expect(screen.getByRole('button', { name: 'Protect' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Backup & Security' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Recovery' })).toBeInTheDocument()
     // Not a tablist.
     expect(screen.queryByRole('tab')).not.toBeInTheDocument()
 
@@ -97,7 +97,7 @@ describe('AppNavDrawer (global nav drawer)', () => {
 
   it('highlights the active section from the URL with aria-current', () => {
     renderDrawer('/wallet?tab=security')
-    expect(screen.getByRole('button', { name: 'Backup & Security' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('button', { name: 'Recovery' })).toHaveAttribute('aria-current', 'page')
     expect(screen.getByRole('button', { name: 'Trade' })).not.toHaveAttribute('aria-current')
   })
 

--- a/frontend/src/test/backup/legacyRecoveredKeys.sync.test.js
+++ b/frontend/src/test/backup/legacyRecoveredKeys.sync.test.js
@@ -1,0 +1,49 @@
+/**
+ * Backup round-trip for the legacyRecoveredKeys domain (spec 062, US4).
+ * Verifies the encrypted recovered-keys map is included in the bundle and
+ * restored in both merge and replace modes without duplication.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { buildBundle, applyBundle } from '../../lib/backup/backupBundle'
+import {
+  loadLegacyRecoveredKeys,
+  saveLegacyRecoveredKeys,
+} from '../../lib/recovery/legacyRecoveredKeysStore'
+
+const SRC = '0x' + '1'.repeat(40)
+const DST = '0x' + '2'.repeat(40)
+const ADDR_A = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+const ADDR_B = '0x' + 'b'.repeat(40)
+const entry = (address, importedAt, ct = 'cipher') => ({ v: 1, kind: 'privateKey', address, ct, iv: 'iv', salt: 'salt', importedAt })
+
+beforeEach(() => globalThis.localStorage?.clear?.())
+
+describe('legacyRecoveredKeys backup sync', () => {
+  it('includes the domain in the bundle and restores it (merge)', () => {
+    saveLegacyRecoveredKeys(SRC, { [ADDR_A.toLowerCase()]: entry(ADDR_A, 100) })
+    const bundle = buildBundle(SRC, 1)
+    expect(bundle.objects.legacyRecoveredKeys[ADDR_A.toLowerCase()].ct).toBe('cipher')
+
+    // Destination already has a different recovered account; merge keeps both.
+    saveLegacyRecoveredKeys(DST, { [ADDR_B.toLowerCase()]: entry(ADDR_B, 50) })
+    applyBundle(DST, bundle, 'merge')
+    const merged = loadLegacyRecoveredKeys(DST)
+    expect(Object.keys(merged).sort()).toEqual([ADDR_A.toLowerCase(), ADDR_B.toLowerCase()].sort())
+  })
+
+  it('replace overwrites the destination with the bundle', () => {
+    saveLegacyRecoveredKeys(SRC, { [ADDR_A.toLowerCase()]: entry(ADDR_A, 100) })
+    const bundle = buildBundle(SRC, 1)
+    saveLegacyRecoveredKeys(DST, { [ADDR_B.toLowerCase()]: entry(ADDR_B, 50) })
+    applyBundle(DST, bundle, 'replace')
+    expect(Object.keys(loadLegacyRecoveredKeys(DST))).toEqual([ADDR_A.toLowerCase()])
+  })
+
+  it('a second merge restore does not duplicate', () => {
+    saveLegacyRecoveredKeys(SRC, { [ADDR_A.toLowerCase()]: entry(ADDR_A, 100) })
+    const bundle = buildBundle(SRC, 1)
+    applyBundle(DST, bundle, 'merge')
+    applyBundle(DST, bundle, 'merge')
+    expect(Object.keys(loadLegacyRecoveredKeys(DST))).toEqual([ADDR_A.toLowerCase()])
+  })
+})

--- a/frontend/src/test/recovery/bip39Suggest.test.js
+++ b/frontend/src/test/recovery/bip39Suggest.test.js
@@ -1,0 +1,57 @@
+/**
+ * BIP-39 word suggestions (spec 062) — typo help as the member types a phrase.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  bip39Words,
+  isBip39Word,
+  suggestWords,
+  currentWord,
+  applySuggestion,
+  unknownWordsIn,
+} from '../../lib/recovery/bip39Suggest'
+
+describe('bip39 wordlist', () => {
+  it('loads the 2048-word English list', () => {
+    const words = bip39Words()
+    expect(words).toHaveLength(2048)
+    expect(words[0]).toBe('abandon')
+    expect(words[words.length - 1]).toBe('zoo')
+  })
+
+  it('recognizes valid and rejects invalid words', () => {
+    expect(isBip39Word('abandon')).toBe(true)
+    expect(isBip39Word('ABANDON')).toBe(true)
+    expect(isBip39Word('notaword')).toBe(false)
+  })
+})
+
+describe('suggestWords', () => {
+  it('returns completions for a prefix, excluding an exact match, capped', () => {
+    const s = suggestWords('aban')
+    expect(s).toContain('abandon')
+    expect(suggestWords('')).toEqual([])
+    expect(suggestWords('zoo')).not.toContain('zoo') // exact full word ⇒ nothing to suggest
+    expect(suggestWords('a', 3)).toHaveLength(3)
+  })
+})
+
+describe('currentWord + applySuggestion', () => {
+  it('identifies the word being typed and completes it', () => {
+    expect(currentWord('legal winner thank ye')).toBe('ye')
+    expect(currentWord('legal winner ')).toBe('') // trailing space ⇒ new word
+    expect(applySuggestion('legal winner thank ye', 'year')).toBe('legal winner thank year ')
+    expect(applySuggestion('legal winner ', 'thank')).toBe('legal winner thank ')
+  })
+})
+
+describe('unknownWordsIn', () => {
+  it('flags completed words that are not valid BIP-39 words', () => {
+    // "wrongg" is a completed (space-followed) invalid word; "aban" is still being typed.
+    expect(unknownWordsIn('legal wrongg aban')).toEqual(['wrongg'])
+    // no trailing space ⇒ last token is still being typed and is not flagged
+    expect(unknownWordsIn('abandon abandon')).toEqual([])
+    // all valid ⇒ nothing flagged
+    expect(unknownWordsIn('legal winner thank ')).toEqual([])
+  })
+})

--- a/frontend/src/test/recovery/legacyKeys.test.js
+++ b/frontend/src/test/recovery/legacyKeys.test.js
@@ -88,18 +88,17 @@ describe('encrypt/decrypt at rest', () => {
 })
 
 describe('legacyKeyVault', () => {
-  let storage
+  // Per-account vault backed by an injected in-memory map (bypasses userStorage).
+  const account = '0x' + '1'.repeat(40)
+  let mem
+  let deps
   beforeEach(() => {
-    const map = new Map()
-    storage = {
-      getItem: (k) => (map.has(k) ? map.get(k) : null),
-      setItem: (k, v) => map.set(k, v),
-      removeItem: (k) => map.delete(k),
-    }
+    mem = {}
+    deps = { load: () => mem, save: (_acc, m) => { mem = m } }
   })
 
   it('stores by lowercased address, lists newest-first, and deletes', () => {
-    const vault = legacyKeyVault(storage)
+    const vault = legacyKeyVault(account, deps)
     vault.set({ address: EXPECTED_ADDR, kind: 'privateKey', importedAt: 100 })
     vault.set({ address: '0x' + 'b'.repeat(40), kind: 'mnemonic', importedAt: 200 })
     expect(vault.list().map((e) => e.importedAt)).toEqual([200, 100])
@@ -111,7 +110,7 @@ describe('legacyKeyVault', () => {
   })
 
   it('re-storing the same address replaces rather than duplicates', () => {
-    const vault = legacyKeyVault(storage)
+    const vault = legacyKeyVault(account, deps)
     vault.set({ address: EXPECTED_ADDR, kind: 'privateKey', importedAt: 1 })
     vault.set({ address: EXPECTED_ADDR.toLowerCase(), kind: 'privateKey', importedAt: 2 })
     expect(vault.list()).toHaveLength(1)

--- a/frontend/src/test/recovery/legacyKeys.test.js
+++ b/frontend/src/test/recovery/legacyKeys.test.js
@@ -1,0 +1,161 @@
+/**
+ * Legacy key & word-list recovery library (Recovery section).
+ * Real ethers + real WebCrypto — no mocks — so the tests exercise the actual
+ * classification, at-rest encryption, vault, and sweep-quote math.
+ */
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest'
+import { registerEthersCrypto } from './registerEthersCrypto'
+import {
+  classifySecret,
+  encryptLegacySecret,
+  decryptLegacySecret,
+  legacyKeyVault,
+  quoteNativeSweep,
+  sweepNativeToSmartAccount,
+  walletFromSecret,
+} from '../../lib/recovery/legacyKeys'
+
+// Hardhat account #0 — private key and 12-word mnemonic both resolve to this.
+const PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+const MNEMONIC = 'test test test test test test test test test test test junk'
+const EXPECTED_ADDR = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+
+beforeAll(() => registerEthersCrypto())
+
+describe('classifySecret', () => {
+  it('recognizes a 0x-prefixed private key and derives its address', () => {
+    const c = classifySecret(PK)
+    expect(c.kind).toBe('privateKey')
+    expect(c.address).toBe(EXPECTED_ADDR)
+    expect(c.secret).toBe(PK)
+  })
+
+  it('accepts a private key without the 0x prefix', () => {
+    const c = classifySecret(PK.slice(2))
+    expect(c.kind).toBe('privateKey')
+    expect(c.address).toBe(EXPECTED_ADDR)
+  })
+
+  it('recognizes a valid BIP-39 word list and normalizes case/whitespace', () => {
+    const c = classifySecret(`  ${MNEMONIC.toUpperCase()}  `)
+    expect(c.kind).toBe('mnemonic')
+    expect(c.address).toBe(EXPECTED_ADDR)
+    expect(c.wordCount).toBe(12)
+    expect(c.secret).toBe(MNEMONIC)
+  })
+
+  it('flags empty input and gibberish distinctly', () => {
+    expect(classifySecret('').kind).toBe('empty')
+    expect(classifySecret('   ').kind).toBe('empty')
+    expect(classifySecret('not a real key at all').kind).toBe('invalid')
+    // 12 words but a bad checksum ⇒ invalid, never a false positive.
+    expect(classifySecret('test test test test test test test test test test test test').kind).toBe('invalid')
+    // Right length hex but not 64 nibbles.
+    expect(classifySecret('0x1234').kind).toBe('invalid')
+  })
+})
+
+describe('encrypt/decrypt at rest', () => {
+  it('round-trips a private key under the right passphrase', async () => {
+    const c = classifySecret(PK)
+    const entry = await encryptLegacySecret({ secret: c.secret, kind: c.kind, address: c.address, passphrase: 'correct horse', deps: { now: 111 } })
+    expect(entry.address).toBe(EXPECTED_ADDR)
+    expect(entry.importedAt).toBe(111)
+    // The ciphertext must not leak the secret.
+    expect(JSON.stringify(entry)).not.toContain(PK)
+    const back = await decryptLegacySecret({ entry, passphrase: 'correct horse' })
+    expect(back).toBe(PK)
+  })
+
+  it('round-trips a mnemonic', async () => {
+    const c = classifySecret(MNEMONIC)
+    const entry = await encryptLegacySecret({ secret: c.secret, kind: c.kind, address: c.address, passphrase: 'passw0rd!' })
+    const back = await decryptLegacySecret({ entry, passphrase: 'passw0rd!' })
+    expect(back).toBe(MNEMONIC)
+  })
+
+  it('rejects a wrong passphrase without leaking data', async () => {
+    const c = classifySecret(PK)
+    const entry = await encryptLegacySecret({ secret: c.secret, kind: c.kind, address: c.address, passphrase: 'right-one-here' })
+    await expect(decryptLegacySecret({ entry, passphrase: 'wrong-one-here' })).rejects.toThrow(/did not unlock/i)
+  })
+
+  it('refuses a too-short passphrase', async () => {
+    await expect(
+      encryptLegacySecret({ secret: PK, kind: 'privateKey', address: EXPECTED_ADDR, passphrase: 'short' })
+    ).rejects.toThrow(/at least 8/i)
+  })
+})
+
+describe('legacyKeyVault', () => {
+  let storage
+  beforeEach(() => {
+    const map = new Map()
+    storage = {
+      getItem: (k) => (map.has(k) ? map.get(k) : null),
+      setItem: (k, v) => map.set(k, v),
+      removeItem: (k) => map.delete(k),
+    }
+  })
+
+  it('stores by lowercased address, lists newest-first, and deletes', () => {
+    const vault = legacyKeyVault(storage)
+    vault.set({ address: EXPECTED_ADDR, kind: 'privateKey', importedAt: 100 })
+    vault.set({ address: '0x' + 'b'.repeat(40), kind: 'mnemonic', importedAt: 200 })
+    expect(vault.list().map((e) => e.importedAt)).toEqual([200, 100])
+    expect(vault.has(EXPECTED_ADDR.toLowerCase())).toBe(true)
+    expect(vault.get(EXPECTED_ADDR.toUpperCase())).toBeTruthy()
+    vault.delete(EXPECTED_ADDR)
+    expect(vault.has(EXPECTED_ADDR)).toBe(false)
+    expect(vault.list()).toHaveLength(1)
+  })
+
+  it('re-storing the same address replaces rather than duplicates', () => {
+    const vault = legacyKeyVault(storage)
+    vault.set({ address: EXPECTED_ADDR, kind: 'privateKey', importedAt: 1 })
+    vault.set({ address: EXPECTED_ADDR.toLowerCase(), kind: 'privateKey', importedAt: 2 })
+    expect(vault.list()).toHaveLength(1)
+    expect(vault.get(EXPECTED_ADDR).importedAt).toBe(2)
+  })
+})
+
+describe('native sweep', () => {
+  const to = '0x' + 'c'.repeat(40)
+  const makeProvider = (balance, gas = 2_000_000_000n) => ({
+    getBalance: async () => balance,
+    getFeeData: async () => ({ maxFeePerGas: gas, gasPrice: gas }),
+  })
+
+  it('quotes sendable = balance minus a padded gas reserve', async () => {
+    const provider = makeProvider(10n ** 17n) // 0.1 ETH
+    const q = await quoteNativeSweep({ kind: 'privateKey', secret: PK, provider })
+    expect(q.from).toBe(EXPECTED_ADDR)
+    // reserve = 21000 * 2gwei * 1.2
+    const expectedReserve = (21000n * 2_000_000_000n * 12n) / 10n
+    expect(q.gasReserve).toBe(expectedReserve)
+    expect(q.sendable).toBe(10n ** 17n - expectedReserve)
+  })
+
+  it('reports zero sendable when the balance cannot cover the fee', async () => {
+    const provider = makeProvider(1000n)
+    const q = await quoteNativeSweep({ kind: 'privateKey', secret: PK, provider })
+    expect(q.sendable).toBe(0n)
+  })
+
+  it('sweep refuses an invalid destination', async () => {
+    await expect(
+      sweepNativeToSmartAccount({ kind: 'privateKey', secret: PK, to: 'nope', provider: makeProvider(10n ** 18n) })
+    ).rejects.toThrow(/valid destination/i)
+  })
+
+  it('sweep refuses when there is nothing to move after fees', async () => {
+    await expect(
+      sweepNativeToSmartAccount({ kind: 'privateKey', secret: PK, to, provider: makeProvider(1n) })
+    ).rejects.toThrow(/nothing to transfer/i)
+  })
+
+  it('walletFromSecret derives the same address for key and phrase', () => {
+    expect(walletFromSecret({ kind: 'privateKey', secret: PK }).address).toBe(EXPECTED_ADDR)
+    expect(walletFromSecret({ kind: 'mnemonic', secret: MNEMONIC }).address).toBe(EXPECTED_ADDR)
+  })
+})

--- a/frontend/src/test/recovery/legacyKeysMultiAsset.test.js
+++ b/frontend/src/test/recovery/legacyKeysMultiAsset.test.js
@@ -1,0 +1,138 @@
+/**
+ * Multi-asset sweep (spec 062, US2) — quoteAllAssets / sweepAllAssets.
+ * A stub registry, provider, signer, and contract drive enumeration, ordering,
+ * gas reserve, and per-asset outcome behavior (including partial failure).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { quoteAllAssets, sweepAllAssets, supportedAssetsForChain } from '../../lib/recovery/legacyKeys'
+
+const USDC = ('0x' + 'a'.repeat(40)).toLowerCase()
+const DAI = ('0x' + 'b'.repeat(40)).toLowerCase()
+const LEGACY_ADDR = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+const TO = '0x' + 'd'.repeat(40)
+const GAS = 2_000_000_000n
+
+// Stub the portfolio registry so tests don't depend on live chain config.
+vi.mock('../../config/assetTaxonomy', () => ({
+  getPortfolioRegistry: () => [
+    { id: 'native', kind: 'native', address: null, symbol: 'ETH', decimals: 18 },
+    { id: 'usdc', kind: 'erc20', address: '0x' + 'a'.repeat(40), symbol: 'USDC', decimals: 6 },
+    { id: 'dai', kind: 'erc20', address: '0x' + 'b'.repeat(40), symbol: 'DAI', decimals: 18 },
+    { id: 'nft', kind: 'nft', address: '0x' + 'c'.repeat(40), symbol: 'NFT', decimals: 0 },
+  ],
+}))
+
+// Stub ethers so the sweep signs/reads through in-memory bookkeeping instead of a chain.
+vi.mock('ethers', async () => {
+  const actual = await vi.importActual('ethers')
+  const ADDR = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+  class StubWallet {
+    constructor() { this.address = ADDR }
+    connect(provider) { this.provider = provider; return this }
+    async sendTransaction() {
+      if (this.provider?._failNative) throw new Error('native reverted')
+      return { hash: '0xnative', wait: async () => ({ status: 1 }) }
+    }
+  }
+  class StubContract {
+    constructor(address, _abi, runner) {
+      const provider = runner?.provider ?? runner
+      this.address = address
+      this.balanceOf = async () => provider?._balances?.[address.toLowerCase()] ?? 0n
+      this.transfer = async (to, value) => {
+        if (provider?._failToken === address.toLowerCase()) throw new Error('ERC20 transfer reverted')
+        provider?._sent?.push({ address: address.toLowerCase(), to, value })
+        return { hash: `0xtx_${address.slice(2, 8)}`, wait: async () => ({ status: 1 }) }
+      }
+    }
+  }
+  return {
+    ...actual,
+    ethers: {
+      ...actual.ethers,
+      Wallet: StubWallet,
+      HDNodeWallet: { ...actual.ethers.HDNodeWallet, fromPhrase: () => new StubWallet() },
+      Contract: StubContract,
+    },
+  }
+})
+
+const PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+
+function makeProvider(balances, extra = {}) {
+  return {
+    getBalance: async () => balances.native ?? 0n,
+    getFeeData: async () => ({ maxFeePerGas: GAS, gasPrice: GAS }),
+    _balances: balances,
+    _sent: [],
+    ...extra,
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('supportedAssetsForChain', () => {
+  it('keeps native + erc20 and drops NFTs', () => {
+    expect(supportedAssetsForChain(1).map((a) => a.symbol)).toEqual(['ETH', 'USDC', 'DAI'])
+  })
+})
+
+describe('quoteAllAssets', () => {
+  it('lists non-zero balances, ERC-20s first then native, and reserves gas', async () => {
+    const provider = makeProvider({ native: 10n ** 17n, [USDC]: 5_000_000n })
+    const q = await quoteAllAssets({ kind: 'privateKey', secret: PK, chainId: 1, provider })
+    expect(q.from).toBe(LEGACY_ADDR)
+    expect(q.holdings.map((h) => h.asset.symbol)).toEqual(['USDC', 'ETH']) // DAI zero → excluded
+    expect(q.hasNative).toBe(true)
+    expect(q.nativeGasReserve).toBe((21000n * GAS * 12n) / 10n)
+  })
+
+  it('omits native when the coin balance is zero', async () => {
+    const provider = makeProvider({ native: 0n, [DAI]: 9n })
+    const q = await quoteAllAssets({ kind: 'privateKey', secret: PK, chainId: 1, provider })
+    expect(q.holdings.map((h) => h.asset.symbol)).toEqual(['DAI'])
+    expect(q.hasNative).toBe(false)
+  })
+})
+
+describe('sweepAllAssets', () => {
+  it('transfers every non-zero asset (ERC-20s then native) with per-asset outcomes', async () => {
+    const provider = makeProvider({ native: 10n ** 17n, [USDC]: 5_000_000n })
+    const progress = []
+    const outcomes = await sweepAllAssets({
+      kind: 'privateKey', secret: PK, to: TO, chainId: 1, provider,
+      onProgress: (o) => progress.push(o.asset.symbol),
+    })
+    expect(outcomes.map((o) => `${o.asset.symbol}:${o.status}`)).toEqual(['USDC:sent', 'ETH:sent'])
+    expect(progress).toEqual(['USDC', 'ETH'])
+    expect(provider._sent).toHaveLength(1) // one ERC-20 transfer recorded
+    expect(provider._sent[0].address).toBe(USDC)
+  })
+
+  it('continues past a single token failure and reports it honestly', async () => {
+    const provider = makeProvider({ native: 10n ** 17n, [USDC]: 5_000_000n, [DAI]: 9n }, { _failToken: USDC })
+    const outcomes = await sweepAllAssets({ kind: 'privateKey', secret: PK, to: TO, chainId: 1, provider })
+    const bySym = Object.fromEntries(outcomes.map((o) => [o.asset.symbol, o.status]))
+    expect(bySym).toEqual({ USDC: 'failed', DAI: 'sent', ETH: 'sent' })
+  })
+
+  it('skips native when it cannot cover the gas reserve', async () => {
+    const provider = makeProvider({ native: 1000n })
+    const outcomes = await sweepAllAssets({ kind: 'privateKey', secret: PK, to: TO, chainId: 1, provider })
+    expect(outcomes).toEqual([
+      { asset: expect.objectContaining({ symbol: 'ETH' }), status: 'skipped', error: expect.any(String) },
+    ])
+  })
+
+  it('refuses an invalid destination', async () => {
+    await expect(
+      sweepAllAssets({ kind: 'privateKey', secret: PK, to: 'nope', chainId: 1, provider: makeProvider({ native: 10n ** 18n }) })
+    ).rejects.toThrow(/valid destination/i)
+  })
+
+  it('refuses sweeping to the legacy account itself', async () => {
+    await expect(
+      sweepAllAssets({ kind: 'privateKey', secret: PK, to: LEGACY_ADDR, chainId: 1, provider: makeProvider({ native: 10n ** 18n }) })
+    ).rejects.toThrow(/destination other than/i)
+  })
+})

--- a/frontend/src/test/recovery/legacyKeysMultiAsset.test.js
+++ b/frontend/src/test/recovery/legacyKeysMultiAsset.test.js
@@ -63,6 +63,7 @@ function makeProvider(balances, extra = {}) {
   return {
     getBalance: async () => balances.native ?? 0n,
     getFeeData: async () => ({ maxFeePerGas: GAS, gasPrice: GAS }),
+    estimateGas: async () => 21000n, // EOA baseline unless a test overrides
     _balances: balances,
     _sent: [],
     ...extra,
@@ -92,6 +93,14 @@ describe('quoteAllAssets', () => {
     const q = await quoteAllAssets({ kind: 'privateKey', secret: PK, chainId: 1, provider })
     expect(q.holdings.map((h) => h.asset.symbol)).toEqual(['DAI'])
     expect(q.hasNative).toBe(false)
+  })
+
+  it('sizes the native reserve + gas limit from a gas estimate to the destination', async () => {
+    // A smart-account recipient needs more than 21k; estimate to `to` and buffer 20%.
+    const provider = makeProvider({ native: 10n ** 18n }, { estimateGas: async () => 90_000n })
+    const q = await quoteAllAssets({ kind: 'privateKey', secret: PK, chainId: 1, provider, to: TO })
+    expect(q.nativeGasLimit).toBe((90_000n * 12n) / 10n) // 108000
+    expect(q.nativeGasReserve).toBe(((90_000n * 12n) / 10n) * GAS)
   })
 })
 

--- a/frontend/src/test/recovery/legacyRecoveredKeysStore.test.js
+++ b/frontend/src/test/recovery/legacyRecoveredKeysStore.test.js
@@ -1,0 +1,60 @@
+/**
+ * Backup-synced recovered-keys store (spec 062, US4).
+ * Uses jsdom localStorage via userStorage; asserts ciphertext-only, load/save
+ * round-trip, and the address-keyed newest-wins merge.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  loadLegacyRecoveredKeys,
+  saveLegacyRecoveredKeys,
+  mergeLegacyRecoveredKeys,
+  LEGACY_KEYS_STORAGE_KEY,
+} from '../../lib/recovery/legacyRecoveredKeysStore'
+
+const ACCOUNT = '0x' + '9'.repeat(40)
+const ADDR_A = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+const ADDR_B = '0x' + 'b'.repeat(40)
+const entry = (address, importedAt, ct = 'cipher') => ({ v: 1, kind: 'privateKey', address, ct, iv: 'iv', salt: 'salt', importedAt })
+
+beforeEach(() => globalThis.localStorage?.clear?.())
+
+describe('load/save round-trip', () => {
+  it('persists a ciphertext-only map keyed by lowercased address', () => {
+    saveLegacyRecoveredKeys(ACCOUNT, { [ADDR_A]: entry(ADDR_A, 10) })
+    const loaded = loadLegacyRecoveredKeys(ACCOUNT)
+    expect(Object.keys(loaded)).toEqual([ADDR_A.toLowerCase()])
+    expect(loaded[ADDR_A.toLowerCase()].ct).toBe('cipher')
+  })
+
+  it('drops malformed / plaintext-looking entries (must have ct)', () => {
+    saveLegacyRecoveredKeys(ACCOUNT, { [ADDR_A]: { address: ADDR_A, secret: 'PLAINTEXT' } })
+    expect(loadLegacyRecoveredKeys(ACCOUNT)).toEqual({})
+  })
+
+  it('uses the documented per-account storage key', () => {
+    saveLegacyRecoveredKeys(ACCOUNT, { [ADDR_A]: entry(ADDR_A, 1) })
+    const physical = `fw_user_${ACCOUNT.toLowerCase()}_${LEGACY_KEYS_STORAGE_KEY}`
+    expect(globalThis.localStorage.getItem(physical)).toBeTruthy()
+  })
+})
+
+describe('mergeLegacyRecoveredKeys', () => {
+  it('unions by address; newest importedAt wins and differing ciphertext is flagged', () => {
+    const current = { [ADDR_A.toLowerCase()]: entry(ADDR_A, 10, 'old') }
+    const incoming = {
+      [ADDR_A.toLowerCase()]: entry(ADDR_A, 20, 'new'),
+      [ADDR_B.toLowerCase()]: entry(ADDR_B, 5),
+    }
+    const { value, conflicts } = mergeLegacyRecoveredKeys(current, incoming)
+    expect(Object.keys(value).sort()).toEqual([ADDR_A.toLowerCase(), ADDR_B.toLowerCase()].sort())
+    expect(value[ADDR_A.toLowerCase()].ct).toBe('new') // newer importedAt wins
+    expect(conflicts).toEqual([{ address: ADDR_A.toLowerCase() }])
+  })
+
+  it('keeps the local entry when it is newer', () => {
+    const current = { [ADDR_A.toLowerCase()]: entry(ADDR_A, 30, 'local') }
+    const incoming = { [ADDR_A.toLowerCase()]: entry(ADDR_A, 20, 'remote') }
+    const { value } = mergeLegacyRecoveredKeys(current, incoming)
+    expect(value[ADDR_A.toLowerCase()].ct).toBe('local')
+  })
+})

--- a/frontend/src/test/recovery/legacyRecoverySource.test.js
+++ b/frontend/src/test/recovery/legacyRecoverySource.test.js
@@ -1,0 +1,46 @@
+/**
+ * Recovery audit record (spec 062, US5). Uses the real client ledger (jsdom
+ * localStorage) to prove the record shape, idempotency, and — critically —
+ * that no key material is ever written.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { captureLegacyRecovery } from '../../data/ledger/sources/legacyRecoverySource'
+import { listClientRecords, listClientRecordsAllChains } from '../../data/ledger/ledgerClientStore'
+
+const ACCOUNT = '0x' + '7'.repeat(40)
+const CHAIN = 137
+const LEGACY = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+const PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+const MNEMONIC = 'test test test test test test test test test test test junk'
+
+beforeEach(() => globalThis.localStorage?.clear?.())
+
+describe('captureLegacyRecovery', () => {
+  it('records address, time, and type — and nothing secret', () => {
+    captureLegacyRecovery(ACCOUNT, CHAIN, { recoveredAddress: LEGACY, source: 'privateKey' })
+    const records = listClientRecords(ACCOUNT, CHAIN)
+    const rec = records.find((r) => r.kind === 'legacy_account_recovered')
+    expect(rec).toBeTruthy()
+    expect(rec.refs.recoveredAddress).toBe(LEGACY.toLowerCase())
+    expect(rec.refs.source).toBe('privateKey')
+    expect(rec.class).toBe('membership')
+    expect(typeof rec.timestamp).toBe('number')
+    // Never any key material in the serialized record.
+    const blob = JSON.stringify(rec)
+    expect(blob).not.toContain(PK)
+    expect(blob).not.toContain(MNEMONIC)
+  })
+
+  it('is idempotent for the same account on the same chain (stable entryId)', () => {
+    captureLegacyRecovery(ACCOUNT, CHAIN, { recoveredAddress: LEGACY, source: 'mnemonic' })
+    captureLegacyRecovery(ACCOUNT, CHAIN, { recoveredAddress: LEGACY, source: 'mnemonic' })
+    const recs = listClientRecordsAllChains(ACCOUNT).filter((r) => r.kind === 'legacy_account_recovered')
+    expect(recs).toHaveLength(1)
+  })
+
+  it('no-ops without an account or address (never throws)', () => {
+    expect(() => captureLegacyRecovery(null, CHAIN, { recoveredAddress: LEGACY })).not.toThrow()
+    expect(() => captureLegacyRecovery(ACCOUNT, CHAIN, {})).not.toThrow()
+    expect(listClientRecordsAllChains(ACCOUNT)).toHaveLength(0)
+  })
+})

--- a/frontend/src/test/recovery/registerEthersCrypto.js
+++ b/frontend/src/test/recovery/registerEthersCrypto.js
@@ -1,0 +1,28 @@
+/**
+ * Test-only shim: register @noble/hashes implementations for ethers' sha256 /
+ * HMAC / PBKDF2 primitives.
+ *
+ * Under vitest+jsdom, Node's global `Buffer` leaks in and ethers' default
+ * sha256 returns a Buffer that its own hexlify rejects ("invalid BytesLike
+ * value … type: Buffer"), which breaks BIP-39 mnemonic parsing. Real browsers
+ * have no `Buffer`, so ethers uses its pure-JS path and this shim is irrelevant
+ * to production — it only makes the mnemonic code path testable here.
+ */
+import { ethers } from 'ethers'
+import { sha256 as nobleSha256 } from '@noble/hashes/sha256'
+import { sha512 as nobleSha512 } from '@noble/hashes/sha512'
+import { hmac as nobleHmac } from '@noble/hashes/hmac'
+import { pbkdf2 as noblePbkdf2 } from '@noble/hashes/pbkdf2'
+
+const hashFor = (algo) => (algo === 'sha256' ? nobleSha256 : nobleSha512)
+
+let registered = false
+export function registerEthersCrypto() {
+  if (registered) return
+  registered = true
+  ethers.sha256.register((data) => nobleSha256(data))
+  ethers.computeHmac.register((algo, key, data) => nobleHmac(hashFor(algo), key, data))
+  ethers.pbkdf2.register((password, salt, iterations, keylen, algo) =>
+    noblePbkdf2(hashFor(algo), password, salt, { c: iterations, dkLen: keylen })
+  )
+}

--- a/specs/062-legacy-account-recovery/checklists/requirements.md
+++ b/specs/062-legacy-account-recovery/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Legacy Account Recovery
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated in one pass; all items pass.
+- The spec deliberately carries **zero** `[NEEDS CLARIFICATION]` markers. Areas that could have been questions were resolved with documented, reasonable defaults in the **Assumptions** section:
+  - "Supported assets" scoped to fungible value (native + recognized tokens); NFTs/collectibles out of scope for the move-funds step (FR-017, disclosed).
+  - EVM externally-owned accounts only; non-EVM (Bitcoin) out of scope.
+  - Word lists resolve via the standard default derivation path (alternate paths deferred to a follow-up).
+  - The at-rest passphrase is per-account and independent of platform sign-in; not platform-resettable.
+- If a reviewer disagrees with any assumption (most likely the NFT/collectibles exclusion or the derivation-path scope), run `/speckit-clarify` to convert it into an explicit decision before `/speckit-plan`.

--- a/specs/062-legacy-account-recovery/contracts/legacyKeys.md
+++ b/specs/062-legacy-account-recovery/contracts/legacyKeys.md
@@ -1,0 +1,53 @@
+# Contract: `lib/recovery/legacyKeys.js` (extended)
+
+Existing functions (shipped) stay unchanged. This feature **adds** multi-asset sweep functions;
+`quoteNativeSweep`/`sweepNativeToSmartAccount` remain for the native-only path but the panel moves to
+the all-asset functions below.
+
+## Existing (unchanged)
+
+- `classifySecret(input) → { kind: 'privateKey'|'mnemonic', address, secret, wordCount } | { kind: 'empty'|'invalid' }`
+- `walletFromSecret({ kind, secret }, provider?) → ethers.Signer`
+- `encryptLegacySecret({ secret, kind, address, passphrase, deps? }) → Promise<VaultEntry>`
+- `decryptLegacySecret({ entry, passphrase, deps? }) → Promise<string>`  *(wrong pass ⇒ throws)*
+- `legacyKeyVault(storage?) → { list, get, has, set, delete }`
+- `quoteNativeSweep({ kind, secret, provider }) → Promise<{ from, balance, gasReserve, sendable, gasLimit, gasPrice }>`
+- `sweepNativeToSmartAccount({ kind, secret, to, provider }) → Promise<ethers.TransactionResponse>`
+
+## New: `quoteAllAssets`
+
+```
+quoteAllAssets({ kind, secret, chainId, provider, registry? }) → Promise<{
+  from: string,
+  holdings: Array<{ asset, balance: bigint }>,   // non-zero only; ERC-20s then native
+  nativeGasReserve: bigint,
+  hasNative: boolean,
+}>
+```
+
+- `registry` defaults to `getPortfolioRegistry(chainId).filter(a => a.kind === 'native' || a.kind === 'erc20')`.
+- Reads native via `provider.getBalance(from)` and each ERC-20 via `balanceOf(from)` **concurrently**.
+- Excludes zero balances. `nativeGasReserve` = `~21000 * gasPrice * 1.2` (from `getFeeData`).
+- Read-only; no signing.
+
+## New: `sweepAllAssets`
+
+```
+sweepAllAssets({ kind, secret, to, chainId, provider, onProgress? }) → Promise<Array<{
+  asset, status: 'sent'|'skipped'|'failed', txHash?: string, error?: string,
+}>>
+```
+
+- Validates `to` (`ethers.isAddress`) and `to !== from`; throws on invalid destination.
+- Transfers **ERC-20s first** (`new ethers.Contract(asset.address, TRANSFER_ABI, signer).transfer(to, value)` → `.wait()`),
+  then **native last** (send `balance - nativeGasReserve` if positive, else native `skipped`).
+- A single asset failure is caught and recorded as `status:'failed'` with `error`; the sweep **continues**.
+- `onProgress(outcome)` (optional) is called after each asset for live UI.
+- **Never** logs the secret; the signer is built once via `walletFromSecret`.
+
+## Errors
+
+- Invalid/empty destination → `throw new Error('Enter a valid destination address.')`
+- Destination equals the legacy address → `throw new Error('Choose a destination other than the legacy account.')`
+- No provider → `throw new Error('No network connection to read balances.')`
+- Per-asset failures never throw out of `sweepAllAssets`; they surface as `failed` outcomes.

--- a/specs/062-legacy-account-recovery/contracts/legacyRecoveredKeysStore.md
+++ b/specs/062-legacy-account-recovery/contracts/legacyRecoveredKeysStore.md
@@ -1,0 +1,51 @@
+# Contract: `lib/recovery/legacyRecoveredKeysStore.js` (new)
+
+Backup-synced accessor over the encrypted legacy-key vault. Only **ciphertext** blobs are read/written
+here — no plaintext ever passes through. Modeled on `lib/custody/vaultReferences.js`.
+
+Storage: `userStorage` key `legacy_recovered_keys`, per-account (`fw_user_<owner>_legacy_recovered_keys`).
+Value shape: `{ [lowerAddress]: VaultEntry }` (see data-model).
+
+## Functions
+
+```
+loadLegacyRecoveredKeys(account) → { [lowerAddress]: VaultEntry }
+saveLegacyRecoveredKeys(account, map) → void
+mergeLegacyRecoveredKeys(current, incoming) → { value, conflicts }
+```
+
+- `merge` unions by lowercased address; on the same address, the entry with the **newer `importedAt`**
+  wins; `conflicts` lists addresses present on both sides with differing ciphertext (informational).
+- `save` is a full-map overwrite (the caller composes merges).
+
+## Synced-object registration (`lib/backup/syncedObjects.js`)
+
+Append one entry to the `syncedObjects` array:
+
+```
+{
+  key: 'legacyRecoveredKeys',
+  label: 'Recovered accounts',
+  networkScoped: false,
+  load:  (account) => loadLegacyRecoveredKeys(account),
+  apply: (account, value, mode) =>
+           mode === 'replace'
+             ? (saveLegacyRecoveredKeys(account, value), { conflicts: [] })
+             : (() => {
+                 const { value: merged, conflicts } =
+                   mergeLegacyRecoveredKeys(loadLegacyRecoveredKeys(account), value)
+                 saveLegacyRecoveredKeys(account, merged)
+                 return { conflicts }
+               })(),
+  merge: (current, incoming) => mergeLegacyRecoveredKeys(current, incoming),
+}
+```
+
+No `assertNetworkTagged` branch is required (`networkScoped: false`).
+
+## Relationship to `legacyKeyVault`
+
+`legacyKeyVault(storage)` (in `legacyKeys.js`) is the imperative CRUD the panel uses. Both read/write
+the **same** `legacy_recovered_keys` key; this store adds the backup `load/apply/merge` surface. To
+avoid drift, `legacyKeyVault` is refactored to resolve its storage key through this module's constant
+(or the constant is shared), so there is a single source of truth for the key name and value shape.

--- a/specs/062-legacy-account-recovery/contracts/recoveryAudit.md
+++ b/specs/062-legacy-account-recovery/contracts/recoveryAudit.md
@@ -1,0 +1,44 @@
+# Contract: `data/ledger/sources/legacyRecoverySource.js` (new)
+
+A thin, secret-safe wrapper over the spec-051 client ledger for the recovery audit record (FR-023/025).
+
+## Function
+
+```
+captureLegacyRecovery(account, chainId, { recoveredAddress, source }) → void
+```
+
+- `account`: the session account (owner of the ledger); lowercased internally.
+- `chainId`: active chain (number).
+- `recoveredAddress`: the legacy account address (lowercased in the record).
+- `source`: `'privateKey' | 'mnemonic'` (the recovery type).
+
+Builds and appends one `ClientLedgerRecord` via `appendClientRecord(account, record)`:
+
+```
+entryId:  clientEntryId(`legacy-recovered:${chainId}:${recoveredAddress.toLowerCase()}`)
+chainId:  Number(chainId)
+account:  String(account).toLowerCase()
+class:    LEDGER_CLASS.MEMBERSHIP
+kind:     'legacy_account_recovered'
+direction: LEDGER_DIRECTION.NONE
+status:   LEDGER_STATUS.SETTLED
+provenance: PROVENANCE.CLIENT
+timestamp: Date.now()
+timestampProvenance: TS_PROVENANCE.DEVICE
+refs:     { recoveredAddress: recoveredAddress.toLowerCase(), source }
+```
+
+## Guarantees
+
+- **Idempotent**: the stable `entryId` means `appendClientRecord` no-ops on a repeat, and the
+  `activityLedger` backup domain unions by `entryId` — re-recovering the same account adds no
+  duplicate (FR-025).
+- **Never throws**: `appendClientRecord` is no-throw; a failed audit write must not break recovery.
+- **No secret material**: only `recoveredAddress`, `timestamp`, and `source` are recorded (FR-024).
+  A unit test asserts the serialized record contains neither the private key nor the mnemonic.
+
+## Caller
+
+`LegacyKeyRecoveryPanel` calls `captureLegacyRecovery` exactly once when a recovery is stored
+(the SAVED transition), using the session `account`/`chainId` and the classified `kind` as `source`.

--- a/specs/062-legacy-account-recovery/data-model.md
+++ b/specs/062-legacy-account-recovery/data-model.md
@@ -1,0 +1,104 @@
+# Phase 1 Data Model: Legacy Account Recovery
+
+All data is **device-local** (`localStorage` via `utils/userStorage.js`, per-account key
+`fw_user_<owner>_<key>`) and, where noted, rides the spec-032 encrypted backup. No on-chain schema.
+
+## Entity: Encrypted Vault Entry (the recovered secret)
+
+The at-rest, passphrase-protected form of a legacy secret. **This is the only place key material
+lives, and only as ciphertext.** Stored in the vault under `legacy_recovered_keys`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `v` | number | Schema version (`1`). |
+| `kind` | `'privateKey' \| 'mnemonic'` | Recovery type. |
+| `address` | string (checksummed) | The account the secret controls. Vault key = lowercased. |
+| `salt` | base64 (16 bytes) | Per-entry PBKDF2 salt. |
+| `iv` | base64 (12 bytes) | AES-GCM IV. |
+| `ct` | base64 | AES-GCM ciphertext of the raw secret (0x-key or phrase). |
+| `iterations` | number | PBKDF2 iterations used (`650000`), stored for forward-compat. |
+| `importedAt` | number (epoch ms) | Used for merge tie-break and list ordering. |
+
+**Invariants**: never contains plaintext secret; wrong passphrase fails the GCM tag (no substitute
+material returned); one entry per lowercased address (re-import replaces).
+
+**Validation**: `classifySecret(input)` must return `kind ∈ {privateKey, mnemonic}` with a derived
+`address` before an entry is created; passphrase ≥ 8 chars and confirmed.
+
+## Entity: Recovered Account (list view)
+
+The non-secret projection the panel lists. Derived from vault entries — no separate store.
+
+| Field | Source | Notes |
+|---|---|---|
+| `address` | entry.address | Displayed shortened; full on hover. |
+| `kind` | entry.kind | "private key" / "word list" label. |
+| `importedAt` | entry.importedAt | "saved <date>". |
+
+## Backup domain: `legacyRecoveredKeys` (synced object)
+
+Registered in `lib/backup/syncedObjects.js`.
+
+| Property | Value |
+|---|---|
+| `key` | `'legacyRecoveredKeys'` |
+| `label` | `'Recovered accounts'` |
+| `networkScoped` | `false` (a legacy EOA address is chain-independent) |
+| `load(account)` | return the vault as `{ [lowerAddress]: entry }` (ciphertext only) |
+| `apply(account, value, 'replace')` | overwrite the local vault with `value` |
+| `apply(account, value, 'merge')` | union by lowercased address; newest `importedAt` wins; returns `{ conflicts }` |
+| `merge(current, incoming)` | pure union helper (same rule), returns `{ value, conflicts }` |
+
+**Backup safety**: only ciphertext blobs travel; a restore alone never exposes a secret (still
+passphrase-locked). No `assertNetworkTagged` branch needed (not network-scoped).
+
+## Reused entity: Address Book Entry (contact-centric)
+
+Created/updated via `useAddressBook()` — **not** a new store (see research R4).
+
+- `Contact = { id, nickname, addresses: SavedAddress[], createdAt, updatedAt }`
+- `SavedAddress = { address (checksummed), chainId, notes, addedAt }`
+- Identity: `(lowercase(address), chainId)`. Upsert = `findByAddress` → `addContact` or `addAddress`.
+- Recovered-account defaults: `nickname` member-editable (default "Recovered account"),
+  `notes = "Recovered from legacy <private key|word list>"`, `chainId` = active chain.
+
+## Reused entity: Activity Ledger Record (audit)
+
+Appended via `appendClientRecord` (spec 051). Non-secret fields only.
+
+| Field | Value |
+|---|---|
+| `entryId` | `clientEntryId('legacy-recovered:'+chainId+':'+lowerAddress)` (stable ⇒ idempotent) |
+| `chainId` | active chain (number) |
+| `account` | session account (lowercased) |
+| `class` | `LEDGER_CLASS.MEMBERSHIP` |
+| `kind` | `'legacy_account_recovered'` |
+| `direction` | `LEDGER_DIRECTION.NONE` |
+| `status` | `LEDGER_STATUS.SETTLED` |
+| `provenance` | `PROVENANCE.CLIENT` |
+| `timestamp` | `Date.now()` |
+| `timestampProvenance` | `TS_PROVENANCE.DEVICE` |
+| `refs` | `{ recoveredAddress: lowerAddress, source: 'privateKey'|'mnemonic' }` |
+
+**Invariant**: no field (including `refs`) may ever contain a private key, mnemonic, or seed.
+
+## Entity: Asset Sweep Plan / Outcome (transient, not persisted)
+
+Produced by `quoteAllAssets` and consumed by `sweepAllAssets`.
+
+- **Holding** `{ asset, balance }` — `asset` is a `getPortfolioRegistry` descriptor
+  (`{ kind, address|null, symbol, decimals, chainId }`); only non-zero balances are included.
+- **Quote** `{ holdings: Holding[], nativeGasReserve: bigint, hasNative: boolean }`.
+- **Outcome** `{ asset, status: 'sent'|'skipped'|'failed', txHash?, error? }[]` — one per holding,
+  order = ERC-20s then native.
+
+## State transitions (import wizard)
+
+```
+intro ──▶ enter ──▶ secure ──▶ SAVED (recovery complete: vault + optional book entry + audit)
+                                   │
+                                   ├─(optional)─▶ transfer(all assets) ──▶ done
+                                   └─(later, from stored-key list) ─▶ unlock ─▶ transfer ─▶ done
+```
+
+Terminal, spec-complete state is **SAVED**; `transfer`/`done` are optional continuations (FR-011).

--- a/specs/062-legacy-account-recovery/plan.md
+++ b/specs/062-legacy-account-recovery/plan.md
@@ -1,0 +1,141 @@
+# Implementation Plan: Legacy Account Recovery
+
+**Branch**: `claude/account-recovery-sheets-6x10c5` | **Date**: 2026-07-22 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/062-legacy-account-recovery/spec.md`
+
+## Summary
+
+Rename the **"Backup & Security"** section to **"Recovery"** and let a member bring a legacy
+EOA into FairWins from a raw **private key** or a **BIP-39 word list**, through a guided series of
+informational bottom sheets. The pasted secret is classified (key vs word list), the controlled
+address is shown for confirmation, and the secret is stored **encrypted at rest** under a
+member-chosen passphrase (PBKDF2-SHA256 → AES-GCM) — never persisted in the clear, never
+transmitted. Storing completes recovery on its own; **moving funds is an optional, recommended
+follow-up** that, when chosen, sweeps **all supported assets** (native + every supported ERC-20
+from the portfolio registry) to a destination smart account, with per-asset honest outcomes and a
+disclosed network fee. Recovered accounts are **first-class**: the member can save them to the
+**address book** (making them usable on every address-entry surface), and the encrypted records ride
+the **spec-032 backup** so they carry forward across devices. Each recovery writes a **spec-051
+activity-ledger audit record** (address + timestamp + type only) — **never** a private key or
+mnemonic in any log, backup, or record beyond the encrypted secret store.
+
+**No smart-contract changes.** This is a frontend-only feature that composes existing subsystems
+(portfolio registry, address book, backup sync, activity ledger) with the recovery library.
+Decision log: [research.md](research.md). Data shapes: [data-model.md](data-model.md).
+Module contracts: [contracts/](contracts/).
+
+## Current state (already shipped on this branch)
+
+PR #949 already delivered **US1 (P1)** and a native-only slice of **US2**:
+
+- `frontend/src/lib/recovery/legacyKeys.js` — `classifySecret`, `encryptLegacySecret`/
+  `decryptLegacySecret` (PBKDF2 650k + AES-GCM), `legacyKeyVault(storage)`, and a **native-only**
+  `quoteNativeSweep`/`sweepNativeToSmartAccount`.
+- `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` — the guided ActionSheet flow
+  (intro → enter → secure → transfer → done) plus a stored-key list.
+- Section renamed to "Recovery" in `config/appNav.js` + `pages/WalletPage.jsx` (tab id `security`
+  and the `backup` alias unchanged); tests in `test/recovery/` and `__tests__/`.
+
+This plan covers the **delta** to reach the full spec: restructure so the transfer is clearly
+optional (US2), extend the sweep to **all supported assets** (US2), **address-book** integration
+(US3), **backup** durability (US4), and the **audit** record (US5).
+
+## Technical Context
+
+**Language/Version**: JavaScript ESM — React 19 + Vite, Node ≥22 (frontend only).
+
+**Primary Dependencies**: `ethers` v6 (already present) for key/mnemonic → signer, balance reads,
+and ERC-20/native transfers; `@noble/hashes` (already present) only in tests to register ethers'
+sha256/HMAC/PBKDF2 under jsdom. **No new runtime dependency.**
+
+**Storage**: `localStorage` via `utils/userStorage.js` (per-account `fw_user_<addr>_<key>`). New
+domain key `legacy_recovered_keys` (the encrypted vault) joins the existing `addressBook`,
+`activity_ledger_v1_<chainId>`, etc.
+
+**Testing**: Vitest + Testing Library (jsdom), axe accessibility matchers — the repo standard.
+
+**Target Platform**: Web SPA (PWA), light + dark themes, mobile + desktop.
+
+**Project Type**: Web application, frontend-only change (no `contracts/`, no `subgraph/`, no gateway).
+
+**Performance Goals**: Recovery ≤ 2 min (SC-001). Asset enumeration is a pure registry read +
+one `balanceOf` per supported token on the active chain (bounded, ≤ ~15 tokens); balance reads run
+concurrently.
+
+**Constraints**: Secret never written unencrypted, never transmitted, never logged (constitution
+Key-management + FR-006/007/024). Fund-moving must never strand funds (leave a gas reserve, native
+last) and must report honest per-asset outcomes (FR-015/016). Balances/transfers scoped to the
+active EVM network (FR-012, Honest-State). WCAG 2.1 AA.
+
+**Scale/Scope**: One new store module, one new sweep function, ~4 focused edits to the existing
+panel, one `syncedObjects` registration, one ledger-source helper. Bounded to a handful of files.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|---|---|
+| **I. Security-First Smart Contracts** | **N/A — no `contracts/` change.** No new on-chain surface. The only value-bearing path is client-side signing with the member's own legacy key to transfer their own funds; guarded by leave-gas-reserve, native-last ordering, and per-asset outcome reporting (never strands). |
+| **II. Test-First & Coverage** | Vitest unit tests for the multi-asset sweep (quote + per-asset success/partial-failure/insufficient-gas), the store module (encrypt/decrypt/merge), address-book upsert, backup round-trip for the new domain, and the audit-record shape (asserting **no secret** in any field). Panel tests for the optional-transfer flow. All must pass in CI. |
+| **III. Honest State, No Mocks** | Real registry + on-chain balances; fee disclosed before signature and capped at the quote; out-of-scope assets (NFTs) disclosed, never implied moved; per-asset honest outcomes; balances scoped to the active network. No mocks in shipped paths. |
+| **IV. Fail Loudly in CI** | No `continue-on-error` added. Lint/test/build gate as usual. |
+| **V. Accessible, Consistent Frontend** | Reuses the shared `ActionSheet` (focus trap, Escape, scroll-lock) and global `.btn`/`.section` styles; theme-aware CSS tokens; axe tests. Network/asset config comes from `config/networks.js` + `config/assetTaxonomy.js` (generated/sync sources) — never hardcoded addresses. |
+| **Key Management** | Secret encrypted at rest under the member passphrase; only the **encrypted** blob is persisted or backed up; secret never logged/printed/transmitted. No deployer/admin keys involved. |
+
+**Result: PASS.** No deviations — Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/062-legacy-account-recovery/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions & rationale
+├── data-model.md        # Phase 1 — entities & storage shapes
+├── quickstart.md        # Phase 1 — end-to-end validation guide
+├── contracts/           # Phase 1 — module/UI contracts (function signatures)
+│   ├── legacyKeys.md
+│   ├── legacyRecoveredKeysStore.md
+│   └── recoveryAudit.md
+├── checklists/
+│   └── requirements.md  # from /speckit-specify
+└── tasks.md             # /speckit-tasks output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── lib/
+│   ├── recovery/
+│   │   ├── legacyKeys.js              # EXTEND: sweepAllAssets/quoteAllAssets alongside native sweep
+│   │   └── legacyRecoveredKeysStore.js # NEW: backup-synced domain store (encrypted vault, no plaintext)
+│   ├── backup/
+│   │   └── syncedObjects.js           # EDIT: register 'legacyRecoveredKeys' domain
+│   └── addressBook/                    # (reuse via useAddressBook hook — no change)
+├── data/ledger/
+│   └── sources/legacyRecoverySource.js # NEW: captureLegacyRecovery(account, chainId, {...}) audit helper
+├── hooks/
+│   ├── useAccountAssets.js            # (reuse: enumerate + balances for an arbitrary address)
+│   └── useAddressBook.js              # (reuse: addContact / findByAddress upsert)
+├── components/account/
+│   ├── LegacyKeyRecoveryPanel.jsx     # EDIT: optional transfer, all-asset UI, save-to-book, audit call
+│   └── LegacyKeyRecoveryPanel.css     # EDIT: asset list + save-to-book styles
+└── config/
+    ├── assetTaxonomy.js               # (reuse: getPortfolioRegistry(chainId))
+    └── networks.js                    # (reuse: nativeCurrency, rpcUrl)
+
+frontend/src/test/recovery/ , components/account/__tests__/  # EXTEND with new suites
+```
+
+**Structure Decision**: Single frontend project (Option 2, frontend leg only). The feature adds two
+new modules (`legacyRecoveredKeysStore.js`, `legacyRecoverySource.js`), extends `legacyKeys.js` and
+the panel, and registers one backup domain. Everything else is reuse of existing hooks/registries,
+honoring YAGNI and the "integrate, don't fork" assumption in the spec.
+
+## Complexity Tracking
+
+> No constitution violations. No entries.

--- a/specs/062-legacy-account-recovery/quickstart.md
+++ b/specs/062-legacy-account-recovery/quickstart.md
@@ -1,0 +1,80 @@
+# Quickstart & Validation: Legacy Account Recovery
+
+End-to-end validation for the feature. Run from `frontend/`.
+
+## Prerequisites
+
+- `npm ci` (deps installed).
+- Test vectors (Hardhat account #0): private key
+  `0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`; word list
+  `test test test test test test test test test test test junk`; both resolve to
+  `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`.
+
+## Automated checks
+
+```bash
+# Unit + component suites for this feature
+npx vitest run src/test/recovery src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
+
+# Cross-cutting suites touched by the integration
+npx vitest run src/test/backup src/test/AppNavDrawer.test.jsx
+
+# Lint + full frontend gate (must be clean, no continue-on-error)
+npx eslint src/lib/recovery src/components/account/LegacyKeyRecoveryPanel.jsx src/data/ledger/sources/legacyRecoverySource.js
+npm run test:frontend
+```
+
+## Scenario 1 — Recover & store (US1, P1)
+
+1. `npm run frontend`, connect a session, open **Recovery** (the renamed section) → "Recover a legacy key".
+2. Paste the test private key → **detected as a private key**, address `0xf39F…2266` shown.
+3. Set a passphrase (≥ 8, confirmed) → **Encrypt & continue** → lands on the **Saved** screen.
+4. **Verify**: DevTools → Application → localStorage → `fw_user_<owner>_legacy_recovered_keys` contains
+   a ciphertext blob and **no** `0xac09…` or `test test …` substring.
+5. Repeat with the word list → detected as a **word list**, same address.
+
+**Expected**: recovery completes at the Saved screen without any transfer required (FR-011).
+
+## Scenario 2 — Optional move-all-assets (US2, P2)
+
+1. From the Saved screen (or a stored-key row → **Move funds** → unlock), open the transfer step.
+2. **Verify**: native + every supported token with a non-zero balance is listed; the destination
+   defaults to the session smart account and is editable; the network fee is disclosed; the UI states
+   that only supported assets move (NFTs excluded).
+3. Confirm → **Verify**: per-asset outcomes appear (sent/failed), ERC-20s before native; a forced
+   single-token failure still reports the others as sent (partial-failure path).
+
+**Expected**: all supported assets are transferred or reported failed with retry — none silently
+dropped (FR-015); the account is never stranded (FR-016).
+
+## Scenario 3 — Address book & platform availability (US3, P2)
+
+1. On the Saved screen, choose **Save to address book** (edit the name), confirm.
+2. Open **Pay & Transfer** (or any `AddressInput` with the book add-on) → the recovered account is
+   selectable/resolvable.
+3. Save again → **Verify**: the existing entry updates, no duplicate (FR-020).
+
+## Scenario 4 — Backup carries it forward (US4, P3)
+
+1. Recover an account, run **Back up my data** in the Recovery section.
+2. In a fresh profile (clear localStorage), **Restore my data (merge)**.
+3. **Verify**: the recovered account reappears in the Recovery list; unlocking still requires the
+   original passphrase; no duplicate after a second merge restore.
+
+## Scenario 5 — Audit without leakage (US5, P2)
+
+1. After a recovery, open the activity/reporting surface (or inspect
+   `fw_user_<owner>_activity_ledger_v1_<chainId>`).
+2. **Verify**: exactly one `kind: 'legacy_account_recovered'` record with `refs.recoveredAddress`,
+   `timestamp`, and `refs.source`; **no** key/mnemonic in any field. Re-recover the same account →
+   no second record (idempotent, FR-025).
+
+## Success mapping
+
+| Scenario | User story | Success criteria |
+|---|---|---|
+| 1 | US1 | SC-001, SC-002, SC-008 |
+| 2 | US2 | SC-003, SC-004 |
+| 3 | US3 | SC-005 |
+| 4 | US4 | SC-006 |
+| 5 | US5 | SC-002, SC-007 |

--- a/specs/062-legacy-account-recovery/research.md
+++ b/specs/062-legacy-account-recovery/research.md
@@ -1,0 +1,132 @@
+# Phase 0 Research: Legacy Account Recovery
+
+All decisions below were validated against the existing codebase (portfolio registry, address book,
+backup sync, activity ledger, recovery library). No open `NEEDS CLARIFICATION` remain.
+
+## R1 — At-rest secret encryption
+
+**Decision**: Encrypt each legacy secret with **AES-GCM** under a key stretched from a member-chosen
+passphrase via **PBKDF2-SHA256 (650k iterations, per-entry 16-byte salt, 12-byte IV)**. Store only
+`{ v, kind, address, salt, iv, ct, iterations, importedAt }` (base64) in `localStorage`.
+
+**Rationale**: Mirrors the passkey blob store (`lib/passkey/prfKeys.js`) posture — AES-GCM, wrong
+key fails the tag, never falls through to substitute material (FR-008). PBKDF2 sits above OWASP's
+600k floor. WebCrypto-only, no new dependency. Already implemented and unit-tested on this branch.
+
+**Alternatives considered**: (a) Wrap under the session's passkey PRF / wallet signature — rejected:
+couples a *separate* legacy secret to session identity and forces a ceremony on every unlock; a
+per-account passphrase is simpler and independent (spec Assumption). (b) scrypt/Argon2 — rejected:
+not in WebCrypto; would add a dependency for marginal gain over 650k PBKDF2 here.
+
+## R2 — Enumerating "all supported assets" for a legacy address
+
+**Decision**: Source the asset list from **`getPortfolioRegistry(chainId)`** (`config/assetTaxonomy.js`),
+filtered to `kind === 'native' || kind === 'erc20'`. Read balances for the **arbitrary** legacy
+address — native via `provider.getBalance(addr)`, ERC-20 via a minimal-ABI
+`balanceOf(addr)` — reusing the exact pattern in **`useAccountAssets.js`** (which already reads
+holdings for an arbitrary "From" account). Only assets with a **non-zero** balance are swept.
+
+**Rationale**: `getPortfolioRegistry` is the canonical "all supported assets on a chain" source
+(native + wrapped-native + stablecoin + curated ERC-20 list). NFTs are excluded by the `kind`
+filter, satisfying the spec's fungible-only scope (FR-017) — disclosed in the UI. Reusing the
+registry (not a hand-maintained list) honors the constitution's "config from generated/sync sources."
+
+**Alternatives considered**: `useChainTokens` — rejected: knows only native + the one stablecoin, so
+it would silently miss USDC/DAI/WETH/etc. (violates FR-015 "never silently drop an asset").
+
+## R3 — Sweeping multiple assets from a legacy EOA (ordering, gas, failure)
+
+**Decision**: Build the signer with **`walletFromSecret({ kind, secret }, provider)`** (ethers
+`Wallet`/`HDNodeWallet.fromPhrase`). Transfer **ERC-20s first** (`Contract.transfer(to, value)` then
+`.wait()`), one per non-zero token, then the **native currency last** with the existing leave-a-gas-
+reserve logic (`~21000 * gasPrice * 1.2`). Return a **per-asset outcome array**
+(`{ asset, status: 'sent'|'skipped'|'failed', txHash?, error? }`); a single token failure does **not**
+abort the rest. If the account cannot cover ERC-20 gas or the native reserve, that asset is reported
+`failed`/`skipped` with an honest reason — funds are never stranded (FR-015/016).
+
+**Rationale**: A legacy EOA pays its own gas from its native balance, so native must move **last** or
+later token transfers can't pay for themselves. Sequential (not batched) because an EOA has no
+smart-account batching; ethers manages nonces sequentially across awaited sends. Per-asset outcomes
+give the honest reporting FR-015 requires and a natural retry surface.
+
+**Alternatives considered**: (a) Reuse `useTransfer().send` — rejected: it is bound to the *connected*
+wallet's signer/`sendCalls`, not a legacy signer. (b) One native sweep only (current behavior) —
+rejected: fails FR-012/015 ("all supported assets"). (c) Gasless EIP-3009 rail — rejected: only the
+network stablecoin supports it and it needs a configured relayer; a legacy sweep self-submits.
+
+## R4 — Address-book integration (platform-wide availability)
+
+**Decision**: On "save to address book," call **`useAddressBook().findByAddress(address, chainId)`**;
+if absent, **`addContact({ nickname, addresses: [{ address, chainId, notes }] }])`**, else
+`addAddress` onto the found contact. Default `nickname` to a member-editable label (e.g. "Recovered
+account"); `notes` records provenance ("Recovered from legacy private key/word list"). No new store.
+
+**Rationale**: Every `AddressBookButton`/`AddressInput` picker reads the same `useAddressBook` hook,
+so an entry added via `addContact` is immediately selectable/resolvable **everywhere** (FR-019). The
+hook persists per-wallet and is already part of the spec-032 backup, so this reuse also advances US4.
+Identity is `(lowercase(address), chainId)`, so the find-then-add upsert prevents duplicates (FR-020).
+
+**Alternatives considered**: A parallel "recovered accounts" registry surfaced into pickers —
+rejected: the address book already *is* the platform-wide reference; forking it violates the spec
+assumption and duplicates backup wiring.
+
+## R5 — Backup durability for recovered accounts
+
+**Decision**: Add a new **synced object** `legacyRecoveredKeys` to
+`lib/backup/syncedObjects.js`, backed by a new `legacyRecoveredKeysStore.js` that reads/writes the
+**encrypted vault** via `userStorage` key `legacy_recovered_keys`. `networkScoped: false` (a legacy
+EOA address is the same across EVM chains). `merge` unions by lowercased address, newest `importedAt`
+winning; `apply('replace')` overwrites, `apply('merge')` unions.
+
+**Rationale**: The vault entries contain **only the passphrase-encrypted blob** (salt/iv/ct) — no
+plaintext — so backing them up satisfies FR-021 while honoring FR-024 (the encrypted-at-rest store is
+the *only* place key material lives, and its ciphertext is safe to persist). Modeled on
+`vaultReferences` (metadata-style union merge). Because `assertNetworkTagged` only validates known
+network-scoped keys, a non-network-scoped domain needs **no** change there.
+
+**Alternatives considered**: (a) Back up decrypted secrets — rejected outright (FR-024). (b) Model on
+`openChallengeCodes` (restore only when no local vault) — rejected: we want per-address union so
+recovering different accounts on different devices all survive a merge restore.
+
+## R6 — Audit record without key leakage
+
+**Decision**: On a completed recovery, append one **client-ledger** record via a new
+`captureLegacyRecovery(account, chainId, { recoveredAddress, source })` helper (a
+`data/ledger/sources/legacyRecoverySource.js` wrapper over `appendClientRecord`):
+`class: LEDGER_CLASS.MEMBERSHIP`, `kind: 'legacy_account_recovered'`, `direction: NONE`,
+`status: SETTLED`, stable `entryId = clientEntryId('legacy-recovered:'+chainId+':'+address)`,
+`refs: { recoveredAddress, source }` — **address/time/type metadata only**.
+
+**Rationale**: The spec-051 client ledger is the durable, append-only, backup-carried audit history
+(FR-023). A **stable** entryId makes the record idempotent — `appendClientRecord` no-ops on an
+existing id and the `activityLedger` domain unions by entryId in both merge and replace — so
+re-recovering the same account creates no misleading duplicate (FR-025). `refs` carries only
+non-secret metadata (FR-024). Reusing `MEMBERSHIP` avoids a ledger-enum/source expansion; a dedicated
+`LEDGER_CLASS.RECOVERY` is a possible follow-up if a distinct report bucket is wanted.
+
+**Alternatives considered**: A separate audit store — rejected: the ledger already provides
+append-only + backup semantics; a parallel store duplicates that and risks a path that isn't scrubbed
+of secrets.
+
+## R7 — Making the transfer optional (flow shape)
+
+**Decision**: Restructure so the import wizard **terminates at a "saved" confirmation** once the
+encrypted secret is stored and (optionally) the address-book entry is created and the audit record
+written. "Move funds to a smart account" becomes an **optional action** presented on the saved screen
+and on each **stored-key list** row (via unlock → all-asset transfer), never a required wizard step.
+
+**Rationale**: FR-011 requires recovery to complete without moving funds. Decoupling storage from
+transfer also lets a member move funds later (e.g. after topping up gas), which the stored-key list
+already enables via unlock-then-transfer.
+
+**Alternatives considered**: Keep transfer as the terminal wizard step with a "skip" — rejected:
+weaker separation; "skip" reads as an incomplete flow rather than a complete recovery.
+
+## R8 — Test environment note (ethers sha256 under jsdom)
+
+**Decision**: Keep the test-only `registerEthersCrypto()` shim (registers `@noble/hashes` for ethers'
+sha256/HMAC/PBKDF2) for any suite that exercises **mnemonic** parsing.
+
+**Rationale**: Under vitest+jsdom, Node's `Buffer` leaks in and ethers' default sha256 returns a
+`Buffer` its own `hexlify` rejects, breaking BIP-39 parsing. Real browsers have no `Buffer` and use
+the pure-JS path, so this is a **test-env-only** shim with no production effect. Already in place.

--- a/specs/062-legacy-account-recovery/spec.md
+++ b/specs/062-legacy-account-recovery/spec.md
@@ -1,0 +1,193 @@
+# Feature Specification: Legacy Account Recovery
+
+**Feature Branch**: `062-legacy-account-recovery`
+
+**Created**: 2026-07-22
+
+**Status**: Draft
+
+**Input**: User description: "Legacy account recovery in the FairWins Recovery section (renamed from 'Backup & Security'). Members who arrive with an older wallet can recover an account from a legacy EOA private key or a BIP-39 word list (recovery phrase) through a guided series of informational bottom sheets. The pasted secret is detected (private key vs word list), the controlled address is shown for confirmation, and the key material is stored securely encrypted at rest on the device under a member-chosen passphrase — never persisted in the clear, never transmitted. Moving funds to a smart account is an OPTIONAL, recommended follow-up (not a required step): when chosen, it transfers ALL supported assets (native currency plus supported ERC-20 tokens) from the legacy account to a destination smart account. Recovered legacy accounts are first-class and available across the platform: the member can save the full account information into the address book, and it becomes usable anywhere addresses are referenced. Recovered legacy accounts are included in the member's persisted encrypted backup data so they carry forward safely across devices. Account recovery must NOT leak any key material (private key or mnemonic) into the event/activity log, but the recovery action IS recorded for audit purposes (address, timestamp, and type only)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Recover a legacy account and store it safely (Priority: P1)
+
+A member who has moved from an older wallet arrives at the **Recovery** section (formerly "Backup & Security") holding either a raw private key or a written recovery phrase (word list). They open a guided flow of informational sheets that explains, at each step, what is about to happen. They paste their secret; the flow recognizes whether it is a private key or a word list and shows them the account address it controls so they can confirm it is the right one. They choose a passphrase, and the secret is encrypted and saved on their device. At no point is the raw secret written to disk unencrypted or sent anywhere.
+
+**Why this priority**: This is the irreducible core. Without the ability to bring a legacy secret in and hold it safely, none of the follow-on value (moving funds, address-book, backup) can exist. Delivered alone it already lets a member consolidate an old account into FairWins' custody model.
+
+**Independent Test**: Paste a known private key and, separately, a known word list; confirm the correct address is shown for each; complete the passphrase step; verify the secret is retrievable only with the correct passphrase and that nothing readable as the secret exists in device storage.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member on the Recovery section, **When** they paste a valid private key, **Then** the flow identifies it as a private key and displays the address it controls for confirmation.
+2. **Given** a member on the Recovery section, **When** they paste a valid 12–24 word recovery phrase, **Then** the flow identifies it as a word list and displays the address it controls.
+3. **Given** a confirmed secret, **When** the member sets a passphrase of sufficient strength and confirms, **Then** the account is saved encrypted on the device and appears in their list of recovered accounts.
+4. **Given** a stored recovered account, **When** the member (or anyone) inspects device storage, **Then** no unencrypted private key or mnemonic is present.
+5. **Given** a stored recovered account, **When** the member later provides the wrong passphrase, **Then** the secret is not revealed and an actionable error is shown.
+6. **Given** invalid or incomplete input, **When** the member attempts to continue, **Then** the flow explains what is wrong and does not store anything.
+
+---
+
+### User Story 2 - Optionally move all supported assets to a smart account (Priority: P2)
+
+After (or any time after) recovering an account, the member is **recommended** — but never required — to move the account's holdings onto a modern smart account. When they choose to, the flow reports every supported asset the legacy account holds (native currency and supported tokens) with balances, lets them pick or confirm the destination smart account, discloses the network fee, and transfers all of it. The member may decline and leave the funds where they are; the recovery is complete without moving anything.
+
+**Why this priority**: This is the headline value — a legacy externally-owned account is a liability, and consolidating its assets onto a recoverable smart account is the point of recovery. It is P2 rather than P1 because a member can validly recover-and-hold first (US1) and move funds later, so it must not block the core flow.
+
+**Independent Test**: With a recovered account holding native currency and at least one supported token, open the move-funds action; verify all balances are shown, a destination can be chosen, the fee is disclosed, and after confirming, the destination receives the assets and the legacy account is drained to the extent fees allow.
+
+**Acceptance Scenarios**:
+
+1. **Given** a recovered account, **When** the member finishes storing it, **Then** moving funds is presented as an optional, recommended next step that can be skipped.
+2. **Given** the member chooses to move funds, **When** balances are read, **Then** the native balance and every supported token balance held by the legacy account are listed.
+3. **Given** listed balances and a chosen destination, **When** the member confirms, **Then** all supported assets are transferred to the destination and the member sees per-asset outcomes.
+4. **Given** the legacy account cannot cover the network fee, **When** the member attempts to move funds, **Then** the flow explains this and does not strand or lose funds.
+5. **Given** a partial failure (one asset transfer fails), **When** the flow completes, **Then** successful transfers are reported as done and failed ones are reported honestly with the ability to retry.
+6. **Given** the member declines to move funds, **When** they exit, **Then** recovery is still recorded as complete and the account remains available.
+
+---
+
+### User Story 3 - Make recovered accounts first-class across the platform (Priority: P2)
+
+The member can save the recovered account's full information into their address book with a name/label, so it is available anywhere the platform lets them reference an address (sending, requesting, selecting a destination, resolving a name). The recovered account is not a dead-end entry buried in the Recovery section — it behaves like any other known account.
+
+**Why this priority**: Recovery is only useful if the account is usable afterward. Address-book integration is what makes the recovered account "available across the platform," which is an explicit requirement. It is P2 because it depends on US1 but is independent of moving funds (US2).
+
+**Independent Test**: Recover an account, save it to the address book, then open an unrelated address-entry surface elsewhere in the app and confirm the recovered account can be selected/resolved there.
+
+**Acceptance Scenarios**:
+
+1. **Given** a recovered account, **When** the member chooses to save it to the address book, **Then** an entry is created/updated with the account address, a member-provided name, and relevant metadata.
+2. **Given** a saved address-book entry for the recovered account, **When** the member uses any address-entry surface elsewhere, **Then** the recovered account is available for selection or name resolution.
+3. **Given** the recovered account already exists in the address book, **When** the member saves it again, **Then** the existing entry is updated rather than duplicated.
+
+---
+
+### User Story 4 - Carry recovered accounts forward in encrypted backup (Priority: P3)
+
+A member who backs up their data and later restores it on another device finds their recovered accounts carried forward safely, so recovery is not lost when a device is replaced.
+
+**Why this priority**: Durability across devices protects the member from losing the recovery work, matching how the platform already persists address book, activity, and other member data. P3 because the feature is usable within a single device without it, and it depends on US1.
+
+**Independent Test**: Recover an account, run a backup, restore into a fresh profile, and confirm the recovered account is present after restore (still gated by its passphrase for any secret material).
+
+**Acceptance Scenarios**:
+
+1. **Given** one or more recovered accounts, **When** the member backs up their data, **Then** the recovered-account records are included in the encrypted backup.
+2. **Given** a backup containing recovered accounts, **When** the member restores on another device, **Then** the recovered accounts appear in the Recovery section.
+3. **Given** a restore that merges with existing local data, **When** the same recovered account exists on both sides, **Then** it is reconciled without duplication or data loss.
+4. **Given** a restored recovered account whose secret was included, **When** the member unlocks it, **Then** the original passphrase is still required.
+
+---
+
+### User Story 5 - Recovery is auditable but never leaks secrets (Priority: P2)
+
+Every recovery is recorded in the member's activity/audit history so there is a durable, honest record that a legacy account was recovered — but that record contains only the account address, the time, and the type of recovery. No private key, mnemonic, or seed ever appears in the activity log, backup, or any other record beyond the encrypted-at-rest secret store.
+
+**Why this priority**: This is a security- and privacy-critical guardrail that must ship with the core flow, not after. It is called out as an explicit requirement and protects the member from the most damaging failure mode (secret leakage). P2 because it accompanies US1's storage behavior and is verifiable independently.
+
+**Independent Test**: Recover an account, then inspect the activity log and the backup payload; confirm exactly one audit entry exists with address/time/type and that no field anywhere contains the secret.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed recovery, **When** the activity/audit history is viewed, **Then** it contains an entry recording the recovered address, timestamp, and recovery type.
+2. **Given** a completed recovery, **When** the activity log and backup payload are inspected in full, **Then** no private key, mnemonic, or seed appears in any field.
+3. **Given** the same account is recovered twice, **When** the audit history is viewed, **Then** the record is idempotent (no misleading duplicate audit noise) while remaining append-only.
+
+---
+
+### Edge Cases
+
+- **Ambiguous or malformed input**: input that is neither a valid private key nor a valid word list (wrong length, bad checksum, typos) is rejected with guidance and nothing is stored.
+- **Weak or mismatched passphrase**: passphrases below the minimum strength, or a confirmation that does not match, block storage until corrected.
+- **Forgotten passphrase**: the member is told up front that the passphrase cannot be reset and that a forgotten passphrase makes the stored copy unrecoverable (their original key still works).
+- **Destination equals source**: moving funds to the same legacy address is prevented or clearly warned against.
+- **No/insufficient balance for fees**: moving funds when the account cannot pay the network fee is explained rather than attempted.
+- **Unsupported assets present**: assets the platform does not support (e.g. arbitrary tokens or collectibles) are not silently dropped without disclosure — the member is told only supported assets are moved.
+- **Network mismatch**: reading balances or moving funds is scoped to the correct network; the member is told which network the action applies to.
+- **Duplicate recovery**: recovering an account already stored updates the existing record rather than creating conflicting copies.
+- **Empty account**: an account with no balance can still be recovered, stored, saved to the address book, and audited.
+- **Backup restore conflicts**: a recovered account present in both local and restored data is reconciled deterministically.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Section & entry**
+
+- **FR-001**: The section formerly named "Backup & Security" MUST be presented to members as "Recovery", while existing deep links to the section continue to work.
+- **FR-002**: The Recovery section MUST offer members a way to recover an account from a legacy private key or a recovery word list, presented through a guided series of informational sheets that explain each step before it happens.
+
+**Import & detection**
+
+- **FR-003**: The flow MUST accept a pasted secret and determine whether it is a private key or a recovery word list, without requiring the member to declare which.
+- **FR-004**: The flow MUST derive and display the account address controlled by the secret so the member can confirm it before storing.
+- **FR-005**: The flow MUST reject input that is not a valid private key or valid word list and explain why, storing nothing in that case.
+
+**Secure storage**
+
+- **FR-006**: The member's secret MUST be stored encrypted at rest under a member-chosen passphrase, and MUST NOT be persisted anywhere in unencrypted form.
+- **FR-007**: The secret MUST NOT be transmitted off the member's device.
+- **FR-008**: Retrieving the stored secret MUST require the correct passphrase; an incorrect passphrase MUST fail closed (never reveal partial or substitute secret material).
+- **FR-009**: The flow MUST require a passphrase of at least a defined minimum strength and a matching confirmation before storing, and MUST inform the member that the passphrase cannot be recovered if forgotten.
+- **FR-010**: The member MUST be able to view the list of their recovered accounts and remove any stored account.
+
+**Moving funds (optional)**
+
+- **FR-011**: Moving funds to a smart account MUST be optional and clearly recommended; completing recovery MUST NOT require moving any funds.
+- **FR-012**: When the member chooses to move funds, the system MUST enumerate all platform-supported assets held by the legacy account — native currency and supported tokens — and show their balances before any transfer.
+- **FR-013**: The member MUST be able to choose or confirm the destination smart account, with a sensible default when a smart account is available in the current session.
+- **FR-014**: The system MUST disclose the network fee before the member confirms, and MUST NOT allow the member to be charged more than what was disclosed.
+- **FR-015**: On confirmation, the system MUST transfer all listed supported assets to the destination and report a per-asset outcome (succeeded/failed), never silently dropping an asset.
+- **FR-016**: If the legacy account cannot cover the network fee, the system MUST explain this and MUST NOT strand or lose funds.
+- **FR-017**: The system MUST disclose which asset types are in scope for the move and MUST NOT imply that out-of-scope assets were moved.
+
+**Platform availability & address book**
+
+- **FR-018**: The member MUST be able to save a recovered account's information (address, a member-provided name, and relevant metadata) into the address book.
+- **FR-019**: A recovered account saved to the address book MUST be usable anywhere the platform references addresses (selection and name resolution), not only within the Recovery section.
+- **FR-020**: Saving a recovered account that already exists in the address book MUST update the existing entry rather than create a duplicate.
+
+**Backup durability**
+
+- **FR-021**: Recovered-account records MUST be included in the member's persisted encrypted backup so they carry forward across devices.
+- **FR-022**: On restore, recovered accounts MUST be reconciled with any existing local records without duplication or data loss.
+
+**Audit without leakage**
+
+- **FR-023**: Each recovery MUST be recorded in the member's activity/audit history with the recovered address, timestamp, and recovery type.
+- **FR-024**: No private key, mnemonic, or seed MUST ever be written to the activity/audit history, the backup payload, or any record other than the encrypted-at-rest secret store.
+- **FR-025**: The recovery audit record MUST be append-only and idempotent, so re-recovering the same account does not create misleading duplicate audit noise.
+
+### Key Entities *(include if feature involves data)*
+
+- **Recovered Account**: a legacy account the member has brought into the platform. Attributes: the controlled address, the recovery type (private key or word list), the time it was recovered, and a reference to its encrypted secret. Contains no plaintext secret.
+- **Encrypted Secret**: the at-rest, passphrase-protected form of the member's private key or word list. Never leaves the device in plaintext; unlockable only with the member's passphrase.
+- **Address Book Entry**: the platform-wide reference to an account (address, name, metadata) that makes a recovered account usable across surfaces.
+- **Audit Record**: an append-only activity entry noting that a recovery occurred (address, timestamp, type) with no secret material.
+- **Asset Holding**: a supported asset (native currency or a supported token) held by the legacy account, with a balance, considered when moving funds.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member can recover an account (paste secret → confirm address → set passphrase → stored) in under 2 minutes without external help.
+- **SC-002**: 100% of stored recovered accounts have no plaintext secret anywhere in device storage, the activity log, or the backup payload.
+- **SC-003**: When moving funds, 100% of the legacy account's supported assets are either transferred or reported as failed with a retry path — none are silently omitted.
+- **SC-004**: A member who declines to move funds still completes recovery successfully in 100% of cases.
+- **SC-005**: A recovered account saved to the address book is selectable/resolvable on at least one unrelated address-entry surface, verified end-to-end.
+- **SC-006**: After backup-and-restore on a different device, 100% of recovered accounts are present, with no duplicates.
+- **SC-007**: Every completed recovery produces exactly one audit record containing address, timestamp, and type, and re-recovering the same account produces no additional misleading audit entries.
+- **SC-008**: An incorrect passphrase never reveals secret material in 100% of attempts.
+
+## Assumptions
+
+- **"Supported assets" means fungible value**: native currency plus the tokens the platform already recognizes per network (the supported-asset registry). Non-fungible tokens/collectibles are out of scope for moving funds in this feature and are disclosed as such.
+- **EVM networks only**: recovery targets the account model the platform already supports for these secrets (EVM externally-owned accounts). Non-EVM networks (e.g. Bitcoin) are out of scope for this feature.
+- **Word lists use the standard derivation**: a recovery phrase resolves to its account using the platform's standard default derivation; alternate derivation paths/indexes are out of scope for v1 and can be a follow-up.
+- **Passphrase is independent of sign-in**: the at-rest passphrase protecting a recovered secret is chosen per stored account and is separate from how the member signs in to FairWins; it cannot be reset by the platform.
+- **Destination default**: when the current session is a smart account, that account is offered as the default move-funds destination; the member can override it.
+- **Backup carries the encrypted secret and/or its metadata**: recovered-account records ride the existing encrypted backup; any secret material that is carried remains passphrase-locked, so a restore alone never exposes a secret.
+- **Retention**: a recovered account and its encrypted secret remain stored until the member removes them, even after funds are moved, so the account stays available for reference and any later action.
+- **Existing subsystems are reused**: the address book, encrypted backup/restore, and activity/audit history are the platform's existing mechanisms; this feature integrates with them rather than introducing parallel stores.

--- a/specs/062-legacy-account-recovery/tasks.md
+++ b/specs/062-legacy-account-recovery/tasks.md
@@ -1,0 +1,218 @@
+---
+
+description: "Task list for Legacy Account Recovery (062)"
+---
+
+# Tasks: Legacy Account Recovery
+
+**Input**: Design documents from `/specs/062-legacy-account-recovery/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Included — the constitution makes Test-First **NON-NEGOTIABLE** (Vitest for all non-trivial frontend logic).
+
+**Organization**: Tasks are grouped by user story. **US1 (P1) is already shipped on this branch (PR #949)** — its tasks are marked complete `[X]` for traceability; new work starts at Phase 2.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- All paths are relative to repo root; frontend lives under `frontend/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Environment ready for the recovery feature.
+
+- [X] T001 Install frontend deps (`cd frontend && npm ci`) and confirm Vitest runs.
+- [X] T002 [P] Confirm the test-only ethers-crypto shim exists at `frontend/src/test/recovery/registerEthersCrypto.js` (registers `@noble/hashes` for ethers sha256/HMAC/PBKDF2 under jsdom; needed by any mnemonic test).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The flow spine and shared storage contract that US2/US3/US4/US5 attach to.
+
+**⚠️ CRITICAL**: Complete before starting US2–US5.
+
+- [ ] T003 Restructure `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` so the import wizard **terminates at a SAVED confirmation** once the encrypted secret is stored (steps: intro → enter → secure → **saved**). Moving funds becomes an optional action offered on the saved screen and on each stored-key row — never a required wizard step (FR-011, research R7). Keep the existing unlock→transfer path for stored keys.
+- [ ] T004 Extract the vault localStorage key + entry shape into a single shared constant so both `legacyKeyVault` (in `frontend/src/lib/recovery/legacyKeys.js`) and the new backup store agree on `legacy_recovered_keys`. No behavior change; refactor + existing tests still green.
+- [ ] T005 [P] Update `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx` for the SAVED terminal state (recovery completes without any transfer; transfer is reachable but optional).
+
+**Checkpoint**: Import completes at SAVED; the optional-transfer/save/audit hooks have a place to attach.
+
+---
+
+## Phase 3: User Story 1 - Recover a legacy account and store it safely (Priority: P1) 🎯 MVP — ALREADY SHIPPED
+
+**Goal**: Detect key vs word list, confirm address, store the secret encrypted at rest under a passphrase.
+
+**Independent Test**: Paste a known key and a known word list; confirm the correct address for each; set a passphrase; verify the secret unlocks only with the right passphrase and no plaintext exists in storage.
+
+- [X] T006 [P] [US1] `classifySecret` / `walletFromSecret` / `encryptLegacySecret` / `decryptLegacySecret` / `legacyKeyVault` in `frontend/src/lib/recovery/legacyKeys.js`.
+- [X] T007 [P] [US1] Guided ActionSheet import flow + stored-key list in `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` (+ `.css`).
+- [X] T008 [US1] Rename section "Backup & Security" → "Recovery" in `frontend/src/config/appNav.js` and `frontend/src/pages/WalletPage.jsx` (tab id `security` + `backup` alias unchanged); update the two passkey messages in `lib/passkey/encryption.js` + `prfKeys.js`.
+- [X] T009 [P] [US1] Library + panel tests in `frontend/src/test/recovery/legacyKeys.test.js` and `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx`; update `AppNavDrawer` + `encryption` tests for the rename.
+
+**Checkpoint**: US1 functional and merged-ready on this branch.
+
+---
+
+## Phase 4: User Story 2 - Optionally move all supported assets to a smart account (Priority: P2)
+
+**Goal**: When the member chooses, sweep native + every supported ERC-20 from the legacy account to a destination smart account, with per-asset honest outcomes and disclosed fees.
+
+**Independent Test**: With a legacy account holding native + ≥1 supported token, open Move funds; verify all balances listed, destination editable, fee disclosed, per-asset outcomes on confirm, and a single-token failure doesn't abort the rest.
+
+### Tests for User Story 2 ⚠️ (write first)
+
+- [ ] T010 [P] [US2] Unit tests for `quoteAllAssets` in `frontend/src/test/recovery/legacyKeysMultiAsset.test.js`: enumerates native + ERC-20s from a stub registry, reads balances for an arbitrary address, excludes zero balances, computes `nativeGasReserve`.
+- [ ] T011 [P] [US2] Unit tests for `sweepAllAssets` in the same file: ERC-20s-before-native ordering, native-last leaves gas reserve, per-asset outcome array, **partial failure** (one token throws → others still `sent`), invalid/`===from` destination throws, insufficient-native → native `skipped`.
+
+### Implementation for User Story 2
+
+- [ ] T012 [US2] Add `quoteAllAssets({ kind, secret, chainId, provider, registry? })` to `frontend/src/lib/recovery/legacyKeys.js` per `contracts/legacyKeys.md` — default registry `getPortfolioRegistry(chainId).filter(kind native|erc20)` (`frontend/src/config/assetTaxonomy.js`); concurrent `getBalance` / `balanceOf` reads; non-zero only.
+- [ ] T013 [US2] Add `sweepAllAssets({ kind, secret, to, chainId, provider, onProgress? })` to the same file: ERC-20 `transfer` (via `TRANSFER_ABI` from `frontend/src/lib/transfer/eip3009Transfer.js`) then native last (reuse the existing reserve logic); catch per-asset failures; return outcomes; never log the secret.
+- [ ] T014 [US2] Rework the transfer step in `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` to use `quoteAllAssets`/`sweepAllAssets`: list every asset + balance, disclose the network fee before signing, disclose that only supported assets move (NFTs excluded, FR-017), render per-asset outcomes, and offer retry on partial failure.
+- [ ] T015 [P] [US2] Add asset-list + per-asset-outcome styles to `frontend/src/components/account/LegacyKeyRecoveryPanel.css` (theme tokens, both themes).
+- [ ] T016 [US2] Extend `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx`: all-asset listing, fee disclosure, per-asset outcomes, partial-failure UI, and that declining the transfer still leaves recovery complete (FR-011).
+
+**Checkpoint**: A member can optionally move all supported assets; declining still completes recovery.
+
+---
+
+## Phase 5: User Story 5 - Recovery is auditable but never leaks secrets (Priority: P2)
+
+**Goal**: Every recovery writes one activity-ledger audit record (address/time/type only); no secret in any log/backup.
+
+**Independent Test**: Recover an account; find exactly one `legacy_account_recovered` ledger record with address/time/source and no secret; re-recovering the same account adds no duplicate.
+
+### Tests for User Story 5 ⚠️ (write first)
+
+- [ ] T017 [P] [US5] Unit tests for `captureLegacyRecovery` in `frontend/src/test/recovery/legacyRecoverySource.test.js`: appends the expected record shape; **serialized record contains neither the private key nor the mnemonic**; stable `entryId` makes a repeat call idempotent; never throws.
+
+### Implementation for User Story 5
+
+- [ ] T018 [P] [US5] Create `frontend/src/data/ledger/sources/legacyRecoverySource.js` exporting `captureLegacyRecovery(account, chainId, { recoveredAddress, source })` per `contracts/recoveryAudit.md` (uses `appendClientRecord`, `clientEntryId`, `LEDGER_CLASS.MEMBERSHIP`, `kind:'legacy_account_recovered'`, `refs` metadata only).
+- [ ] T019 [US5] Call `captureLegacyRecovery` exactly once at the SAVED transition in `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` (session `account`/`chainId`, `source` = classified `kind`); guard so a failed audit write never breaks recovery.
+- [ ] T020 [US5] Add a panel test asserting the audit helper is invoked once on save with address/type (and not with any secret) in `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx`.
+
+**Checkpoint**: Recovery is audited; no secret leaks; idempotent.
+
+---
+
+## Phase 6: User Story 3 - Make recovered accounts first-class across the platform (Priority: P2)
+
+**Goal**: Save the recovered account into the address book (upsert), making it usable on every address surface.
+
+**Independent Test**: Recover → Save to address book → the account is selectable/resolvable on an unrelated `AddressInput`/picker; saving again updates rather than duplicates.
+
+### Tests for User Story 3 ⚠️ (write first)
+
+- [ ] T021 [P] [US3] Panel test in `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx`: "Save to address book" calls the address-book upsert with `{ nickname, addresses:[{ address, chainId, notes }] }`; re-saving an existing address updates (no duplicate) via `findByAddress`.
+
+### Implementation for User Story 3
+
+- [ ] T022 [US3] Add a "Save to address book" action on the SAVED screen of `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` using `useAddressBook()` (`findByAddress` → `addContact` or `addAddress`), with an editable name (default "Recovered account") and provenance `notes` (research R4, FR-018/019/020).
+- [ ] T023 [P] [US3] Style the save-to-book control + confirmation in `frontend/src/components/account/LegacyKeyRecoveryPanel.css`.
+
+**Checkpoint**: Recovered accounts are usable platform-wide via the address book.
+
+---
+
+## Phase 7: User Story 4 - Carry recovered accounts forward in encrypted backup (Priority: P3)
+
+**Goal**: Recovered-account ciphertext records ride the spec-032 backup and survive restore without duplication.
+
+**Independent Test**: Recover → back up → restore in a fresh profile → the account reappears (still passphrase-locked); a second merge restore creates no duplicate.
+
+### Tests for User Story 4 ⚠️ (write first)
+
+- [ ] T024 [P] [US4] Unit tests for the store in `frontend/src/test/recovery/legacyRecoveredKeysStore.test.js`: `load/save` round-trip; `mergeLegacyRecoveredKeys` unions by lowercased address with newest `importedAt` winning and reports conflicts; payload is ciphertext-only (no plaintext).
+- [ ] T025 [P] [US4] Backup-integration test in `frontend/src/test/backup/legacyRecoveredKeys.sync.test.js`: `buildBundle`/`applyBundle` include and restore the `legacyRecoveredKeys` domain in merge and replace modes without duplication.
+
+### Implementation for User Story 4
+
+- [ ] T026 [US4] Create `frontend/src/lib/recovery/legacyRecoveredKeysStore.js` (`loadLegacyRecoveredKeys` / `saveLegacyRecoveredKeys` / `mergeLegacyRecoveredKeys`) over `userStorage` key `legacy_recovered_keys`, sharing the constant from T004; ciphertext only (contracts/legacyRecoveredKeysStore.md).
+- [ ] T027 [US4] Register the `legacyRecoveredKeys` synced object (`networkScoped:false`, `load`/`apply`/`merge`) in `frontend/src/lib/backup/syncedObjects.js` (no `assertNetworkTagged` branch needed).
+- [ ] T028 [US4] Verify `legacyKeyVault` and the store read/write the same key/shape after T004 (no drift); adjust if needed.
+
+**Checkpoint**: Recovered accounts persist across devices via encrypted backup.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+- [ ] T029 [P] Accessibility: add an axe test for the new SAVED/transfer/save-to-book UI states in `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx` (WCAG 2.1 AA, both themes).
+- [ ] T030 [P] Docs: add `docs/developer-guide/legacy-account-recovery.md` and a CLAUDE.md guardrail bullet summarizing the Recovery section (encrypted-at-rest vault, all-asset sweep, address-book/backup/audit integration, no-secret-in-logs rule).
+- [ ] T031 Run the full frontend gate: `npm run test:frontend` + `npx eslint` over changed files; ensure green with no `continue-on-error`.
+- [ ] T032 Execute `specs/062-legacy-account-recovery/quickstart.md` scenarios 1–5 and confirm each success-criteria mapping.
+- [ ] T033 Update PR #949 description to reflect the full feature (US1–US5) and push.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: done.
+- **Foundational (Phase 2)**: T003 (SAVED restructure) and T004 (shared key constant) block the new stories. T003 is a prerequisite for T014/T019/T022 (they attach to SAVED); T004 is a prerequisite for T026/T028.
+- **User Stories (Phase 4–7)**: all depend on Phase 2. US2, US5, US3 are independent of each other (different concerns, mostly different files) and can proceed in parallel; US4 depends on T004.
+- **Polish (Phase 8)**: after the desired stories are complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: shipped.
+- **US2 (P2)**: needs T003. Independent of US3/US4/US5.
+- **US5 (P2)**: needs T003. Independent of US2/US3/US4.
+- **US3 (P2)**: needs T003. Independent of US2/US4/US5.
+- **US4 (P3)**: needs T004. Independent of US2/US3/US5.
+
+### Within Each User Story
+
+- Tests first (write and see them fail), then implementation, then wire into the panel.
+- Library functions (`legacyKeys.js`, store, ledger source) before the panel edits that consume them.
+
+### Parallel Opportunities
+
+- T010/T011 (US2 tests) ∥ T017 (US5 test) ∥ T024/T025 (US4 tests) — different files.
+- T012/T013 (legacyKeys.js) ∥ T018 (legacyRecoverySource.js) ∥ T026 (store) — different files, after Phase 2.
+- CSS tasks T015/T023 ∥ their component logic.
+- Docs T030 ∥ code once behavior is settled.
+
+**⚠️ Serialize panel edits**: T014, T019, T022 all edit `LegacyKeyRecoveryPanel.jsx` — do them sequentially (or one combined pass) to avoid conflicts, even though their stories are logically independent.
+
+---
+
+## Parallel Example: post-Foundational fan-out
+
+```bash
+# After T003 + T004, three stories' libraries in parallel (different files):
+Task: "US2 — quoteAllAssets/sweepAllAssets in frontend/src/lib/recovery/legacyKeys.js (+ tests)"
+Task: "US5 — captureLegacyRecovery in frontend/src/data/ledger/sources/legacyRecoverySource.js (+ tests)"
+Task: "US4 — legacyRecoveredKeysStore.js + syncedObjects registration (+ tests)"
+# Then serialize the LegacyKeyRecoveryPanel.jsx edits (T014 → T019 → T022).
+```
+
+---
+
+## Implementation Strategy
+
+### MVP
+
+US1 (P1) is the MVP and is **already delivered** on this branch. The remaining phases are incremental value on top.
+
+### Incremental Delivery (recommended order)
+
+1. Phase 2 (SAVED restructure + shared key) → foundation for the delta.
+2. **US2** (all-asset sweep) → the headline value; test → demo.
+3. **US5** (audit, security-critical) → ships alongside the core storage behavior.
+4. **US3** (address book) → makes recovered accounts first-class.
+5. **US4** (backup durability) → cross-device safety.
+6. Phase 8 polish → a11y, docs, quickstart, PR update.
+
+### Notes
+
+- Each story is independently testable; stop at any checkpoint to validate.
+- Commit after each task or logical group; keep secrets out of every log and record.
+- Serialize the shared-file (`LegacyKeyRecoveryPanel.jsx`) edits.

--- a/specs/062-legacy-account-recovery/tasks.md
+++ b/specs/062-legacy-account-recovery/tasks.md
@@ -35,9 +35,9 @@ description: "Task list for Legacy Account Recovery (062)"
 
 **⚠️ CRITICAL**: Complete before starting US2–US5.
 
-- [ ] T003 Restructure `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` so the import wizard **terminates at a SAVED confirmation** once the encrypted secret is stored (steps: intro → enter → secure → **saved**). Moving funds becomes an optional action offered on the saved screen and on each stored-key row — never a required wizard step (FR-011, research R7). Keep the existing unlock→transfer path for stored keys.
-- [ ] T004 Extract the vault localStorage key + entry shape into a single shared constant so both `legacyKeyVault` (in `frontend/src/lib/recovery/legacyKeys.js`) and the new backup store agree on `legacy_recovered_keys`. No behavior change; refactor + existing tests still green.
-- [ ] T005 [P] Update `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx` for the SAVED terminal state (recovery completes without any transfer; transfer is reachable but optional).
+- [X] T003 Restructure `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` so the import wizard **terminates at a SAVED confirmation** once the encrypted secret is stored (steps: intro → enter → secure → **saved**). Moving funds becomes an optional action offered on the saved screen and on each stored-key row — never a required wizard step (FR-011, research R7). Keep the existing unlock→transfer path for stored keys.
+- [X] T004 Extract the vault localStorage key + entry shape into a single shared constant so both `legacyKeyVault` (in `frontend/src/lib/recovery/legacyKeys.js`) and the new backup store agree on `legacy_recovered_keys`. No behavior change; refactor + existing tests still green.
+- [X] T005 [P] Update `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx` for the SAVED terminal state (recovery completes without any transfer; transfer is reachable but optional).
 
 **Checkpoint**: Import completes at SAVED; the optional-transfer/save/audit hooks have a place to attach.
 
@@ -66,16 +66,16 @@ description: "Task list for Legacy Account Recovery (062)"
 
 ### Tests for User Story 2 ⚠️ (write first)
 
-- [ ] T010 [P] [US2] Unit tests for `quoteAllAssets` in `frontend/src/test/recovery/legacyKeysMultiAsset.test.js`: enumerates native + ERC-20s from a stub registry, reads balances for an arbitrary address, excludes zero balances, computes `nativeGasReserve`.
-- [ ] T011 [P] [US2] Unit tests for `sweepAllAssets` in the same file: ERC-20s-before-native ordering, native-last leaves gas reserve, per-asset outcome array, **partial failure** (one token throws → others still `sent`), invalid/`===from` destination throws, insufficient-native → native `skipped`.
+- [X] T010 [P] [US2] Unit tests for `quoteAllAssets` in `frontend/src/test/recovery/legacyKeysMultiAsset.test.js`: enumerates native + ERC-20s from a stub registry, reads balances for an arbitrary address, excludes zero balances, computes `nativeGasReserve`.
+- [X] T011 [P] [US2] Unit tests for `sweepAllAssets` in the same file: ERC-20s-before-native ordering, native-last leaves gas reserve, per-asset outcome array, **partial failure** (one token throws → others still `sent`), invalid/`===from` destination throws, insufficient-native → native `skipped`.
 
 ### Implementation for User Story 2
 
-- [ ] T012 [US2] Add `quoteAllAssets({ kind, secret, chainId, provider, registry? })` to `frontend/src/lib/recovery/legacyKeys.js` per `contracts/legacyKeys.md` — default registry `getPortfolioRegistry(chainId).filter(kind native|erc20)` (`frontend/src/config/assetTaxonomy.js`); concurrent `getBalance` / `balanceOf` reads; non-zero only.
-- [ ] T013 [US2] Add `sweepAllAssets({ kind, secret, to, chainId, provider, onProgress? })` to the same file: ERC-20 `transfer` (via `TRANSFER_ABI` from `frontend/src/lib/transfer/eip3009Transfer.js`) then native last (reuse the existing reserve logic); catch per-asset failures; return outcomes; never log the secret.
-- [ ] T014 [US2] Rework the transfer step in `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` to use `quoteAllAssets`/`sweepAllAssets`: list every asset + balance, disclose the network fee before signing, disclose that only supported assets move (NFTs excluded, FR-017), render per-asset outcomes, and offer retry on partial failure.
-- [ ] T015 [P] [US2] Add asset-list + per-asset-outcome styles to `frontend/src/components/account/LegacyKeyRecoveryPanel.css` (theme tokens, both themes).
-- [ ] T016 [US2] Extend `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx`: all-asset listing, fee disclosure, per-asset outcomes, partial-failure UI, and that declining the transfer still leaves recovery complete (FR-011).
+- [X] T012 [US2] Add `quoteAllAssets({ kind, secret, chainId, provider, registry? })` to `frontend/src/lib/recovery/legacyKeys.js` per `contracts/legacyKeys.md` — default registry `getPortfolioRegistry(chainId).filter(kind native|erc20)` (`frontend/src/config/assetTaxonomy.js`); concurrent `getBalance` / `balanceOf` reads; non-zero only.
+- [X] T013 [US2] Add `sweepAllAssets({ kind, secret, to, chainId, provider, onProgress? })` to the same file: ERC-20 `transfer` (via `TRANSFER_ABI` from `frontend/src/lib/transfer/eip3009Transfer.js`) then native last (reuse the existing reserve logic); catch per-asset failures; return outcomes; never log the secret.
+- [X] T014 [US2] Rework the transfer step in `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` to use `quoteAllAssets`/`sweepAllAssets`: list every asset + balance, disclose the network fee before signing, disclose that only supported assets move (NFTs excluded, FR-017), render per-asset outcomes, and offer retry on partial failure.
+- [X] T015 [P] [US2] Add asset-list + per-asset-outcome styles to `frontend/src/components/account/LegacyKeyRecoveryPanel.css` (theme tokens, both themes).
+- [X] T016 [US2] Extend `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx`: all-asset listing, fee disclosure, per-asset outcomes, partial-failure UI, and that declining the transfer still leaves recovery complete (FR-011).
 
 **Checkpoint**: A member can optionally move all supported assets; declining still completes recovery.
 
@@ -89,13 +89,13 @@ description: "Task list for Legacy Account Recovery (062)"
 
 ### Tests for User Story 5 ⚠️ (write first)
 
-- [ ] T017 [P] [US5] Unit tests for `captureLegacyRecovery` in `frontend/src/test/recovery/legacyRecoverySource.test.js`: appends the expected record shape; **serialized record contains neither the private key nor the mnemonic**; stable `entryId` makes a repeat call idempotent; never throws.
+- [X] T017 [P] [US5] Unit tests for `captureLegacyRecovery` in `frontend/src/test/recovery/legacyRecoverySource.test.js`: appends the expected record shape; **serialized record contains neither the private key nor the mnemonic**; stable `entryId` makes a repeat call idempotent; never throws.
 
 ### Implementation for User Story 5
 
-- [ ] T018 [P] [US5] Create `frontend/src/data/ledger/sources/legacyRecoverySource.js` exporting `captureLegacyRecovery(account, chainId, { recoveredAddress, source })` per `contracts/recoveryAudit.md` (uses `appendClientRecord`, `clientEntryId`, `LEDGER_CLASS.MEMBERSHIP`, `kind:'legacy_account_recovered'`, `refs` metadata only).
-- [ ] T019 [US5] Call `captureLegacyRecovery` exactly once at the SAVED transition in `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` (session `account`/`chainId`, `source` = classified `kind`); guard so a failed audit write never breaks recovery.
-- [ ] T020 [US5] Add a panel test asserting the audit helper is invoked once on save with address/type (and not with any secret) in `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx`.
+- [X] T018 [P] [US5] Create `frontend/src/data/ledger/sources/legacyRecoverySource.js` exporting `captureLegacyRecovery(account, chainId, { recoveredAddress, source })` per `contracts/recoveryAudit.md` (uses `appendClientRecord`, `clientEntryId`, `LEDGER_CLASS.MEMBERSHIP`, `kind:'legacy_account_recovered'`, `refs` metadata only).
+- [X] T019 [US5] Call `captureLegacyRecovery` exactly once at the SAVED transition in `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` (session `account`/`chainId`, `source` = classified `kind`); guard so a failed audit write never breaks recovery.
+- [X] T020 [US5] Add a panel test asserting the audit helper is invoked once on save with address/type (and not with any secret) in `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx`.
 
 **Checkpoint**: Recovery is audited; no secret leaks; idempotent.
 
@@ -109,12 +109,12 @@ description: "Task list for Legacy Account Recovery (062)"
 
 ### Tests for User Story 3 ⚠️ (write first)
 
-- [ ] T021 [P] [US3] Panel test in `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx`: "Save to address book" calls the address-book upsert with `{ nickname, addresses:[{ address, chainId, notes }] }`; re-saving an existing address updates (no duplicate) via `findByAddress`.
+- [X] T021 [P] [US3] Panel test in `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx`: "Save to address book" calls the address-book upsert with `{ nickname, addresses:[{ address, chainId, notes }] }`; re-saving an existing address updates (no duplicate) via `findByAddress`.
 
 ### Implementation for User Story 3
 
-- [ ] T022 [US3] Add a "Save to address book" action on the SAVED screen of `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` using `useAddressBook()` (`findByAddress` → `addContact` or `addAddress`), with an editable name (default "Recovered account") and provenance `notes` (research R4, FR-018/019/020).
-- [ ] T023 [P] [US3] Style the save-to-book control + confirmation in `frontend/src/components/account/LegacyKeyRecoveryPanel.css`.
+- [X] T022 [US3] Add a "Save to address book" action on the SAVED screen of `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` using `useAddressBook()` (`findByAddress` → `addContact` or `addAddress`), with an editable name (default "Recovered account") and provenance `notes` (research R4, FR-018/019/020).
+- [X] T023 [P] [US3] Style the save-to-book control + confirmation in `frontend/src/components/account/LegacyKeyRecoveryPanel.css`.
 
 **Checkpoint**: Recovered accounts are usable platform-wide via the address book.
 
@@ -128,14 +128,14 @@ description: "Task list for Legacy Account Recovery (062)"
 
 ### Tests for User Story 4 ⚠️ (write first)
 
-- [ ] T024 [P] [US4] Unit tests for the store in `frontend/src/test/recovery/legacyRecoveredKeysStore.test.js`: `load/save` round-trip; `mergeLegacyRecoveredKeys` unions by lowercased address with newest `importedAt` winning and reports conflicts; payload is ciphertext-only (no plaintext).
-- [ ] T025 [P] [US4] Backup-integration test in `frontend/src/test/backup/legacyRecoveredKeys.sync.test.js`: `buildBundle`/`applyBundle` include and restore the `legacyRecoveredKeys` domain in merge and replace modes without duplication.
+- [X] T024 [P] [US4] Unit tests for the store in `frontend/src/test/recovery/legacyRecoveredKeysStore.test.js`: `load/save` round-trip; `mergeLegacyRecoveredKeys` unions by lowercased address with newest `importedAt` winning and reports conflicts; payload is ciphertext-only (no plaintext).
+- [X] T025 [P] [US4] Backup-integration test in `frontend/src/test/backup/legacyRecoveredKeys.sync.test.js`: `buildBundle`/`applyBundle` include and restore the `legacyRecoveredKeys` domain in merge and replace modes without duplication.
 
 ### Implementation for User Story 4
 
-- [ ] T026 [US4] Create `frontend/src/lib/recovery/legacyRecoveredKeysStore.js` (`loadLegacyRecoveredKeys` / `saveLegacyRecoveredKeys` / `mergeLegacyRecoveredKeys`) over `userStorage` key `legacy_recovered_keys`, sharing the constant from T004; ciphertext only (contracts/legacyRecoveredKeysStore.md).
-- [ ] T027 [US4] Register the `legacyRecoveredKeys` synced object (`networkScoped:false`, `load`/`apply`/`merge`) in `frontend/src/lib/backup/syncedObjects.js` (no `assertNetworkTagged` branch needed).
-- [ ] T028 [US4] Verify `legacyKeyVault` and the store read/write the same key/shape after T004 (no drift); adjust if needed.
+- [X] T026 [US4] Create `frontend/src/lib/recovery/legacyRecoveredKeysStore.js` (`loadLegacyRecoveredKeys` / `saveLegacyRecoveredKeys` / `mergeLegacyRecoveredKeys`) over `userStorage` key `legacy_recovered_keys`, sharing the constant from T004; ciphertext only (contracts/legacyRecoveredKeysStore.md).
+- [X] T027 [US4] Register the `legacyRecoveredKeys` synced object (`networkScoped:false`, `load`/`apply`/`merge`) in `frontend/src/lib/backup/syncedObjects.js` (no `assertNetworkTagged` branch needed).
+- [X] T028 [US4] Verify `legacyKeyVault` and the store read/write the same key/shape after T004 (no drift); adjust if needed.
 
 **Checkpoint**: Recovered accounts persist across devices via encrypted backup.
 
@@ -143,8 +143,8 @@ description: "Task list for Legacy Account Recovery (062)"
 
 ## Phase 8: Polish & Cross-Cutting Concerns
 
-- [ ] T029 [P] Accessibility: add an axe test for the new SAVED/transfer/save-to-book UI states in `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx` (WCAG 2.1 AA, both themes).
-- [ ] T030 [P] Docs: add `docs/developer-guide/legacy-account-recovery.md` and a CLAUDE.md guardrail bullet summarizing the Recovery section (encrypted-at-rest vault, all-asset sweep, address-book/backup/audit integration, no-secret-in-logs rule).
+- [X] T029 [P] Accessibility: add an axe test for the new SAVED/transfer/save-to-book UI states in `frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx` (WCAG 2.1 AA, both themes).
+- [X] T030 [P] Docs: add `docs/developer-guide/legacy-account-recovery.md` and a CLAUDE.md guardrail bullet summarizing the Recovery section (encrypted-at-rest vault, all-asset sweep, address-book/backup/audit integration, no-secret-in-logs rule).
 - [ ] T031 Run the full frontend gate: `npm run test:frontend` + `npx eslint` over changed files; ensure green with no `continue-on-error`.
 - [ ] T032 Execute `specs/062-legacy-account-recovery/quickstart.md` scenarios 1–5 and confirm each success-criteria mapping.
 - [ ] T033 Update PR #949 description to reflect the full feature (US1–US5) and push.


### PR DESCRIPTION
## Summary

Renames the **"Backup & Security"** section to **"Recovery"** and adds full support for recovering an account from a legacy EOA **private key** or **BIP-39 word list**, through a guided series of informational bottom sheets. Frontend-only — no contracts, no gateway — composing existing subsystems (portfolio registry, address book, spec-032 backup, spec-051 activity ledger).

Specified and planned via Spec Kit under `specs/062-legacy-account-recovery/` (spec → plan → research/data-model/contracts/quickstart → tasks).

## User stories delivered

- **US1 — Recover & store safely.** Detect private key vs word list, show the controlled address for confirmation, encrypt the secret at rest under a member-chosen passphrase (PBKDF2-SHA256 650k → AES-GCM). Never persisted in the clear, never transmitted, never logged. Import completes at a **SAVED** state.
- **US2 — Optionally move all supported assets.** Moving funds is optional and recommended. When chosen, sweeps **native + every supported ERC-20** from `getPortfolioRegistry`, ERC-20s first then native (leaving a gas reserve), with **per-asset outcomes** — one asset failing never aborts the rest; NFTs excluded and disclosed. Fee/scope disclosed before signing.
- **US3 — First-class across the platform.** Save the recovered account to the address book (`useAddressBook` upsert) so it's usable on every address surface.
- **US4 — Backup durability.** Recovered accounts (ciphertext only) ride the spec-032 backup via a new non-network-scoped `legacyRecoveredKeys` synced object; the vault is per-account with a single shared storage key.
- **US5 — Auditable, never leaks secrets.** Each recovery writes one client-ledger record (`legacy_account_recovered`, address/time/type only) with a stable, idempotent entryId — no key material anywhere.

Plus **BIP-39 word suggestions**: live completions and typo flagging as the member types a recovery phrase.

## Key modules

| Concern | File |
|---|---|
| Classify / encrypt / decrypt / vault / all-asset sweep | `frontend/src/lib/recovery/legacyKeys.js` |
| Backup-synced encrypted store (ciphertext only) | `frontend/src/lib/recovery/legacyRecoveredKeysStore.js` |
| BIP-39 suggestions | `frontend/src/lib/recovery/bip39Suggest.js` |
| Audit ledger record | `frontend/src/data/ledger/sources/legacyRecoverySource.js` |
| Guided bottom-sheet UI | `frontend/src/components/account/LegacyKeyRecoveryPanel.jsx` |
| Backup registration | `frontend/src/lib/backup/syncedObjects.js` |
| Section rename | `frontend/src/config/appNav.js`, `frontend/src/pages/WalletPage.jsx` |

## Tests

Vitest suites for: classification + encrypt/decrypt round-trip + wrong-passphrase rejection, the per-account vault, the multi-asset quote/sweep (ordering, gas reserve, **partial failure**, invalid/self destination), the backup store merge + bundle round-trip, the audit record (**asserts no secret in the serialized record** + idempotency), the BIP-39 helper, and the rewritten panel flow (SAVED completion, optional all-asset transfer, save-to-book, unlock/remove) plus an **axe** accessibility check. Section-rename tests updated (nav drawer, passkey messages).

All recovery/backup/ledger/nav/passkey suites pass (150+ tests); `eslint .` reports 0 errors.

## Notes

- **EVM externally-owned accounts only**; word lists resolve via the standard default derivation path.
- The at-rest passphrase is per-account and **cannot be reset** by the platform (disclosed to the member).
- Docs: `docs/developer-guide/legacy-account-recovery.md` + a CLAUDE.md guardrail bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)