### PR TITLE
feat(recovery): biometric-first key protection, dark-mode contrast, recovered acting-account

### DIFF
--- a/frontend/src/components/account/AccountSwitcher.css
+++ b/frontend/src/components/account/AccountSwitcher.css
@@ -1,0 +1,100 @@
+/* Global acting-account switcher. Theme tokens with light-mode fallbacks so it
+   reads in both themes (and against the wallet bottom sheet's surface). */
+
+.acct-switch {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.acct-switch__caption {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #8a959e);
+}
+
+.acct-switch__trigger,
+.acct-switch__opt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 22%, transparent);
+  background: color-mix(in srgb, var(--text-primary, #1f2933) 5%, transparent);
+  color: var(--text-primary, #1f2933);
+  font-size: 0.9rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.acct-switch__trigger:hover,
+.acct-switch__opt:hover {
+  border-color: var(--brand-primary, #36b37e);
+}
+
+.acct-switch__label {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.acct-switch__tag {
+  font-size: 0.68rem;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--brand-secondary, #4c9aff) 20%, transparent);
+  color: var(--brand-secondary, #4c9aff);
+  flex-shrink: 0;
+}
+
+.acct-switch__addr {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.78rem;
+  color: var(--text-muted, #8a959e);
+  flex-shrink: 0;
+}
+
+.acct-switch__chevron {
+  color: var(--text-muted, #8a959e);
+  flex-shrink: 0;
+}
+
+.acct-switch__menu {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 4px;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  border-radius: 10px;
+  border: 1px solid var(--border-color, #e3e7eb);
+  background: var(--surface-color, #ffffff);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.acct-switch__opt {
+  border: 1px solid transparent;
+  background: none;
+}
+
+.acct-switch__check {
+  color: var(--brand-primary, #36b37e);
+  font-weight: 700;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/account/AccountSwitcher.jsx
+++ b/frontend/src/components/account/AccountSwitcher.jsx
@@ -1,0 +1,129 @@
+/**
+ * Global "acting account" switcher (spec 062 follow-up). Lets a member choose
+ * which account the app acts as — their personal wallet, a multisig vault
+ * (spec 043), or a recovered legacy account (spec 062) — writing the shared
+ * active identity (CustodyContext via useActiveAccount) that Trade, Transfer, and
+ * every money-moving surface already read.
+ *
+ * Selecting a legacy account first unlocks it (biometric or passphrase, via
+ * LegacyUnlockDialog) into an in-memory signer; the key is never persisted.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+import { useWallet } from '../../hooks/useWalletManagement'
+import { useActiveAccount } from '../../hooks/useActiveAccount'
+import { useCustodyVaults } from '../../hooks/useCustodyVaults'
+import { useLegacyAccounts } from '../../hooks/useLegacyAccounts'
+import BlockiesAvatar from '../ui/BlockiesAvatar'
+import LegacyUnlockDialog from './LegacyUnlockDialog'
+import './AccountSwitcher.css'
+
+const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
+const KIND_TAG = { vault: 'Multisig', legacy: 'Recovered' }
+
+export default function AccountSwitcher({ deps = {} }) {
+  const { address, chainId } = useWallet()
+  const { identity, operateAsPersonal, operateAsVault, operateAsLegacy } = useActiveAccount()
+  const { vaults } = useCustodyVaults()
+  const legacyAccounts = useLegacyAccounts()
+
+  const [open, setOpen] = useState(false)
+  const [unlockEntry, setUnlockEntry] = useState(null)
+  const wrapRef = useRef(null)
+
+  const accounts = useMemo(() => {
+    const list = [{ id: 'personal', kind: 'personal', address, label: 'Personal wallet' }]
+    for (const v of vaults || []) {
+      if (v?.address) list.push({ id: `vault:${v.address}`, kind: 'vault', address: v.address, chainId: v.chainId, label: v.label || short(v.address) })
+    }
+    return list.concat(legacyAccounts)
+  }, [address, vaults, legacyAccounts])
+
+  const currentId = useMemo(() => {
+    if (identity.mode === 'vault') return `vault:${identity.vaultAddress}`
+    if (identity.mode === 'legacy') return `legacy:${String(identity.address).toLowerCase()}`
+    return 'personal'
+  }, [identity])
+
+  const selected = accounts.find((a) => a.id === currentId) || accounts[0]
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onDocClick = (e) => { if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false) }
+    const onKey = (e) => { if (e.key === 'Escape') setOpen(false) }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => { document.removeEventListener('mousedown', onDocClick); document.removeEventListener('keydown', onKey) }
+  }, [open])
+
+  const choose = useCallback((acc) => {
+    setOpen(false)
+    if (acc.kind === 'personal') return operateAsPersonal()
+    if (acc.kind === 'vault') return operateAsVault({ address: acc.address, chainId: acc.chainId, label: acc.label })
+    if (acc.kind === 'legacy') { setUnlockEntry(acc.entry); return undefined } // unlock, then operateAsLegacy
+    return undefined
+  }, [operateAsPersonal, operateAsVault])
+
+  const onUnlocked = useCallback((signer) => {
+    if (unlockEntry) {
+      // Unlocked for the CURRENT chain — submit re-checks this before sending.
+      operateAsLegacy({ address: unlockEntry.address, chainId, kind: unlockEntry.kind, label: short(unlockEntry.address), signer })
+    }
+    setUnlockEntry(null)
+  }, [unlockEntry, chainId, operateAsLegacy])
+
+  // Only worth showing when there's more than the personal wallet to choose from.
+  if (accounts.length <= 1) return null
+
+  const row = (acc, withTag = true) => (
+    <>
+      <BlockiesAvatar address={acc.address} size={20} />
+      <span className="acct-switch__label">
+        {acc.label || short(acc.address)}
+        {withTag && KIND_TAG[acc.kind] && <span className="acct-switch__tag">{KIND_TAG[acc.kind]}</span>}
+      </span>
+      <span className="acct-switch__addr">{short(acc.address)}</span>
+    </>
+  )
+
+  return (
+    <div className="acct-switch" ref={wrapRef}>
+      <span className="acct-switch__caption">Acting as</span>
+      <button
+        type="button"
+        className="acct-switch__trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label="Change acting account"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {row(selected)}
+        <span className="acct-switch__chevron" aria-hidden="true">▾</span>
+      </button>
+      {open && (
+        <ul className="acct-switch__menu" role="listbox">
+          {accounts.map((acc) => (
+            <li key={acc.id} role="option" aria-selected={acc.id === currentId}>
+              <button type="button" className="acct-switch__opt" onClick={() => choose(acc)}>
+                {row(acc)}
+                {acc.id === currentId && <span className="acct-switch__check" aria-hidden="true">✓</span>}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <LegacyUnlockDialog
+        open={Boolean(unlockEntry)}
+        entry={unlockEntry}
+        onClose={() => setUnlockEntry(null)}
+        onUnlocked={onUnlocked}
+        deps={deps}
+      />
+    </div>
+  )
+}
+
+AccountSwitcher.propTypes = {
+  deps: PropTypes.object,
+}

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.css
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.css
@@ -24,7 +24,7 @@
   justify-content: space-between;
   gap: 12px;
   padding: 10px 12px;
-  border: 1px solid var(--border-color, #e3e7eb);
+  border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 18%, transparent);
   border-radius: 10px;
   background: var(--bg-primary, #f7f9fa);
 }
@@ -64,7 +64,7 @@
   resize: vertical;
   min-height: 64px;
   padding: 10px 12px;
-  border: 1px solid var(--border-color, #e3e7eb);
+  border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 18%, transparent);
   border-radius: 8px;
   background: var(--bg-primary, #f7f9fa);
   color: var(--text-primary, #1f2933);
@@ -92,7 +92,7 @@
   font-size: 0.82rem;
   padding: 4px 10px;
   border-radius: 999px;
-  border: 1px solid var(--border-color, #e3e7eb);
+  border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 18%, transparent);
   background: var(--bg-primary, #f7f9fa);
   color: var(--text-primary, #1f2933);
   cursor: pointer;
@@ -101,6 +101,26 @@
 .lkr-suggest__chip:hover {
   border-color: var(--brand-primary, #36b37e);
   color: var(--brand-primary, #36b37e);
+}
+
+/* --- Protection fallback link --- */
+.lkr-alt {
+  text-align: center;
+  margin: 10px 0 0 !important;
+}
+
+.lkr-linkbtn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--brand-primary, #36b37e);
+  font-size: 0.86rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.lkr-linkbtn:hover {
+  text-decoration: underline;
 }
 
 /* --- Passphrase fields --- */
@@ -118,7 +138,7 @@
 
 .lkr-field input {
   padding: 10px 12px;
-  border: 1px solid var(--border-color, #e3e7eb);
+  border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 18%, transparent);
   border-radius: 8px;
   background: var(--bg-primary, #f7f9fa);
   color: var(--text-primary, #1f2933);
@@ -152,7 +172,7 @@
 
 /* --- Balance quote --- */
 .lkr-quote {
-  border: 1px solid var(--border-color, #e3e7eb);
+  border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 18%, transparent);
   border-radius: 10px;
   padding: 10px 12px;
   margin: 12px 0;
@@ -195,10 +215,14 @@
 }
 
 /* --- SAVED screen optional actions --- */
+/* On the --surface-color sheet the plain --border-color is nearly invisible, so
+   these optional-action cards vanished. Lift them with a faint fill + a
+   text-derived border that stays visible in both themes. */
 .lkr-saved-action {
-  border: 1px solid var(--border-color, #e3e7eb);
+  border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 16%, transparent);
+  background: color-mix(in srgb, var(--text-primary, #1f2933) 4%, transparent);
   border-radius: 10px;
-  padding: 10px 12px;
+  padding: 12px;
   margin: 10px 0;
 }
 
@@ -225,7 +249,7 @@
   flex: 1;
   min-width: 0;
   padding: 8px 10px;
-  border: 1px solid var(--border-color, #e3e7eb);
+  border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 18%, transparent);
   border-radius: 8px;
   background: var(--bg-primary, #f7f9fa);
   color: var(--text-primary, #1f2933);

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
@@ -29,11 +29,14 @@ import ActionSheet from './ActionSheet'
 import {
   classifySecret,
   encryptLegacySecret,
+  encryptLegacySecretWithPasskey,
   decryptLegacySecret,
+  decryptLegacySecretWithPasskey,
   legacyKeyVault,
   quoteAllAssets,
   sweepAllAssets,
 } from '../../lib/recovery/legacyKeys'
+import { readSession } from '../../connectors/passkey'
 import { suggestWords, applySuggestion, currentWord, unknownWordsIn } from '../../lib/recovery/bip39Suggest'
 import './LegacyKeyRecoveryPanel.css'
 
@@ -69,6 +72,13 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
   const [passphrase, setPassphrase] = useState('')
   const [passphrase2, setPassphrase2] = useState('')
   const [active, setActive] = useState(null) // { kind, address, secret }
+
+  // Biometric-first protection: when the session is a passkey, protect the key
+  // with this device's biometrics (no password); fall back to a passphrase only
+  // when biometrics aren't available or the member opts out.
+  const sessionCredentialId = useMemo(() => (deps.readSession ?? readSession)()?.credentialId || null, [deps.readSession])
+  const biometricAvailable = loginMethod === 'passkey' && Boolean(sessionCredentialId)
+  const [protectMode, setProtectMode] = useState('passkey') // 'passkey' | 'passphrase'
 
   // Save-to-address-book state (on the SAVED screen).
   const [bookName, setBookName] = useState('')
@@ -136,10 +146,11 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
     setOutcomes(null)
     setUnlockEntry(null)
     setUnlockPass('')
+    setProtectMode(biometricAvailable ? 'passkey' : 'passphrase')
     const suggest = suggestedDest()
     setDestInput(suggest)
     setDestResolved(suggest)
-  }, [suggestedDest])
+  }, [suggestedDest, biometricAvailable])
 
   const openWizard = useCallback(() => {
     resetWizard()
@@ -167,27 +178,39 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
     }
     setActive({ kind: c.kind, address: c.address, secret: c.secret })
     setBookName('Recovered account')
+    setProtectMode(biometricAvailable ? 'passkey' : 'passphrase')
     setNotice(null)
     setStep('secure')
-  }, [rawSecret])
+  }, [rawSecret, biometricAvailable])
 
   // Encrypt + store, write the audit record, land on SAVED (recovery is now complete).
+  // Biometric protection uses a WebAuthn assertion (no passphrase); the passphrase
+  // path is the fallback.
   const storeAndContinue = useCallback(async () => {
     if (!active) return
-    if (passphrase !== passphrase2) {
+    const usePasskey = protectMode === 'passkey' && biometricAvailable
+    if (!usePasskey && passphrase !== passphrase2) {
       setNotice({ kind: 'error', text: 'The two passphrases do not match.' })
       return
     }
     setNotice(null)
     setPhase('encrypting')
     try {
-      const entry = await encryptLegacySecret({
-        secret: active.secret,
-        kind: active.kind,
-        address: active.address,
-        passphrase,
-        deps,
-      })
+      const entry = usePasskey
+        ? await encryptLegacySecretWithPasskey({
+            secret: active.secret,
+            kind: active.kind,
+            address: active.address,
+            credentialId: sessionCredentialId,
+            deps,
+          })
+        : await encryptLegacySecret({
+            secret: active.secret,
+            kind: active.kind,
+            address: active.address,
+            passphrase,
+            deps,
+          })
       vault.set(entry)
       refreshStored()
       // Audit WITHOUT key material (address/time/type only). Never breaks recovery.
@@ -203,7 +226,7 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
       setPhase('idle')
       setNotice({ kind: 'error', text: e.message })
     }
-  }, [active, passphrase, passphrase2, deps, vault, refreshStored, sessionAddress, chainId])
+  }, [active, protectMode, biometricAvailable, sessionCredentialId, passphrase, passphrase2, deps, vault, refreshStored, sessionAddress, chainId])
 
   // Save the recovered account to the address book (upsert; usable platform-wide).
   const saveToBook = useCallback(() => {
@@ -285,7 +308,9 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
     setNotice(null)
     setPhase('encrypting')
     try {
-      const secret = await decryptLegacySecret({ entry: unlockEntry, passphrase: unlockPass, deps })
+      const secret = unlockEntry.protection === 'passkey'
+        ? await decryptLegacySecretWithPasskey({ entry: unlockEntry, deps })
+        : await decryptLegacySecret({ entry: unlockEntry, passphrase: unlockPass, deps })
       setActive({ kind: unlockEntry.kind, address: unlockEntry.address, secret })
       setUnlockPass('')
       setPhase('idle')
@@ -445,45 +470,91 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
           </div>
         )}
 
-        {/* Step 3 — passphrase → encrypt at rest. */}
+        {/* Step 3 — protect at rest: biometrics first, passphrase fallback. */}
         {step === 'secure' && (
           <div className="recover-step">
-            <p>
-              Choose a passphrase to encrypt this {active ? KIND_LABEL[active.kind] : 'key'} on this device. You
-              will need it to move funds later. <strong>We can&apos;t reset it</strong> — if you forget it, the
-              stored copy is unrecoverable (your original key still works).
-            </p>
-            <label className="lkr-field">
-              <span>Passphrase</span>
-              <input
-                type="password"
-                value={passphrase}
-                onChange={(e) => { setPassphrase(e.target.value); setNotice(null) }}
-                placeholder="At least 8 characters"
-                autoComplete="new-password"
-              />
-            </label>
-            <label className="lkr-field">
-              <span>Confirm passphrase</span>
-              <input
-                type="password"
-                value={passphrase2}
-                onChange={(e) => { setPassphrase2(e.target.value); setNotice(null) }}
-                autoComplete="new-password"
-              />
-            </label>
-            {noticeEl}
-            <div className="recover-step__actions">
-              <button type="button" className="btn" onClick={() => setStep('enter')} disabled={busy}>Back</button>
-              <button
-                type="button"
-                className="btn btn-primary"
-                disabled={busy || passphrase.length < 8 || passphrase !== passphrase2}
-                onClick={storeAndContinue}
-              >
-                {phase === 'encrypting' ? 'Encrypting…' : 'Encrypt & save'}
-              </button>
-            </div>
+            {protectMode === 'passkey' && biometricAvailable ? (
+              <>
+                <p>
+                  Protect this {active ? KIND_LABEL[active.kind] : 'key'} with <strong>this device&apos;s
+                  biometrics</strong> (Face/Touch ID). No password to remember — only this passkey can unlock it,
+                  and it stays encrypted on this device.
+                </p>
+                <p className="recover-step__hint">
+                  Uses the same passkey you sign in with. If you replace this device, unlock again there or
+                  re-import your original {active ? KIND_LABEL[active.kind] : 'key'}.
+                </p>
+                {noticeEl}
+                <div className="recover-step__actions">
+                  <button type="button" className="btn" onClick={() => setStep('enter')} disabled={busy}>Back</button>
+                  <button type="button" className="btn btn-primary" disabled={busy} onClick={storeAndContinue}>
+                    {phase === 'encrypting' ? 'Confirming…' : 'Protect with biometrics'}
+                  </button>
+                </div>
+                <p className="lkr-alt">
+                  <button type="button" className="lkr-linkbtn" onClick={() => { setNotice(null); setProtectMode('passphrase') }}>
+                    Use a passphrase instead
+                  </button>
+                </p>
+              </>
+            ) : (
+              <>
+                <p>
+                  Choose a passphrase to encrypt this {active ? KIND_LABEL[active.kind] : 'key'} on this device. You
+                  will need it to move funds later. <strong>We can&apos;t reset it</strong> — if you forget it, the
+                  stored copy is unrecoverable (your original key still works). You can save it in your password
+                  manager.
+                </p>
+                {/* Hidden identity hint so password managers offer to save this passphrase against the account. */}
+                <input
+                  type="text"
+                  className="sr-only"
+                  tabIndex={-1}
+                  aria-hidden="true"
+                  autoComplete="username"
+                  value={active?.address || ''}
+                  readOnly
+                />
+                <label className="lkr-field">
+                  <span>Passphrase</span>
+                  <input
+                    type="password"
+                    value={passphrase}
+                    onChange={(e) => { setPassphrase(e.target.value); setNotice(null) }}
+                    placeholder="At least 8 characters"
+                    autoComplete="new-password"
+                  />
+                </label>
+                <label className="lkr-field">
+                  <span>Confirm passphrase</span>
+                  <input
+                    type="password"
+                    value={passphrase2}
+                    onChange={(e) => { setPassphrase2(e.target.value); setNotice(null) }}
+                    autoComplete="new-password"
+                  />
+                </label>
+                {noticeEl}
+                <div className="recover-step__actions">
+                  <button type="button" className="btn" onClick={() => setStep('enter')} disabled={busy}>Back</button>
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    disabled={busy || passphrase.length < 8 || passphrase !== passphrase2}
+                    onClick={storeAndContinue}
+                  >
+                    {phase === 'encrypting' ? 'Encrypting…' : 'Encrypt & save'}
+                  </button>
+                </div>
+                {biometricAvailable && (
+                  <p className="lkr-alt">
+                    <button type="button" className="lkr-linkbtn" onClick={() => { setNotice(null); setProtectMode('passkey') }}>
+                      Use this device&apos;s biometrics instead
+                    </button>
+                  </p>
+                )}
+              </>
+            )}
           </div>
         )}
 
@@ -535,24 +606,42 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
         {/* Step 3b — unlock a previously stored key before moving funds. */}
         {step === 'unlock' && (
           <div className="recover-step">
-            <p>Enter the passphrase for <code>{shortAddr(unlockEntry?.address)}</code> to move its funds.</p>
-            <label className="lkr-field">
-              <span>Passphrase</span>
-              <input
-                type="password"
-                value={unlockPass}
-                onChange={(e) => { setUnlockPass(e.target.value); setNotice(null) }}
-                autoComplete="off"
-                aria-label="Passphrase"
-              />
-            </label>
-            {noticeEl}
-            <div className="recover-step__actions">
-              <button type="button" className="btn" onClick={closeWizard} disabled={busy}>Cancel</button>
-              <button type="button" className="btn btn-primary" disabled={busy || !unlockPass} onClick={doUnlock}>
-                {phase === 'encrypting' ? 'Unlocking…' : 'Unlock'}
-              </button>
-            </div>
+            {unlockEntry?.protection === 'passkey' ? (
+              <>
+                <p>
+                  Unlock <code>{shortAddr(unlockEntry?.address)}</code> with <strong>this device&apos;s
+                  biometrics</strong> to move its funds.
+                </p>
+                {noticeEl}
+                <div className="recover-step__actions">
+                  <button type="button" className="btn" onClick={closeWizard} disabled={busy}>Cancel</button>
+                  <button type="button" className="btn btn-primary" disabled={busy} onClick={doUnlock}>
+                    {phase === 'encrypting' ? 'Confirming…' : 'Unlock with biometrics'}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p>Enter the passphrase for <code>{shortAddr(unlockEntry?.address)}</code> to move its funds.</p>
+                <label className="lkr-field">
+                  <span>Passphrase</span>
+                  <input
+                    type="password"
+                    value={unlockPass}
+                    onChange={(e) => { setUnlockPass(e.target.value); setNotice(null) }}
+                    autoComplete="off"
+                    aria-label="Passphrase"
+                  />
+                </label>
+                {noticeEl}
+                <div className="recover-step__actions">
+                  <button type="button" className="btn" onClick={closeWizard} disabled={busy}>Cancel</button>
+                  <button type="button" className="btn btn-primary" disabled={busy || !unlockPass} onClick={doUnlock}>
+                    {phase === 'encrypting' ? 'Unlocking…' : 'Unlock'}
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         )}
 

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
@@ -76,7 +76,10 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
   // Biometric-first protection: when the session is a passkey, protect the key
   // with this device's biometrics (no password); fall back to a passphrase only
   // when biometrics aren't available or the member opts out.
-  const sessionCredentialId = useMemo(() => (deps.readSession ?? readSession)()?.credentialId || null, [deps.readSession])
+  // Read the session's passkey credential inline (cheap localStorage read) so it
+  // always reflects the CURRENT session — a memo keyed on deps.readSession alone
+  // went stale across sign-in/out and account switches.
+  const sessionCredentialId = (deps.readSession ?? readSession)()?.credentialId || null
   const biometricAvailable = loginMethod === 'passkey' && Boolean(sessionCredentialId)
   const [protectMode, setProtectMode] = useState('passkey') // 'passkey' | 'passphrase'
 

--- a/frontend/src/components/account/LegacyUnlockDialog.jsx
+++ b/frontend/src/components/account/LegacyUnlockDialog.jsx
@@ -1,0 +1,108 @@
+/**
+ * Unlock a recovered legacy account into a live signer so the app can "act as"
+ * it (spec 062 follow-up). Biometric-protected keys unlock with one Face/Touch ID
+ * assertion (no input); passphrase-protected keys prompt for the passphrase. On
+ * success the provider-connected ethers signer is handed back to the caller,
+ * which passes it to CustodyContext.operateAsLegacy — the key stays in memory
+ * only, never persisted.
+ */
+
+import { useCallback, useState } from 'react'
+import PropTypes from 'prop-types'
+import { useWallet } from '../../hooks/useWalletManagement'
+import { getNetwork } from '../../config/networks'
+import { unlockLegacyAccount } from '../../lib/recovery/legacyKeys'
+import ActionSheet from './ActionSheet'
+import './LegacyKeyRecoveryPanel.css'
+
+const shortAddr = (a) => (a ? `${a.substring(0, 6)}…${a.substring(a.length - 4)}` : '')
+
+export default function LegacyUnlockDialog({ open, entry, onClose, onUnlocked, deps = {} }) {
+  const { provider, chainId } = useWallet()
+  const [passphrase, setPassphrase] = useState('')
+  const [phase, setPhase] = useState('idle') // idle | unlocking
+  const [error, setError] = useState(null)
+
+  const isPasskey = entry?.protection === 'passkey'
+  const networkName = getNetwork(chainId)?.name || 'this network'
+
+  const close = useCallback(() => {
+    if (phase === 'unlocking') return
+    setPassphrase('')
+    setError(null)
+    onClose?.()
+  }, [phase, onClose])
+
+  const doUnlock = useCallback(async () => {
+    if (!entry) return
+    setError(null)
+    setPhase('unlocking')
+    try {
+      const signer = await unlockLegacyAccount({
+        entry,
+        passphrase,
+        provider: deps.provider ?? provider,
+        deps,
+      })
+      setPhase('idle')
+      setPassphrase('')
+      onUnlocked?.(signer)
+    } catch (e) {
+      setPhase('idle')
+      setError(e.message)
+    }
+  }, [entry, passphrase, provider, deps, onUnlocked])
+
+  const busy = phase === 'unlocking'
+
+  return (
+    <ActionSheet open={open} onClose={close} title="Use this account" closeDisabled={busy}>
+      <div className="recover-step">
+        <p>
+          Act as <code>{shortAddr(entry?.address)}</code> — the app will sign with this recovered account on{' '}
+          {networkName} until you switch back.
+        </p>
+        {isPasskey ? (
+          <>
+            <p className="recover-step__hint">Unlock with this device&apos;s biometrics (Face/Touch ID).</p>
+            {error && <p role="alert" className="lkr-notice lkr-notice--error">{error}</p>}
+            <div className="recover-step__actions">
+              <button type="button" className="btn" onClick={close} disabled={busy}>Cancel</button>
+              <button type="button" className="btn btn-primary" onClick={doUnlock} disabled={busy}>
+                {busy ? 'Confirming…' : 'Unlock with biometrics'}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <label className="lkr-field">
+              <span>Passphrase</span>
+              <input
+                type="password"
+                value={passphrase}
+                onChange={(e) => { setPassphrase(e.target.value); setError(null) }}
+                autoComplete="off"
+                aria-label="Passphrase"
+              />
+            </label>
+            {error && <p role="alert" className="lkr-notice lkr-notice--error">{error}</p>}
+            <div className="recover-step__actions">
+              <button type="button" className="btn" onClick={close} disabled={busy}>Cancel</button>
+              <button type="button" className="btn btn-primary" onClick={doUnlock} disabled={busy || !passphrase}>
+                {busy ? 'Unlocking…' : 'Unlock'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </ActionSheet>
+  )
+}
+
+LegacyUnlockDialog.propTypes = {
+  open: PropTypes.bool,
+  entry: PropTypes.object,
+  onClose: PropTypes.func,
+  onUnlocked: PropTypes.func,
+  deps: PropTypes.object,
+}

--- a/frontend/src/components/account/RecoverAccountPanel.css
+++ b/frontend/src/components/account/RecoverAccountPanel.css
@@ -160,3 +160,35 @@
 .recover-step__actions .btn {
   flex: 1;
 }
+
+/* Buttons inside a recovery sheet step. The global button{} paints
+   --bg-secondary (DARKER than the --surface-color sheet) with a transparent
+   border, so actions read as low-contrast dark rectangles and .btn-primary —
+   which has no base rule — looks identical to the secondary. Give both a clear
+   affordance that works in light and dark. Shared by both recovery panels. */
+.recover-step .btn {
+  background: color-mix(in srgb, var(--text-primary, #1f2933) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 26%, transparent);
+  color: var(--text-primary, #1f2933);
+  font-weight: 600;
+}
+
+.recover-step .btn:hover:not(:disabled) {
+  border-color: var(--brand-primary, #36b37e);
+}
+
+.recover-step .btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.recover-step .btn-primary {
+  background: var(--brand-primary, #36b37e);
+  border-color: var(--brand-primary, #36b37e);
+  color: #fff;
+}
+
+.recover-step .btn-primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 88%, #000);
+  border-color: color-mix(in srgb, var(--brand-primary, #36b37e) 88%, #000);
+}

--- a/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
@@ -43,7 +43,9 @@ vi.mock('../../../data/ledger/sources/legacyRecoverySource', () => ({ captureLeg
 const lib = vi.hoisted(() => ({
   classifySecret: vi.fn(),
   encryptLegacySecret: vi.fn(),
+  encryptLegacySecretWithPasskey: vi.fn(),
   decryptLegacySecret: vi.fn(),
+  decryptLegacySecretWithPasskey: vi.fn(),
   quoteAllAssets: vi.fn(),
   sweepAllAssets: vi.fn(),
   store: new Map(),
@@ -51,7 +53,9 @@ const lib = vi.hoisted(() => ({
 vi.mock('../../../lib/recovery/legacyKeys', () => ({
   classifySecret: lib.classifySecret,
   encryptLegacySecret: lib.encryptLegacySecret,
+  encryptLegacySecretWithPasskey: lib.encryptLegacySecretWithPasskey,
   decryptLegacySecret: lib.decryptLegacySecret,
+  decryptLegacySecretWithPasskey: lib.decryptLegacySecretWithPasskey,
   quoteAllAssets: lib.quoteAllAssets,
   sweepAllAssets: lib.sweepAllAssets,
   legacyKeyVault: () => ({
@@ -109,6 +113,53 @@ describe('LegacyKeyRecoveryPanel', () => {
     )
     // Closing here (Done) leaves recovery complete without moving funds.
     expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+  })
+
+  it('protects the key with biometrics (no passphrase) when a passkey is available', async () => {
+    const user = userEvent.setup()
+    lib.encryptLegacySecretWithPasskey.mockResolvedValue({ v: 2, protection: 'passkey', address: LEGACY_ADDR, credentialId: 'cred-1', importedAt: 1, ct: 'x' })
+    // deps.readSession makes a passkey credential available → biometric-first.
+    render(<LegacyKeyRecoveryPanel deps={{ readSession: () => ({ credentialId: 'cred-1' }) }} />)
+    await user.click(screen.getByRole('button', { name: 'Recover a legacy key' }))
+    await user.click(screen.getByRole('button', { name: 'Get started' }))
+    lib.classifySecret.mockReturnValue({ kind: 'privateKey', address: LEGACY_ADDR, secret: '0xkey' })
+    await user.type(screen.getByLabelText('Private key or recovery word list'), '0xkey')
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    // Biometric step: no passphrase fields, a "Protect with biometrics" action.
+    expect(screen.queryByLabelText('Passphrase')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Protect with biometrics' }))
+    await waitFor(() =>
+      expect(lib.encryptLegacySecretWithPasskey).toHaveBeenCalledWith(expect.objectContaining({ credentialId: 'cred-1' }))
+    )
+    expect(lib.encryptLegacySecret).not.toHaveBeenCalled()
+    expect(await screen.findByTestId('lkr-saved')).toBeInTheDocument()
+  })
+
+  it('lets the member fall back to a passphrase from the biometric step', async () => {
+    const user = userEvent.setup()
+    render(<LegacyKeyRecoveryPanel deps={{ readSession: () => ({ credentialId: 'cred-1' }) }} />)
+    await user.click(screen.getByRole('button', { name: 'Recover a legacy key' }))
+    await user.click(screen.getByRole('button', { name: 'Get started' }))
+    lib.classifySecret.mockReturnValue({ kind: 'privateKey', address: LEGACY_ADDR, secret: '0xkey' })
+    await user.type(screen.getByLabelText('Private key or recovery word list'), '0xkey')
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.click(screen.getByRole('button', { name: 'Use a passphrase instead' }))
+    expect(screen.getByLabelText('Passphrase')).toBeInTheDocument()
+  })
+
+  it('unlocks a biometric-protected stored key without a passphrase', async () => {
+    lib.store.set(LEGACY_ADDR.toLowerCase(), { protection: 'passkey', kind: 'privateKey', address: LEGACY_ADDR, importedAt: 42, credentialId: 'cred-1', ct: 'x' })
+    lib.decryptLegacySecretWithPasskey.mockResolvedValue('0xkey')
+    lib.quoteAllAssets.mockResolvedValue({ from: LEGACY_ADDR, holdings: [], nativeGasReserve: 1n, hasNative: false })
+    const user = userEvent.setup()
+    render(<LegacyKeyRecoveryPanel />)
+    await user.click(screen.getByRole('button', { name: 'Move funds' }))
+    // No passphrase field — biometric unlock button instead.
+    expect(screen.queryByLabelText('Passphrase')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Unlock with biometrics' }))
+    await waitFor(() => expect(lib.decryptLegacySecretWithPasskey).toHaveBeenCalled())
+    expect(await screen.findByLabelText('Destination smart account')).toBeInTheDocument()
   })
 
   it('suggests BIP-39 completions while typing a word list', async () => {

--- a/frontend/src/components/fairwins/TradePanel.jsx
+++ b/frontend/src/components/fairwins/TradePanel.jsx
@@ -59,10 +59,12 @@ function TradePanel() {
   const { isConnected, chainId, address, loginMethod } = useWallet()
   const { native: nativeSymbol, stable: stableSymbol } = useChainTokens()
 
-  // Account selection (spec 043): trade as the personal wallet or as one of the
-  // member's saved multisig vaults. Selecting a vault turns every order into a
-  // threshold-gated proposal; balances shown below always follow the selection.
-  const { identity, isVault, operateAsVault, operateAsPersonal, operateAsLegacy } = useActiveAccount()
+  // Account selection (spec 043 + 062): trade as the personal wallet, one of the
+  // member's saved multisig vaults, or a recovered legacy account. A vault turns
+  // every order into a threshold-gated proposal; a recovered account signs each
+  // order with its unlocked in-memory key. Balances always follow the selection.
+  const { identity, isVault, isLegacy, operateAsVault, operateAsPersonal, operateAsLegacy } =
+    useActiveAccount()
   const { vaults } = useCustodyVaults()
   const legacyAccounts = useLegacyAccounts()
   const [unlockEntry, setUnlockEntry] = useState(null)
@@ -215,20 +217,27 @@ function TradePanel() {
       return
     }
     if (value.startsWith('legacy:')) {
-      const acc = legacyAccounts.find((l) => l.id === value)
-      if (acc) setUnlockEntry(acc.entry) // unlock (biometric/passphrase) → operateAsLegacy
+      // Unlock (biometric/passphrase) before acting; operateAsLegacy on success.
+      const acct = legacyAccounts.find((a) => a.id === value)
+      if (acct) setUnlockEntry(acct.entry)
       return
     }
     const vault = vaults.find((v) => v.address === value)
     if (vault) operateAsVault(vault)
   }
 
-  const handleLegacyUnlocked = useCallback((signer) => {
+  const handleLegacyUnlocked = (signer) => {
     if (unlockEntry) {
-      operateAsLegacy({ address: unlockEntry.address, chainId, kind: unlockEntry.kind, label: shortAddress(unlockEntry.address), signer })
+      operateAsLegacy({
+        address: unlockEntry.address,
+        chainId,
+        kind: unlockEntry.kind,
+        label: shortAddress(unlockEntry.address),
+        signer,
+      })
     }
     setUnlockEntry(null)
-  }, [unlockEntry, chainId, operateAsLegacy])
+  }
 
   // A Limit order's floor: limit price (output per 1 unit paid) × quantity,
   // enforced on-chain as the swap's minimum received.
@@ -323,7 +332,9 @@ function TradePanel() {
   const severity = impactSeverity(quote?.priceImpactPercent)
   const canExecute =
     !loading &&
-    passkeyReady &&
+    // A recovered account signs with its own EOA key, not the passkey rail, so
+    // passkey readiness doesn't gate it.
+    (passkeyReady || isLegacy) &&
     !isPerpsOrder &&
     amount &&
     parseFloat(amount) > 0 &&
@@ -344,9 +355,11 @@ function TradePanel() {
       : 'personal'
   const feeBadge = isVault
     ? { className: 'trade-badge-proposal', text: 'Multisig proposal' }
-    : passkeySponsored
-      ? { className: 'trade-badge-gasless', text: '⚡ Gasless · sponsored' }
-      : { className: 'trade-badge-fee', text: 'Network fee applies' }
+    : isLegacy
+      ? { className: 'trade-badge-fee', text: 'Network fee applies' }
+      : passkeySponsored
+        ? { className: 'trade-badge-gasless', text: '⚡ Gasless · sponsored' }
+        : { className: 'trade-badge-fee', text: 'Network fee applies' }
 
   return (
     <div className="trade-panel">
@@ -385,9 +398,9 @@ function TradePanel() {
               {(v.label || shortAddress(v.address)) + ' · Multisig'}
             </option>
           ))}
-          {legacyAccounts.map((l) => (
-            <option key={l.id} value={l.id}>
-              {(l.label || shortAddress(l.address)) + ' · Recovered'}
+          {legacyAccounts.map((a) => (
+            <option key={a.id} value={a.id}>
+              {(a.label || shortAddress(a.address)) + ' · Recovered'}
             </option>
           ))}
         </select>
@@ -397,6 +410,12 @@ function TradePanel() {
           onClose={() => setUnlockEntry(null)}
           onUnlocked={handleLegacyUnlocked}
         />
+        {isLegacy && (
+          <p className="trade-account-note" role="note">
+            Orders sign with your recovered account&apos;s key on {networkName}. You pay the
+            network fee — recovered accounts aren&apos;t gasless.
+          </p>
+        )}
         <dl className="trade-account-rows">
           <div className="trade-account-row">
             <dt>Available to trade ({symbolFor(fromToken)})</dt>
@@ -417,7 +436,7 @@ function TradePanel() {
             owners approve.
           </p>
         )}
-        {!passkeyReady && (
+        {!passkeyReady && !isLegacy && (
           <p className="trade-account-note" role="note">
             Passkey accounts can’t send transactions on {networkName} yet — connect a
             browser wallet to trade here.
@@ -688,7 +707,7 @@ function TradePanel() {
               : 'Enter an amount'}
       </button>
 
-      {isPasskey && passkeyReady && !isVault && (
+      {isPasskey && passkeyReady && !isVault && !isLegacy && (
         <p className="trade-session-note">
           One passkey confirmation covers the whole order — including the spending
           permission when it’s needed.

--- a/frontend/src/components/fairwins/TradePanel.jsx
+++ b/frontend/src/components/fairwins/TradePanel.jsx
@@ -14,6 +14,8 @@ import { useWallet } from '../../hooks'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { useActiveAccount } from '../../hooks/useActiveAccount'
 import { useCustodyVaults } from '../../hooks/useCustodyVaults'
+import { useLegacyAccounts } from '../../hooks/useLegacyAccounts'
+import LegacyUnlockDialog from '../account/LegacyUnlockDialog'
 import SensitiveValue from '../common/SensitiveValue'
 import InfoTip from '../ui/InfoTip'
 import './TradePanel.css'
@@ -60,8 +62,10 @@ function TradePanel() {
   // Account selection (spec 043): trade as the personal wallet or as one of the
   // member's saved multisig vaults. Selecting a vault turns every order into a
   // threshold-gated proposal; balances shown below always follow the selection.
-  const { identity, isVault, operateAsVault, operateAsPersonal } = useActiveAccount()
+  const { identity, isVault, operateAsVault, operateAsPersonal, operateAsLegacy } = useActiveAccount()
   const { vaults } = useCustodyVaults()
+  const legacyAccounts = useLegacyAccounts()
+  const [unlockEntry, setUnlockEntry] = useState(null)
 
   // Session rails: passkey accounts transact through their smart account —
   // gasless (FairWins-sponsored) where the network has a sponsor paymaster
@@ -210,9 +214,21 @@ function TradePanel() {
       operateAsPersonal()
       return
     }
+    if (value.startsWith('legacy:')) {
+      const acc = legacyAccounts.find((l) => l.id === value)
+      if (acc) setUnlockEntry(acc.entry) // unlock (biometric/passphrase) → operateAsLegacy
+      return
+    }
     const vault = vaults.find((v) => v.address === value)
     if (vault) operateAsVault(vault)
   }
+
+  const handleLegacyUnlocked = useCallback((signer) => {
+    if (unlockEntry) {
+      operateAsLegacy({ address: unlockEntry.address, chainId, kind: unlockEntry.kind, label: shortAddress(unlockEntry.address), signer })
+    }
+    setUnlockEntry(null)
+  }, [unlockEntry, chainId, operateAsLegacy])
 
   // A Limit order's floor: limit price (output per 1 unit paid) × quantity,
   // enforced on-chain as the swap's minimum received.
@@ -321,7 +337,11 @@ function TradePanel() {
         ? `1 ${quote.tokenOutSymbol} = ${quote.executionPriceInverted} ${quote.tokenInSymbol}`
         : null
 
-  const accountValue = isVault ? identity.vaultAddress : 'personal'
+  const accountValue = isVault
+    ? identity.vaultAddress
+    : identity.mode === 'legacy' && identity.address
+      ? `legacy:${String(identity.address).toLowerCase()}`
+      : 'personal'
   const feeBadge = isVault
     ? { className: 'trade-badge-proposal', text: 'Multisig proposal' }
     : passkeySponsored
@@ -365,7 +385,18 @@ function TradePanel() {
               {(v.label || shortAddress(v.address)) + ' · Multisig'}
             </option>
           ))}
+          {legacyAccounts.map((l) => (
+            <option key={l.id} value={l.id}>
+              {(l.label || shortAddress(l.address)) + ' · Recovered'}
+            </option>
+          ))}
         </select>
+        <LegacyUnlockDialog
+          open={Boolean(unlockEntry)}
+          entry={unlockEntry}
+          onClose={() => setUnlockEntry(null)}
+          onUnlocked={handleLegacyUnlocked}
+        />
         <dl className="trade-account-rows">
           <div className="trade-account-row">
             <dt>Available to trade ({symbolFor(fromToken)})</dt>

--- a/frontend/src/components/wallet/TransferForm.jsx
+++ b/frontend/src/components/wallet/TransferForm.jsx
@@ -6,10 +6,12 @@ import QRScanner from '../ui/QRScanner'
 import SensitiveValue from '../common/SensitiveValue'
 import TransferAssetSelect from './TransferAssetSelect'
 import TransferFromSelect from './TransferFromSelect'
+import LegacyUnlockDialog from '../account/LegacyUnlockDialog'
 import { useTransfer, TRANSFER_KIND } from '../../hooks/useTransfer'
 import { useWallet } from '../../hooks/useWalletManagement'
 import { useActiveAccount } from '../../hooks/useActiveAccount'
 import { useCustodyVaults } from '../../hooks/useCustodyVaults'
+import { useLegacyAccounts } from '../../hooks/useLegacyAccounts'
 import { useAccountAssets } from '../../hooks/useAccountAssets'
 import usePortfolio from '../../hooks/usePortfolio'
 import { useAddressScreening } from '../../hooks/useAddressScreening'
@@ -36,8 +38,10 @@ export default function TransferForm({ onSent }) {
     send, status, error, quoteGaslessForAsset, balanceOf, refreshBalances, tokens, isPasskey,
   } = useTransfer()
   const { address, chainId } = useWallet()
-  const { identity, isVault, operateAsPersonal, operateAsVault } = useActiveAccount()
+  const { identity, isVault, operateAsPersonal, operateAsVault, operateAsLegacy } = useActiveAccount()
   const { vaults } = useCustodyVaults()
+  const legacyAccounts = useLegacyAccounts()
+  const [unlockEntry, setUnlockEntry] = useState(null)
   const portfolio = usePortfolio()
   // When operating as a vault, source the asset list + balances from the vault's own on-chain holdings
   // (it lives on the connected chain and isn't part of the personal wallet's portfolio scan).
@@ -189,10 +193,14 @@ export default function TransferForm({ onSent }) {
         chainId: Number(v.chainId),
       })
     }
-    return list
-  }, [address, vaults, connectedChainId])
+    return list.concat(legacyAccounts)
+  }, [address, vaults, connectedChainId, legacyAccounts])
 
-  const fromValue = isVault && identity?.vaultAddress ? `vault:${identity.vaultAddress}` : 'personal'
+  const fromValue = isVault && identity?.vaultAddress
+    ? `vault:${identity.vaultAddress}`
+    : identity?.mode === 'legacy' && identity.address
+      ? `legacy:${String(identity.address).toLowerCase()}`
+      : 'personal'
 
   const handleFromChange = useCallback(
     (account) => {
@@ -200,11 +208,23 @@ export default function TransferForm({ onSent }) {
       setFormError(null)
       if (account.kind === 'vault') {
         operateAsVault({ address: account.address, chainId: account.chainId, label: account.label })
+      } else if (account.kind === 'legacy') {
+        setUnlockEntry(account.entry) // unlock (biometric/passphrase) → operateAsLegacy on success
       } else {
         operateAsPersonal()
       }
     },
     [operateAsVault, operateAsPersonal],
+  )
+
+  const handleLegacyUnlocked = useCallback(
+    (signer) => {
+      if (unlockEntry) {
+        operateAsLegacy({ address: unlockEntry.address, chainId: connectedChainId, kind: unlockEntry.kind, label: short(unlockEntry.address), signer })
+      }
+      setUnlockEntry(null)
+    },
+    [unlockEntry, connectedChainId, operateAsLegacy],
   )
 
   // Advisory sanctions pre-check on the resolved recipient, against the SELECTED asset's chain.
@@ -332,6 +352,12 @@ export default function TransferForm({ onSent }) {
               value={fromValue}
               onChange={handleFromChange}
               disabled={busy}
+            />
+            <LegacyUnlockDialog
+              open={Boolean(unlockEntry)}
+              entry={unlockEntry}
+              onClose={() => setUnlockEntry(null)}
+              onUnlocked={handleLegacyUnlocked}
             />
             {isVault && (
               <span className="pt-hint">

--- a/frontend/src/components/wallet/TransferForm.jsx
+++ b/frontend/src/components/wallet/TransferForm.jsx
@@ -38,15 +38,17 @@ export default function TransferForm({ onSent }) {
     send, status, error, quoteGaslessForAsset, balanceOf, refreshBalances, tokens, isPasskey,
   } = useTransfer()
   const { address, chainId } = useWallet()
-  const { identity, isVault, operateAsPersonal, operateAsVault, operateAsLegacy } = useActiveAccount()
+  const { identity, isVault, isLegacy, operateAsPersonal, operateAsVault, operateAsLegacy } = useActiveAccount()
   const { vaults } = useCustodyVaults()
   const legacyAccounts = useLegacyAccounts()
   const [unlockEntry, setUnlockEntry] = useState(null)
   const portfolio = usePortfolio()
-  // When operating as a vault, source the asset list + balances from the vault's own on-chain holdings
-  // (it lives on the connected chain and isn't part of the personal wallet's portfolio scan).
+  // Assets + balances come from whichever account we're ACTING AS — a vault or a
+  // recovered legacy account — not the connected wallet (each holds its own funds
+  // on the connected chain and isn't part of the personal portfolio scan).
   const vaultAddress = isVault && identity?.vaultAddress ? identity.vaultAddress : null
-  const vaultAssets = useAccountAssets(vaultAddress)
+  const actingAddress = vaultAddress || (isLegacy && identity?.address ? identity.address : null)
+  const actingAssets = useAccountAssets(actingAddress)
   const { screenOne } = useAddressScreening()
   const { showNotification } = useNotification()
   const { switchChainAsync, isPending: switching } = useSwitchChain()
@@ -94,7 +96,7 @@ export default function TransferForm({ onSent }) {
         name: tokens.nativeName,
         decimals: tokens.nativeDecimals,
         networkName: tokens.networkName,
-        balance: isVault ? null : toNum(balanceOf(TRANSFER_KIND.NATIVE)),
+        balance: actingAddress ? null : toNum(balanceOf(TRANSFER_KIND.NATIVE)),
       })
     }
     if (tokens.stableAddress) {
@@ -107,14 +109,14 @@ export default function TransferForm({ onSent }) {
         name: tokens.stableName,
         decimals: tokens.stableDecimals,
         networkName: tokens.networkName,
-        balance: isVault ? null : toNum(balanceOf(TRANSFER_KIND.STABLE)),
+        balance: actingAddress ? null : toNum(balanceOf(TRANSFER_KIND.STABLE)),
       })
     }
 
     // Native Bitcoin — personal wallet only (custody vaults are EVM Safes and
     // can never hold BTC). Balance is the SPENDABLE amount: what a send can
     // actually move (protected/pending value is disclosed in the panel).
-    if (!isVault && btc.status === 'ready') {
+    if (!actingAddress && btc.status === 'ready') {
       put({
         key: 'bitcoin:native',
         chainId: btc.networkId,
@@ -128,7 +130,7 @@ export default function TransferForm({ onSent }) {
       })
     }
 
-    const source = isVault ? vaultAssets.holdings : portfolio.holdings
+    const source = actingAddress ? actingAssets.holdings : portfolio.holdings
     for (const h of source || []) {
       if (h.asset.kind !== 'native' && h.asset.kind !== 'erc20') continue // no NFTs in a value transfer
       const keepZero = h.asset.kind === 'native' || isConnectedStableAddr(h.asset.address)
@@ -152,7 +154,7 @@ export default function TransferForm({ onSent }) {
       if (ac !== bc) return ac - bc
       return (b.balance ?? 0) - (a.balance ?? 0)
     })
-  }, [isVault, vaultAssets.holdings, portfolio.holdings, tokens, connectedChainId, balanceOf, isConnectedStableAddr, btc.status, btc.networkId, btc.balances.spendableSats])
+  }, [actingAddress, actingAssets.holdings, portfolio.holdings, tokens, connectedChainId, balanceOf, isConnectedStableAddr, btc.status, btc.networkId, btc.balances.spendableSats])
 
   // Default to the connected chain's stablecoin, then its native coin, then whatever's first.
   const defaultKey = useMemo(() => {

--- a/frontend/src/components/wallet/TransferFromSelect.jsx
+++ b/frontend/src/components/wallet/TransferFromSelect.jsx
@@ -47,6 +47,7 @@ export default function TransferFromSelect({ accounts = [], value, onChange, dis
       <span className="pt-from-label">
         {account.label || short(account.address)}
         {account.kind === 'vault' && <span className="pt-from-tag">Vault</span>}
+        {account.kind === 'legacy' && <span className="pt-from-tag">Recovered</span>}
       </span>
       <span className="pt-from-addr">{short(account.address)}</span>
     </>

--- a/frontend/src/components/wallet/WalletButton.css
+++ b/frontend/src/components/wallet/WalletButton.css
@@ -738,3 +738,9 @@
     }
   }
 }
+
+/* Global acting-account switcher wrapper (spec 062). Collapses to nothing when
+   the switcher self-hides (only a personal wallet), so no empty gap appears. */
+.dropdown-account-switcher:not(:empty) {
+  margin-top: 12px;
+}

--- a/frontend/src/components/wallet/WalletButton.jsx
+++ b/frontend/src/components/wallet/WalletButton.jsx
@@ -17,6 +17,7 @@ import NavIcon from '../nav/NavIcon'
 import PremiumPurchaseModal from '../ui/PremiumPurchaseModal'
 import AddressQRModal from '../ui/AddressQRModal'
 import { RoleDetailsSection } from './RoleDetailsCard'
+import AccountSwitcher from '../account/AccountSwitcher'
 import walletIcon from '../../assets/wallet_no_text.svg'
 import './WalletButton.css'
 import './RoleDetailsCard.css'
@@ -213,6 +214,12 @@ function WalletButton({ className = '' }) {
                   >
                     <NavIcon name="qrcode" size={18} />
                   </button>
+                </div>
+                {/* Global acting-account switcher: personal wallet, multisig
+                    vaults, or a recovered legacy account. Self-hides when the
+                    member has only their personal wallet. */}
+                <div className="dropdown-account-switcher">
+                  <AccountSwitcher />
                 </div>
               </div>
 

--- a/frontend/src/contexts/CustodyContext.jsx
+++ b/frontend/src/contexts/CustodyContext.jsx
@@ -10,6 +10,10 @@ import { CustodyContext } from './CustodyContext'
 export function CustodyProvider({ children }) {
   const { address } = useWallet()
   const [active, setActive] = useState({ mode: 'personal' })
+  // Spec 062: when operating as a recovered legacy account, the unlocked ethers
+  // signer lives here in MEMORY ONLY — never persisted, never serialized, cleared
+  // on any identity change. It is the private-key material, so it must not leak.
+  const [legacySigner, setLegacySigner] = useState(null)
   const prevAddress = useRef(address)
 
   // Reset to the personal wallet whenever the connected account actually changes or disconnects. This is a
@@ -20,11 +24,13 @@ export function CustodyProvider({ children }) {
       prevAddress.current = address
       // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset on account change
       setActive({ mode: 'personal' })
+      setLegacySigner(null) // drop the in-memory legacy key on account change
     }
   }, [address])
 
   const operateAsVault = useCallback((vault) => {
     if (!vault?.address || vault.chainId == null) return
+    setLegacySigner(null)
     setActive({
       mode: 'vault',
       vaultAddress: vault.address,
@@ -33,11 +39,29 @@ export function CustodyProvider({ children }) {
     })
   }, [])
 
-  const operateAsPersonal = useCallback(() => setActive({ mode: 'personal' }), [])
+  const operateAsPersonal = useCallback(() => {
+    setLegacySigner(null)
+    setActive({ mode: 'personal' })
+  }, [])
+
+  // Operate as a recovered legacy account. The caller unlocks it first (biometric
+  // or passphrase → provider-connected signer) and passes that signer; we hold it
+  // in memory for the session and expose the identity for display + gating.
+  const operateAsLegacy = useCallback((descriptor) => {
+    if (!descriptor?.address || !descriptor.signer) return
+    setLegacySigner(descriptor.signer)
+    setActive({
+      mode: 'legacy',
+      address: descriptor.address,
+      chainId: descriptor.chainId != null ? Number(descriptor.chainId) : undefined,
+      kind: descriptor.kind || 'privateKey',
+      label: descriptor.label || '',
+    })
+  }, [])
 
   const value = useMemo(
-    () => ({ active, operateAsVault, operateAsPersonal }),
-    [active, operateAsVault, operateAsPersonal],
+    () => ({ active, legacySigner, operateAsVault, operateAsPersonal, operateAsLegacy }),
+    [active, legacySigner, operateAsVault, operateAsPersonal, operateAsLegacy],
   )
 
   return <CustodyContext.Provider value={value}>{children}</CustodyContext.Provider>

--- a/frontend/src/contexts/DexContext.jsx
+++ b/frontend/src/contexts/DexContext.jsx
@@ -27,7 +27,11 @@ const ZERO = '0x0000000000000000000000000000000000000000'
 export function DexProvider({ children }) {
   const { provider, address, isConnected, sendCalls } = useWallet()
   // Spec 043 (US3): swapping while operating as a vault becomes a threshold-gated vault proposal.
-  const { isVault: operatingAsVault, canActAsVault, identity: activeIdentity, submit: submitAsActive } = useActiveAccount()
+  const {
+    isVault: operatingAsVault, canActAsVault,
+    isLegacy: operatingAsLegacy, canActAsLegacy,
+    identity: activeIdentity, submit: submitAsActive,
+  } = useActiveAccount()
   const wagmiChainId = useChainId()
   const chainId = wagmiChainId || getCurrentChainId()
   const network = getNetwork(chainId)
@@ -46,7 +50,11 @@ export function DexProvider({ children }) {
   // member operates as one (on the vault's own network), else the connected
   // wallet. Balances and swap recipients follow this address so "available to
   // trade" is accurate for the selected account (Spec 043).
-  const tradingAddress = operatingAsVault && canActAsVault ? activeIdentity.vaultAddress : address
+  const tradingAddress = operatingAsVault && canActAsVault
+    ? activeIdentity.vaultAddress
+    : operatingAsLegacy && activeIdentity?.address
+      ? activeIdentity.address
+      : address
 
   const dexConfig = network?.dex || null
   const stableConfig = network?.stablecoin || null
@@ -268,6 +276,15 @@ export function DexProvider({ children }) {
         return { proposed: true, safeTxHash: res.safeTxHash }
       }
 
+      // Spec 062: as a recovered legacy account, sign with its unlocked key (via
+      // the active-account seam), executing immediately — never the connected wallet.
+      if (operatingAsLegacy) {
+        if (!canActAsLegacy) throw new Error('Unlock the recovered account on its network to act as it.')
+        const res = await submitAsActive({ batch: [call] })
+        await fetchBalances()
+        return { sent: true, txHash: res.txHash }
+      }
+
       if (typeof sendCalls !== 'function') throw new Error('Wallet not connected')
       const res = await sendCalls([call])
       if (res?.state === 'failed') throw new Error(res.reason || 'Transaction failed')
@@ -280,7 +297,7 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [contracts, addresses, operatingAsVault, canActAsVault, submitAsActive, sendCalls, fetchBalances])
+  }, [contracts, addresses, operatingAsVault, canActAsVault, operatingAsLegacy, canActAsLegacy, submitAsActive, sendCalls, fetchBalances])
 
   const unwrapNative = useCallback(async (amount) => {
     if (!contracts) {
@@ -299,6 +316,13 @@ export function DexProvider({ children }) {
         return { proposed: true, safeTxHash: res.safeTxHash }
       }
 
+      if (operatingAsLegacy) {
+        if (!canActAsLegacy) throw new Error('Unlock the recovered account on its network to act as it.')
+        const res = await submitAsActive({ batch: [call] })
+        await fetchBalances()
+        return { sent: true, txHash: res.txHash }
+      }
+
       if (typeof sendCalls !== 'function') throw new Error('Wallet not connected')
       const res = await sendCalls([call])
       if (res?.state === 'failed') throw new Error(res.reason || 'Transaction failed')
@@ -311,7 +335,7 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [contracts, addresses, operatingAsVault, canActAsVault, submitAsActive, sendCalls, fetchBalances])
+  }, [contracts, addresses, operatingAsVault, canActAsVault, operatingAsLegacy, canActAsLegacy, submitAsActive, sendCalls, fetchBalances])
 
   // Decimals lookup for a token by address used in quote/swap calls below.
   // Defaults to 18 (native/wrapped) when the token isn't in our known set.
@@ -517,6 +541,28 @@ export function DexProvider({ children }) {
         return { proposed: true, safeTxHash: res.safeTxHash }
       }
 
+      // Spec 062: swap AS a recovered legacy account. Same [approve?, swap] batch,
+      // recipient = the legacy account, signed by its unlocked key via the
+      // active-account seam (sequential txs for an EOA), executed immediately.
+      // Approve is included only when the current allowance is short.
+      if (operatingAsLegacy) {
+        if (!canActAsLegacy) throw new Error('Unlock the recovered account on its network to swap as it.')
+        const legacyAllowance = await new ethers.Contract(tokenIn, ERC20_ABI, readProvider)
+          .allowance(tradingAddress, addresses.SWAP_ROUTER_02)
+        const batch = []
+        if (legacyAllowance < amountInWei) {
+          batch.push({ to: tokenIn, value: 0n, data: erc20.encodeFunctionData('approve', [addresses.SWAP_ROUTER_02, amountInWei]) })
+        }
+        batch.push({
+          to: addresses.SWAP_ROUTER_02,
+          value: 0n,
+          data: contracts.swapRouter.interface.encodeFunctionData('exactInputSingle', [swapParams(tradingAddress)]),
+        })
+        const res = await submitAsActive({ batch })
+        await fetchBalances()
+        return { sent: true, txHash: res.txHash }
+      }
+
       // Personal mode rides the unified spec-041 write rail: one batch through
       // sendCalls covers approval (only when needed, for the exact amount) and
       // the swap — a single WebAuthn ceremony for passkey sessions, sequential
@@ -553,7 +599,7 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [contracts, tradingAddress, readProvider, getBestQuote, fetchBalances, decimalsOf, addresses, operatingAsVault, canActAsVault, activeIdentity, submitAsActive, sendCalls])
+  }, [contracts, tradingAddress, readProvider, getBestQuote, fetchBalances, decimalsOf, addresses, operatingAsVault, canActAsVault, operatingAsLegacy, canActAsLegacy, activeIdentity, submitAsActive, sendCalls])
 
   const value = {
     balances,

--- a/frontend/src/hooks/useActiveAccount.js
+++ b/frontend/src/hooks/useActiveAccount.js
@@ -43,17 +43,26 @@ export function useActiveAccount() {
         // is gone (e.g. after a reload cleared the in-memory signer), the member
         // must re-unlock the account before acting as it.
         if (!legacySigner) throw new Error('Unlock this recovered account again to act as it.')
+        // The unlocked signer is bound to the provider at unlock time; if the
+        // member has since switched networks, sending would land on the wrong
+        // chain. Refuse until they're back on the network they unlocked on
+        // (mirrors the vault network guard).
+        if (active.chainId != null && Number(chainId) !== Number(active.chainId)) {
+          throw new Error('Switch back to the network where you unlocked this recovered account before acting as it.')
+        }
         return submitAsActiveAccount(payload, { mode: 'personal', signer: legacySigner })
       }
       return submitAsActiveAccount(payload, { mode: 'personal', signer })
     },
-    [active, signer, provider, legacySigner],
+    [active, chainId, signer, provider, legacySigner],
   )
 
   // Whether a vault action can currently be sent (connected to the vault's network).
   const canActAsVault = isVault && Number(chainId) === Number(active.chainId)
-  // A legacy account can act only while its unlocked signer is still in memory.
-  const canActAsLegacy = isLegacy && Boolean(legacySigner)
+  // A legacy account can act only while its unlocked signer is still in memory AND
+  // the wallet is on the network it was unlocked for (else a switch would send on
+  // the wrong chain).
+  const canActAsLegacy = isLegacy && Boolean(legacySigner) && (active.chainId == null || Number(chainId) === Number(active.chainId))
 
   return { identity: active, isVault, isLegacy, canActAsVault, canActAsLegacy, submit, operateAsPersonal, operateAsVault, operateAsLegacy }
 }

--- a/frontend/src/hooks/useActiveAccount.js
+++ b/frontend/src/hooks/useActiveAccount.js
@@ -17,10 +17,13 @@ export function useActiveAccount() {
   // useFriendMarketCreation must not hard-crash when it is absent (e.g. in isolated component tests).
   const custody = useContext(CustodyContext)
   const active = custody?.active ?? PERSONAL
+  const legacySigner = custody?.legacySigner ?? null
   const operateAsPersonal = custody?.operateAsPersonal ?? NOOP
   const operateAsVault = custody?.operateAsVault ?? NOOP
+  const operateAsLegacy = custody?.operateAsLegacy ?? NOOP
   const { chainId, signer, provider } = useWallet()
   const isVault = active.mode === 'vault'
+  const isLegacy = active.mode === 'legacy'
 
   const submit = useCallback(
     async (payload) => {
@@ -35,15 +38,24 @@ export function useActiveAccount() {
           provider,
         })
       }
+      if (active.mode === 'legacy') {
+        // Sign with the unlocked legacy key held in memory by CustodyContext. If it
+        // is gone (e.g. after a reload cleared the in-memory signer), the member
+        // must re-unlock the account before acting as it.
+        if (!legacySigner) throw new Error('Unlock this recovered account again to act as it.')
+        return submitAsActiveAccount(payload, { mode: 'personal', signer: legacySigner })
+      }
       return submitAsActiveAccount(payload, { mode: 'personal', signer })
     },
-    [active, signer, provider],
+    [active, signer, provider, legacySigner],
   )
 
   // Whether a vault action can currently be sent (connected to the vault's network).
   const canActAsVault = isVault && Number(chainId) === Number(active.chainId)
+  // A legacy account can act only while its unlocked signer is still in memory.
+  const canActAsLegacy = isLegacy && Boolean(legacySigner)
 
-  return { identity: active, isVault, canActAsVault, submit, operateAsPersonal, operateAsVault }
+  return { identity: active, isVault, isLegacy, canActAsVault, canActAsLegacy, submit, operateAsPersonal, operateAsVault, operateAsLegacy }
 }
 
 export default useActiveAccount

--- a/frontend/src/hooks/useLegacyAccounts.js
+++ b/frontend/src/hooks/useLegacyAccounts.js
@@ -1,0 +1,37 @@
+// Spec 062 follow-up — the recovered legacy accounts available to the connected
+// member, shaped for the account switcher. Read-only projection of the encrypted
+// vault (ciphertext + metadata only); the entry is carried so the switcher can
+// unlock it on selection.
+
+import { useMemo } from 'react'
+import { useWallet } from './useWalletManagement'
+import { legacyKeyVault } from '../lib/recovery/legacyKeys'
+
+const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
+
+/**
+ * @returns {Array<{ id:string, kind:'legacy', address:string, label:string,
+ *   protection:'passkey'|'passphrase', entry:object }>}
+ */
+export function useLegacyAccounts() {
+  const { address } = useWallet()
+  return useMemo(() => {
+    if (!address) return []
+    let list = []
+    try {
+      list = legacyKeyVault(address).list()
+    } catch {
+      return []
+    }
+    return list.map((entry) => ({
+      id: `legacy:${String(entry.address).toLowerCase()}`,
+      kind: 'legacy',
+      address: entry.address,
+      label: short(entry.address),
+      protection: entry.protection === 'passkey' ? 'passkey' : 'passphrase',
+      entry,
+    }))
+  }, [address])
+}
+
+export default useLegacyAccounts

--- a/frontend/src/hooks/useTransfer.js
+++ b/frontend/src/hooks/useTransfer.js
@@ -66,7 +66,11 @@ const ERC20_IFACE = new ethers.Interface(TRANSFER_ABI)
 
 export function useTransfer() {
   const { address, chainId, signer, provider, loginMethod, sendCalls } = useWallet()
-  const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
+  const {
+    isVault: operatingAsVault, canActAsVault,
+    isLegacy: operatingAsLegacy, canActAsLegacy,
+    submit: submitAsActive,
+  } = useActiveAccount()
   const tokens = useChainTokens()
   const isPasskey = loginMethod === 'passkey'
 
@@ -262,6 +266,32 @@ export function useTransfer() {
         }
       }
 
+      // Spec 062: when acting as a recovered legacy account, the transfer must be
+      // signed by that account's unlocked key — NOT the connected wallet. Route it
+      // through the active-account seam (submit uses the in-memory legacySigner and
+      // re-checks the chain), mirroring the vault branch. Never falls through to the
+      // connected signer below.
+      if (operatingAsLegacy) {
+        if (!canActAsLegacy) throw new Error('Unlock the recovered account on its network to send from it.')
+        const payload = a.isNative
+          ? { to, value, data: '0x' }
+          : { to: a.address, value: 0n, data: ERC20_IFACE.encodeFunctionData('transfer', [to, value]) }
+        setError(null)
+        setStatus('submitting')
+        try {
+          const res = await submitAsActive(payload)
+          setStatus('success')
+          const result = { sent: true, txHash: res.txHash, route: 'legacy', id: null }
+          setLastResult(result)
+          return result
+        } catch (err) {
+          const message = err?.shortMessage || err?.message || 'Could not send from the recovered account.'
+          setError(message)
+          setStatus('error')
+          throw err
+        }
+      }
+
       const gasless = passkeySponsored || (a.isNetworkStable && stableDomainVersion != null && hasRelayer)
       const entry = recordTransfer(address, {
         chainId,
@@ -382,7 +412,7 @@ export function useTransfer() {
         throw err
       }
     },
-    [signer, isPasskey, meta, isNetworkStableAsset, tokens.stableName, tokens.nativeDecimals, passkeySponsored, address, chainId, sendCalls, stableDomainVersion, hasRelayer, refreshBalances, operatingAsVault, canActAsVault, submitAsActive]
+    [signer, isPasskey, meta, isNetworkStableAsset, tokens.stableName, tokens.nativeDecimals, passkeySponsored, address, chainId, sendCalls, stableDomainVersion, hasRelayer, refreshBalances, operatingAsVault, canActAsVault, operatingAsLegacy, canActAsLegacy, submitAsActive]
   )
 
   return useMemo(

--- a/frontend/src/lib/custody/submitAsActiveAccount.js
+++ b/frontend/src/lib/custody/submitAsActiveAccount.js
@@ -48,7 +48,24 @@ export async function submitAsActiveAccount(payload, ctx) {
     await approveTx.wait()
     return { kind: 'proposed', safeTxHash }
   }
-  // personal mode — unchanged single-signer behaviour
+  // Single-signer mode (personal wallet, or a recovered legacy account whose
+  // unlocked signer is passed in). A `batch` (e.g. [approve, swap]) is sent as
+  // SEQUENTIAL signed transactions, each awaited to inclusion so ordering holds
+  // (the approve must be mined before the swap that relies on the allowance).
+  // An EOA cannot atomically batch, so this is the honest equivalent.
+  if (Array.isArray(payload.batch) && payload.batch.length > 0) {
+    let lastHash = null
+    for (const call of payload.batch) {
+      const tx = await ctx.signer.sendTransaction({
+        to: call.to,
+        value: call.value ?? 0n,
+        data: call.data ?? '0x',
+      })
+      if (tx?.wait) await tx.wait()
+      lastHash = tx?.hash ?? tx
+    }
+    return { kind: 'sent', txHash: lastHash }
+  }
   const sent = await ctx.signer.sendTransaction({
     to: payload.to,
     value: payload.value ?? 0n,

--- a/frontend/src/lib/recovery/legacyKeys.js
+++ b/frontend/src/lib/recovery/legacyKeys.js
@@ -235,6 +235,19 @@ export async function unlockLegacySecret({ entry, passphrase, deps = {} }) {
 }
 
 /**
+ * Unlock a stored recovered account into a live, provider-connected ethers signer
+ * that can be used to "act as" that account (spec 062 follow-up). The secret is
+ * decrypted (biometric or passphrase) into a signer and returned; the caller
+ * holds it in memory only for the session and never persists it.
+ *
+ * @returns {Promise<ethers.Signer>}
+ */
+export async function unlockLegacyAccount({ entry, passphrase, provider, deps = {} }) {
+  const secret = await unlockLegacySecret({ entry, passphrase, deps })
+  return walletFromSecret({ kind: entry.kind, secret }, provider)
+}
+
+/**
  * Per-account, device-local vault of encrypted legacy keys, keyed by lowercased
  * address so a given legacy account is stored once. Backed by the same
  * per-account storage the spec-032 backup reads (legacyRecoveredKeysStore), so

--- a/frontend/src/lib/recovery/legacyKeys.js
+++ b/frontend/src/lib/recovery/legacyKeys.js
@@ -24,11 +24,18 @@ import { ethers } from 'ethers'
 import { getPortfolioRegistry } from '../../config/assetTaxonomy'
 import { TRANSFER_ABI } from '../transfer/eip3009Transfer'
 import { loadLegacyRecoveredKeys, saveLegacyRecoveredKeys } from './legacyRecoveredKeysStore'
+import { getAssertion } from '../passkey/credentials'
+import { prfSalt, EncryptionUnavailable } from '../passkey/prfKeys'
 
 // PBKDF2 work factor. OWASP's 2023 floor for PBKDF2-HMAC-SHA256 is 600k; we sit
 // above it. Stored per-entry so a future bump stays backward-compatible.
 export const PBKDF2_ITERATIONS = 650000
 const MIN_PASSPHRASE_LEN = 8
+
+// HKDF context for the biometric (passkey-PRF) wrapping key. Distinct from the
+// spec-041 master-seed KEK info ('fairwins-kek-v1') so the same PRF output can
+// never derive both keys — domain separation.
+const LEGACY_PRF_KEK_INFO = new TextEncoder().encode('fairwins-legacy-kek-v1')
 
 // BIP-39 word lists come in these lengths only.
 const VALID_WORD_COUNTS = [12, 15, 18, 21, 24]
@@ -145,6 +152,86 @@ export async function decryptLegacySecret({ entry, passphrase, deps = {} }) {
   } catch {
     throw new Error('That passphrase did not unlock this key. Check it and try again.')
   }
+}
+
+// Derive an AES-GCM wrapping key from a passkey PRF assertion output (biometric).
+async function kekFromPrfOutput(prfOutput, subtle) {
+  const ikm = await subtle.importKey('raw', prfOutput, 'HKDF', false, ['deriveKey'])
+  return subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(32), info: LEGACY_PRF_KEK_INFO },
+    ikm,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+
+async function runPrfAssertion(credentialId, deps) {
+  const assertion = await (deps.getAssertion ?? getAssertion)({
+    challenge: randomBytes(32),
+    credentialId,
+    prfSalt: (deps.prfSalt ?? prfSalt)(),
+    deps: deps.assertionDeps,
+  })
+  if (!assertion?.prfOutput) {
+    throw new EncryptionUnavailable('this passkey/authenticator cannot derive biometric key material (PRF unsupported)')
+  }
+  return assertion.prfOutput
+}
+
+/**
+ * Encrypt a classified secret at rest under a BIOMETRIC (passkey-PRF) key — no
+ * passphrase. One WebAuthn assertion (Face/Touch ID) yields the PRF output; the
+ * secret is wrapped under an AES-GCM key derived from it. Unlockable only by the
+ * same passkey on this account, so a stolen blob is useless without the device's
+ * biometric. The returned entry records `protection:'passkey'` + the credential
+ * id so unlock knows which ceremony to run.
+ *
+ * @returns {Promise<object>} vault entry (v2, passkey-protected)
+ */
+export async function encryptLegacySecretWithPasskey({ secret, kind, address, credentialId, deps = {} }) {
+  if (!secret) throw new Error('Nothing to encrypt.')
+  if (!credentialId) throw new EncryptionUnavailable('no passkey is available on this device to protect the key')
+  const subtle = subtleOf(deps)
+  const prfOutput = await runPrfAssertion(credentialId, deps)
+  const key = await kekFromPrfOutput(prfOutput, subtle)
+  const iv = randomBytes(12)
+  const ct = new Uint8Array(await subtle.encrypt({ name: 'AES-GCM', iv }, key, new TextEncoder().encode(secret)))
+  return {
+    v: 2,
+    protection: 'passkey',
+    kind,
+    address,
+    credentialId,
+    iv: toB64(iv),
+    ct: toB64(ct),
+    importedAt: deps.now ?? Date.now(),
+  }
+}
+
+/** Recover a biometric-protected secret (one WebAuthn assertion). Fails closed. */
+export async function decryptLegacySecretWithPasskey({ entry, deps = {} }) {
+  if (!entry?.credentialId) throw new Error('This stored key is missing its passkey reference.')
+  const subtle = subtleOf(deps)
+  const prfOutput = await runPrfAssertion(entry.credentialId, deps)
+  const key = await kekFromPrfOutput(prfOutput, subtle)
+  try {
+    const pt = await subtle.decrypt({ name: 'AES-GCM', iv: fromB64(entry.iv) }, key, fromB64(entry.ct))
+    return new TextDecoder().decode(pt)
+  } catch {
+    throw new Error('Biometric unlock did not recover this key on this device.')
+  }
+}
+
+/**
+ * Unified unlock: recover the raw secret from a vault entry regardless of how it
+ * was protected. Passkey entries run a biometric assertion (no passphrase);
+ * passphrase entries need `passphrase`. Callers that sign as a legacy account use
+ * this so the unlock method is transparent to them.
+ */
+export async function unlockLegacySecret({ entry, passphrase, deps = {} }) {
+  if (entry?.protection === 'passkey') return decryptLegacySecretWithPasskey({ entry, deps })
+  return decryptLegacySecret({ entry, passphrase, deps })
 }
 
 /**

--- a/frontend/src/test/TradePanel.test.jsx
+++ b/frontend/src/test/TradePanel.test.jsx
@@ -35,6 +35,8 @@ vi.mock('../hooks', () => ({ useWallet: mockUseWallet }))
 vi.mock('../hooks/useChainTokens', () => ({ useChainTokens: mockUseChainTokens }))
 vi.mock('../hooks/useActiveAccount', () => ({ useActiveAccount: mockUseActiveAccount }))
 vi.mock('../hooks/useCustodyVaults', () => ({ useCustodyVaults: mockUseCustodyVaults }))
+vi.mock('../hooks/useLegacyAccounts', () => ({ useLegacyAccounts: () => [] }))
+vi.mock('../components/account/LegacyUnlockDialog', () => ({ default: () => null }))
 
 import TradePanel from '../components/fairwins/TradePanel'
 

--- a/frontend/src/test/account/AccountSwitcher.test.jsx
+++ b/frontend/src/test/account/AccountSwitcher.test.jsx
@@ -1,0 +1,72 @@
+/**
+ * Global acting-account switcher (spec 062 follow-up): lists personal + vaults +
+ * recovered legacy accounts, writes the shared active identity, and unlocks a
+ * legacy account (via the dialog) before acting as it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+
+const active = vi.hoisted(() => ({
+  identity: { mode: 'personal' },
+  operateAsPersonal: vi.fn(),
+  operateAsVault: vi.fn(),
+  operateAsLegacy: vi.fn(),
+}))
+const vaultsMock = vi.hoisted(() => ({ vaults: [] }))
+const legacyMock = vi.hoisted(() => ({ list: [] }))
+const FAKE_SIGNER = { id: 'legacy-signer' }
+
+vi.mock('../../hooks/useWalletManagement', () => ({ useWallet: () => ({ address: '0x' + 'a'.repeat(40), chainId: 137, provider: {} }) }))
+vi.mock('../../hooks/useActiveAccount', () => ({ useActiveAccount: () => active }))
+vi.mock('../../hooks/useCustodyVaults', () => ({ useCustodyVaults: () => vaultsMock }))
+vi.mock('../../hooks/useLegacyAccounts', () => ({ useLegacyAccounts: () => legacyMock.list }))
+vi.mock('../../components/ui/BlockiesAvatar', () => ({ default: () => <span data-testid="avatar" /> }))
+// Stub the unlock dialog: when open, one click "unlocks" and returns a signer.
+vi.mock('../../components/account/LegacyUnlockDialog', () => ({
+  default: ({ open, onUnlocked }) => (open ? <button onClick={() => onUnlocked(FAKE_SIGNER)}>do-unlock</button> : null),
+}))
+
+import AccountSwitcher from '../../components/account/AccountSwitcher'
+
+const VAULT = { address: '0x' + 'b'.repeat(40), chainId: 137, label: 'Coop' }
+const LEGACY = { id: `legacy:0x${'c'.repeat(40)}`, kind: 'legacy', address: '0x' + 'C'.repeat(40), label: 'old', protection: 'passphrase', entry: { address: '0x' + 'C'.repeat(40), kind: 'privateKey', protection: 'passphrase' } }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  active.identity = { mode: 'personal' }
+  vaultsMock.vaults = []
+  legacyMock.list = []
+})
+
+describe('AccountSwitcher', () => {
+  it('hides when only the personal wallet is available', () => {
+    const { container } = render(<AccountSwitcher />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('lists personal + vault + legacy and switches to personal/vault directly', () => {
+    vaultsMock.vaults = [VAULT]
+    legacyMock.list = [LEGACY]
+    render(<AccountSwitcher />)
+    fireEvent.click(screen.getByRole('button', { name: /change acting account/i }))
+    const menu = screen.getByRole('listbox')
+    expect(within(menu).getByText('Coop')).toBeInTheDocument()
+    expect(within(menu).getByText('Recovered')).toBeInTheDocument() // legacy tag
+
+    fireEvent.click(within(menu).getByText('Coop'))
+    expect(active.operateAsVault).toHaveBeenCalledWith(expect.objectContaining({ address: VAULT.address }))
+  })
+
+  it('unlocks a legacy account then acts as it with the returned signer', () => {
+    legacyMock.list = [LEGACY]
+    render(<AccountSwitcher />)
+    fireEvent.click(screen.getByRole('button', { name: /change acting account/i }))
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('old'))
+    // Dialog opened → simulate a successful unlock.
+    fireEvent.click(screen.getByText('do-unlock'))
+    expect(active.operateAsLegacy).toHaveBeenCalledWith(
+      expect.objectContaining({ address: LEGACY.address, chainId: 137, signer: FAKE_SIGNER })
+    )
+    expect(active.operateAsPersonal).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/custody/CustodyContext.test.jsx
+++ b/frontend/src/test/custody/CustodyContext.test.jsx
@@ -41,6 +41,53 @@ describe('CustodyContext', () => {
     expect(screen.getByTestId('mode')).toHaveTextContent('personal')
   })
 
+  it('operates as a recovered legacy account and holds its signer, clearing on switch-back', () => {
+    const signer = { sendTransaction: vi.fn() }
+    function LegacyProbe() {
+      const { active, legacySigner, operateAsLegacy, operateAsPersonal } = useCustody()
+      return (
+        <div>
+          <span data-testid="mode">{active.mode}</span>
+          <span data-testid="legacy-addr">{active.address || ''}</span>
+          <span data-testid="has-signer">{legacySigner ? 'yes' : 'no'}</span>
+          <button onClick={() => operateAsLegacy({ address: '0xLegacy', chainId: 137, kind: 'privateKey', label: 'Old', signer })}>as-legacy</button>
+          <button onClick={operateAsPersonal}>as-personal</button>
+        </div>
+      )
+    }
+    render(
+      <CustodyProvider>
+        <LegacyProbe />
+      </CustodyProvider>,
+    )
+    fireEvent.click(screen.getByText('as-legacy'))
+    expect(screen.getByTestId('mode')).toHaveTextContent('legacy')
+    expect(screen.getByTestId('legacy-addr')).toHaveTextContent('0xLegacy')
+    expect(screen.getByTestId('has-signer')).toHaveTextContent('yes')
+    fireEvent.click(screen.getByText('as-personal'))
+    expect(screen.getByTestId('mode')).toHaveTextContent('personal')
+    expect(screen.getByTestId('has-signer')).toHaveTextContent('no') // in-memory key dropped
+  })
+
+  it('ignores a legacy descriptor with no signer (never acts as an un-unlocked key)', () => {
+    function BadLegacy() {
+      const { active, operateAsLegacy } = useCustody()
+      return (
+        <div>
+          <span data-testid="mode">{active.mode}</span>
+          <button onClick={() => operateAsLegacy({ address: '0xLegacy', chainId: 137 })}>bad</button>
+        </div>
+      )
+    }
+    render(
+      <CustodyProvider>
+        <BadLegacy />
+      </CustodyProvider>,
+    )
+    fireEvent.click(screen.getByText('bad'))
+    expect(screen.getByTestId('mode')).toHaveTextContent('personal')
+  })
+
   it('ignores an invalid vault (missing address/chainId)', () => {
     function BadProbe() {
       const { active, operateAsVault } = useCustody()

--- a/frontend/src/test/custody/operateAsTransfer.test.jsx
+++ b/frontend/src/test/custody/operateAsTransfer.test.jsx
@@ -67,3 +67,43 @@ describe('useTransfer while operating as a vault', () => {
     expect(submit).not.toHaveBeenCalled()
   })
 })
+
+// Spec 062 — operating as a recovered legacy account must SIGN with that account's unlocked key (routed
+// through submit(), which uses the in-memory legacySigner), never fall through to the connected wallet.
+// Guards the security-review finding that selecting "Recovered" silently signed with the connected signer.
+describe('useTransfer while operating as a recovered legacy account', () => {
+  beforeEach(() => {
+    submit.mockReset()
+    activeAccount = { isLegacy: true, canActAsLegacy: true, submit }
+  })
+
+  it('sends a native transfer through the legacy signer (submit), not the connected wallet', async () => {
+    submit.mockResolvedValue({ kind: 'sent', txHash: '0xdeadbeef' })
+    const { result } = renderHook(() => useTransfer())
+    let out
+    await act(async () => {
+      out = await result.current.send({
+        kind: TRANSFER_KIND.NATIVE,
+        to: '0xbbbb000000000000000000000000000000000002',
+        amount: '2',
+      })
+    })
+    expect(submit).toHaveBeenCalledTimes(1)
+    const payload = submit.mock.calls[0][0]
+    expect(payload.to.toLowerCase()).toBe('0xbbbb000000000000000000000000000000000002')
+    expect(payload.value).toBe(2000000000000000000n) // 2e18
+    expect(payload.data).toBe('0x')
+    expect(out.sent).toBe(true)
+    expect(out.route).toBe('legacy')
+    expect(out.txHash).toBe('0xdeadbeef')
+  })
+
+  it('refuses to send when the recovered account is not unlocked on this network', async () => {
+    activeAccount = { isLegacy: true, canActAsLegacy: false, submit }
+    const { result } = renderHook(() => useTransfer())
+    await expect(
+      result.current.send({ kind: TRANSFER_KIND.NATIVE, to: '0xbbbb000000000000000000000000000000000002', amount: '1' }),
+    ).rejects.toThrow(/unlock|network/i)
+    expect(submit).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/custody/useActiveAccount.legacy.test.jsx
+++ b/frontend/src/test/custody/useActiveAccount.legacy.test.jsx
@@ -2,15 +2,17 @@
 // unlocked in-memory legacy signer (via the audited personal submit path), and
 // refuses to act when the signer is gone.
 
+import { useState } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 const PERSONAL_SIGNER = { id: 'personal' }
 const LEGACY_SIGNER = { id: 'legacy' }
 
+let connectedChainId = 137
 vi.mock('../../hooks', () => ({ useWallet: () => ({ address: '0xowner' }) }))
 vi.mock('../../hooks/useWalletManagement', () => ({
-  useWallet: () => ({ chainId: 137, signer: PERSONAL_SIGNER, provider: {} }),
+  useWallet: () => ({ chainId: connectedChainId, signer: PERSONAL_SIGNER, provider: {} }),
 }))
 
 const submitSpy = vi.fn(async () => ({ kind: 'sent', txHash: '0xabc' }))
@@ -22,18 +24,20 @@ import { CustodyProvider } from '../../contexts/CustodyContext.jsx'
 import { useActiveAccount } from '../../hooks/useActiveAccount'
 
 function Probe({ withSigner = true }) {
+  const [, force] = useState(0)
   const { identity, canActAsLegacy, submit, operateAsLegacy } = useActiveAccount()
   return (
     <div>
       <span data-testid="mode">{identity.mode}</span>
       <span data-testid="can">{canActAsLegacy ? 'yes' : 'no'}</span>
       <button onClick={() => operateAsLegacy({ address: '0xLegacy', chainId: 137, kind: 'privateKey', signer: withSigner ? LEGACY_SIGNER : undefined })}>as-legacy</button>
+      <button onClick={() => force((n) => n + 1)}>re-render</button>
       <button onClick={() => submit({ to: '0xdead', value: 1n }).catch((e) => { document.title = e.message })}>submit</button>
     </div>
   )
 }
 
-beforeEach(() => submitSpy.mockClear())
+beforeEach(() => { submitSpy.mockClear(); connectedChainId = 137; document.title = '' })
 
 describe('useActiveAccount — legacy acting account', () => {
   it('signs with the unlocked legacy signer via the personal submit path', async () => {
@@ -47,6 +51,19 @@ describe('useActiveAccount — legacy acting account', () => {
     const [, ctx] = submitSpy.mock.calls[0]
     expect(ctx.signer).toBe(LEGACY_SIGNER) // the legacy key, not the connected wallet
     expect(ctx.signer).not.toBe(PERSONAL_SIGNER)
+  })
+
+  it('refuses to send on the wrong network after unlocking (no wrong-chain send)', async () => {
+    render(<CustodyProvider><Probe /></CustodyProvider>)
+    fireEvent.click(screen.getByText('as-legacy')) // unlocked for chainId 137
+    expect(screen.getByTestId('can')).toHaveTextContent('yes')
+    // Member switches networks after unlocking.
+    connectedChainId = 999
+    fireEvent.click(screen.getByText('re-render'))
+    expect(screen.getByTestId('can')).toHaveTextContent('no') // gated off on the wrong chain
+    fireEvent.click(screen.getByText('submit'))
+    await waitFor(() => expect(document.title).toMatch(/Switch back to the network/i))
+    expect(submitSpy).not.toHaveBeenCalled() // never sent on the wrong chain
   })
 
   it('refuses to act as a legacy account with no signer in memory', async () => {

--- a/frontend/src/test/custody/useActiveAccount.legacy.test.jsx
+++ b/frontend/src/test/custody/useActiveAccount.legacy.test.jsx
@@ -1,0 +1,62 @@
+// Spec 062 follow-up — acting as a recovered legacy account signs with the
+// unlocked in-memory legacy signer (via the audited personal submit path), and
+// refuses to act when the signer is gone.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const PERSONAL_SIGNER = { id: 'personal' }
+const LEGACY_SIGNER = { id: 'legacy' }
+
+vi.mock('../../hooks', () => ({ useWallet: () => ({ address: '0xowner' }) }))
+vi.mock('../../hooks/useWalletManagement', () => ({
+  useWallet: () => ({ chainId: 137, signer: PERSONAL_SIGNER, provider: {} }),
+}))
+
+const submitSpy = vi.fn(async () => ({ kind: 'sent', txHash: '0xabc' }))
+vi.mock('../../lib/custody/submitAsActiveAccount', () => ({
+  submitAsActiveAccount: (...args) => submitSpy(...args),
+}))
+
+import { CustodyProvider } from '../../contexts/CustodyContext.jsx'
+import { useActiveAccount } from '../../hooks/useActiveAccount'
+
+function Probe({ withSigner = true }) {
+  const { identity, canActAsLegacy, submit, operateAsLegacy } = useActiveAccount()
+  return (
+    <div>
+      <span data-testid="mode">{identity.mode}</span>
+      <span data-testid="can">{canActAsLegacy ? 'yes' : 'no'}</span>
+      <button onClick={() => operateAsLegacy({ address: '0xLegacy', chainId: 137, kind: 'privateKey', signer: withSigner ? LEGACY_SIGNER : undefined })}>as-legacy</button>
+      <button onClick={() => submit({ to: '0xdead', value: 1n }).catch((e) => { document.title = e.message })}>submit</button>
+    </div>
+  )
+}
+
+beforeEach(() => submitSpy.mockClear())
+
+describe('useActiveAccount — legacy acting account', () => {
+  it('signs with the unlocked legacy signer via the personal submit path', async () => {
+    render(<CustodyProvider><Probe /></CustodyProvider>)
+    fireEvent.click(screen.getByText('as-legacy'))
+    expect(screen.getByTestId('mode')).toHaveTextContent('legacy')
+    expect(screen.getByTestId('can')).toHaveTextContent('yes')
+
+    fireEvent.click(screen.getByText('submit'))
+    await waitFor(() => expect(submitSpy).toHaveBeenCalled())
+    const [, ctx] = submitSpy.mock.calls[0]
+    expect(ctx.signer).toBe(LEGACY_SIGNER) // the legacy key, not the connected wallet
+    expect(ctx.signer).not.toBe(PERSONAL_SIGNER)
+  })
+
+  it('refuses to act as a legacy account with no signer in memory', async () => {
+    render(<CustodyProvider><Probe withSigner={false} /></CustodyProvider>)
+    fireEvent.click(screen.getByText('as-legacy'))
+    // Descriptor without a signer is ignored → stays personal, never acts on an un-unlocked key.
+    expect(screen.getByTestId('mode')).toHaveTextContent('personal')
+    fireEvent.click(screen.getByText('submit'))
+    await waitFor(() => expect(submitSpy).toHaveBeenCalled())
+    // Falls back to the connected (personal) signer, not a phantom legacy key.
+    expect(submitSpy.mock.calls[0][1].signer).toBe(PERSONAL_SIGNER)
+  })
+})

--- a/frontend/src/test/recovery/legacyKeysPasskey.test.js
+++ b/frontend/src/test/recovery/legacyKeysPasskey.test.js
@@ -1,0 +1,77 @@
+/**
+ * Biometric (passkey-PRF) protection for recovered keys (spec 062 follow-up).
+ * Real WebCrypto; getAssertion is stubbed to return a fixed PRF output so the
+ * round-trip, fail-closed, and unified-unlock behavior are exercised without a
+ * real authenticator.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import {
+  encryptLegacySecretWithPasskey,
+  decryptLegacySecretWithPasskey,
+  unlockLegacySecret,
+  encryptLegacySecret,
+} from '../../lib/recovery/legacyKeys'
+
+const PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+const ADDR = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+const prf = (fill) => new Uint8Array(32).fill(fill)
+const assertionReturning = (out) => vi.fn(async () => ({ credentialId: 'cred-1', prfOutput: out }))
+
+describe('biometric-protected legacy secret', () => {
+  it('round-trips under the same passkey PRF output, storing ciphertext only', async () => {
+    const entry = await encryptLegacySecretWithPasskey({
+      secret: PK, kind: 'privateKey', address: ADDR, credentialId: 'cred-1',
+      deps: { getAssertion: assertionReturning(prf(7)), now: 1 },
+    })
+    expect(entry.protection).toBe('passkey')
+    expect(entry.credentialId).toBe('cred-1')
+    expect(entry.salt).toBeUndefined() // no passphrase KDF material
+    expect(JSON.stringify(entry)).not.toContain(PK)
+
+    const back = await decryptLegacySecretWithPasskey({ entry, deps: { getAssertion: assertionReturning(prf(7)) } })
+    expect(back).toBe(PK)
+  })
+
+  it('fails closed when the biometric yields a different PRF output', async () => {
+    const entry = await encryptLegacySecretWithPasskey({
+      secret: PK, kind: 'privateKey', address: ADDR, credentialId: 'cred-1',
+      deps: { getAssertion: assertionReturning(prf(7)) },
+    })
+    await expect(
+      decryptLegacySecretWithPasskey({ entry, deps: { getAssertion: assertionReturning(prf(9)) } })
+    ).rejects.toThrow(/Biometric unlock/i)
+  })
+
+  it('rejects a non-PRF authenticator instead of storing weakly', async () => {
+    await expect(
+      encryptLegacySecretWithPasskey({
+        secret: PK, kind: 'privateKey', address: ADDR, credentialId: 'cred-1',
+        deps: { getAssertion: vi.fn(async () => ({ credentialId: 'cred-1' })) }, // no prfOutput
+      })
+    ).rejects.toThrow(/PRF unsupported/i)
+  })
+
+  it('requires a credential to protect with', async () => {
+    await expect(
+      encryptLegacySecretWithPasskey({ secret: PK, kind: 'privateKey', address: ADDR, credentialId: '', deps: {} })
+    ).rejects.toThrow(/no passkey/i)
+  })
+})
+
+describe('unlockLegacySecret (unified)', () => {
+  it('runs a biometric assertion for passkey-protected entries', async () => {
+    const getAssertion = assertionReturning(prf(3))
+    const entry = await encryptLegacySecretWithPasskey({
+      secret: PK, kind: 'privateKey', address: ADDR, credentialId: 'cred-1', deps: { getAssertion },
+    })
+    const back = await unlockLegacySecret({ entry, deps: { getAssertion: assertionReturning(prf(3)) } })
+    expect(back).toBe(PK)
+  })
+
+  it('uses the passphrase for passphrase-protected entries', async () => {
+    const entry = await encryptLegacySecret({ secret: PK, kind: 'privateKey', address: ADDR, passphrase: 'longenough' })
+    expect(entry.protection).toBeUndefined() // legacy/passphrase shape
+    const back = await unlockLegacySecret({ entry, passphrase: 'longenough' })
+    expect(back).toBe(PK)
+  })
+})


### PR DESCRIPTION
Follow-up refinements to the merged legacy account recovery (spec 062), from in-app feedback. Branch restarted from `main` after #949 merged.

## Delivered

### 1. Biometric-first key protection (passphrase fallback)
> "The added account should not ask for a password unless absolutely necessary — use biometrics if possible and fall back to a password that can be saved to a password manager."

- `legacyKeys.js` gains `encryptLegacySecretWithPasskey` / `decryptLegacySecretWithPasskey`: one WebAuthn assertion (Face/Touch ID) yields a PRF output → `HKDF` (info `fairwins-legacy-kek-v1`, **domain-separated** from the spec-041 master-seed KEK) → AES-GCM. Plus `unlockLegacySecret()` that branches on the stored entry's `protection`.
- Passkey-protected entries store only ciphertext + `credentialId` (no KDF salt); they **fail closed** on a different PRF output.
- The Recovery panel defaults to **"Protect with biometrics" (no password)** when the session is a passkey; a **"Use a passphrase instead"** fallback remains, the passphrase field carries a hidden `username` hint so **password managers** can save it, and stored passkey-protected keys unlock via biometrics (no passphrase prompt).

### 2. Dark-mode contrast
> "The contrast of areas in dark mode needs to be better, such as the optional fund transfer."

- The recovery-sheet step buttons now have real affordance (the global `button{}` paints `--bg-secondary`, *darker* than the `--surface-color` sheet, and `.btn-primary` had no rule at all) with a green primary; the SAVED optional-action cards and inputs get visible, text-derived borders/fills in both themes.

### 3–4. Global + per-screen account switcher — recovered accounts as full acting signers
> "The user should be able to select the account to act globally (like multisigs) or select it per-screen on Transfer and Trade; a dropdown on the wallet bottom sheet for global changes."

Recovered legacy accounts are now **full acting signers** — the app signs value ops with the unlocked legacy key, exactly like a multisig vault is an acting identity (spec 043 seam):

- `CustodyContext.operateAsLegacy(descriptor)` + a **memory-only** `legacySigner` (never persisted/serialized; cleared on any identity change, account switch, or disconnect). Descriptors without an unlocked signer are ignored.
- `useActiveAccount` exposes `isLegacy` / `canActAsLegacy` / `operateAsLegacy`; in legacy mode `submit()` signs with the unlocked key and **refuses a wrong-chain send** (the in-memory signer is bound to the unlock-time provider).
- **AccountSwitcher** — reusable "Acting as" dropdown (personal + vaults + recovered), mounted in the wallet bottom sheet; self-hides when only the personal wallet exists.
- **Transfer** and **Trade** each list recovered accounts in their per-screen selector; picking one opens the unlock dialog (biometric/passphrase) → `operateAsLegacy`.
- The money engines actually sign as the recovered account (no muted path): `useTransfer` and `DexContext` (`swap` / `wrapNative` / `unwrapNative`) route through the active-account seam with the unlocked key, building the `[approve?, action]` batch as sequential EOA txs (`submitAsActiveAccount`); balances + swap recipient follow the acting account. Recovered trades are honestly "network fee applies".

## Security
Given this handles key material, a `/security-review` focused on key-material handling and signer routing ran on the final state (head `f68cbcb`): **no high-confidence vulnerabilities**. Verified — the raw secret is never logged, transmitted, or persisted in the clear (legacy transfers deliberately skip the ledger so no key/tx leaks); the in-memory signer is never serialized and is cleared on every identity transition; PBKDF2-650k + per-entry random salt/IV and HKDF domain separation are sound and fail closed; and every value op while acting as a recovered account signs with the unlocked legacy key (never the connected wallet), with a correct chain guard against cross-chain replay.

## Tests
Biometric-crypto (round-trip, fail-closed, non-PRF reject, unified unlock), panel (biometric protect, passphrase fallback, biometric unlock), CustodyContext legacy set/clear + no-signer guard, `useActiveAccount` legacy routing + wrong-chain refusal, AccountSwitcher, and legacy Transfer routing/refusal; full affected group (Trade / Transfer / DexContext / custody / account / recovery) green, `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vqgr1bwkbV1bbhQBKcGVKm)_