### PR TITLE
fix(my-wagers): lift bottom sheet above mobile bottom nav

### DIFF
--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -17,7 +17,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  /* Modal tier — must sit above the mobile bottom nav (.section-icon-nav, 1200)
+     and the nav drawer (1401) so the sheet is never occluded by the Pay/Request/
+     Wager bar on mobile. Matches the shared full-screen modal tier used by the
+     asset/collectible detail sheets. The nested sub-modal backdrop (1100) is
+     scoped to this stacking context, so it still layers above the sheet. */
+  z-index: 2000;
   padding: 1rem;
   animation: mmFadeIn 0.2s ease-out;
 }


### PR DESCRIPTION
## Summary

On mobile, the **My Wagers** bottom sheet rendered *behind* the Pay / Request / Wager bottom nav bar (see the reported screenshot — the nav glyphs overlap the sheet's content near the bottom edge).

**Root cause:** a z-index ordering conflict.

| Element | Selector | z-index |
| --- | --- | --- |
| My Wagers sheet backdrop | `.my-markets-modal-backdrop` | **1000** (too low) |
| Mobile bottom nav | `.section-icon-nav` | 1200 |
| Nav drawer | `.app-nav-drawer` | 1401 |

Because the sheet's backdrop sat at 1000 — below the bottom nav (1200) and nav drawer (1401) — the nav chrome painted on top of it.

## Fix

Raise `.my-markets-modal-backdrop` to the codebase's established full-screen **modal tier** (`z-index: 2000`), the same tier documented and used by the asset and collectible detail sheets ("above header (1000) and nav drawer (1401)"). The sheet is now always in front of the nav chrome.

The nested resolution / acceptance / decrypt sub-modals (backdrop `z-index: 1100`) render inline inside `.my-markets-modal-backdrop`, so they live within that stacking context and continue to layer correctly above the sheet — no change needed there.

## Scope

- One CSS declaration changed (`frontend/src/components/fairwins/MyMarketsModal.css`), plus an explanatory comment.
- No JS/behavior changes; no markup changes.

## Testing

Pure CSS stacking fix. jsdom (Vitest) does not compute stacking contexts, so there is no unit assertion to add; the existing `MyMarketsModal.test.jsx` behavior is unaffected. Verified the change is isolated to the backdrop's `z-index` and that all sub-modals render inline (no React portals escaping the stacking context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Th44wAhGfPrq5ahTguaaq

---
_Generated by [Claude Code](https://claude.ai/code/session_014Th44wAhGfPrq5ahTguaaq)_