### PR TITLE
feat(wallet): wallet header identity reflects the acting account

### DIFF
--- a/frontend/src/components/wallet/WalletButton.css
+++ b/frontend/src/components/wallet/WalletButton.css
@@ -238,6 +238,20 @@
   color: var(--text-primary, #ffffff);
 }
 
+/* Spec 063 — badge showing which acting account the wallet identity reflects
+   (Recovered / Multisig), so the top area makes the active account obvious. */
+.account-acting-tag {
+  align-self: flex-start;
+  font-size: 0.62rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 7px;
+  border-radius: 999px;
+  color: var(--brand-secondary, #4c9aff);
+  background: color-mix(in srgb, var(--brand-secondary, #4c9aff) 18%, transparent);
+}
+
 /* Extended Dropdown */
 .wallet-dropdown-extended {
   min-width: 340px;

--- a/frontend/src/components/wallet/WalletButton.jsx
+++ b/frontend/src/components/wallet/WalletButton.jsx
@@ -38,9 +38,13 @@ function WalletButton({ className = '' }) {
   const [isOpen, setIsOpen] = useState(false)
   const [showAddressQR, setShowAddressQR] = useState(false)
   const { address, isConnected } = useAccount()
-  // Spec 063 (US1): Receive shows the account the member is ACTING AS (a vault or recovered
-  // account), not always the connected wallet, so funds are received into the selected account.
-  const { address: receiveAddress } = useEffectiveAccount()
+  // Spec 063 (US1): the whole wallet identity — biticon, address, copy, balance, QR — reflects the
+  // account the member is ACTING AS (personal / multisig / recovered), not always the connected
+  // passkey, so it's obvious at a glance which account they're using. Falls back to the connected
+  // wallet when no acting account is selected.
+  const { address: actingAddress, label: actingLabel, type: actingType, isActingAccount } = useEffectiveAccount()
+  const displayAddress = actingAddress || address
+  const acctTypeLabel = actingType === 'vault' ? 'Multisig' : actingType === 'legacy' ? 'Recovered' : actingType === 'derived' ? 'Recovered' : null
   const { openConnectModal, disconnectWallet } = useWallet()
   const chainId = useChainId()
   const navigate = useNavigate()
@@ -173,7 +177,7 @@ function WalletButton({ className = '' }) {
             aria-expanded={isOpen}
             aria-haspopup="true"
           >
-            <BlockiesAvatar address={address} size={24} />
+            <BlockiesAvatar address={displayAddress} size={24} />
           </button>
 
           {isOpen && (
@@ -184,17 +188,17 @@ function WalletButton({ className = '' }) {
             >
               <div className="dropdown-header">
                 <div className="account-info">
-                  <BlockiesAvatar address={address} size={40} />
+                  <BlockiesAvatar address={displayAddress} size={40} />
                   <div className="account-details">
                     <button
                       type="button"
                       className="account-address-full account-address-copy"
-                      onClick={() => copyAddress(address)}
-                      title={address}
-                      aria-label={addressCopied ? 'Address copied' : 'Copy wallet address'}
+                      onClick={() => copyAddress(displayAddress)}
+                      title={displayAddress}
+                      aria-label={addressCopied ? 'Address copied' : 'Copy account address'}
                     >
                       <span className="account-address-value">
-                        {addressCopied ? 'Copied!' : shortenAddress(address)}
+                        {addressCopied ? 'Copied!' : shortenAddress(displayAddress)}
                       </span>
                       <NavIcon
                         name={addressCopied ? 'check' : 'copy'}
@@ -202,6 +206,9 @@ function WalletButton({ className = '' }) {
                         className="account-address-copy-icon"
                       />
                     </button>
+                    {isActingAccount && (
+                      <span className="account-acting-tag">{actingLabel || acctTypeLabel}</span>
+                    )}
                     <span className="usdc-balance">
                       {balanceLoading
                         ? 'Loading...'
@@ -340,7 +347,7 @@ function WalletButton({ className = '' }) {
         <AddressQRModal
           isOpen
           onClose={() => setShowAddressQR(false)}
-          address={receiveAddress || address}
+          address={displayAddress}
           variant="quick"
         />
       )}

--- a/frontend/src/test/WalletButton.test.jsx
+++ b/frontend/src/test/WalletButton.test.jsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 // import { axe } from 'vitest-axe' // Unused, commented out for now
 import WalletButton from '../components/wallet/WalletButton'
 import { WalletContext, ThemeContext, ROLES, ROLE_INFO, UIContext, UserPreferencesContext, FriendMarketsContext } from '../contexts'
+import { CustodyContext } from '../contexts/CustodyContext'
 import { BrowserRouter } from 'react-router-dom'
 
 // Mock wagmi hooks
@@ -323,7 +324,7 @@ describe('WalletButton Component - Wagers', () => {
 
       await user.click(screen.getByRole('button', { name: /wallet account/i }))
 
-      const copyButton = await screen.findByRole('button', { name: /copy wallet address/i })
+      const copyButton = await screen.findByRole('button', { name: /copy account address/i })
       await user.click(copyButton)
 
       // Visible confirmation, and the full address landed on the clipboard
@@ -332,6 +333,27 @@ describe('WalletButton Component - Wagers', () => {
       expect(await navigator.clipboard.readText()).toBe(
         '0x1234567890123456789012345678901234567890'
       )
+    })
+
+    it('reflects the ACTING account (not the connected passkey) in the header identity + QR', async () => {
+      const user = userEvent.setup()
+      const ACTING = '0x5250000000000000000000000000000000000abc'
+      renderWithProviders(
+        <CustodyContext.Provider value={{ active: { mode: 'legacy', address: ACTING, label: 'Recovered' } }}>
+          <WalletButton />
+        </CustodyContext.Provider>,
+      )
+      await user.click(screen.getByRole('button', { name: /wallet account/i }))
+
+      // Copy targets the acting account's address, and its type tag is shown.
+      const copyBtn = await screen.findByRole('button', { name: /copy account address/i })
+      expect(copyBtn).toHaveAttribute('title', ACTING)
+      expect(screen.getByText('Recovered')).toBeInTheDocument()
+
+      // The QR shows the acting account's address, not the connected wallet.
+      await user.click(screen.getByRole('button', { name: /show wallet address qr code/i }))
+      const qrModal = await screen.findByRole('dialog', { name: /address qr modal/i })
+      expect(qrModal).toHaveAttribute('data-address', ACTING)
     })
 
     it('opens the address QR modal from the dropdown header and closes the dropdown', async () => {


### PR DESCRIPTION
Follow-up to spec 063 (merged in #951), from in-app feedback on the wallet view.

## Problem

In the wallet dropdown, the top area — the biticon, address, click-to-copy, balance, and QR — always showed the **connected passkey**, even while acting as a recovered or multisig account. The "Acting as" selector sat below as a separate row, so it wasn't obvious at a glance which account was actually in use.

## Change

The **entire top identity now follows the acting account** (`useEffectiveAccount`):

- The collapsed header biticon and the dropdown-header avatar resolve to whichever account is active — so you can spot the active account immediately.
- Click-to-copy copies the **acting account's** address; the QR encodes it too (balance already followed the acting account via `DexContext`).
- A small type tag (**Recovered** / **Multisig**) appears next to the address for quick identification.
- Falls back to the connected wallet when acting as personal.

This makes all the identity functionality — balance, click-to-copy, QR — consistent for every acting account, not just the connected passkey.

## Tests

Added a WalletButton case: with a legacy acting account, the header copy button targets that account's address, its "Recovered" tag renders, and the QR modal encodes the acting address (not the connected wallet). WalletButton suite (11) + `useEffectiveAccount` (6) green; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vqgr1bwkbV1bbhQBKcGVKm)_