### PR TITLE
feat(assets): universal asset selector for Pay/Request/Wager + trade view (spec 064)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/063-cross-chain-legacy-recovery"
+  "feature_directory": "specs/064-universal-asset-selector"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,5 +182,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/063-cross-chain-legacy-recovery/plan.md
+at specs/064-universal-asset-selector/plan.md
 <!-- SPECKIT END -->

--- a/frontend/src/components/fairwins/CreateChallengePanel.jsx
+++ b/frontend/src/components/fairwins/CreateChallengePanel.jsx
@@ -1,13 +1,18 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import { isAddress } from 'ethers'
+import { useSwitchChain } from 'wagmi'
 import { useOpenChallengeCreate, OPEN_RESOLUTION_TYPES } from '../../hooks/useOpenChallengeCreate'
 import { useWeb3 } from '../../hooks/useWeb3'
 import { useChainTokens } from '../../hooks/useChainTokens'
+import { useSelectableAssets } from '../../hooks/useSelectableAssets'
 import { ResolutionType, isOracleModelExposed } from '../../constants/wagerDefaults'
+import { ASSET_ACTIVITIES } from '../../lib/assets/assetActivity'
+import { getNetwork } from '../../config/networks'
 import AddressInput from '../ui/AddressInput'
 import AddressBookButton from '../ui/AddressBookButton'
 import QRScanner from '../ui/QRScanner'
 import AmountKeypad from '../ui/AmountKeypad'
+import UniversalAssetSelect from '../ui/UniversalAssetSelect'
 import PolymarketBrowser from './PolymarketBrowser'
 import ClaimCodeResultPanel from './ClaimCodeResultPanel'
 import { toDatetimeLocal, fromDatetimeLocal, HOUR_MS } from './wagerTimeline'
@@ -55,7 +60,14 @@ function CreateChallengePanel({
   initialMarket = null,
 }) {
   const { createOpenChallenge, busy } = useOpenChallengeCreate()
-  const { capabilities } = useChainTokens()
+  const { capabilities, chainId: connectedChainId } = useChainTokens()
+  const { switchChainAsync, isPending: switching } = useSwitchChain()
+  // Stake asset (spec 064 US3): the wager was USDC-locked; it now escrows ANY
+  // ERC-20 the account holds. The head-to-head escrow pulls the stake via
+  // `transferFrom`, so the selector is scoped to ERC-20 kinds only — the native
+  // coin and non-EVM Bitcoin are excluded by the `wager` capability profile.
+  const { options: assetOptions, defaultKey: assetDefaultKey } = useSelectableAssets({ activity: ASSET_ACTIVITIES.WAGER })
+  const [selectedAssetKey, setSelectedAssetKey] = useState(null)
   // Oracle settlement is only offered where the Polymarket CTF is reachable and
   // the model is exposed; otherwise the pill shows locked (spec 052 consolidation).
   const polymarketAvailable =
@@ -96,6 +108,40 @@ function CreateChallengePanel({
   const isThirdParty = Number(resolutionType) === OPEN_RESOLUTION_TYPES.ThirdParty
   const isOracle = Number(resolutionType) === OPEN_RESOLUTION_TYPES.Polymarket
 
+  // Selection with fallback to the activity default (connected stablecoin ⇒ USDC,
+  // so the first-render default is unchanged). The member's pick always wins (FR-013).
+  const activeAssetKey = selectedAssetKey && assetOptions.some((o) => o.key === selectedAssetKey)
+    ? selectedAssetKey
+    : assetDefaultKey
+  const stakeAsset = assetOptions.find((o) => o.key === activeAssetKey) || null
+  const stakeSymbol = stakeAsset?.symbol || 'USDC'
+  // A stake asset on another network is create-gated behind a switch (the wager is
+  // created + escrowed on the connected chain) — only once the wallet is connected.
+  // We only claim a mismatch when the connected chain is actually known (honest state:
+  // never gate on an unknown/NaN chain).
+  const assetChainMismatch =
+    Boolean(stakeAsset) && Number.isFinite(Number(connectedChainId)) &&
+    Number(stakeAsset.chainId) !== Number(connectedChainId)
+  const chainGateActive = isConnected && assetChainMismatch
+  const switchTargetName = assetChainMismatch
+    ? getNetwork(stakeAsset.chainId)?.name || `network ${stakeAsset.chainId}`
+    : null
+
+  const handleSelectAsset = useCallback((option) => {
+    setSelectedAssetKey(option.key)
+    setError(null)
+  }, [])
+
+  const handleSwitchAssetNetwork = useCallback(async () => {
+    if (!stakeAsset) return
+    setError(null)
+    try {
+      await switchChainAsync({ chainId: Number(stakeAsset.chainId) })
+    } catch (err) {
+      setError(err?.shortMessage || err?.message || 'Could not switch network.')
+    }
+  }, [stakeAsset, switchChainAsync])
+
   // Let an embedding host react to the oracle path (the home screen hides its
   // secondary actions while an oracle challenge is being composed — the market +
   // side picker need the room and the goal is a no-scroll view).
@@ -120,7 +166,7 @@ function CreateChallengePanel({
     ? `${market.question} — creator takes ${sideName(side)} · settled automatically by Polymarket`
     : ''
 
-  const canCreate = Number(stake) > 0 && !busy && (
+  const canCreate = Number(stake) > 0 && !busy && Boolean(stakeAsset) && !chainGateActive && (
     isOracle
       ? Boolean(market && oracleTimeline?.eligible && side !== '')
       : (description.trim().length > 0 && arbitratorValid && deadlinesValid)
@@ -184,10 +230,16 @@ function CreateChallengePanel({
     // Normalize the pad string (e.g. "10." → "10", "10.50" → "10.5").
     const cleanStake = Number(stake) > 0 ? String(Number(stake)) : stake
     try {
+      // The selected stake token (spec 064): the create hook denominates escrow +
+      // payout in it (defaulting to USDC when the default asset is chosen). A held
+      // ERC-20 the registry doesn't allowlist surfaces the friendly NotAllowedToken
+      // error from the hook — never a silent failure.
+      const stakeTokenAddress = stakeAsset?.address || undefined
       const payload = isOracle
         ? {
             description: composedDescription,
             stake: cleanStake,
+            token: stakeTokenAddress,
             resolutionType: OPEN_RESOLUTION_TYPES.Polymarket,
             oracleConditionId: market.conditionId,
             creatorIsYes: side === '0',
@@ -208,6 +260,7 @@ function CreateChallengePanel({
         : {
             description: description.trim(),
             stake: cleanStake,
+            token: stakeTokenAddress,
             resolutionType: Number(resolutionType),
             arbitrator: isThirdParty ? arbitratorAddr : undefined,
             acceptDeadline: Number.isFinite(acceptMs) ? Math.floor(acceptMs / 1000) : undefined,
@@ -220,7 +273,7 @@ function CreateChallengePanel({
     } finally {
       setProgress(null)
     }
-  }, [isConnected, onConnect, isOracle, composedDescription, stake, market, side, oracleTimeline, description, resolutionType, isThirdParty, arbitratorAddr, acceptMs, resolveMs, createOpenChallenge]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isConnected, onConnect, isOracle, composedDescription, stake, stakeAsset, market, side, oracleTimeline, description, resolutionType, isThirdParty, arbitratorAddr, acceptMs, resolveMs, createOpenChallenge]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Resume a create that was waiting on the wallet: the moment the connection lands, continue.
   useEffect(() => {
@@ -277,13 +330,26 @@ function CreateChallengePanel({
   return (
     <form className={`fm-form fm-pay-form${embedded ? ' oc-create-embedded' : ''}`} onSubmit={handleCreate}>
       {/* Payments-style hero (spec 052): the stake amount is the centerpiece,
-          entered with the on-screen number pad. Token is USDC-locked here. */}
+          entered with the on-screen number pad. The stake asset is chosen with the
+          universal selector (spec 064) — any held ERC-20, not USDC-locked. */}
       <div className="fm-pay-hero">
         <AmountKeypad
           value={stake}
           onChange={setStake}
           prefix="$"
-          token="USDC"
+          token={stakeSymbol}
+          tokenSlot={(
+            <>
+              <span className="sr-only">Stake asset</span>
+              <UniversalAssetSelect
+                label="Stake asset"
+                options={assetOptions}
+                value={activeAssetKey}
+                onChange={handleSelectAsset}
+                disabled={busy}
+              />
+            </>
+          )}
           disabled={busy}
           ariaLabel="Stake amount, each side"
           id="oc-stake"
@@ -408,9 +474,20 @@ function CreateChallengePanel({
       {error && <div className="fm-error-banner" role="alert">{error}</div>}
 
       <div className="fm-success-actions">
-        <button type="submit" className="fm-btn-primary" disabled={!canCreate}>
-          {busy ? 'Opening…' : 'Lock in!'}
-        </button>
+        {chainGateActive ? (
+          <button
+            type="button"
+            className="fm-btn-primary"
+            onClick={handleSwitchAssetNetwork}
+            disabled={switching || busy}
+          >
+            {switching ? 'Switching…' : `Switch to ${switchTargetName} to stake ${stakeSymbol}`}
+          </button>
+        ) : (
+          <button type="submit" className="fm-btn-primary" disabled={!canCreate}>
+            {busy ? 'Opening…' : 'Lock in!'}
+          </button>
+        )}
       </div>
     </form>
   )

--- a/frontend/src/components/fairwins/PayPanel.jsx
+++ b/frontend/src/components/fairwins/PayPanel.jsx
@@ -5,11 +5,17 @@ import AmountKeypad from '../ui/AmountKeypad'
 import AddressInput from '../ui/AddressInput'
 import AddressBookButton from '../ui/AddressBookButton'
 import QRScanner from '../ui/QRScanner'
+import UniversalAssetSelect from '../ui/UniversalAssetSelect'
+import BitcoinSendPanel from '../wallet/BitcoinSendPanel'
 import { useWallet } from '../../hooks'
-import { useTransfer, TRANSFER_KIND } from '../../hooks/useTransfer'
+import { useTransfer } from '../../hooks/useTransfer'
+import { useSelectableAssets } from '../../hooks/useSelectableAssets'
+import { useActiveAccount } from '../../hooks/useActiveAccount'
+import { useBitcoinWallet } from '../../hooks/useBitcoinWallet'
 import { useAddressScreening } from '../../hooks/useAddressScreening'
 import { useNotification } from '../../hooks/useUI'
 import { getNetwork } from '../../config/networks'
+import { ASSET_ACTIVITIES } from '../../lib/assets/assetActivity'
 import { getDefaultCurrencyKind } from '../../utils/homePreference'
 import { parsePaymentRequest, NOTE_MAX_LENGTH } from '../../lib/payments/paymentRequest'
 
@@ -23,63 +29,109 @@ function formatUnitsForKeypad(units, decimals) {
 }
 
 /**
- * PayPanel (spec 058 US1) — the home surface's default mode: send value to a
- * recipient with the same amount-hero + numpad layout as the wager create
- * view. Composes the standard recipient stack (AddressInput + address book +
- * QR scanner) and submits through the existing useTransfer engine — the
- * screening, gasless routing, honest lifecycle, and never-stranded fallbacks
- * are all inherited, not reimplemented (FR-004/FR-018).
+ * PayPanel (spec 058 US1 + spec 064 US1) — the home surface's default mode: send
+ * value to a recipient with the payments-style amount-hero + numpad layout.
  *
- * Contract: specs/058-send-request-home/contracts/home-mode-components.md
+ * The currency control under the amount is the UNIVERSAL asset selector (spec 064):
+ * a member can pay with ANY platform-supported asset the acting account holds across
+ * every configured network — each shown with its nested asset logo (glyph + network
+ * sub-badge) — not just the connected network's native coin and stablecoin. Non-EVM
+ * Bitcoin is supported here and routes through the existing Bitcoin send panel; an
+ * asset on another network is gated behind a "Switch to {network}" step. All routing
+ * (screening, gasless, honest lifecycle, never-stranded fallbacks) is inherited from
+ * the useTransfer engine via `send({ asset })`, never reimplemented.
+ *
+ * Contract: specs/064-universal-asset-selector/contracts/universal-asset-selector.md
  */
 function PayPanel({ onSuccess }) {
   const { isConnected, chainId, openConnectModal } = useWallet()
-  const { send, status, error: sendError, quoteGasless, balanceOf, refreshBalances, tokens } = useTransfer()
+  const { send, status, error: sendError, refreshBalances } = useTransfer()
+  const { identity, isVault, isLegacy } = useActiveAccount()
   const { screenOne } = useAddressScreening()
   const { showNotification } = useNotification()
   const { switchChainAsync, isPending: switching } = useSwitchChain()
+  const btc = useBitcoinWallet()
 
-  const [kind, setKind] = useState(getDefaultCurrencyKind)
+  // Assets + balances come from whichever account we're ACTING AS (a vault or a
+  // recovered legacy account), else the personal portfolio — consistent with the
+  // Transfer form (FR-014).
+  const actingAddress = isVault && identity?.vaultAddress
+    ? identity.vaultAddress
+    : isLegacy && identity?.address
+      ? identity.address
+      : null
+  const { options, defaultKey, isGasless } = useSelectableAssets({ activity: ASSET_ACTIVITIES.PAY, actingAddress })
+
+  const [selectedKey, setSelectedKey] = useState(null)
   const [amount, setAmount] = useState('')
   const [toRaw, setToRaw] = useState('')
   const [toResolved, setToResolved] = useState('')
   const [note, setNote] = useState('')
   const [scanOpen, setScanOpen] = useState(false)
   const [scanNotice, setScanNotice] = useState(null)
-  // Advisory screening result, remembered WITH the address it was for — the
-  // status is derived by matching, so a recipient edit never shows a stale
-  // verdict and the effect needs no synchronous reset.
+  // Advisory screening result, remembered WITH the address it was for.
   const [screeningResult, setScreeningResult] = useState(null) // { addr, status } | null
   const [formError, setFormError] = useState(null)
   const [confirming, setConfirming] = useState(false)
-  // A scanned request payable on another network pins that chain until the
-  // user switches — the Pay action is replaced by a switch affordance (FR-016).
+  // A scanned request payable on another network pins that chain until the user
+  // switches, even when we hold no matching asset to preselect (FR-007).
   const [pinnedChainId, setPinnedChainId] = useState(null)
 
-  const connectedChainId = Number(tokens.chainId ?? chainId)
+  const connectedChainId = Number(chainId)
   const busy = status === 'signing' || status === 'submitting' || status === 'pending'
-  const symbol = kind === TRANSFER_KIND.STABLE ? tokens.stable : tokens.native
-  const gasless = quoteGasless(kind)
-  const bal = balanceOf(kind)
+
+  // Preference-aware default (spec 058): the home currency preference still picks
+  // the STARTING asset — 'native' preselects the connected native coin, otherwise
+  // the activity default (connected stablecoin) — before generalizing to any held
+  // asset (spec 064). The member's own pick always overrides once made (FR-013).
+  const preferredDefaultKey = useMemo(() => {
+    if (getDefaultCurrencyKind() === 'native') {
+      const nativeOpt = options.find((o) => Number(o.chainId) === connectedChainId && o.kind === 'native')
+      if (nativeOpt) return nativeOpt.key
+    }
+    return defaultKey
+  }, [options, connectedChainId, defaultKey])
+
+  // Selection with fallback: keep the member's pick while it's valid, else the
+  // preference-aware activity default. (FR-013)
+  const activeKey = selectedKey && options.some((o) => o.key === selectedKey) ? selectedKey : preferredDefaultKey
+  const selectedAsset = options.find((o) => o.key === activeKey) || null
+
+  const isBitcoin = selectedAsset?.kind === 'btc-native'
+  const symbol = selectedAsset?.symbol || ''
+  const bal = selectedAsset?.balance ?? null
+  const gasless = selectedAsset ? isGasless(selectedAsset) : false
 
   useEffect(() => { refreshBalances() }, [refreshBalances])
 
-  // Derived, not synced: the pin stays with the draft (a scanned request is
-  // payable on ITS network), and the mismatch simply computes false once the
-  // user has switched onto that network.
-  const chainMismatch = pinnedChainId != null && Number(pinnedChainId) !== connectedChainId
-  const pinnedNetworkName = chainMismatch ? (getNetwork(pinnedChainId)?.name || `network ${pinnedChainId}`) : null
+  // Wrong-chain: the selected EVM asset lives on a network the wallet isn't on, or
+  // a scanned request pinned another chain. Bitcoin is non-EVM and never gated here.
+  const assetChainId = selectedAsset && !isBitcoin ? Number(selectedAsset.chainId) : connectedChainId
+  // Only claim a mismatch when the connected chain is actually known (honest state:
+  // never gate on an unknown/NaN chain).
+  const knownConnectedChain = Number.isFinite(connectedChainId)
+  const chainMismatch =
+    !isBitcoin && knownConnectedChain &&
+    ((pinnedChainId != null && Number(pinnedChainId) !== connectedChainId) ||
+      (Boolean(selectedAsset) && assetChainId !== connectedChainId))
+  const switchTargetChainId = pinnedChainId != null && Number(pinnedChainId) !== connectedChainId
+    ? Number(pinnedChainId)
+    : chainMismatch
+      ? assetChainId
+      : null
+  const switchTargetName = switchTargetChainId != null
+    ? getNetwork(switchTargetChainId)?.name || `network ${switchTargetChainId}`
+    : null
 
-  // Advisory sanctions pre-check on the resolved recipient (on-chain guards
-  // remain the enforcement).
+  // Advisory sanctions pre-check on the resolved recipient (on-chain guards enforce).
   useEffect(() => {
     let cancelled = false
     if (!toResolved) return undefined
-    Promise.resolve(screenOne(toResolved, connectedChainId))
+    Promise.resolve(screenOne(toResolved, assetChainId))
       .then((s) => { if (!cancelled) setScreeningResult({ addr: toResolved, status: s }) })
       .catch(() => { if (!cancelled) setScreeningResult({ addr: toResolved, status: 'uncertain' }) })
     return () => { cancelled = true }
-  }, [toResolved, screenOne, connectedChainId])
+  }, [toResolved, screenOne, assetChainId])
 
   const screening = screeningResult && screeningResult.addr === toResolved ? screeningResult.status : null
 
@@ -93,11 +145,9 @@ function PayPanel({ onSuccess }) {
     return Number(amount) > Number(bal)
   }, [bal, amount, amountValid])
 
-  const stableUnavailable = kind === TRANSFER_KIND.STABLE && !tokens.stableAddress
-
   const canPay =
-    isConnected && !chainMismatch && Boolean(toResolved) && amountValid && !overBalance &&
-    screening !== 'restricted' && !stableUnavailable && !busy
+    isConnected && Boolean(selectedAsset) && !chainMismatch && Boolean(toResolved) && amountValid &&
+    !overBalance && screening !== 'restricted' && !busy
 
   const applyAddress = useCallback((addr) => {
     setToRaw(addr)
@@ -111,12 +161,19 @@ function PayPanel({ onSuccess }) {
     setConfirming(false); setPinnedChainId(null)
   }, [])
 
+  const handleSelectAsset = useCallback((option) => {
+    setSelectedKey(option.key)
+    setPinnedChainId(null)
+    setConfirming(false)
+    setFormError(null)
+  }, [])
+
   /**
    * A scan is either a payment request (full prefill), a bare address
-   * (recipient-only prefill, FR-009), or unusable. A request denominated in
-   * a token that is not its network's stablecoin prefills NOTHING — never a
-   * wrong-asset send (edge case). A request on another network pins that
-   * chain and surfaces the switch before any send (FR-016).
+   * (recipient-only prefill), or unusable. A request denominated in a token that is
+   * not its network's stablecoin prefills NOTHING — never a wrong-asset send. A
+   * request on another network preselects the held asset when we have it, else pins
+   * that chain and surfaces the switch (FR-007).
    */
   const handleScan = useCallback((decodedText) => {
     setScanOpen(false)
@@ -129,7 +186,7 @@ function PayPanel({ onSuccess }) {
     const targetChainId = parsed.chainId ?? connectedChainId
     const targetNetwork = getNetwork(targetChainId)
 
-    let nextKind = kind
+    let wantAddress = null // null ⇒ native
     let decimals = null
     if (parsed.tokenAddress) {
       const stableAddr = targetNetwork?.stablecoin?.address
@@ -137,33 +194,39 @@ function PayPanel({ onSuccess }) {
         setScanNotice("This request asks for a token FairWins doesn't send on that network, so nothing was filled in.")
         return
       }
-      nextKind = TRANSFER_KIND.STABLE
+      wantAddress = stableAddr
       decimals = targetNetwork.stablecoin.decimals ?? 6
     } else if (parsed.amountUnits != null) {
-      nextKind = TRANSFER_KIND.NATIVE
       decimals = targetNetwork?.nativeCurrency?.decimals ?? 18
     }
 
     applyAddress(parsed.to)
-    setKind(nextKind)
+    const match = options.find(
+      (o) =>
+        Number(o.chainId) === Number(targetChainId) &&
+        (wantAddress ? o.address && o.address.toLowerCase() === wantAddress.toLowerCase() : o.kind === 'native'),
+    )
+    if (match) setSelectedKey(match.key)
     if (parsed.amountUnits != null && decimals != null) setAmount(formatUnitsForKeypad(parsed.amountUnits, decimals))
     if (parsed.note) setNote(parsed.note)
     setPinnedChainId(parsed.chainId != null && Number(parsed.chainId) !== connectedChainId ? Number(parsed.chainId) : null)
-  }, [applyAddress, connectedChainId, kind])
+  }, [applyAddress, connectedChainId, options])
 
   const handleSwitch = useCallback(async () => {
     setFormError(null)
+    if (switchTargetChainId == null) return
     try {
-      await switchChainAsync({ chainId: Number(pinnedChainId) })
+      await switchChainAsync({ chainId: Number(switchTargetChainId) })
+      setPinnedChainId(null)
     } catch (err) {
       setFormError(err?.shortMessage || err?.message || 'Could not switch network.')
     }
-  }, [switchChainAsync, pinnedChainId])
+  }, [switchChainAsync, switchTargetChainId])
 
   const handleSend = useCallback(async () => {
     setFormError(null)
     try {
-      const res = await send({ kind, to: toResolved, amount })
+      const res = await send({ asset: selectedAsset, to: toResolved, amount })
       if (res?.proposed) {
         showNotification(
           `Proposed sending ${amount} ${symbol} to ${short(toResolved)} from the vault — its signers must approve it.`,
@@ -183,17 +246,45 @@ function PayPanel({ onSuccess }) {
       setConfirming(false)
       setFormError(err?.shortMessage || err?.message || 'Transfer failed.')
     }
-  }, [send, kind, toResolved, amount, symbol, showNotification, resetDraft, onSuccess])
+  }, [send, selectedAsset, toResolved, amount, symbol, showNotification, resetDraft, onSuccess])
 
-  // The restricted-screening case is NOT repeated here — it already renders
-  // as its own alert banner under the recipient field.
   const blockReason = !amountValid
-    ? null // an untouched form needs no error banner; the disabled button is enough
+    ? null
     : overBalance
       ? `That's more ${symbol} than you have.`
-      : stableUnavailable
-        ? `No ${symbol} is configured on this network.`
-        : null
+      : null
+
+  const assetSelect = (
+    <UniversalAssetSelect
+      label="Currency"
+      options={options}
+      value={activeKey}
+      onChange={handleSelectAsset}
+      isGasless={isGasless}
+      disabled={busy}
+    />
+  )
+
+  // Bitcoin (spec 061) has its own amount/fee/send surface — swap the EVM body for
+  // the Bitcoin send panel, keeping the asset selector so the member can switch back.
+  if (isBitcoin) {
+    return (
+      <div className="fm-form fm-pay-form pay-panel">
+        <div className="fm-pay-hero fm-pay-hero-asset">
+          {assetSelect}
+        </div>
+        {!isConnected ? (
+          <div className="fm-success-actions">
+            <button type="button" className="fm-btn-primary" onClick={() => openConnectModal()}>
+              Connect wallet
+            </button>
+          </div>
+        ) : (
+          <BitcoinSendPanel btc={btc} usdPerBtc={null} onSent={onSuccess} />
+        )}
+      </div>
+    )
+  }
 
   if (confirming) {
     return (
@@ -201,10 +292,10 @@ function PayPanel({ onSuccess }) {
         <div className="pay-confirm" aria-live="polite">
           <div className="pay-confirm-amount">{amount} {symbol}</div>
           <div className="pay-confirm-row"><span className="k">To</span><span className="v">{short(toResolved)}</span></div>
-          <div className="pay-confirm-row"><span className="k">Network</span><span className="v">{tokens.networkName}</span></div>
+          <div className="pay-confirm-row"><span className="k">Network</span><span className="v">{selectedAsset?.networkName}</span></div>
           <div className="pay-confirm-row">
             <span className="k">Fee</span>
-            <span className="v">{gasless ? 'Gasless — no network fee' : `You pay the ${tokens.native} network fee`}</span>
+            <span className="v">{gasless ? 'Gasless — no network fee' : 'You pay the network fee'}</span>
           </div>
           {note && <div className="pay-confirm-row"><span className="k">Note</span><span className="v">{note}</span></div>}
         </div>
@@ -227,10 +318,9 @@ function PayPanel({ onSuccess }) {
 
   return (
     <div className="fm-form fm-pay-form pay-panel">
-      {/* Amount hero — the shared payments-style keypad; the currency dropdown
-          sits directly under the amount (in place of a static pill) and shows
-          the network's REAL symbols (honest state — no fake "USDC" on networks
-          without it). */}
+      {/* Amount hero — the shared payments-style keypad; the universal asset selector
+          sits directly under the amount (in place of the old native/stable pill) and
+          shows every held asset with its nested logo. */}
       <div className="fm-pay-hero">
         <AmountKeypad
           value={amount}
@@ -239,17 +329,8 @@ function PayPanel({ onSuccess }) {
           token={symbol}
           tokenSlot={(
             <>
-              <label className="sr-only" htmlFor="pay-token">Currency</label>
-              <select
-                id="pay-token"
-                className="fm-token-select fm-pay-token-select"
-                value={kind}
-                onChange={(e) => setKind(e.target.value)}
-                disabled={busy}
-              >
-                <option value={TRANSFER_KIND.STABLE}>{tokens.stable}</option>
-                <option value={TRANSFER_KIND.NATIVE}>{tokens.native}</option>
-              </select>
+              <span className="sr-only">Currency</span>
+              {assetSelect}
             </>
           )}
           disabled={busy}
@@ -263,14 +344,12 @@ function PayPanel({ onSuccess }) {
         <label className="fm-label" htmlFor="pay-to">To</label>
         <div className="fm-input-with-action">
           <div className="fm-address-input-wrap">
-            {/* No inline address-book addon — the icon button beside the field
-                is the single address-book affordance (design feedback). */}
             <AddressInput
               id="pay-to"
               value={toRaw}
               onChange={(e) => setToRaw(e.target.value)}
               onResolvedChange={(addr) => setToResolved(addr || '')}
-              chainId={connectedChainId}
+              chainId={assetChainId}
               placeholder="0x…, %callsign, or ENS name"
               disabled={busy}
             />
@@ -336,7 +415,7 @@ function PayPanel({ onSuccess }) {
           </button>
         ) : chainMismatch ? (
           <button type="button" className="fm-btn-primary" onClick={handleSwitch} disabled={switching || busy}>
-            {switching ? 'Switching…' : `Switch to ${pinnedNetworkName} to pay this request`}
+            {switching ? 'Switching…' : `Switch to ${switchTargetName} to pay`}
           </button>
         ) : (
           <button type="button" className="fm-btn-primary" onClick={() => setConfirming(true)} disabled={!canPay}>

--- a/frontend/src/components/fairwins/RequestPanel.jsx
+++ b/frontend/src/components/fairwins/RequestPanel.jsx
@@ -1,90 +1,112 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import AmountKeypad from '../ui/AmountKeypad'
 import RequestQRModal from './RequestQRModal'
+import UniversalAssetSelect from '../ui/UniversalAssetSelect'
 import { useWallet } from '../../hooks'
-import { useChainTokens } from '../../hooks/useChainTokens'
 import { useEffectiveAccount } from '../../hooks/useEffectiveAccount'
+import { useSelectableAssets } from '../../hooks/useSelectableAssets'
+import { useBitcoinWallet } from '../../hooks/useBitcoinWallet'
+import { formatBip21 } from '../../lib/bitcoin/addresses'
+import { ASSET_ACTIVITIES } from '../../lib/assets/assetActivity'
 import { getDefaultCurrencyKind } from '../../utils/homePreference'
 import { buildPaymentRequestUri, NOTE_MAX_LENGTH } from '../../lib/payments/paymentRequest'
 
 const shortAddr = (a) => (a && a.length > 10 ? `${a.slice(0, 6)}…${a.slice(-4)}` : a || '')
 
 /**
- * RequestPanel (spec 058 US2) — ask someone for value: the same amount hero +
- * note layout, and a "Request" action that builds a standard EIP-681 payment
- * request (recipient = the connected wallet's address, amount, currency,
- * network; the note rides as an additive `message` param). The QR is shown in
- * the shared branded QR dialog (RequestQRModal) — the same surface the app
- * uses for receive-address QRs — so the panel stays compact. Requests are
- * ephemeral — displayed, never persisted.
+ * RequestPanel (spec 058 US2 + spec 064 US2) — ask someone for value in ANY
+ * platform-supported asset the acting account holds, chosen with the universal asset
+ * selector (nested logos + network sub-badge). The "Request" action builds a standard
+ * payment request encoding the selected asset's identity: an EIP-681 URI for EVM
+ * assets (native `value=` or ERC-20 `/transfer` form), or a BIP-21 `bitcoin:` URI for
+ * a Bitcoin request. Requests are ephemeral — displayed, never persisted — and a shown
+ * request is invalidated whenever the selected asset or acting account changes so a
+ * stale QR can never point at the wrong asset/account (FR-010).
  *
- * Contract: specs/058-send-request-home/contracts/home-mode-components.md
+ * Contract: specs/064-universal-asset-selector/contracts/universal-asset-selector.md
  */
 function RequestPanel() {
   const { address: connectedAddress, isConnected, openConnectModal } = useWallet()
-  const tokens = useChainTokens()
   // Spec 063 (US1): the request must be addressed to the account the member is ACTING AS
-  // (a vault or recovered account), not always the connected wallet — otherwise funds land
-  // in the wrong account. Fall back to the connected wallet when no acting account is
-  // selected (the effective address is only absent when truly disconnected).
+  // (a vault or recovered account), not always the connected wallet.
   const { address: effectiveAddress, isActingAccount, label: actingLabel, type: actingType } = useEffectiveAccount()
   const address = effectiveAddress || connectedAddress
 
-  const [kind, setKindState] = useState(getDefaultCurrencyKind)
+  const actingAddress = isActingAccount ? effectiveAddress : null
+  const { options, defaultKey } = useSelectableAssets({ activity: ASSET_ACTIVITIES.REQUEST, actingAddress })
+  const btc = useBitcoinWallet()
+
+  const [selectedKey, setSelectedKey] = useState(null)
   const [amount, setAmountState] = useState('')
   const [note, setNoteState] = useState('')
-  const [generated, setGenerated] = useState(null) // { uri, note, amount, symbol, address, chainId } | null
+  const [generated, setGenerated] = useState(null) // { uri, note, amount, symbol, accountKey, assetKey } | null
   const [formError, setFormError] = useState(null)
 
-  const symbol = kind === 'stable' ? tokens.stable : tokens.native
+  // Preference-aware default (spec 058): 'native' preselects the connected native
+  // coin, else the activity default (connected stablecoin). The member's pick wins.
+  const preferredDefaultKey = useMemo(() => {
+    if (getDefaultCurrencyKind() === 'native') {
+      const nativeOpt = options.find((o) => o.kind === 'native')
+      if (nativeOpt) return nativeOpt.key
+    }
+    return defaultKey
+  }, [options, defaultKey])
+
+  const activeKey = selectedKey && options.some((o) => o.key === selectedKey) ? selectedKey : preferredDefaultKey
+  const selectedAsset = options.find((o) => o.key === activeKey) || null
+  const symbol = selectedAsset?.symbol || ''
+  const isBitcoin = selectedAsset?.kind === 'btc-native'
+
   const amountValid = Number.isFinite(Number(amount)) && Number(amount) > 0
-  const stableUnavailable = kind === 'stable' && !tokens.stableAddress
 
-  // A generated request is only valid for the wallet + network it was built
-  // for: if the user switches account or chain while the modal is open, the
-  // guard nulls it out so the QR can never pay the previous address/network.
-  const safeGenerated = generated && generated.address === address && generated.chainId === tokens.chainId
-    ? generated
-    : null
+  // A generated request is only valid for the acting account + asset it was built
+  // for: any change nulls it so the QR can never pay the previous address/asset.
+  const safeGenerated =
+    generated && generated.accountKey === address && generated.assetKey === activeKey ? generated : null
 
-  // Any input change invalidates a displayed code (belt-and-braces alongside
-  // the modal's focus trap, so a stale QR is never shown after an edit).
-  const setKind = useCallback((v) => { setKindState(v); setGenerated(null); setFormError(null) }, [])
+  // Any input change invalidates a displayed code (belt-and-braces alongside the
+  // modal's focus trap, so a stale QR is never shown after an edit).
   const setAmount = useCallback((v) => { setAmountState(v); setGenerated(null); setFormError(null) }, [])
   const setNote = useCallback((v) => { setNoteState(v); setGenerated(null); setFormError(null) }, [])
+  const handleSelectAsset = useCallback((option) => {
+    setSelectedKey(option.key); setGenerated(null); setFormError(null)
+  }, [])
 
   const handleRequest = useCallback(() => {
     setFormError(null)
+    if (!selectedAsset) { setFormError('Pick an asset to request.'); return }
     try {
+      if (isBitcoin) {
+        // BIP-21 request against a freshly issued receive address (never reused).
+        if (btc.status !== 'ready') {
+          setFormError('Your Bitcoin wallet is not ready — unlock it to request BTC.')
+          return
+        }
+        const entry = btc.receive?.nextReceiveAddress?.()
+        const btcAddress = entry?.address
+        if (!btcAddress) { setFormError('Could not get a Bitcoin receive address.'); return }
+        const amountSats = Math.round(Number(amount) * 1e8)
+        const uri = formatBip21(btcAddress, { amountSats, label: note?.trim() || undefined })
+        setGenerated({ uri, note: note.trim(), amount, symbol, accountKey: address, assetKey: activeKey })
+        return
+      }
+      // EVM: native `value=` form, or the `/transfer` form for any ERC-20.
       const uri = buildPaymentRequestUri({
-        chainId: tokens.chainId,
+        chainId: selectedAsset.chainId,
         to: address,
-        kind,
-        tokenAddress: tokens.stableAddress,
-        decimals: kind === 'stable' ? tokens.stableDecimals : tokens.nativeDecimals,
+        kind: selectedAsset.kind === 'native' ? 'native' : 'stable',
+        tokenAddress: selectedAsset.address,
+        decimals: selectedAsset.decimals,
         amount,
         note,
       })
-      setGenerated({ uri, note: note.trim(), amount, symbol, address, chainId: tokens.chainId })
+      setGenerated({ uri, note: note.trim(), amount, symbol, accountKey: address, assetKey: activeKey })
     } catch (err) {
       setFormError(err?.message || 'Could not create the request.')
     }
-  }, [tokens, address, kind, amount, note, symbol])
+  }, [selectedAsset, isBitcoin, btc, amount, note, symbol, address, activeKey])
 
-  const currencySelect = (
-    <>
-      <label className="sr-only" htmlFor="request-token">Currency</label>
-      <select
-        id="request-token"
-        className="fm-token-select fm-pay-token-select"
-        value={kind}
-        onChange={(e) => setKind(e.target.value)}
-      >
-        <option value="stable">{tokens.stable}</option>
-        <option value="native">{tokens.native}</option>
-      </select>
-    </>
-  )
+  const requestDisabled = !amountValid || !selectedAsset || (isBitcoin && btc.status !== 'ready')
 
   return (
     <div className="fm-form fm-pay-form request-panel">
@@ -94,7 +116,18 @@ function RequestPanel() {
           onChange={setAmount}
           prefix="$"
           token={symbol}
-          tokenSlot={currencySelect}
+          tokenSlot={(
+            <>
+              <span className="sr-only">Currency</span>
+              <UniversalAssetSelect
+                label="Currency"
+                options={options}
+                value={activeKey}
+                onChange={handleSelectAsset}
+                disabled={false}
+              />
+            </>
+          )}
           ariaLabel="Amount to request"
           id="request-amount"
         />
@@ -119,9 +152,14 @@ function RequestPanel() {
           {actingLabel ? ` · ${actingLabel}` : ` · ${shortAddr(address)}`}
         </p>
       )}
+      {isBitcoin && (
+        <p className="fm-pay-acting-note" role="note">
+          Paid to a fresh Bitcoin address on {selectedAsset?.networkName || 'Bitcoin'}.
+        </p>
+      )}
 
-      {stableUnavailable && (
-        <div className="fm-error-banner" role="alert">No {symbol} is configured on this network.</div>
+      {isBitcoin && btc.status !== 'ready' && (
+        <div className="fm-error-banner" role="alert">Unlock your Bitcoin wallet to request BTC.</div>
       )}
       {formError && <div className="fm-error-banner" role="alert">{formError}</div>}
 
@@ -135,7 +173,7 @@ function RequestPanel() {
             type="button"
             className="fm-btn-primary"
             onClick={handleRequest}
-            disabled={!amountValid || stableUnavailable}
+            disabled={requestDisabled}
           >
             Request
           </button>

--- a/frontend/src/components/fairwins/__tests__/OpenChallengeModal.norecover.test.jsx
+++ b/frontend/src/components/fairwins/__tests__/OpenChallengeModal.norecover.test.jsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
+// Spec 064: the create panel's stake selector needs the portfolio graph; stub the
+// data hook so this provider-light test stays isolated (real selector still renders).
+vi.mock('../../../hooks/useSelectableAssets', async () => await import('../../../test/helpers/selectableAssetsMock'))
+
 // The modal renders MakerPanel by default; mock its create hook so it renders without a chain.
 vi.mock('../../../hooks/useOpenChallengeCreate', async (importOriginal) => {
   const actual = await importOriginal()

--- a/frontend/src/components/ui/README.md
+++ b/frontend/src/components/ui/README.md
@@ -340,6 +340,43 @@ import { HelperText } from '@/components/ui'
 
 ---
 
+### UniversalAssetSelect
+
+The single reusable asset picker for the home **Pay / Request / Wager** surfaces and
+the wallet **Transfer** ("trade") view (spec 064). Each option renders the Earn-page
+nested `AssetLogo` (asset glyph + network sub-badge), the symbol, its network, the held
+balance, and a ⚡ marker when the asset is gasless on its network — so a member can
+distinguish two same-symbol assets on different networks at a glance.
+
+Purely presentational: it renders whatever activity-scoped `options` it is given and
+never derives the asset list, eligibility, or routing.
+
+**Props:**
+- `options` (SelectableAsset[]): already activity-scoped list (from `useSelectableAssets`)
+- `value` (string): selected option `key`
+- `onChange` (fn): called with the full selected option
+- `isGasless` (fn): `(option) => boolean` for the per-row ⚡ marker (Bitcoin always false)
+- `disabled` (bool), `label` (string, default `'Asset'`), `size` (number, logo px)
+
+**Data + activity scoping:**
+- `hooks/useSelectableAssets({ activity, actingAddress })` builds the option list from the
+  acting account's cross-network portfolio (personal / vault / recovered legacy).
+- `lib/assets/assetActivity.js` holds the **activity capability profiles**: `pay`,
+  `request`, and `transfer` allow every asset kind **including non-EVM Bitcoin**; `wager`
+  is EVM **ERC-20 only** (the escrow pulls the stake via `transferFrom`, so the native
+  coin and Bitcoin are excluded by list construction — never a submit-time failure).
+- An asset on a network other than the connected one is **switch-gated** by the consuming
+  panel; the component itself stays presentational.
+
+**Accessibility Features:**
+- `role="listbox"` / `role="option"` with `aria-selected`; keyboard operable
+  (Enter/Space to toggle, Escape and outside-click to close)
+- The nested logo is decorative (`aria-hidden`); symbol + network text always carry the
+  meaning, so the logo is never the sole information channel
+- Balances still loading render a pending indicator, never a fake `0`
+
+---
+
 ## Design System Integration
 
 All components use CSS custom properties from the brand design system:

--- a/frontend/src/components/ui/UniversalAssetSelect.css
+++ b/frontend/src/components/ui/UniversalAssetSelect.css
@@ -1,0 +1,133 @@
+/* UniversalAssetSelect (spec 064) — reusable nested-logo asset dropdown.
+   Theme-aware via the app's CSS custom properties; dark mode inherits them. */
+
+.uas-select {
+  position: relative;
+  width: 100%;
+}
+
+.uas-trigger {
+  align-items: center;
+  background: var(--input-bg, var(--bg-secondary, #fff));
+  border: 1px solid var(--border-color, #d5dbe1);
+  border-radius: 12px;
+  color: var(--text-primary, #14181d);
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+  padding: 8px 12px;
+  width: 100%;
+}
+.uas-trigger:hover:not(:disabled) {
+  border-color: var(--accent-color, #36b37e);
+}
+.uas-trigger:focus-visible {
+  outline: 2px solid var(--accent-color, #36b37e);
+  outline-offset: 1px;
+}
+.uas-trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.uas-current {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  min-width: 0;
+}
+.uas-current-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  text-align: left;
+}
+.uas-sym {
+  font-weight: 700;
+  line-height: 1.2;
+}
+.uas-sub {
+  color: var(--text-secondary, #67727e);
+  font-size: 0.8rem;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.uas-chevron {
+  color: var(--text-secondary, #67727e);
+  flex: none;
+}
+.uas-pending {
+  color: var(--text-secondary, #67727e);
+}
+
+.uas-list {
+  background: var(--surface-color, var(--bg-secondary, #fff));
+  border: 1px solid var(--border-color, #d5dbe1);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  list-style: none;
+  margin: 6px 0 0;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 6px;
+  position: absolute;
+  width: 100%;
+  z-index: 30;
+}
+.uas-li {
+  margin: 0;
+}
+.uas-option {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 10px;
+  color: var(--text-primary, #14181d);
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  padding: 8px 10px;
+  text-align: left;
+  width: 100%;
+}
+.uas-option:hover,
+.uas-option:focus-visible {
+  background: var(--hover-bg, rgba(54, 179, 126, 0.1));
+  outline: none;
+}
+.uas-option.active {
+  background: var(--accent-soft, rgba(54, 179, 126, 0.16));
+}
+.uas-option-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+.uas-option-top {
+  align-items: center;
+  display: flex;
+  gap: 6px;
+}
+.uas-option-sub {
+  color: var(--text-secondary, #67727e);
+  display: flex;
+  font-size: 0.8rem;
+  gap: 8px;
+  justify-content: space-between;
+}
+.uas-network {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.uas-bal {
+  flex: none;
+}
+.uas-gasless {
+  color: var(--accent-color, #36b37e);
+  font-size: 0.85rem;
+}

--- a/frontend/src/components/ui/UniversalAssetSelect.jsx
+++ b/frontend/src/components/ui/UniversalAssetSelect.jsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import AssetLogo from '../wallet/AssetLogo'
+import SensitiveValue from '../common/SensitiveValue'
+import './UniversalAssetSelect.css'
+
+/**
+ * UniversalAssetSelect (spec 064) — one reusable asset dropdown for the home
+ * Pay/Request/Wager surfaces AND the wallet Transfer ("trade") view. Each option
+ * carries the Earn-page NESTED asset logo (the asset glyph + its network sub-badge,
+ * via the shared AssetLogo artwork) so a member can tell at a glance WHAT the asset
+ * is and WHICH chain it lives on — the core of this feature (FR-003).
+ *
+ * Purely presentational (FR-001): it renders whatever activity-scoped `options` the
+ * caller passes (built by useSelectableAssets) and never derives eligibility, the
+ * asset list, or routing. Gasless truth is passed in via `isGasless` so this
+ * component never re-derives it (FR-005).
+ *
+ * Accessible (FR-015): listbox/option roles, keyboard operable, and the decorative
+ * logo is aria-hidden — the symbol + network text always carry the meaning.
+ */
+
+/** AssetLogo only badges numeric EVM chains; a Bitcoin option (string id) renders its glyph alone. */
+const evmBadgeChainId = (chainId) => (typeof chainId === 'number' ? chainId : null)
+
+export default function UniversalAssetSelect({
+  options = [],
+  value,
+  onChange,
+  isGasless = () => false,
+  disabled = false,
+  label = 'Asset',
+  size = 28,
+}) {
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef(null)
+
+  const selected = options.find((o) => o.key === value) || options[0] || null
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onDocClick = (e) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false)
+    }
+    const onKey = (e) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const handleSelect = useCallback(
+    (option) => {
+      onChange?.(option)
+      setOpen(false)
+    },
+    [onChange],
+  )
+
+  const renderBalance = (option) =>
+    option?.balance == null ? (
+      <span className="uas-pending" aria-label="balance loading">…</span>
+    ) : (
+      <SensitiveValue>{option.balance}</SensitiveValue>
+    )
+
+  return (
+    <div className="uas-select" ref={wrapRef}>
+      <button
+        type="button"
+        className="uas-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={label}
+        disabled={disabled || options.length === 0}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {selected ? (
+          <span className="uas-current">
+            <AssetLogo
+              symbol={selected.symbol}
+              chainId={evmBadgeChainId(selected.chainId)}
+              showBadge
+              size={size}
+            />
+            <span className="uas-current-text">
+              <span className="uas-sym">{selected.symbol}</span>
+              <span className="uas-sub">
+                {selected.networkName} · Balance: {renderBalance(selected)}
+              </span>
+            </span>
+          </span>
+        ) : (
+          <span className="uas-sub">No assets available</span>
+        )}
+        <span className="uas-chevron" aria-hidden="true">▾</span>
+      </button>
+
+      {open && options.length > 0 && (
+        <ul className="uas-list" role="listbox" aria-label={label}>
+          {options.map((option) => (
+            <li key={option.key} className="uas-li">
+              <button
+                type="button"
+                role="option"
+                aria-selected={option.key === selected?.key}
+                className={`uas-option ${option.key === selected?.key ? 'active' : ''}`}
+                onClick={() => handleSelect(option)}
+              >
+                <AssetLogo
+                  symbol={option.symbol}
+                  chainId={evmBadgeChainId(option.chainId)}
+                  showBadge
+                  size={size}
+                />
+                <span className="uas-option-body">
+                  <span className="uas-option-top">
+                    <span className="uas-sym">{option.symbol}</span>
+                    {isGasless(option) && (
+                      <span className="uas-gasless" title="Gasless on this network" aria-label="gasless">⚡</span>
+                    )}
+                  </span>
+                  <span className="uas-option-sub">
+                    <span className="uas-network">{option.networkName}</span>
+                    <span className="uas-bal">Balance: {renderBalance(option)}</span>
+                  </span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/__tests__/UniversalAssetSelect.test.jsx
+++ b/frontend/src/components/ui/__tests__/UniversalAssetSelect.test.jsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import UniversalAssetSelect from '../UniversalAssetSelect'
+
+// SensitiveValue reads a privacy context — stub it to render children verbatim.
+vi.mock('../../common/SensitiveValue', () => ({
+  default: ({ children }) => <span>{children}</span>,
+}))
+// AssetLogo renders inline SVG; stub to a testable marker carrying its props.
+vi.mock('../../wallet/AssetLogo', () => ({
+  default: ({ symbol, chainId }) => (
+    <span data-testid="asset-logo" data-symbol={symbol} data-chain={String(chainId)} aria-hidden="true" />
+  ),
+}))
+
+const USDC = '0x2791bca1f2de4661ed88a30c99a7a9449aa84174'
+const OPTIONS = [
+  { key: '137:native', chainId: 137, kind: 'native', symbol: 'MATIC', networkName: 'Polygon', balance: 5 },
+  { key: `137:${USDC}`, chainId: 137, kind: 'erc20', address: USDC, symbol: 'USDC', networkName: 'Polygon', balance: 100 },
+  { key: '1:0xwbtc', chainId: 1, kind: 'erc20', address: '0xwbtc', symbol: 'WBTC', networkName: 'Ethereum', balance: null },
+  { key: 'bitcoin:native', chainId: 'bitcoin', kind: 'btc-native', symbol: 'BTC', networkName: 'Bitcoin', balance: 0.25 },
+]
+
+describe('UniversalAssetSelect', () => {
+  it('renders the selected asset with a nested logo and network', () => {
+    render(<UniversalAssetSelect options={OPTIONS} value="137:native" onChange={() => {}} />)
+    const trigger = screen.getByRole('button', { name: 'Asset' })
+    expect(within(trigger).getByTestId('asset-logo')).toHaveAttribute('data-symbol', 'MATIC')
+    expect(trigger).toHaveTextContent('Polygon')
+  })
+
+  it('opens a listbox with one nested logo per option and symbol+network text', async () => {
+    const user = userEvent.setup()
+    render(<UniversalAssetSelect options={OPTIONS} value="137:native" onChange={() => {}} />)
+    await user.click(screen.getByRole('button', { name: 'Asset' }))
+    const list = screen.getByRole('listbox')
+    const opts = within(list).getAllByRole('option')
+    expect(opts).toHaveLength(4)
+    // Each option row shows a nested logo + its symbol + network.
+    expect(within(list).getAllByTestId('asset-logo')).toHaveLength(4)
+    expect(within(list).getByText('WBTC')).toBeInTheDocument()
+    expect(within(list).getByText('Ethereum')).toBeInTheDocument()
+  })
+
+  it('passes an EVM chainId to the logo but null for a Bitcoin (string-id) option', async () => {
+    const user = userEvent.setup()
+    render(<UniversalAssetSelect options={OPTIONS} value="137:native" onChange={() => {}} />)
+    await user.click(screen.getByRole('button', { name: 'Asset' }))
+    const list = screen.getByRole('listbox')
+    const logos = within(list).getAllByTestId('asset-logo')
+    const btc = logos.find((l) => l.getAttribute('data-symbol') === 'BTC')
+    const usdc = logos.find((l) => l.getAttribute('data-symbol') === 'USDC')
+    expect(btc).toHaveAttribute('data-chain', 'null')
+    expect(usdc).toHaveAttribute('data-chain', '137')
+  })
+
+  it('shows a pending indicator (not 0) for a null balance', async () => {
+    const user = userEvent.setup()
+    render(<UniversalAssetSelect options={OPTIONS} value="137:native" onChange={() => {}} />)
+    await user.click(screen.getByRole('button', { name: 'Asset' }))
+    const wbtcOption = screen.getByRole('option', { name: /WBTC/ })
+    expect(within(wbtcOption).getByLabelText('balance loading')).toBeInTheDocument()
+    expect(wbtcOption).not.toHaveTextContent('Balance: 0')
+  })
+
+  it('marks only gasless options with ⚡', async () => {
+    const user = userEvent.setup()
+    const isGasless = (o) => Number(o.chainId) === 137
+    render(<UniversalAssetSelect options={OPTIONS} value="137:native" onChange={() => {}} isGasless={isGasless} />)
+    await user.click(screen.getByRole('button', { name: 'Asset' }))
+    expect(screen.getAllByLabelText('gasless')).toHaveLength(2) // MATIC + USDC on Polygon
+  })
+
+  it('fires onChange with the full option and closes on select', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<UniversalAssetSelect options={OPTIONS} value="137:native" onChange={onChange} />)
+    await user.click(screen.getByRole('button', { name: 'Asset' }))
+    await user.click(screen.getByRole('option', { name: /USDC/ }))
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ key: `137:${USDC}`, symbol: 'USDC' }))
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('closes on Escape', async () => {
+    const user = userEvent.setup()
+    render(<UniversalAssetSelect options={OPTIONS} value="137:native" onChange={() => {}} />)
+    await user.click(screen.getByRole('button', { name: 'Asset' }))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('disables the trigger and shows an empty state when there are no options', () => {
+    render(<UniversalAssetSelect options={[]} onChange={() => {}} />)
+    const trigger = screen.getByRole('button', { name: 'Asset' })
+    expect(trigger).toBeDisabled()
+    expect(trigger).toHaveTextContent('No assets available')
+  })
+})

--- a/frontend/src/components/wallet/TransferAssetSelect.jsx
+++ b/frontend/src/components/wallet/TransferAssetSelect.jsx
@@ -1,12 +1,16 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import SensitiveValue from '../common/SensitiveValue'
+import UniversalAssetSelect from '../ui/UniversalAssetSelect'
 
 /**
- * Asset picker for the Transfer form — a dropdown of every transferable asset in the connected account's
- * cross-network portfolio (spec: "the assets should be a dropdown of all assets from the portfolio").
- * Each row shows the symbol, its network, and the held balance; a ⚡ marks assets whose network is
- * configured for gasless sends. Purely presentational: eligibility + gasless truth are decided by the
- * caller (useTransfer) and passed in, so this component never re-derives routing.
+ * Asset picker for the Transfer ("trade") form. As of spec 064 this is a thin wrapper
+ * over the shared UniversalAssetSelect, so the Transfer view lists the SAME
+ * cross-network portfolio assets it always has — now each shown with the nested asset
+ * logo (glyph + network sub-badge) that the Earn page and the home Pay/Request/Wager
+ * selectors use. Behavior is unchanged: eligibility + per-asset gasless truth are
+ * decided by the caller (useTransfer) and passed in; this component never re-derives
+ * routing.
+ *
+ * Kept as a named component (rather than deleting it) so existing call sites and their
+ * accessible label ("Asset to send") are untouched.
  */
 export default function TransferAssetSelect({
   options = [],
@@ -15,86 +19,14 @@ export default function TransferAssetSelect({
   isGasless = () => false,
   disabled = false,
 }) {
-  const [open, setOpen] = useState(false)
-  const wrapRef = useRef(null)
-
-  const selected = options.find((o) => o.key === value) || options[0] || null
-
-  useEffect(() => {
-    if (!open) return undefined
-    const onDocClick = (e) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false)
-    }
-    const onKey = (e) => {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', onDocClick)
-    document.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('mousedown', onDocClick)
-      document.removeEventListener('keydown', onKey)
-    }
-  }, [open])
-
-  const handleSelect = useCallback(
-    (option) => {
-      onChange?.(option)
-      setOpen(false)
-    },
-    [onChange],
-  )
-
-  const renderBalance = (option) =>
-    option?.balance == null ? '…' : <SensitiveValue>{option.balance}</SensitiveValue>
-
   return (
-    <div className="pt-select" ref={wrapRef}>
-      <button
-        type="button"
-        className="pt-select-trigger"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-label="Asset to send"
-        disabled={disabled || options.length === 0}
-        onClick={() => setOpen((o) => !o)}
-      >
-        {selected ? (
-          <span className="pt-select-current">
-            <span className="pt-select-sym">{selected.symbol}</span>
-            <span className="pt-select-sub">
-              {selected.networkName} · Balance: {renderBalance(selected)}
-            </span>
-          </span>
-        ) : (
-          <span className="pt-select-sub">No transferable assets</span>
-        )}
-        <span className="pt-select-chevron" aria-hidden="true">▾</span>
-      </button>
-
-      {open && options.length > 0 && (
-        <ul className="pt-select-list" role="listbox" aria-label="Assets">
-          {options.map((option) => (
-            <li key={option.key} className="pt-select-li">
-              <button
-                type="button"
-                role="option"
-                aria-selected={option.key === selected?.key}
-                className={`pt-select-option ${option.key === selected?.key ? 'active' : ''}`}
-                onClick={() => handleSelect(option)}
-              >
-                <span className="pt-select-sym">{option.symbol}</span>
-                <span className="pt-select-option-meta">
-                  <span className="pt-select-network">{option.networkName}</span>
-                  {isGasless(option) && (
-                    <span className="pt-select-gasless" title="Gasless on this network">⚡</span>
-                  )}
-                </span>
-                <span className="pt-select-bal">Balance: {renderBalance(option)}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
+    <UniversalAssetSelect
+      label="Asset to send"
+      options={options}
+      value={value}
+      onChange={onChange}
+      isGasless={isGasless}
+      disabled={disabled}
+    />
   )
 }

--- a/frontend/src/hooks/__tests__/useSelectableAssets.test.jsx
+++ b/frontend/src/hooks/__tests__/useSelectableAssets.test.jsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useSelectableAssets } from '../useSelectableAssets'
+import { ASSET_ACTIVITIES } from '../../lib/assets/assetActivity'
+
+// --- mocked data sources (mutated per test) ---------------------------------
+const USDC = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'
+const WBTC1 = '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'
+
+let portfolioHoldings = []
+let vaultHoldings = []
+let btcState = { status: 'idle', networkId: null, balances: { spendableSats: 0 } }
+
+const balanceOf = (kind) => (kind === 'stable' ? '100' : '5')
+const quoteGaslessForAsset = (asset) => Number(asset?.chainId) === 137
+
+vi.mock('../useWalletManagement', () => ({
+  useWallet: () => ({ address: '0xAaAa000000000000000000000000000000000001', chainId: 137 }),
+}))
+vi.mock('../useChainTokens', () => ({
+  useChainTokens: () => ({
+    chainId: 137, networkName: 'Polygon',
+    native: 'MATIC', nativeName: 'Polygon', nativeDecimals: 18,
+    stable: 'USDC', stableName: 'USD Coin', stableDecimals: 6, stableAddress: USDC,
+  }),
+}))
+vi.mock('../useBitcoinWallet', () => ({ useBitcoinWallet: () => btcState }))
+vi.mock('../usePortfolio', () => ({ default: () => ({ holdings: portfolioHoldings, status: 'ready' }) }))
+vi.mock('../useAccountAssets', () => ({ useAccountAssets: () => ({ holdings: vaultHoldings, refresh: vi.fn() }) }))
+vi.mock('../useTransfer', () => ({
+  TRANSFER_KIND: { NATIVE: 'native', STABLE: 'stable' },
+  useTransfer: () => ({ balanceOf, quoteGaslessForAsset }),
+}))
+vi.mock('../../config/bitcoinNetworks', () => ({
+  getBitcoinNetwork: (id) => (id === 'bitcoin' ? { id: 'bitcoin', name: 'Bitcoin', isTestnet: false } : null),
+}))
+
+const holding = (over) => ({
+  asset: {
+    kind: 'erc20', id: over.address, address: over.address, symbol: over.symbol,
+    name: over.name || over.symbol, decimals: over.decimals ?? 18, chainId: over.chainId ?? 137,
+  },
+  balance: over.balance ?? 0,
+  network: over.network || 'Polygon',
+})
+
+beforeEach(() => {
+  portfolioHoldings = []
+  vaultHoldings = []
+  btcState = { status: 'idle', networkId: null, balances: { spendableSats: 0 } }
+})
+
+describe('useSelectableAssets — assembly', () => {
+  it('always includes the connected native + stablecoin even before holdings load', () => {
+    const { result } = renderHook(() => useSelectableAssets({ activity: ASSET_ACTIVITIES.PAY }))
+    const keys = result.current.options.map((o) => o.key)
+    expect(keys).toContain('137:native')
+    expect(keys).toContain(`137:${USDC.toLowerCase()}`)
+  })
+
+  it('merges held holdings and drops non-stable zero-balance rows', () => {
+    portfolioHoldings = [
+      holding({ address: WBTC1, symbol: 'WBTC', decimals: 8, chainId: 137, balance: 0.5 }),
+      holding({ address: '0xzero', symbol: 'ZERO', chainId: 137, balance: 0 }),
+    ]
+    const { result } = renderHook(() => useSelectableAssets({ activity: ASSET_ACTIVITIES.PAY }))
+    const syms = result.current.options.map((o) => o.symbol)
+    expect(syms).toContain('WBTC')
+    expect(syms).not.toContain('ZERO')
+  })
+
+  it('sorts connected-chain assets before off-chain ones', () => {
+    portfolioHoldings = [holding({ address: WBTC1, symbol: 'WBTC', decimals: 8, chainId: 1, balance: 2, network: 'Ethereum' })]
+    const { result } = renderHook(() => useSelectableAssets({ activity: ASSET_ACTIVITIES.PAY }))
+    const chains = result.current.options.map((o) => o.chainId)
+    // every 137 option precedes the first 1 option
+    const firstOffChain = chains.indexOf(1)
+    expect(firstOffChain).toBeGreaterThan(-1)
+    expect(chains.slice(0, firstOffChain).every((c) => c === 137)).toBe(true)
+  })
+})
+
+describe('useSelectableAssets — Bitcoin scoping', () => {
+  it('includes native Bitcoin for pay when the BTC wallet is ready + personal', () => {
+    btcState = { status: 'ready', networkId: 'bitcoin', balances: { spendableSats: 150000000 } }
+    const { result } = renderHook(() => useSelectableAssets({ activity: ASSET_ACTIVITIES.PAY }))
+    const btc = result.current.options.find((o) => o.kind === 'btc-native')
+    expect(btc).toBeTruthy()
+    expect(btc.balance).toBeCloseTo(1.5)
+    expect(result.current.isGasless(btc)).toBe(false) // BTC never gasless
+  })
+
+  it('excludes Bitcoin from the wager activity (EVM ERC-20 escrow only)', () => {
+    btcState = { status: 'ready', networkId: 'bitcoin', balances: { spendableSats: 150000000 } }
+    const { result } = renderHook(() => useSelectableAssets({ activity: ASSET_ACTIVITIES.WAGER }))
+    expect(result.current.options.some((o) => o.kind === 'btc-native')).toBe(false)
+    expect(result.current.options.some((o) => o.kind === 'native')).toBe(false)
+    expect(result.current.options.every((o) => o.kind === 'erc20')).toBe(true)
+  })
+
+  it('does not include Bitcoin when acting as a vault/legacy account', () => {
+    btcState = { status: 'ready', networkId: 'bitcoin', balances: { spendableSats: 150000000 } }
+    const { result } = renderHook(() =>
+      useSelectableAssets({ activity: ASSET_ACTIVITIES.PAY, actingAddress: '0xVault' }),
+    )
+    expect(result.current.options.some((o) => o.kind === 'btc-native')).toBe(false)
+  })
+})
+
+describe('useSelectableAssets — acting account + gasless + default', () => {
+  it('lists the acting account holdings when actingAddress is set', () => {
+    vaultHoldings = [holding({ address: WBTC1, symbol: 'WBTC', decimals: 8, chainId: 137, balance: 3 })]
+    const { result } = renderHook(() =>
+      useSelectableAssets({ activity: ASSET_ACTIVITIES.PAY, actingAddress: '0xVault' }),
+    )
+    expect(result.current.options.some((o) => o.symbol === 'WBTC')).toBe(true)
+  })
+
+  it('gasless quote is delegated per-asset (Polygon gasless, Ethereum not)', () => {
+    portfolioHoldings = [holding({ address: WBTC1, symbol: 'WBTC', decimals: 8, chainId: 1, balance: 1, network: 'Ethereum' })]
+    const { result } = renderHook(() => useSelectableAssets({ activity: ASSET_ACTIVITIES.PAY }))
+    const poly = result.current.options.find((o) => o.chainId === 137 && o.kind === 'native')
+    const eth = result.current.options.find((o) => o.chainId === 1)
+    expect(result.current.isGasless(poly)).toBe(true)
+    expect(result.current.isGasless(eth)).toBe(false)
+  })
+
+  it('defaults to the connected stablecoin', () => {
+    const { result } = renderHook(() => useSelectableAssets({ activity: ASSET_ACTIVITIES.PAY }))
+    expect(result.current.defaultKey).toBe(`137:${USDC.toLowerCase()}`)
+  })
+})

--- a/frontend/src/hooks/useSelectableAssets.js
+++ b/frontend/src/hooks/useSelectableAssets.js
@@ -1,0 +1,145 @@
+import { useCallback, useMemo } from 'react'
+import { useTransfer, TRANSFER_KIND } from './useTransfer'
+import { useWallet } from './useWalletManagement'
+import { useChainTokens } from './useChainTokens'
+import { useBitcoinWallet } from './useBitcoinWallet'
+import usePortfolio from './usePortfolio'
+import { useAccountAssets } from './useAccountAssets'
+import { getBitcoinNetwork } from '../config/bitcoinNetworks'
+import { filterAssetsForActivity, defaultAssetKey } from '../lib/assets/assetActivity'
+
+const toNum = (v) => (v == null || v === '' ? null : Number(v))
+
+/**
+ * useSelectableAssets (spec 064) — the shared, activity-scoped, acting-account-aware
+ * asset option list behind the Universal Asset Selector. It generalizes the
+ * `assetOptions` assembly previously inlined in the wallet Transfer form so the home
+ * Pay/Request/Wager surfaces and the Transfer ("trade") view all list an identical
+ * asset set (FR-001, FR-002).
+ *
+ * Data sources (never new network reads — this is a pure memo over already-fetched
+ * state):
+ *   - the connected chain's native + stablecoin (always present, even at zero
+ *     balance, so a form is usable before balances load);
+ *   - native Bitcoin (spec 061) when the passkey BTC wallet is ready AND the acting
+ *     account is personal (custody vaults / recovered EOAs are EVM and can't hold BTC);
+ *   - every native/erc20 holding of the ACTING source — personal `usePortfolio`, or
+ *     `useAccountAssets(actingAddress)` for a vault / recovered legacy account.
+ *
+ * The list is then filtered by the activity's capability profile (FR-008): Bitcoin
+ * and the native coin drop out of `wager` (EVM ERC-20 escrow only), etc.
+ *
+ * Routing is NOT re-derived here: `isGasless(option)` delegates to the send engine's
+ * per-asset quote (Bitcoin forced false — never gasless, FR-005).
+ *
+ * @param {{ activity: 'pay'|'request'|'wager'|'transfer', actingAddress?: string|null }} params
+ * @returns {{ options: object[], defaultKey: string|null, isGasless: (o:object)=>boolean }}
+ */
+export function useSelectableAssets({ activity, actingAddress = null } = {}) {
+  const { chainId } = useWallet()
+  const { balanceOf, quoteGaslessForAsset } = useTransfer()
+  const tokens = useChainTokens()
+  const btc = useBitcoinWallet()
+  const portfolio = usePortfolio()
+  const actingAssets = useAccountAssets(actingAddress)
+
+  const connectedChainId = Number(tokens.chainId ?? chainId)
+
+  const isConnectedStableAddr = useCallback(
+    (addr) => Boolean(addr && tokens.stableAddress && addr.toLowerCase() === tokens.stableAddress.toLowerCase()),
+    [tokens.stableAddress],
+  )
+
+  // The full (pre-activity-filter) option list — mirrors TransferForm.assetOptions.
+  const allOptions = useMemo(() => {
+    const byKey = new Map()
+    const put = (opt) => byKey.set(opt.key, { ...(byKey.get(opt.key) || {}), ...opt })
+
+    if (tokens.native) {
+      put({
+        key: `${connectedChainId}:native`,
+        chainId: connectedChainId,
+        kind: 'native',
+        address: null,
+        symbol: tokens.native,
+        name: tokens.nativeName,
+        decimals: tokens.nativeDecimals,
+        networkName: tokens.networkName,
+        balance: actingAddress ? null : toNum(balanceOf(TRANSFER_KIND.NATIVE)),
+      })
+    }
+    if (tokens.stableAddress) {
+      put({
+        key: `${connectedChainId}:${tokens.stableAddress.toLowerCase()}`,
+        chainId: connectedChainId,
+        kind: 'erc20',
+        address: tokens.stableAddress,
+        symbol: tokens.stable,
+        name: tokens.stableName,
+        decimals: tokens.stableDecimals,
+        networkName: tokens.networkName,
+        balance: actingAddress ? null : toNum(balanceOf(TRANSFER_KIND.STABLE)),
+      })
+    }
+
+    // Native Bitcoin — personal wallet only. Balance is the SPENDABLE amount.
+    if (!actingAddress && btc.status === 'ready') {
+      put({
+        key: 'bitcoin:native',
+        chainId: btc.networkId,
+        kind: 'btc-native',
+        address: null,
+        symbol: 'BTC',
+        name: 'Bitcoin',
+        decimals: 8,
+        networkName: getBitcoinNetwork(btc.networkId)?.name || 'Bitcoin',
+        balance: (btc.balances?.spendableSats ?? 0) / 1e8,
+      })
+    }
+
+    const source = actingAddress ? actingAssets.holdings : portfolio.holdings
+    for (const h of source || []) {
+      if (h.asset.kind !== 'native' && h.asset.kind !== 'erc20') continue // no NFTs in a value action
+      const keepZero = h.asset.kind === 'native' || isConnectedStableAddr(h.asset.address)
+      if (!(h.balance > 0) && !keepZero) continue
+      put({
+        key: `${Number(h.asset.chainId)}:${String(h.asset.id).toLowerCase()}`,
+        chainId: Number(h.asset.chainId),
+        kind: h.asset.kind,
+        address: h.asset.address || null,
+        symbol: h.asset.symbol,
+        name: h.asset.name,
+        decimals: h.asset.decimals,
+        networkName: h.network,
+        balance: h.balance,
+      })
+    }
+
+    return [...byKey.values()].sort((a, b) => {
+      const ac = a.chainId === connectedChainId ? 0 : 1
+      const bc = b.chainId === connectedChainId ? 0 : 1
+      if (ac !== bc) return ac - bc
+      return (b.balance ?? 0) - (a.balance ?? 0)
+    })
+  }, [
+    actingAddress, actingAssets.holdings, portfolio.holdings, tokens, connectedChainId,
+    balanceOf, isConnectedStableAddr, btc.status, btc.networkId, btc.balances?.spendableSats,
+  ])
+
+  const options = useMemo(() => filterAssetsForActivity(activity, allOptions), [activity, allOptions])
+
+  const defaultKey = useMemo(
+    () => defaultAssetKey(activity, options, { connectedChainId, stableAddress: tokens.stableAddress }),
+    [activity, options, connectedChainId, tokens.stableAddress],
+  )
+
+  // Bitcoin is never gasless (FR-005/FR-015); otherwise defer to the engine's quote.
+  const isGasless = useCallback(
+    (opt) => (opt?.kind === 'btc-native' ? false : quoteGaslessForAsset(opt)),
+    [quoteGaslessForAsset],
+  )
+
+  return { options, defaultKey, isGasless }
+}
+
+export default useSelectableAssets

--- a/frontend/src/lib/assets/__tests__/assetActivity.test.js
+++ b/frontend/src/lib/assets/__tests__/assetActivity.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ASSET_ACTIVITIES,
+  allowedKindsForActivity,
+  filterAssetsForActivity,
+  defaultAssetKey,
+} from '../assetActivity'
+
+const opt = (over = {}) => ({
+  key: `${over.chainId ?? 137}:${over.address ? over.address.toLowerCase() : over.kind ?? 'native'}`,
+  chainId: 137,
+  kind: 'erc20',
+  address: null,
+  symbol: 'TKN',
+  ...over,
+})
+
+// A representative cross-network list: connected(137) native + stablecoin + a
+// token, an off-chain token (1), and Bitcoin.
+const USDC = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'
+const WBTC = '0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6'
+function sampleOptions() {
+  return [
+    opt({ chainId: 137, kind: 'native', address: null, symbol: 'MATIC', key: '137:native' }),
+    opt({ chainId: 137, kind: 'erc20', address: USDC, symbol: 'USDC', key: `137:${USDC.toLowerCase()}` }),
+    opt({ chainId: 137, kind: 'erc20', address: WBTC, symbol: 'WBTC', key: `137:${WBTC.toLowerCase()}` }),
+    opt({ chainId: 1, kind: 'erc20', address: WBTC, symbol: 'WBTC', key: `1:${WBTC.toLowerCase()}` }),
+    opt({ chainId: 'bitcoin', kind: 'btc-native', address: null, symbol: 'BTC', key: 'bitcoin:native' }),
+  ]
+}
+
+describe('allowedKindsForActivity', () => {
+  it('pay/request/transfer allow every kind including btc-native', () => {
+    for (const a of [ASSET_ACTIVITIES.PAY, ASSET_ACTIVITIES.REQUEST, ASSET_ACTIVITIES.TRANSFER]) {
+      const kinds = allowedKindsForActivity(a)
+      expect(kinds).toContain('native')
+      expect(kinds).toContain('erc20')
+      expect(kinds).toContain('btc-native')
+    }
+  })
+
+  it('wager allows only erc20', () => {
+    expect(allowedKindsForActivity(ASSET_ACTIVITIES.WAGER)).toEqual(['erc20'])
+  })
+
+  it('defaults to all kinds for an unknown activity (never silently emptied)', () => {
+    expect(allowedKindsForActivity('mystery')).toContain('btc-native')
+  })
+})
+
+describe('filterAssetsForActivity', () => {
+  it('keeps Bitcoin + native for pay/request', () => {
+    const kept = filterAssetsForActivity(ASSET_ACTIVITIES.PAY, sampleOptions())
+    expect(kept.some((o) => o.kind === 'btc-native')).toBe(true)
+    expect(kept.some((o) => o.kind === 'native')).toBe(true)
+    expect(kept).toHaveLength(5)
+  })
+
+  it('drops native + Bitcoin for wager, leaving ERC-20s only', () => {
+    const kept = filterAssetsForActivity(ASSET_ACTIVITIES.WAGER, sampleOptions())
+    expect(kept.every((o) => o.kind === 'erc20')).toBe(true)
+    expect(kept.some((o) => o.kind === 'native')).toBe(false)
+    expect(kept.some((o) => o.kind === 'btc-native')).toBe(false)
+    expect(kept).toHaveLength(3)
+  })
+
+  it('tolerates empty / nullish input', () => {
+    expect(filterAssetsForActivity(ASSET_ACTIVITIES.PAY, [])).toEqual([])
+    expect(filterAssetsForActivity(ASSET_ACTIVITIES.PAY, undefined)).toEqual([])
+  })
+})
+
+describe('defaultAssetKey', () => {
+  it('prefers the connected network stablecoin', () => {
+    const key = defaultAssetKey(ASSET_ACTIVITIES.PAY, sampleOptions(), {
+      connectedChainId: 137,
+      stableAddress: USDC,
+    })
+    expect(key).toBe(`137:${USDC.toLowerCase()}`)
+  })
+
+  it('falls back to connected native when no stablecoin matches', () => {
+    const opts = sampleOptions().filter((o) => o.symbol !== 'USDC')
+    const key = defaultAssetKey(ASSET_ACTIVITIES.PAY, opts, { connectedChainId: 137, stableAddress: USDC })
+    expect(key).toBe('137:native')
+  })
+
+  it('falls back to the first option when neither stablecoin nor native present', () => {
+    const opts = [opt({ chainId: 1, kind: 'erc20', address: WBTC, key: `1:${WBTC.toLowerCase()}` })]
+    const key = defaultAssetKey(ASSET_ACTIVITIES.PAY, opts, { connectedChainId: 137, stableAddress: USDC })
+    expect(key).toBe(`1:${WBTC.toLowerCase()}`)
+  })
+
+  it('wager defaults to the connected stablecoin (USDC unchanged)', () => {
+    const opts = filterAssetsForActivity(ASSET_ACTIVITIES.WAGER, sampleOptions())
+    const key = defaultAssetKey(ASSET_ACTIVITIES.WAGER, opts, { connectedChainId: 137, stableAddress: USDC })
+    expect(key).toBe(`137:${USDC.toLowerCase()}`)
+  })
+
+  it('returns null for an empty list', () => {
+    expect(defaultAssetKey(ASSET_ACTIVITIES.PAY, [], { connectedChainId: 137 })).toBeNull()
+  })
+})

--- a/frontend/src/lib/assets/assetActivity.js
+++ b/frontend/src/lib/assets/assetActivity.js
@@ -1,0 +1,77 @@
+/**
+ * Activity capability profiles (spec 064) — the single source of truth for WHICH
+ * selectable assets each activity may offer, so an asset an activity can never act
+ * on is filtered OUT of that activity's list rather than failing silently at submit
+ * time (honest-state, Constitution III; FR-008).
+ *
+ * Pure, synchronous, framework-free: no React, no chain libs. Fully unit-testable.
+ *
+ *   pay / request / transfer → all kinds, including non-EVM Bitcoin (btc-native).
+ *   wager                    → EVM ERC-20 ONLY. The head-to-head escrow pulls the
+ *                              stake via ERC-20 `transferFrom`, so the native coin
+ *                              (not a transferable token) and Bitcoin (non-EVM) are
+ *                              excluded; the on-chain stake-token allowlist
+ *                              (`NotAllowedToken`) is the backstop for a held ERC-20
+ *                              the registry doesn't accept.
+ */
+
+export const ASSET_ACTIVITIES = Object.freeze({
+  PAY: 'pay',
+  REQUEST: 'request',
+  WAGER: 'wager',
+  TRANSFER: 'transfer',
+})
+
+// Every asset kind a SelectableAsset can carry.
+const ALL_KINDS = ['native', 'erc20', 'btc-native']
+
+// Which kinds each activity may offer. Unknown activities default to "all kinds"
+// (a new consumer is never silently emptied) — add an explicit entry to restrict.
+const ACTIVITY_ALLOWED_KINDS = {
+  [ASSET_ACTIVITIES.PAY]: ALL_KINDS,
+  [ASSET_ACTIVITIES.REQUEST]: ALL_KINDS,
+  [ASSET_ACTIVITIES.TRANSFER]: ALL_KINDS,
+  [ASSET_ACTIVITIES.WAGER]: ['erc20'],
+}
+
+/** The asset kinds `activity` may offer (defaults to all kinds for unknown ids). */
+export function allowedKindsForActivity(activity) {
+  return ACTIVITY_ALLOWED_KINDS[activity] || ALL_KINDS
+}
+
+/**
+ * Remove options the activity can't act on (e.g. Bitcoin/native out of `wager`).
+ * Exclusion is by list construction, never a submit-time error (FR-008).
+ */
+export function filterAssetsForActivity(activity, options = []) {
+  const allowed = new Set(allowedKindsForActivity(activity))
+  return (options || []).filter((o) => allowed.has(o?.kind))
+}
+
+/**
+ * The activity's default selection key, given its (already-filtered) options.
+ *
+ * Precedence: the connected network's stablecoin → the connected network's native
+ * coin → the first available option. `wager` has no native option, so it falls to
+ * the connected stablecoin then the first ERC-20 — keeping USDC the unchanged
+ * default (FR-011, FR-013).
+ */
+export function defaultAssetKey(activity, options = [], { connectedChainId = null, stableAddress = null } = {}) {
+  const list = options || []
+  if (list.length === 0) return null
+
+  const stable =
+    stableAddress &&
+    list.find(
+      (o) =>
+        Number(o.chainId) === Number(connectedChainId) &&
+        o.address &&
+        o.address.toLowerCase() === stableAddress.toLowerCase(),
+    )
+  if (stable) return stable.key
+
+  const native = list.find((o) => Number(o.chainId) === Number(connectedChainId) && o.kind === 'native')
+  if (native) return native.key
+
+  return list[0].key
+}

--- a/frontend/src/test/CreateChallengePanel.test.jsx
+++ b/frontend/src/test/CreateChallengePanel.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 
 // Mock the create flow so the panel renders deterministically (no chain/IPFS).
 const createOpenChallenge = vi.fn()
@@ -9,8 +9,23 @@ vi.mock('../hooks/useOpenChallengeCreate', async (importOriginal) => {
 })
 
 // Chain capability gate — flip per-test via this holder (drives the oracle pill).
-const capsHolder = { capabilities: { polymarketSidebets: true } }
+const capsHolder = { capabilities: { polymarketSidebets: true }, chainId: 137 }
 vi.mock('../hooks/useChainTokens', () => ({ useChainTokens: () => capsHolder }))
+
+// Universal asset selector option list (spec 064 US3) — ERC-20 only for wager.
+const USDC = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+const WBTC1 = '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'
+const usdcOpt = { key: `137:${USDC.toLowerCase()}`, chainId: 137, kind: 'erc20', address: USDC, symbol: 'USDC', name: 'USD Coin', decimals: 6, networkName: 'Polygon', balance: 100 }
+const wethOpt = { key: '137:0xweth', chainId: 137, kind: 'erc20', address: '0xWeThPolygon000000000000000000000000000001', symbol: 'WETH', name: 'Wrapped Ether', decimals: 18, networkName: 'Polygon', balance: 4 }
+const wbtcEthOpt = { key: `1:${WBTC1.toLowerCase()}`, chainId: 1, kind: 'erc20', address: WBTC1, symbol: 'WBTC', name: 'Wrapped BTC', decimals: 8, networkName: 'Ethereum', balance: 1 }
+const wagerAssets = { options: [usdcOpt, wethOpt, wbtcEthOpt], defaultKey: usdcOpt.key, isGasless: () => false }
+vi.mock('../hooks/useSelectableAssets', () => ({
+  useSelectableAssets: () => wagerAssets,
+  default: () => wagerAssets,
+}))
+
+const switchHolder = { switchChainAsync: vi.fn(async () => {}), isPending: false }
+vi.mock('wagmi', () => ({ useSwitchChain: () => switchHolder }))
 
 // Stub the market browser: the panel's contract with it is onSelectMarket(normalizedMarket).
 const FAR_END = new Date(Date.now() + 10 * 24 * 3600 * 1000).toISOString()
@@ -35,23 +50,43 @@ const tapAmount = (amount) => {
     fireEvent.click(screen.getByRole('button', { name: ch === '.' ? 'Decimal point' : ch }))
   }
 }
+const pickStakeAsset = (name) => {
+  fireEvent.click(screen.getByRole('button', { name: 'Stake asset' }))
+  fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name }))
+}
 
-describe('CreateChallengePanel (spec 053 — shared create panel)', () => {
+describe('CreateChallengePanel (spec 053 + spec 064 US3)', () => {
   beforeEach(() => {
     createOpenChallenge.mockReset()
     capsHolder.capabilities = { polymarketSidebets: true }
+    capsHolder.chainId = 137
+    wagerAssets.options = [usdcOpt, wethOpt, wbtcEthOpt]
+    wagerAssets.defaultKey = usdcOpt.key
+    switchHolder.switchChainAsync = vi.fn(async () => {})
   })
 
   it('renders inline when embedded (the payments-style create form, no modal chrome)', () => {
     const { container } = render(<CreateChallengePanel embedded onClose={() => {}} />)
     expect(screen.getByTestId('amount-keypad-hero')).toHaveTextContent('$0')
     expect(screen.getByLabelText(/what's the wager/i, { selector: 'input' })).toBeInTheDocument()
-    // Embedded → no modal backdrop wrapper.
     expect(container.querySelector('.friend-markets-modal-backdrop')).toBeNull()
     expect(container.querySelector('.oc-create-embedded')).not.toBeNull()
   })
 
-  it('creates a self-resolved challenge and calls onDone', async () => {
+  it('defaults the stake asset to USDC (unchanged first-render behavior)', () => {
+    render(<CreateChallengePanel embedded onClose={() => {}} />)
+    expect(screen.getByRole('button', { name: 'Stake asset' })).toHaveTextContent('USDC')
+  })
+
+  it('offers only ERC-20 stake assets in the selector (spec 064 US3)', () => {
+    render(<CreateChallengePanel embedded onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Stake asset' }))
+    const list = screen.getByRole('listbox')
+    expect(within(list).getByRole('option', { name: /USDC/ })).toBeInTheDocument()
+    expect(within(list).getByRole('option', { name: /WETH/ })).toBeInTheDocument()
+  })
+
+  it('creates a self-resolved challenge denominated in the default USDC and calls onDone', async () => {
     createOpenChallenge.mockResolvedValue({ code: 'river tiger kite zoo', wagerId: 1n, txHash: '0x1' })
     const onDone = vi.fn()
     render(<CreateChallengePanel embedded onClose={() => {}} onDone={onDone} />)
@@ -62,8 +97,33 @@ describe('CreateChallengePanel (spec 053 — shared create panel)', () => {
     expect(createBtn).toBeEnabled()
     fireEvent.click(createBtn)
     await waitFor(() => expect(createOpenChallenge).toHaveBeenCalled())
-    expect(createOpenChallenge.mock.calls[0][0].resolutionType).toBe(OPEN_RESOLUTION_TYPES.Either)
+    const payload = createOpenChallenge.mock.calls[0][0]
+    expect(payload.resolutionType).toBe(OPEN_RESOLUTION_TYPES.Either)
+    expect(payload.token).toBe(USDC) // stake token denomination (spec 064)
     expect(await screen.findByText('river tiger kite zoo')).toBeInTheDocument()
+  })
+
+  it('passes the selected stake token to the create hook (spec 064 US3)', async () => {
+    createOpenChallenge.mockResolvedValue({ code: 'aa bb cc dd', wagerId: 2n, txHash: '0x2' })
+    render(<CreateChallengePanel embedded onClose={() => {}} />)
+    pickStakeAsset(/WETH/)
+    fireEvent.change(screen.getByLabelText(/what's the wager/i, { selector: 'input' }), { target: { value: 'Coin flip' } })
+    tapAmount('5')
+    fireEvent.click(screen.getByRole('button', { name: /lock in/i }))
+    await waitFor(() => expect(createOpenChallenge).toHaveBeenCalled())
+    expect(createOpenChallenge.mock.calls[0][0].token).toBe(wethOpt.address)
+  })
+
+  it('gates a wrong-network stake asset behind a switch and never creates off-chain (spec 064 US3)', async () => {
+    render(<CreateChallengePanel embedded onClose={() => {}} />)
+    pickStakeAsset(/WBTC/) // WBTC lives on Ethereum (chain 1); connected to Polygon (137)
+    fireEvent.change(screen.getByLabelText(/what's the wager/i, { selector: 'input' }), { target: { value: 'Coin flip' } })
+    tapAmount('5')
+    const switchBtn = screen.getByRole('button', { name: /switch to ethereum to stake WBTC/i })
+    expect(screen.queryByRole('button', { name: /lock in/i })).toBeNull()
+    fireEvent.click(switchBtn)
+    await waitFor(() => expect(switchHolder.switchChainAsync).toHaveBeenCalledWith({ chainId: 1 }))
+    expect(createOpenChallenge).not.toHaveBeenCalled()
   })
 
   it('opens the connect flow from the primary button when disconnected, then resumes the create once connected', async () => {
@@ -75,11 +135,9 @@ describe('CreateChallengePanel (spec 053 — shared create panel)', () => {
     tapAmount('10')
     const openBtn = screen.getByRole('button', { name: /lock in/i })
     expect(openBtn).toBeEnabled()
-    // Disconnected → tapping opens the connect panel and does NOT create yet.
     fireEvent.click(openBtn)
     await waitFor(() => expect(onConnect).toHaveBeenCalled())
     expect(createOpenChallenge).not.toHaveBeenCalled()
-    // The wallet connects → the pending create resumes on its own (no second tap).
     createOpenChallenge.mockResolvedValue({ code: 'river tiger kite zoo', wagerId: 1n, txHash: '0x1' })
     rerender(<CreateChallengePanel embedded onClose={() => {}} isConnected onConnect={onConnect} />)
     await waitFor(() => expect(createOpenChallenge).toHaveBeenCalled())
@@ -95,10 +153,8 @@ describe('CreateChallengePanel (spec 053 — shared create panel)', () => {
   it('opens the market-search step when oracle is chosen, then returns with a side picker', () => {
     render(<CreateChallengePanel embedded onClose={() => {}} />)
     fireEvent.click(screen.getByRole('radio', { name: /^event$/i }))
-    // Swaps to the market-search sub-view.
     expect(screen.getByTestId('pm-browser')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /pick eligible/i }))
-    // Returns to the create view with the picked market + side picker.
     expect(screen.getByText('Will ETH flip BTC?')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /taking yes/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /taking no/i })).toBeInTheDocument()

--- a/frontend/src/test/PayPanel.test.jsx
+++ b/frontend/src/test/PayPanel.test.jsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 
 const USDC = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+const WETH1 = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
 const RECIPIENT = '0x2222222222222222222222222222222222222222'
 const BOOK_ADDR = '0x3333333333333333333333333333333333333333'
 
@@ -21,19 +22,45 @@ const resetTransferHolder = () => {
     status: 'idle',
     error: null,
     send: vi.fn(async () => ({ txHash: '0xhash', route: 'gasless', id: 't1' })),
-    quoteGasless: () => true,
-    balanceOf: (kind) => (kind === 'stable' ? '100' : '2'),
     refreshBalances: vi.fn(),
-    tokens: {
-      chainId: 137, networkName: 'Polygon',
-      native: 'POL', nativeName: 'Polygon', nativeDecimals: 18,
-      stable: 'USDC', stableName: 'USD Coin', stableAddress: USDC, stableDecimals: 6,
-    },
   })
 }
 vi.mock('../hooks/useTransfer', () => ({
   useTransfer: () => transferHolder,
   TRANSFER_KIND: { NATIVE: 'native', STABLE: 'stable' },
+}))
+
+// The universal selector's option list is mocked so the panel test controls exactly
+// which assets are offered (assembly itself is covered by useSelectableAssets tests).
+const nativeOpt = { key: '137:native', chainId: 137, kind: 'native', address: null, symbol: 'POL', name: 'Polygon', decimals: 18, networkName: 'Polygon', balance: 2 }
+const stableOpt = { key: `137:${USDC.toLowerCase()}`, chainId: 137, kind: 'erc20', address: USDC, symbol: 'USDC', name: 'USD Coin', decimals: 6, networkName: 'Polygon', balance: 100 }
+const wethOpt = { key: `1:${WETH1.toLowerCase()}`, chainId: 1, kind: 'erc20', address: WETH1, symbol: 'WETH', name: 'Wrapped Ether', decimals: 18, networkName: 'Ethereum', balance: 3 }
+const btcOpt = { key: 'bitcoin:native', chainId: 'bitcoin', kind: 'btc-native', address: null, symbol: 'BTC', name: 'Bitcoin', decimals: 8, networkName: 'Bitcoin', balance: 0.5 }
+const selectableHolder = { options: [], defaultKey: null }
+const resetSelectable = () => {
+  selectableHolder.options = [stableOpt, nativeOpt, wethOpt]
+  selectableHolder.defaultKey = stableOpt.key
+}
+vi.mock('../hooks/useSelectableAssets', () => ({
+  useSelectableAssets: () => ({
+    options: selectableHolder.options,
+    defaultKey: selectableHolder.defaultKey,
+    isGasless: (o) => Number(o?.chainId) === 137,
+  }),
+  default: () => ({
+    options: selectableHolder.options,
+    defaultKey: selectableHolder.defaultKey,
+    isGasless: (o) => Number(o?.chainId) === 137,
+  }),
+}))
+
+vi.mock('../hooks/useActiveAccount', () => ({
+  useActiveAccount: () => ({ identity: { mode: 'personal' }, isVault: false, isLegacy: false }),
+}))
+const btcHolder = { status: 'idle', networkId: null, balances: { spendableSats: 0 } }
+vi.mock('../hooks/useBitcoinWallet', () => ({ useBitcoinWallet: () => btcHolder }))
+vi.mock('../components/wallet/BitcoinSendPanel', () => ({
+  default: () => <div data-testid="btc-send-panel">bitcoin send</div>,
 }))
 
 const screeningHolder = { result: 'clear' }
@@ -47,8 +74,6 @@ vi.mock('../hooks/useUI', () => ({ useNotification: () => notifyHolder }))
 const switchHolder = { switchChainAsync: vi.fn(async () => {}), isPending: false }
 vi.mock('wagmi', () => ({ useSwitchChain: () => switchHolder }))
 
-// Standard address entry stack, stubbed: the input reports raw changes and
-// resolves anything address-shaped; book + scanner surface their callbacks.
 vi.mock('../components/ui/AddressInput', () => ({
   default: ({ id, value, onChange, onResolvedChange, disabled }) => (
     <input
@@ -86,51 +111,64 @@ const typeAmount = (digits) => {
 }
 const setRecipient = (addr) => fireEvent.change(screen.getByLabelText('To'), { target: { value: addr } })
 const payButton = () => screen.getByRole('button', { name: /^pay$/i })
+const currencyTrigger = () => screen.getByRole('button', { name: 'Currency' })
+const pickAsset = (name) => {
+  fireEvent.click(currencyTrigger())
+  fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name }))
+}
 const scanWith = (payload) => {
   scanHolder.payload = payload
   fireEvent.click(screen.getByRole('button', { name: /scan qr code/i }))
   fireEvent.click(screen.getByRole('button', { name: /simulate scan/i }))
 }
 
-describe('PayPanel (spec 058 US1)', () => {
+describe('PayPanel (spec 058 US1 + spec 064 US1)', () => {
   beforeEach(() => {
     localStorage.clear()
     resetTransferHolder()
+    resetSelectable()
     walletHolder.isConnected = true
     walletHolder.openConnectModal = vi.fn()
     screeningHolder.result = 'clear'
     notifyHolder.showNotification = vi.fn()
     switchHolder.switchChainAsync = vi.fn(async () => {})
+    Object.assign(btcHolder, { status: 'idle', networkId: null, balances: { spendableSats: 0 } })
   })
 
-  it('defaults the hero to the stablecoin (USDC) and shows honest symbols in the currency dropdown', () => {
+  it('defaults the currency to the connected stablecoin (USDC)', () => {
     render(<PayPanel />)
-    const select = screen.getByLabelText('Currency')
-    expect(select).toHaveValue('stable')
-    expect(screen.getByRole('option', { name: 'USDC' }).selected).toBe(true)
-    fireEvent.change(select, { target: { value: 'native' } })
-    expect(screen.getByRole('option', { name: 'POL' }).selected).toBe(true)
+    expect(currencyTrigger()).toHaveTextContent('USDC')
   })
 
   it('starts on the preferred currency kind from the device preference', async () => {
     const { setDefaultCurrencyKind } = await import('../utils/homePreference')
     setDefaultCurrencyKind('native')
     render(<PayPanel />)
-    expect(screen.getByLabelText('Currency')).toHaveValue('native')
+    expect(currencyTrigger()).toHaveTextContent('POL')
   })
 
-  it('keeps Pay disabled at zero amount and without a resolved recipient (FR-005)', async () => {
+  it('lists every held asset with its network in the universal selector (spec 064 US1)', () => {
+    render(<PayPanel />)
+    fireEvent.click(currencyTrigger())
+    const list = screen.getByRole('listbox')
+    expect(within(list).getByRole('option', { name: /USDC/ })).toBeInTheDocument()
+    expect(within(list).getByRole('option', { name: /POL/ })).toBeInTheDocument()
+    const weth = within(list).getByRole('option', { name: /WETH/ })
+    expect(weth).toHaveTextContent('Ethereum')
+  })
+
+  it('keeps Pay disabled at zero amount and without a resolved recipient', async () => {
     render(<PayPanel />)
     expect(payButton()).toBeDisabled()
     typeAmount(['5'])
-    expect(payButton()).toBeDisabled() // amount but no recipient
+    expect(payButton()).toBeDisabled()
     setRecipient(RECIPIENT)
     await waitFor(() => expect(payButton()).toBeEnabled())
     setRecipient('not-an-address')
     expect(payButton()).toBeDisabled()
   })
 
-  it('blocks an amount above the balance with a clear reason (FR-005)', async () => {
+  it('blocks an amount above the balance with a clear reason', async () => {
     render(<PayPanel />)
     setRecipient(RECIPIENT)
     typeAmount(['9', '9', '9'])
@@ -138,7 +176,7 @@ describe('PayPanel (spec 058 US1)', () => {
     expect(payButton()).toBeDisabled()
   })
 
-  it('blocks a screening-restricted recipient (FR-005)', async () => {
+  it('blocks a screening-restricted recipient', async () => {
     screeningHolder.result = 'restricted'
     render(<PayPanel />)
     typeAmount(['5'])
@@ -150,8 +188,7 @@ describe('PayPanel (spec 058 US1)', () => {
   it('opens the connect modal instead of Pay when disconnected', () => {
     walletHolder.isConnected = false
     render(<PayPanel />)
-    const connect = screen.getByRole('button', { name: /connect wallet/i })
-    fireEvent.click(connect)
+    fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }))
     expect(walletHolder.openConnectModal).toHaveBeenCalled()
   })
 
@@ -161,32 +198,53 @@ describe('PayPanel (spec 058 US1)', () => {
     expect(screen.getByLabelText('To')).toHaveValue(BOOK_ADDR)
   })
 
-  it('pays through the existing transfer engine after an honest fee confirm (FR-004)', async () => {
+  it('pays the selected asset through the existing engine after an honest fee confirm', async () => {
     render(<PayPanel />)
     typeAmount(['1', '2', '.', '5'])
     setRecipient(RECIPIENT)
     await waitFor(() => expect(payButton()).toBeEnabled())
     fireEvent.click(payButton())
-    // Confirm step disclosing amount, network, and the gasless fee line.
     const confirm = screen.getByTestId('pay-confirm')
     expect(confirm).toHaveTextContent('12.5 USDC')
     expect(confirm).toHaveTextContent('Polygon')
     expect(confirm).toHaveTextContent(/gasless — no network fee/i)
     fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }))
-    await waitFor(() => expect(transferHolder.send).toHaveBeenCalledWith({ kind: 'stable', to: RECIPIENT, amount: '12.5' }))
+    await waitFor(() =>
+      expect(transferHolder.send).toHaveBeenCalledWith(
+        expect.objectContaining({ asset: expect.objectContaining({ symbol: 'USDC' }), to: RECIPIENT, amount: '12.5' }),
+      ),
+    )
     expect(notifyHolder.showNotification).toHaveBeenCalledWith(expect.stringMatching(/sent 12\.5 USDC/i), 'success')
-    // Draft cleared after success.
     await waitFor(() => expect(screen.getByLabelText('To')).toHaveValue(''))
   })
 
-  it('discloses a user-paid fee honestly when the route is not gasless', async () => {
-    transferHolder.quoteGasless = () => false
+  it('discloses a user-paid fee honestly for a non-gasless asset (WETH on Ethereum)', async () => {
     render(<PayPanel />)
-    typeAmount(['5'])
-    setRecipient(RECIPIENT)
-    await waitFor(() => expect(payButton()).toBeEnabled())
-    fireEvent.click(payButton())
-    expect(screen.getByTestId('pay-confirm')).toHaveTextContent(/you pay the POL network fee/i)
+    pickAsset(/WETH/)
+    // WETH lives on Ethereum (chain 1) while connected to Polygon → switch-gated first.
+    const switchBtn = screen.getByRole('button', { name: /switch to .* to pay/i })
+    expect(switchBtn).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^pay$/i })).toBeNull()
+  })
+
+  it('gates a wrong-network asset behind a switch and never sends off-chain (spec 064 US1)', async () => {
+    render(<PayPanel />)
+    pickAsset(/WETH/)
+    const switchBtn = screen.getByRole('button', { name: /switch to ethereum to pay/i })
+    fireEvent.click(switchBtn)
+    await waitFor(() => expect(switchHolder.switchChainAsync).toHaveBeenCalledWith({ chainId: 1 }))
+    expect(transferHolder.send).not.toHaveBeenCalled()
+  })
+
+  it('routes a Bitcoin selection through the Bitcoin send panel (spec 064 US1)', () => {
+    btcHolder.status = 'ready'
+    btcHolder.networkId = 'bitcoin'
+    selectableHolder.options = [stableOpt, nativeOpt, btcOpt]
+    render(<PayPanel />)
+    pickAsset(/BTC/)
+    expect(screen.getByTestId('btc-send-panel')).toBeInTheDocument()
+    // No EVM confirm/keypad pay button in the Bitcoin body.
+    expect(screen.queryByRole('button', { name: /^pay$/i })).toBeNull()
   })
 
   it('surfaces a send failure and returns to the editable form', async () => {
@@ -201,17 +259,17 @@ describe('PayPanel (spec 058 US1)', () => {
     expect(screen.getByLabelText('To')).toHaveValue(RECIPIENT)
   })
 
-  describe('QR scanning (FR-008/FR-009/FR-016)', () => {
+  describe('QR scanning', () => {
     it('prefills recipient, amount, currency, and note from a full payment request', () => {
       render(<PayPanel />)
       scanWith(`ethereum:${USDC}@137/transfer?address=${RECIPIENT}&uint256=12500000&message=pizza%20night`)
       expect(screen.getByLabelText('To')).toHaveValue(RECIPIENT)
       expect(screen.getByTestId('amount-keypad-hero')).toHaveTextContent('12.5')
-      expect(screen.getByLabelText('Currency')).toHaveValue('stable')
+      expect(currencyTrigger()).toHaveTextContent('USDC')
       expect(screen.getByLabelText('Note')).toHaveValue('pizza night')
     })
 
-    it('prefills only the recipient from a plain address QR (FR-009)', () => {
+    it('prefills only the recipient from a plain address QR', () => {
       render(<PayPanel />)
       typeAmount(['7'])
       scanWith(RECIPIENT)
@@ -219,7 +277,7 @@ describe('PayPanel (spec 058 US1)', () => {
       expect(screen.getByTestId('amount-keypad-hero')).toHaveTextContent('7')
     })
 
-    it('rejects a foreign-token request with NO partial prefill (wrong-asset edge case)', () => {
+    it('rejects a foreign-token request with NO partial prefill', () => {
       render(<PayPanel />)
       scanWith(`ethereum:0x4444444444444444444444444444444444444444@137/transfer?address=${RECIPIENT}&uint256=1000000`)
       expect(screen.getByText(/doesn't send on that network/i)).toBeInTheDocument()
@@ -233,12 +291,11 @@ describe('PayPanel (spec 058 US1)', () => {
       expect(screen.getByText(/isn't a payment request or address/i)).toBeInTheDocument()
     })
 
-    it('surfaces a network mismatch with a switch affordance before any send (FR-016)', async () => {
+    it('surfaces a network mismatch with a switch affordance before any send', async () => {
       render(<PayPanel />)
-      // A native request pinned to Ethereum mainnet while connected to Polygon.
       scanWith(`ethereum:${RECIPIENT}@1?value=1000000000000000000`)
       expect(screen.getByLabelText('To')).toHaveValue(RECIPIENT)
-      const switchBtn = screen.getByRole('button', { name: /switch to .* to pay this request/i })
+      const switchBtn = screen.getByRole('button', { name: /switch to .* to pay/i })
       expect(screen.queryByRole('button', { name: /^pay$/i })).toBeNull()
       fireEvent.click(switchBtn)
       await waitFor(() => expect(switchHolder.switchChainAsync).toHaveBeenCalledWith({ chainId: 1 }))

--- a/frontend/src/test/RequestPanel.test.jsx
+++ b/frontend/src/test/RequestPanel.test.jsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { ethers } from 'ethers'
 
 const MY_ADDRESS = ethers.getAddress('0x5555555555555555555555555555555555555555')
 const USDC = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+const WETH1 = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
 
 const walletHolder = { isConnected: true, address: MY_ADDRESS, openConnectModal: vi.fn() }
 vi.mock('../hooks', () => ({
@@ -14,8 +15,21 @@ vi.mock('../hooks', () => ({
   }),
 }))
 
-const tokensHolder = {}
-vi.mock('../hooks/useChainTokens', () => ({ useChainTokens: () => tokensHolder }))
+const effectiveHolder = { address: MY_ADDRESS, isActingAccount: false, label: null, type: null }
+vi.mock('../hooks/useEffectiveAccount', () => ({ useEffectiveAccount: () => effectiveHolder }))
+
+const nativeOpt = { key: '137:native', chainId: 137, kind: 'native', address: null, symbol: 'POL', name: 'Polygon', decimals: 18, networkName: 'Polygon', balance: 2 }
+const stableOpt = { key: `137:${USDC.toLowerCase()}`, chainId: 137, kind: 'erc20', address: USDC, symbol: 'USDC', name: 'USD Coin', decimals: 6, networkName: 'Polygon', balance: 100 }
+const wethOpt = { key: `1:${WETH1.toLowerCase()}`, chainId: 1, kind: 'erc20', address: WETH1, symbol: 'WETH', name: 'Wrapped Ether', decimals: 18, networkName: 'Ethereum', balance: 3 }
+const btcOpt = { key: 'bitcoin:native', chainId: 'bitcoin', kind: 'btc-native', address: null, symbol: 'BTC', name: 'Bitcoin', decimals: 8, networkName: 'Bitcoin', balance: 0.5 }
+const selectableHolder = { options: [], defaultKey: null }
+vi.mock('../hooks/useSelectableAssets', () => ({
+  useSelectableAssets: () => ({ options: selectableHolder.options, defaultKey: selectableHolder.defaultKey, isGasless: () => false }),
+  default: () => ({ options: selectableHolder.options, defaultKey: selectableHolder.defaultKey, isGasless: () => false }),
+}))
+
+const btcHolder = { status: 'idle', receive: { nextReceiveAddress: vi.fn(() => ({ address: 'bc1qexampleaddress' })) } }
+vi.mock('../hooks/useBitcoinWallet', () => ({ useBitcoinWallet: () => btcHolder }))
 
 const clipboardHolder = { copied: false, error: null, copy: vi.fn() }
 vi.mock('../hooks/useClipboard', () => ({ useClipboard: () => clipboardHolder }))
@@ -33,21 +47,23 @@ const typeAmount = (digits) => {
   }
 }
 const requestButton = () => screen.getByRole('button', { name: /^request$/i })
+const currencyTrigger = () => screen.getByRole('button', { name: 'Currency' })
+const pickAsset = (name) => {
+  fireEvent.click(currencyTrigger())
+  fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name }))
+}
 
-describe('RequestPanel (spec 058 US2)', () => {
+describe('RequestPanel (spec 058 US2 + spec 064 US2)', () => {
   beforeEach(() => {
     localStorage.clear()
     walletHolder.isConnected = true
     walletHolder.address = MY_ADDRESS
     walletHolder.openConnectModal = vi.fn()
-    clipboardHolder.copied = false
-    clipboardHolder.error = null
+    Object.assign(effectiveHolder, { address: MY_ADDRESS, isActingAccount: false, label: null, type: null })
     clipboardHolder.copy = vi.fn()
-    Object.assign(tokensHolder, {
-      chainId: 137, networkName: 'Polygon',
-      native: 'POL', nativeDecimals: 18,
-      stable: 'USDC', stableAddress: USDC, stableDecimals: 6,
-    })
+    selectableHolder.options = [stableOpt, nativeOpt, wethOpt]
+    selectableHolder.defaultKey = stableOpt.key
+    Object.assign(btcHolder, { status: 'idle', receive: { nextReceiveAddress: vi.fn(() => ({ address: 'bc1qexampleaddress' })) } })
   })
 
   it('keeps Request disabled until an amount is entered', () => {
@@ -57,16 +73,25 @@ describe('RequestPanel (spec 058 US2)', () => {
     expect(requestButton()).toBeEnabled()
   })
 
-  it('opens the connect modal before a code can be generated (US2 scenario 4)', () => {
+  it('lists receivable assets with their networks in the selector (spec 064 US2)', () => {
+    render(<RequestPanel />)
+    fireEvent.click(currencyTrigger())
+    const list = screen.getByRole('listbox')
+    expect(within(list).getByRole('option', { name: /USDC/ })).toBeInTheDocument()
+    expect(within(list).getByRole('option', { name: /WETH/ })).toHaveTextContent('Ethereum')
+  })
+
+  it('opens the connect modal before a code can be generated', () => {
     walletHolder.isConnected = false
     walletHolder.address = null
+    effectiveHolder.address = null
     render(<RequestPanel />)
     typeAmount(['4'])
     fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }))
     expect(walletHolder.openConnectModal).toHaveBeenCalled()
   })
 
-  it('generates a valid EIP-681 QR in a modal carrying address, amount, currency, network, and note (FR-006/FR-007)', () => {
+  it('generates a valid EIP-681 QR carrying address, amount, currency, network, and note', () => {
     render(<RequestPanel />)
     typeAmount(['1', '2', '.', '5'])
     fireEvent.change(screen.getByLabelText(/what's it for/i), { target: { value: 'pizza night' } })
@@ -74,22 +99,40 @@ describe('RequestPanel (spec 058 US2)', () => {
     const expected = buildPaymentRequestUri({
       chainId: 137, to: MY_ADDRESS, kind: 'stable', tokenAddress: USDC, decimals: 6, amount: '12.5', note: 'pizza night',
     })
-    // The QR is presented in the shared branded dialog.
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.getByTestId('request-qr')).toHaveAttribute('data-value', expected)
-    // The note is ALSO plain text under the code (third-party wallets ignore the param).
     expect(screen.getByText('pizza night')).toBeInTheDocument()
   })
 
-  it('generates a native-coin request when the currency dropdown is on the native kind', () => {
+  it('generates a native-coin request when the native asset is selected', () => {
     render(<RequestPanel />)
-    fireEvent.change(screen.getByLabelText('Currency'), { target: { value: 'native' } })
+    pickAsset(/POL/)
     typeAmount(['2'])
     fireEvent.click(requestButton())
-    const expected = buildPaymentRequestUri({
-      chainId: 137, to: MY_ADDRESS, kind: 'native', decimals: 18, amount: '2',
-    })
+    const expected = buildPaymentRequestUri({ chainId: 137, to: MY_ADDRESS, kind: 'native', decimals: 18, amount: '2' })
     expect(screen.getByTestId('request-qr')).toHaveAttribute('data-value', expected)
+  })
+
+  it('encodes the asset network for a cross-network asset (WETH on Ethereum) (spec 064 US2)', () => {
+    render(<RequestPanel />)
+    pickAsset(/WETH/)
+    typeAmount(['1'])
+    fireEvent.click(requestButton())
+    const value = screen.getByTestId('request-qr').getAttribute('data-value')
+    expect(value).toContain(`${WETH1}@1`) // token contract on chain 1
+    expect(value).toContain('/transfer')
+  })
+
+  it('generates a BIP-21 bitcoin request against a fresh receive address (spec 064 US2)', () => {
+    btcHolder.status = 'ready'
+    selectableHolder.options = [stableOpt, nativeOpt, btcOpt]
+    render(<RequestPanel />)
+    pickAsset(/BTC/)
+    typeAmount(['1'])
+    fireEvent.click(requestButton())
+    const value = screen.getByTestId('request-qr').getAttribute('data-value')
+    expect(value).toMatch(/^bitcoin:bc1qexampleaddress/)
+    expect(btcHolder.receive.nextReceiveAddress).toHaveBeenCalled()
   })
 
   it('copies the request URI from the modal', () => {
@@ -98,15 +141,6 @@ describe('RequestPanel (spec 058 US2)', () => {
     fireEvent.click(requestButton())
     fireEvent.click(screen.getByRole('button', { name: /copy/i }))
     expect(clipboardHolder.copy).toHaveBeenCalledWith(screen.getByTestId('request-qr').getAttribute('data-value'))
-  })
-
-  it('shares via the clipboard fallback when the Web Share API is unavailable (FR-007)', () => {
-    render(<RequestPanel />)
-    typeAmount(['3'])
-    fireEvent.click(requestButton())
-    fireEvent.click(screen.getByRole('button', { name: /share/i }))
-    expect(clipboardHolder.copy).toHaveBeenCalledWith(expect.stringContaining('Pay me 3 USDC'))
-    expect(clipboardHolder.copy).toHaveBeenCalledWith(expect.stringContaining('ethereum:'))
   })
 
   it('closes the QR modal, returning to the editable form', () => {
@@ -119,35 +153,23 @@ describe('RequestPanel (spec 058 US2)', () => {
     expect(requestButton()).toBeInTheDocument()
   })
 
-  it('invalidates a generated request when the connected account changes (no stale payee)', () => {
+  it('invalidates a generated request when the acting account changes (no stale payee)', () => {
     const { rerender } = render(<RequestPanel />)
     typeAmount(['5'])
     fireEvent.click(requestButton())
     expect(screen.getByRole('dialog')).toBeInTheDocument()
-    // The wallet switches to a different account: the modal must drop the
-    // now-stale request rather than keep paying the previous address.
-    walletHolder.address = ethers.getAddress('0x9999999999999999999999999999999999999999')
+    effectiveHolder.address = ethers.getAddress('0x9999999999999999999999999999999999999999')
     rerender(<RequestPanel />)
     expect(screen.queryByRole('dialog')).toBeNull()
     expect(screen.queryByTestId('request-qr')).toBeNull()
   })
 
-  it('invalidates a generated request when the network changes', () => {
-    const { rerender } = render(<RequestPanel />)
+  it('invalidates a generated request when the selected asset changes (FR-010)', () => {
+    render(<RequestPanel />)
     typeAmount(['5'])
     fireEvent.click(requestButton())
     expect(screen.getByRole('dialog')).toBeInTheDocument()
-    tokensHolder.chainId = 1
-    rerender(<RequestPanel />)
+    pickAsset(/POL/)
     expect(screen.queryByRole('dialog')).toBeNull()
-  })
-
-  it('blocks a stablecoin request honestly when the network has none configured', () => {
-    tokensHolder.stableAddress = null
-    tokensHolder.stable = 'USC'
-    render(<RequestPanel />)
-    typeAmount(['3'])
-    expect(screen.getByRole('alert')).toHaveTextContent(/no USC is configured/i)
-    expect(requestButton()).toBeDisabled()
   })
 })

--- a/frontend/src/test/TransferForm.test.jsx
+++ b/frontend/src/test/TransferForm.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 // Mock the standard address input to a plain field that resolves whatever is typed — keeps the test off
@@ -140,6 +140,27 @@ describe('TransferForm', () => {
 
     await user.click(switchBtn)
     await waitFor(() => expect(switchChainAsync).toHaveBeenCalledWith({ chainId: 1 }))
+  })
+
+  it('renders each asset option with the nested asset logo (spec 064 US4)', async () => {
+    holdings = [
+      {
+        asset: { id: 'native', chainId: 1, kind: 'native', symbol: 'ETH', name: 'Ethereum', decimals: 18, address: null },
+        balance: 2, network: 'Ethereum',
+      },
+    ]
+    const user = userEvent.setup()
+    const { container } = render(<TransferForm />)
+    await user.click(screen.getByLabelText('Asset to send'))
+    const list = await screen.findByRole('listbox')
+    // Every option carries a nested AssetLogo (the Earn-page artwork), so same-symbol
+    // assets on different networks are distinguishable at a glance.
+    const options = within(list).getAllByRole('option')
+    expect(options.length).toBeGreaterThan(0)
+    for (const opt of options) {
+      expect(opt.querySelector('.asset-logo')).not.toBeNull()
+    }
+    expect(container.querySelector('.uas-select')).not.toBeNull()
   })
 
   it('funds from a Protect vault: shows the vault balance, gates on it, and sends a proposal', async () => {

--- a/frontend/src/test/accessibility.test.jsx
+++ b/frontend/src/test/accessibility.test.jsx
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+
+// Spec 064: stub the asset-selector data hook so provider-light home panels render
+// (the real UniversalAssetSelect component still renders, so a11y stays covered).
+vi.mock('../hooks/useSelectableAssets', async () => await import('./helpers/selectableAssetsMock'))
 import userEvent from '@testing-library/user-event'
 import { axe } from 'vitest-axe'
 import Button from '../components/ui/Button'

--- a/frontend/src/test/acting/requestActingAccount.test.jsx
+++ b/frontend/src/test/acting/requestActingAccount.test.jsx
@@ -5,6 +5,12 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+
+// Spec 064: stub the asset-selector data hook so this provider-light test stays isolated.
+vi.mock('../../hooks/useSelectableAssets', async () => await import('../helpers/selectableAssetsMock'))
+vi.mock('../../hooks/useBitcoinWallet', () => ({
+  useBitcoinWallet: () => ({ status: 'idle', receive: { nextReceiveAddress: () => null } }),
+}))
 import { ethers } from 'ethers'
 import { CustodyContext } from '../../contexts/CustodyContext'
 

--- a/frontend/src/test/claimCode/OpenChallengeCodeBackup.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeCodeBackup.test.jsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
+// Spec 064: stub the stake-asset data hook so this provider-light test stays isolated.
+vi.mock('../../hooks/useSelectableAssets', async () => await import('../helpers/selectableAssetsMock'))
+
 // Mock the flow hooks so the modal renders without chain/IPFS; the vault uses real crypto + localStorage.
 const createOpenChallenge = vi.fn()
 vi.mock('../../hooks/useOpenChallengeCreate', async (importOriginal) => {

--- a/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
+// Spec 064: stub the stake-asset data hook so this provider-light test stays isolated.
+vi.mock('../../hooks/useSelectableAssets', async () => await import('../helpers/selectableAssetsMock'))
+
 // Mock the create flow so the modal renders deterministically (no chain/IPFS).
 const createOpenChallenge = vi.fn()
 vi.mock('../../hooks/useOpenChallengeCreate', async (importOriginal) => {

--- a/frontend/src/test/claimCode/publicModeState.test.jsx
+++ b/frontend/src/test/claimCode/publicModeState.test.jsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 
+// Spec 064: stub the stake-asset data hook so this provider-light test stays isolated.
+vi.mock('../../hooks/useSelectableAssets', async () => await import('../helpers/selectableAssetsMock'))
+
 // Mock the create flow so the modal renders deterministically (no chain/IPFS).
 const createOpenChallenge = vi.fn()
 vi.mock('../../hooks/useOpenChallengeCreate', async (importOriginal) => {

--- a/frontend/src/test/helpers/selectableAssetsMock.js
+++ b/frontend/src/test/helpers/selectableAssetsMock.js
@@ -1,0 +1,28 @@
+// Shared test double for the spec-064 useSelectableAssets hook.
+//
+// The home Pay/Request/Wager panels and the Transfer view now derive their asset
+// list from useSelectableAssets, which transitively needs the WalletProvider /
+// portfolio graph. Tests that render those panels for OTHER reasons (challenge
+// creation, acting-account wiring, home a11y) stub the DATA hook with this fixture
+// so they stay provider-light — the real UniversalAssetSelect component still
+// renders, so its markup/a11y remain under test.
+//
+// Usage (vi.mock is hoisted, so reference this via an async factory import):
+//   vi.mock('<rel>/hooks/useSelectableAssets', async () =>
+//     await import('<rel>/test/helpers/selectableAssetsMock'))
+
+// Chain 61 (Ethereum Classic) matches the global wagmi useChainId() test mock in
+// src/test/setup.js, so panels that gate on the connected chain (Wager create) see
+// no false network mismatch when they render with this fixture.
+const USDC = '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359'
+const CHAIN = 61
+
+const OPTIONS = [
+  { key: `${CHAIN}:${USDC}`, chainId: CHAIN, kind: 'erc20', address: USDC, symbol: 'USDC', name: 'USD Coin', decimals: 6, networkName: 'Ethereum Classic', balance: 100 },
+  { key: `${CHAIN}:native`, chainId: CHAIN, kind: 'native', address: null, symbol: 'ETC', name: 'Ethereum Classic', decimals: 18, networkName: 'Ethereum Classic', balance: 5 },
+]
+
+const API = { options: OPTIONS, defaultKey: `${CHAIN}:${USDC}`, isGasless: () => false }
+
+export const useSelectableAssets = () => API
+export default useSelectableAssets

--- a/frontend/src/test/home.axe.test.jsx
+++ b/frontend/src/test/home.axe.test.jsx
@@ -1,5 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, within } from '@testing-library/react'
+
+// Spec 064: stub the asset-selector data hook so provider-light home panels render
+// (the real UniversalAssetSelect component still renders, so a11y stays covered).
+vi.mock('../hooks/useSelectableAssets', async () => await import('./helpers/selectableAssetsMock'))
+vi.mock('../hooks/useActiveAccount', () => ({
+  useActiveAccount: () => ({ identity: { mode: 'personal' }, isVault: false, isLegacy: false }),
+}))
+vi.mock('../hooks/useBitcoinWallet', () => ({
+  useBitcoinWallet: () => ({ status: 'idle', receive: { nextReceiveAddress: () => null } }),
+}))
 import { axe } from 'vitest-axe'
 import { MemoryRouter } from 'react-router-dom'
 

--- a/frontend/src/test/paymentRequestRoundTrip.test.jsx
+++ b/frontend/src/test/paymentRequestRoundTrip.test.jsx
@@ -20,6 +20,18 @@ vi.mock('../hooks', () => ({
   useWallet: () => ({ isConnected: true, address: REQUESTER, chainId: 137, openConnectModal: vi.fn() }),
 }))
 vi.mock('../hooks/useChainTokens', () => ({ useChainTokens: () => TOKENS }))
+// Spec 064: the panels derive their asset list from useSelectableAssets. Stub it on
+// chain 137 (matching the mocked connected chain) so the USDC request round-trips.
+const rtNative = { key: '137:native', chainId: 137, kind: 'native', address: null, symbol: 'POL', name: 'Polygon', decimals: 18, networkName: 'Polygon', balance: 5 }
+const rtStable = { key: `137:${USDC.toLowerCase()}`, chainId: 137, kind: 'erc20', address: USDC, symbol: 'USDC', name: 'USD Coin', decimals: 6, networkName: 'Polygon', balance: 1000 }
+const rtApi = { options: [rtStable, rtNative], defaultKey: rtStable.key, isGasless: () => true }
+vi.mock('../hooks/useSelectableAssets', () => ({ useSelectableAssets: () => rtApi, default: () => rtApi }))
+vi.mock('../hooks/useActiveAccount', () => ({
+  useActiveAccount: () => ({ identity: { mode: 'personal' }, isVault: false, isLegacy: false }),
+}))
+vi.mock('../hooks/useBitcoinWallet', () => ({
+  useBitcoinWallet: () => ({ status: 'idle', receive: { nextReceiveAddress: () => null } }),
+}))
 vi.mock('../hooks/useClipboard', () => ({ useClipboard: () => ({ copied: false, copy: vi.fn() }) }))
 vi.mock('qrcode.react', () => ({
   QRCodeSVG: (props) => <svg data-testid="request-qr" data-value={props.value} />,
@@ -92,7 +104,8 @@ describe('Request → scan → Pay round trip (spec 058 US2/SC-003)', () => {
     // 3. Everything is prefilled, ready to confirm.
     expect(screen.getByLabelText('To')).toHaveValue(REQUESTER)
     expect(screen.getByTestId('amount-keypad-hero')).toHaveTextContent('12.5')
-    expect(screen.getByLabelText('Currency')).toHaveValue('stable')
+    // The universal selector's trigger shows the resolved currency (USDC).
+    expect(screen.getByRole('button', { name: 'Currency' })).toHaveTextContent('USDC')
     expect(screen.getByLabelText('Note')).toHaveValue('pizza night')
     const pay = screen.getByRole('button', { name: /^pay$/i })
     await vi.waitFor(() => expect(pay).toBeEnabled())

--- a/specs/064-universal-asset-selector/checklists/requirements.md
+++ b/specs/064-universal-asset-selector/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Universal Asset Selector
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- The three clarification decisions (held-only list, network-switch gating,
+  activity-scoped exclusion of non-EVM assets) were resolved inline in the spec's
+  Clarifications section using the reference behavior of the existing wallet
+  Transfer form, so no open [NEEDS CLARIFICATION] markers remain.
+- The spec deliberately references prior-feature *behaviors* (portfolio holdings,
+  send engine, nested asset logo) as reused capabilities without prescribing
+  implementation, keeping it stakeholder-readable while binding scope to "no new
+  on-chain behavior."

--- a/specs/064-universal-asset-selector/contracts/universal-asset-selector.md
+++ b/specs/064-universal-asset-selector/contracts/universal-asset-selector.md
@@ -1,0 +1,139 @@
+# Frontend Contracts: Universal Asset Selector
+
+No smart-contract or HTTP interfaces change. These are the **frontend component /
+hook contracts** the feature introduces or wires. They are the stable API other
+code depends on and what the Vitest tests assert against.
+
+---
+
+## `UniversalAssetSelect` (component)
+
+`frontend/src/components/ui/UniversalAssetSelect.jsx`
+
+Presentational dropdown of `SelectableAsset` options rendering each with the nested
+`AssetLogo`. A superset of the existing `TransferAssetSelect` (adds the logo). Owns
+no data derivation, routing, or eligibility — those are the caller's / hook's job.
+
+### Props
+
+| Prop | Type | Default | Meaning |
+|------|------|---------|---------|
+| `options` | `SelectableAsset[]` | `[]` | Already activity-scoped list (caller applies the capability profile). |
+| `value` | `string` | — | Selected option `key`. |
+| `onChange` | `(option: SelectableAsset) => void` | — | Fires with the full option on selection. |
+| `isGasless` | `(option) => boolean` | `() => false` | Per-row gasless marker source (from `quoteGaslessForAsset`; Bitcoin forced `false`). |
+| `disabled` | `boolean` | `false` | Disables the trigger. |
+| `label` | `string` | `'Asset'` | Accessible name for the trigger/listbox. |
+| `size` | `number` | `28` | `AssetLogo` size in px. |
+
+### Behavior contract
+
+- Renders a button trigger showing the selected option's **nested `AssetLogo`**
+  (`<AssetLogo symbol chainId={evmChainId} showBadge />`; for a `btc-native` option
+  pass no EVM badge), symbol, network, and balance (balance `null` → pending glyph,
+  never `0`).
+- Opens a `role="listbox"`; each row is `role="option"` with `aria-selected`, shows
+  the nested logo + symbol + network + balance + ⚡ when `isGasless(option)`.
+- Keyboard operable: Enter/Space toggles, Escape closes, outside-click closes;
+  focus semantics match `TransferAssetSelect` today.
+- Decorative logo is `aria-hidden`; symbol + network text always present (FR-015).
+- Empty `options` → disabled trigger reading "No assets available" (honest empty
+  state, no crash).
+
+---
+
+## `useSelectableAssets` (hook)
+
+`frontend/src/hooks/useSelectableAssets.js`
+
+Builds the activity-scoped, acting-account-aware option list. Generalizes
+`TransferForm`'s `assetOptions` `useMemo` (research R1).
+
+### Signature
+
+```js
+const {
+  options,        // SelectableAsset[]  — already filtered for `activity`
+  defaultKey,     // string | null      — activity default (capability profile)
+  isGasless,      // (option) => boolean — per-asset gasless quote (BTC → false)
+} = useSelectableAssets({ activity, actingAddress })
+```
+
+| Input | Type | Meaning |
+|-------|------|---------|
+| `activity` | `'pay' \| 'request' \| 'wager' \| 'transfer'` | Selects the capability profile that filters kinds. |
+| `actingAddress` | `string \| null` | When set (vault/legacy), list that account's holdings; else personal portfolio. |
+
+### Behavior contract
+
+- Assembles options per data-model derivation rules (defaults + Bitcoin + holdings),
+  then applies `filterAssetsForActivity(activity, …)`.
+- `isGasless(option)` delegates to `useTransfer().quoteGaslessForAsset`, forcing
+  `false` for `kind === 'btc-native'` (FR-005; Bitcoin never gasless).
+- `defaultKey` from `defaultAssetKey(activity, options, …)` (FR-011, FR-013).
+- Recomputed (memoized) on changes to holdings, connected chain, acting account, or
+  Bitcoin readiness; never performs new network reads itself.
+
+---
+
+## `lib/assets/assetActivity.js` (pure policy)
+
+```js
+export const ASSET_ACTIVITIES = { PAY:'pay', REQUEST:'request', WAGER:'wager', TRANSFER:'transfer' }
+
+// Which SelectableAsset.kind values an activity may offer.
+export function allowedKindsForActivity(activity): Array<'native'|'erc20'|'btc-native'>
+
+// Remove options the activity can't act on (non-EVM out of wager, etc.).
+export function filterAssetsForActivity(activity, options): SelectableAsset[]
+
+// Activity default selection key per the capability table.
+export function defaultAssetKey(activity, options, { connectedChainId, stableAddress }): string | null
+```
+
+Contract: pure, synchronous, no hooks/imports of React or chain libs; fully unit
+testable. `wager` allows only `erc20`; `pay`/`request`/`transfer` allow all kinds.
+
+---
+
+## Consumer wiring contracts (behavior deltas only)
+
+### `PayPanel` (US1)
+- Replace the two-option `<select>` in the `tokenSlot` with `UniversalAssetSelect`
+  fed by `useSelectableAssets({ activity: 'pay', actingAddress })`.
+- On select, drive amount denomination, balance, and gasless disclosure from the
+  option; submit via `useTransfer().send({ asset: selectedOption, to, amount })`.
+- Wrong-chain selection → primary action becomes "Switch to {network}" (FR-007).
+- Bitcoin selection routes through the existing Bitcoin send path; fee disclosure
+  says Bitcoin is never gasless (FR-009, US1 scenario 5).
+
+### `RequestPanel` (US2)
+- Replace the `<select>` with `UniversalAssetSelect`
+  (`activity: 'request'`). Build the request from the selected option
+  (`buildPaymentRequestUri` with the option's token/decimals/chain, or the Bitcoin
+  request form for a `btc-native` option).
+- Changing the selected asset or acting account invalidates a displayed request
+  (FR-010) — extend the existing `safeGenerated` guard to include the asset key.
+
+### `CreateChallengePanel` (US3)
+- Replace `token="USDC"` hero with `UniversalAssetSelect`
+  (`activity: 'wager'` → ERC-20 only, no native, no Bitcoin), default USDC.
+- Pass the selected option's address as `form.token` to `createOpenChallenge`
+  (already supported; defaults to USDC when absent). Wrong-chain → switch-gated.
+- A non-allowlisted ERC-20 surfaces the existing `NotAllowedToken` friendly error.
+
+### `TransferForm` + `TransferAssetSelect` ("trade" view, US4)
+- `TransferForm` builds its list via `useSelectableAssets({ activity: 'transfer', actingAddress })`
+  (or keeps its list and swaps the select) and renders `UniversalAssetSelect`, so
+  the same assets now show nested logos. Execution flow unchanged (FR-012, SC-002).
+- `TransferAssetSelect` becomes a thin re-export/wrapper of `UniversalAssetSelect`
+  (or is removed and call sites updated) to avoid two divergent dropdowns.
+
+---
+
+## Test contract (SC-006)
+
+Each contract above ships Vitest coverage: option assembly + activity scoping
+(Bitcoin in Pay/Request, out of Wager), per-asset gasless marker, network-switch
+gating, Wager denomination via `form.token`, request invalidation on asset change,
+nested-logo render per row, listbox a11y roles, and unchanged Transfer asset set.

--- a/specs/064-universal-asset-selector/data-model.md
+++ b/specs/064-universal-asset-selector/data-model.md
@@ -1,0 +1,82 @@
+# Phase 1 Data Model: Universal Asset Selector
+
+No persisted data and no on-chain schema. These are the in-memory shapes the
+frontend selector operates on, all derived from existing sources (portfolio
+holdings, network config, the send engine's quotes). Field names mirror what
+`TransferForm`/`useTransfer`/`AssetLogo` already use so the extraction is a
+straight generalization.
+
+## SelectableAsset
+
+One choosable option in the selector. Built by `useSelectableAssets` from held
+holdings plus the connected network's always-present defaults.
+
+| Field | Type | Source | Notes |
+|-------|------|--------|-------|
+| `key` | string | derived | Stable id `${chainId}:${registryId}` (registryId = `native`, lowercased token address, or `btc-native`'s `bitcoin:native`). Dedupe + selection key. |
+| `chainId` | number \| string | holding / network | EVM numeric chainId, or a Bitcoin string network id (`'bitcoin'`). Consumers guard the string case with `isBitcoinNetworkId`. |
+| `kind` | `'native'` \| `'erc20'` \| `'btc-native'` | holding | Drives routing branch + activity eligibility. |
+| `address` | string \| null | holding | Token contract address; `null` for native and Bitcoin. |
+| `symbol` | string | holding / config | e.g. `USDC`, `WBTC`, `BTC`. Always shown as text (a11y). |
+| `name` | string | holding / config | Human name; used by the send engine's ledger record. |
+| `decimals` | number | holding / config | For amount parsing at send time. |
+| `networkName` | string | network config | Shown as the row's network label; e.g. `Polygon`, `Bitcoin`. |
+| `balance` | number \| null | balances | Held amount; `null` = still loading (shown as pending, never fake-zero). |
+| `gasless` | boolean | `quoteGaslessForAsset` (via `isGasless(option)`) | Per-asset gasless truth; Bitcoin is always `false`. Rendered as ⚡ marker. |
+
+**Derivation rules** (from research R1/R7):
+- Always include the connected chain's native + stablecoin (even at `balance: 0`)
+  so a form is usable before balances load.
+- Include native Bitcoin only when `useBitcoinWallet().status === 'ready'` and the
+  acting account is personal (vaults/legacy EVM accounts can't hold BTC).
+- Include every `native`/`erc20` holding from the acting source
+  (`usePortfolio` personal, else `useAccountAssets(actingAddress)`); keep
+  zero-balance only for native + the connected stablecoin, drop other zero rows.
+- Sort connected-chain-first, then by descending balance.
+
+**Validation / invariants**:
+- An option is never emitted for a chain with no network config (edge case
+  "unreachable/unsupported network").
+- `key` is unique; later same-key inserts merge (defaults merge with their held row).
+- When the currently-selected `key` is absent from the freshly computed list, the
+  consumer falls back: connected stablecoin → connected native → first option
+  (FR-013).
+
+## ActivityCapabilityProfile
+
+Pure policy (in `lib/assets/assetActivity.js`) describing which `SelectableAsset`
+kinds an activity may offer. No data storage.
+
+| Activity | Allowed kinds | Excludes | Default selection |
+|----------|---------------|----------|-------------------|
+| `pay` | `native`, `erc20`, `btc-native` | — | connected stablecoin → native → first |
+| `request` | `native`, `erc20`, `btc-native` | — | connected stablecoin → native → first |
+| `wager` | `erc20` only | `native`, `btc-native` (non-EVM) | connected stablecoin (USDC) → first erc20 |
+| `transfer` | `native`, `erc20`, `btc-native` | — | connected stablecoin → native → first |
+
+**Rules**:
+- `filterAssetsForActivity(activity, options)` removes disallowed kinds so an
+  unsupported asset never appears in that activity (FR-008). Exclusion is by list
+  construction, not a submit-time error.
+- `defaultAssetKey(activity, options, { connectedChainId, stableAddress })`
+  returns the activity's default per the table (FR-011, FR-013).
+- Wager excludes native because the escrow pulls the stake via ERC-20
+  `transferFrom`; the on-chain `NotAllowedToken` allowlist is the backstop for a
+  held ERC-20 the registry doesn't accept (surfaced as the existing friendly error).
+
+## Relationships
+
+```
+usePortfolio / useAccountAssets ─┐
+useChainTokens (native+stable) ──┤
+useBitcoinWallet (BTC, personal) ┼─▶ useSelectableAssets({ activity, actingAddress })
+config/networks + assetTaxonomy ─┘         │  applies ActivityCapabilityProfile
+                                            ▼
+                                     SelectableAsset[]  ──▶ UniversalAssetSelect (renders AssetLogo per row)
+                                            │
+                                            ▼  selected SelectableAsset
+                        useTransfer.send({ asset }) / buildPaymentRequestUri / createOpenChallenge({ token })
+```
+
+Nothing here is new persisted state; every field traces to an existing source, and
+the two new shapes are computed, not stored.

--- a/specs/064-universal-asset-selector/plan.md
+++ b/specs/064-universal-asset-selector/plan.md
@@ -1,0 +1,149 @@
+# Implementation Plan: Universal Asset Selector
+
+**Branch**: `claude/universal-asset-selector-ytlm7v` | **Date**: 2026-07-23 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/064-universal-asset-selector/spec.md`
+
+## Summary
+
+Replace the narrow asset controls on the home **Pay**, **Request**, and **Wager**
+views (native + stablecoin only; Wager hard-locked to USDC) and upgrade the
+wallet **Transfer** ("trade") view's plain asset dropdown, with a single reusable
+**universal asset selector**. The selector lists any platform-supported asset the
+acting account holds across every configured network — the same cross-network
+portfolio the Transfer form already assembles — and renders each option with the
+Earn page's **nested asset logo** (`AssetLogo`: asset glyph + network sub-badge).
+Non-EVM assets (Bitcoin) appear and function where supported (Pay, Request) and
+are excluded from EVM-only activities (Wager escrow, Transfer's on-connected-chain
+send is already gated). All routing is delegated to the existing `useTransfer`
+send engine (which already accepts a full asset descriptor and quotes gasless
+per-asset), so this feature adds **no new on-chain behavior, contracts, or network
+config** — it is pure frontend presentation + wiring.
+
+The design extracts two shared frontend primitives from the existing
+`TransferForm`/`TransferAssetSelect` pair so all four surfaces share one code path:
+
+1. **`useSelectableAssets(options)`** — a hook that builds the activity-scoped,
+   acting-account-aware option list from `usePortfolio` / `useAccountAssets` /
+   `useChainTokens` / `useBitcoinWallet`, generalizing the `assetOptions` useMemo
+   currently inlined in `TransferForm`.
+2. **`UniversalAssetSelect`** — a presentational dropdown that renders each option
+   with `AssetLogo` (nested badge), symbol, network, balance, and gasless marker;
+   a superset of today's `TransferAssetSelect` with the nested logo added.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2022), React 18 + Vite (frontend only).
+
+**Primary Dependencies**: React, wagmi/viem (chain switch), ethers (already used
+by the send engine), Vitest + Testing Library. Reused app modules:
+`hooks/useTransfer`, `hooks/usePortfolio`, `hooks/useAccountAssets`,
+`hooks/useChainTokens`, `hooks/useBitcoinWallet`, `hooks/useActiveAccount`,
+`components/wallet/AssetLogo`, `config/assetTaxonomy` (`getPortfolioRegistry`,
+`getUnderlyingMeta`), `config/networks`, `config/bitcoinNetworks`
+(`isBitcoinNetworkId`).
+
+**Storage**: None new. Reads existing portfolio holdings + network config; writes
+nothing persistent. Amount/preference behavior from spec 058 is untouched.
+
+**Testing**: Vitest component/unit tests under
+`frontend/src/components/**/__tests__/` and hook tests. Follows existing patterns
+(`TransferForm` tests, `AssetLogo` render tests).
+
+**Target Platform**: Web SPA (desktop + mobile home surface), same browsers the
+app already targets.
+
+**Project Type**: Web frontend (React). No backend, contract, or subgraph changes.
+
+**Performance Goals**: Selector opens and filters instantly for realistic
+portfolios (tens of assets across ~5 networks); option-list assembly is a pure
+`useMemo` over already-fetched holdings — no new network round-trips introduced by
+the selector itself.
+
+**Constraints**: WCAG 2.1 AA (keyboard + screen-reader operable; nested logo is
+decorative and never the sole meaning carrier). Honest-state (Constitution III):
+never offer an asset an activity can't act on; never sign against the wrong chain;
+balances shown as pending, not fake-zero. No hardcoded addresses/ABIs — all asset
+identity comes from existing config/sync artifacts.
+
+**Scale/Scope**: 4 consuming surfaces (Pay, Request, Wager, Transfer); 1 new hook,
+1 new presentational component (+ CSS), 1 small capability-profile helper; wiring
+edits to `PayPanel`, `RequestPanel`, `CreateChallengePanel`, `TransferForm`;
+refactor `TransferAssetSelect` to delegate to (or be replaced by) the new
+component.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Security-First Smart Contracts (NON-NEGOTIABLE)** — ✅ N/A. No `contracts/`
+  changes; no new on-chain behavior (FR-016). No Slither/Medusa/security-agent gate
+  triggered.
+- **II. Test-First & Comprehensive Coverage (NON-NEGOTIABLE)** — ✅ Vitest tests
+  ship with the hook, the component, and each rewired panel (option assembly,
+  activity scoping, network-switch gating, Bitcoin inclusion/exclusion, fallback
+  on invalid selection, a11y roles). No contract interfaces change.
+- **III. Honest State, No Mocks/Placeholders** — ✅ Central to the design: assets
+  come from real portfolio holdings + network config; unsupported assets are
+  excluded per activity so nothing fails silently at submit; balances are pending
+  vs. real; per-asset gasless truth comes from the engine's own quote; Bitcoin is
+  network-scoped via `isBitcoinNetworkId` and never passed to EVM code.
+- **IV. Fail Loudly in CI** — ✅ No `continue-on-error`; ESLint/tests gate as usual.
+- **V. Accessible, Consistent Frontend** — ✅ Keyboard/listbox semantics, labels,
+  decorative logo (`aria-hidden`) with text carrying meaning; addresses/ABIs/config
+  from sync artifacts, never hand-copied. axe/Lighthouse CI unaffected/greened.
+
+**Result**: PASS. No violations; Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/064-universal-asset-selector/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (frontend component/hook contracts)
+│   └── universal-asset-selector.md
+├── checklists/
+│   └── requirements.md  # From /speckit-specify
+└── tasks.md             # From /speckit-tasks (not created here)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── components/
+│   ├── ui/
+│   │   ├── UniversalAssetSelect.jsx        # NEW — reusable nested-logo asset dropdown
+│   │   └── UniversalAssetSelect.css        # NEW — styles (dark-mode aware, a11y)
+│   ├── wallet/
+│   │   ├── AssetLogo.jsx                    # REUSED unchanged (nested logo artwork)
+│   │   ├── TransferForm.jsx                 # EDIT — use hook + UniversalAssetSelect ("trade" view)
+│   │   └── TransferAssetSelect.jsx          # EDIT — thin wrapper over UniversalAssetSelect (or removed)
+│   └── fairwins/
+│       ├── PayPanel.jsx                     # EDIT — swap <select> for UniversalAssetSelect (US1)
+│       ├── RequestPanel.jsx                 # EDIT — swap <select> for UniversalAssetSelect (US2)
+│       └── CreateChallengePanel.jsx         # EDIT — USDC-locked → escrow-eligible selector (US3)
+├── hooks/
+│   └── useSelectableAssets.js               # NEW — activity-scoped, acting-account asset options
+├── lib/
+│   └── assets/
+│       └── assetActivity.js                 # NEW — activity capability profiles + filtering
+└── ...
+frontend/src/**/__tests__/                   # NEW/EDIT — Vitest coverage
+```
+
+**Structure Decision**: Web frontend only. New shared pieces live in `components/ui`
+(the reusable selector) and `hooks/` + `lib/assets/` (data + policy), mirroring how
+the app already separates presentational UI, data hooks, and pure config/policy.
+The four consuming surfaces are edited in place; the existing `TransferForm`
+`assetOptions` logic and `TransferAssetSelect` are the extraction source so the
+"trade" view keeps identical behavior while gaining the nested logo.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Section intentionally empty.

--- a/specs/064-universal-asset-selector/quickstart.md
+++ b/specs/064-universal-asset-selector/quickstart.md
@@ -1,0 +1,82 @@
+# Quickstart: Universal Asset Selector
+
+Validation guide proving the feature end-to-end. Frontend-only; no contracts,
+subgraph, or deploys involved.
+
+## Prerequisites
+
+- Repo installed: `npm install` at root (and `frontend/` deps as usual).
+- An account with holdings on more than one configured network (e.g. USDC + native
+  on the connected chain, plus WBTC/WETH on another), and — for the Bitcoin checks —
+  a ready passkey Bitcoin wallet (spec 061).
+
+## Run the tests (primary validation)
+
+```bash
+npm run test:frontend
+```
+
+Expected: the new suites pass —
+- `hooks/__tests__/useSelectableAssets.test.*` — option assembly, activity scoping,
+  acting-account source, zero-balance defaults, invalid-selection fallback.
+- `lib/assets/__tests__/assetActivity.test.*` — allowed kinds, filter, default key.
+- `components/ui/__tests__/UniversalAssetSelect.test.*` — nested `AssetLogo` per
+  row, symbol/network/balance text, gasless marker, listbox a11y, empty state.
+- `components/fairwins/__tests__/PayPanel.*`, `RequestPanel.*`,
+  `CreateChallengePanel.*` — selector wiring, switch-gating, Wager denomination.
+- `components/wallet/__tests__/TransferForm.*` — unchanged asset set, now with logos.
+
+## Run the app (manual walkthrough)
+
+```bash
+npm run frontend
+```
+
+### Scenario A — Pay any held asset (US1)
+1. Land on Home → **Pay**. Open the currency selector under the amount.
+2. **Expect**: every held asset across all networks is listed, each with a nested
+   logo (glyph + network sub-badge), symbol, network, balance, ⚡ where gasless.
+3. Pick a non-default asset **on the connected chain**, enter an amount, choose a
+   recipient, Pay. **Expect**: settles through the normal confirm/screening/fee flow.
+4. Pick a held asset **on another network**. **Expect**: primary button reads
+   "Switch to {network}"; only after switching can you pay. No wrong-chain send.
+
+### Scenario B — Bitcoin in Pay/Request, not in Wager (US1/US2/US3)
+1. With a ready BTC wallet, open the **Pay** selector. **Expect**: Bitcoin appears
+   with its logo; selecting it routes the existing BTC send path; fee text says
+   Bitcoin is never gasless.
+2. Open **Request**, select Bitcoin, generate. **Expect**: a Bitcoin-appropriate
+   request is produced; the view discloses the paid-to account.
+3. Open **Wager**. Open the stake selector. **Expect**: Bitcoin is **absent**;
+   native coin is absent; only ERC-20 assets (USDC + tokens) are offered.
+
+### Scenario C — Request any asset (US2)
+1. Home → **Request**. Select a non-stablecoin held asset, enter an amount, Request.
+2. **Expect**: the generated payment request/QR encodes that asset + network.
+3. Change the selected asset. **Expect**: the displayed request is invalidated
+   (no stale QR for the previous asset).
+
+### Scenario D — Wager beyond USDC (US3)
+1. Home → **Wager**. **Expect**: default asset is USDC (unchanged first-render).
+2. Select another held, allowlisted ERC-20; set a stake; create the challenge.
+3. **Expect**: stake/escrow/payout denominate in the selected asset. Selecting a
+   held ERC-20 the registry doesn't allow surfaces "That stake token is not
+   allowed." (no silent failure).
+
+### Scenario E — Trade view nested logos (US4)
+1. Open the wallet **Transfer** ("trade") view.
+2. **Expect**: the same assets as before, now each with a nested logo matching Earn
+   and the home selector; the send flow is otherwise identical.
+
+## Accessibility check
+
+- Tab to the selector; open/close and choose with the keyboard (Enter/Space/Escape).
+- With a screen reader, each option announces symbol + network + balance (the logo
+  is decorative/`aria-hidden`).
+- `npm run test:frontend` + CI axe/Lighthouse show no new a11y violations (SC-006).
+
+## Done when
+
+- All new + existing frontend tests pass; ESLint clean.
+- Manual scenarios A–E behave as described; no wrong-chain send, no unsupported
+  asset offered where it can't work, no fake balances.

--- a/specs/064-universal-asset-selector/research.md
+++ b/specs/064-universal-asset-selector/research.md
@@ -1,0 +1,172 @@
+# Phase 0 Research: Universal Asset Selector
+
+All unknowns are resolved against the existing codebase — this is a frontend
+presentation/wiring feature over capabilities the app already ships. No external
+technology choices were required.
+
+## R1 — Where the full cross-network asset list already exists
+
+**Decision**: Reuse the option-assembly logic that `frontend/src/components/wallet/TransferForm.jsx`
+already implements in its `assetOptions` `useMemo`, and extract it into a shared
+hook `useSelectableAssets`.
+
+**Rationale**: `TransferForm` already composes exactly the target list:
+- connected chain's native + stablecoin (always present, even at zero balance);
+- native Bitcoin when `useBitcoinWallet().status === 'ready'` (personal wallet only);
+- every held holding from `usePortfolio().holdings` (personal) or
+  `useAccountAssets(actingAddress).holdings` (vault / recovered legacy), filtered
+  to `native`/`erc20` (no NFTs), keeping zero-balance only for native + the
+  connected stablecoin;
+- keyed `${chainId}:${registryId}`, sorted connected-chain-first then by balance.
+
+Extracting it (rather than re-deriving) guarantees the "trade" view and the home
+views list an identical asset set, satisfying FR-002 and SC-001.
+
+**Alternatives considered**: Building a fresh list from `getPortfolioRegistry`
+directly — rejected: it would duplicate the balance/acting-account/Bitcoin merge
+already solved in `TransferForm`, risking drift and violating DRY/YAGNI
+(Constitution "Simplicity").
+
+## R2 — The nested asset logo (Earn page visual)
+
+**Decision**: Reuse `frontend/src/components/wallet/AssetLogo.jsx` unchanged, with
+`showBadge` and a `chainId`, exactly as `EarnLendView` uses it
+(`<AssetLogo symbol={…} chainId={…} showBadge size={32} />`).
+
+**Rationale**: `AssetLogo` already renders the primary asset glyph plus a network
+sub-badge from bundled inline SVG (no external CDNs), is `aria-hidden` (decorative),
+and already maps the app's symbols (ETH/BTC/MATIC/POL/ETC/USDC/WBTC…) and network
+badges (1/61/137/testnets). This is precisely "the nested asset logos from the
+earn page." Satisfies FR-003 and SC-002.
+
+**Badge chain id for Bitcoin**: `AssetLogo`'s `NETWORK_BADGES` is keyed by numeric
+EVM chainId; Bitcoin's network id is a string (`'bitcoin'`). For a BTC row we pass
+`chainId={null}` (or omit `showBadge`) so BTC renders its own glyph without a
+mismatched badge — BTC on its home network needs no sub-badge (same rule
+`AssetLogo` already applies to a native coin on its home mainnet). No change to
+`AssetLogo` required.
+
+**Alternatives considered**: A new logo component — rejected: duplicates artwork
+and diverges from Earn/Portfolio, violating Constitution V (consistency).
+
+## R3 — Routing: does the send engine already accept arbitrary assets?
+
+**Decision**: Delegate all sends to `useTransfer().send({ asset, to, amount })`;
+the view never re-derives routing. Use `quoteGaslessForAsset(asset)` for the
+per-row and selected gasless marker.
+
+**Rationale**: `useTransfer.send` already normalizes a full `asset` descriptor
+(native | network-stablecoin | arbitrary ERC-20) into its routing table, guards
+that the asset's chain matches the connected chain (`Switch to this asset's network
+before sending`), keeps the EIP-3009 gasless rail only for the network stablecoin,
+records honest ledger `kind` (`token` for non-stable ERC-20s), and preserves
+never-stranded fallbacks. Bitcoin sends route through the parallel
+`useBitcoinWallet` / `BitcoinSendPanel` path that `TransferForm` already switches
+to for `kind === 'btc-native'`. Satisfies FR-005, FR-009, and the "no new on-chain
+behavior" clause (FR-016).
+
+**Alternatives considered**: Extending `PayPanel` to build its own transfer calls
+— rejected: reimplements routing the engine already owns and would drift from the
+honest-lifecycle/gasless logic (Constitution III).
+
+## R4 — Network-mismatch handling
+
+**Decision**: When the selected asset's `chainId !== connectedChainId`, replace the
+activity's primary action with a "Switch to {network}" button using wagmi
+`useSwitchChain` (`switchChainAsync`), the exact pattern already in `TransferForm`
+and `PayPanel`'s scanned-request switch flow.
+
+**Rationale**: Transfers/wagers are signed on the connected chain; the engine also
+guards this server-side of the UI. Consistent, honest, no cross-chain illusion.
+Satisfies FR-007 and SC-003.
+
+## R5 — Activity capability scoping (which assets each activity may offer)
+
+**Decision**: Introduce a tiny pure module `lib/assets/assetActivity.js` exposing a
+capability profile per activity and a filter:
+- `pay` / `request`: allow all kinds, including `btc-native` (Bitcoin).
+- `wager`: EVM escrow only → exclude `btc-native` (and any future non-EVM kind);
+  optionally further restrict to escrow-eligible tokens.
+- `transfer` ("trade"): matches today's Transfer behavior (native + erc20 +
+  btc-native as a switchable/parallel path); the nested logo is the only visible
+  change.
+
+`useSelectableAssets({ activity })` applies the profile so unsupported assets never
+appear. Bitcoin exclusion in Wager is by list construction, not a submit-time
+error. Satisfies FR-008, SC-004.
+
+**Rationale**: Centralizing the rule keeps every surface honest and consistent, and
+makes "what can Wager hold?" a single, testable source of truth rather than
+scattered conditionals.
+
+**Alternatives considered**: Show-but-disable unsupported assets — rejected per the
+spec clarification: an asset that can *never* work in an activity is excluded to
+keep the list clean; only *temporarily* unusable (wrong-chain) assets stay visible
+and switch-gated.
+
+## R6 — Wager denomination beyond USDC
+
+**Decision**: Replace `CreateChallengePanel`'s hard-coded `token="USDC"` with the
+selector, defaulting to the connected network's stablecoin (USDC where available)
+so first-render behavior is unchanged; the created challenge denominates stake and
+payout in the selected escrow-eligible asset.
+
+**Rationale**: Satisfies FR-011, US3, SC-005. **Confirmed against the code**:
+`hooks/useOpenChallengeCreate.js` already reads `form.token` and only falls back to
+the network `paymentToken` (USDC) when it is absent/zero
+(`const tokenAddr = (form.token && form.token !== ZeroAddress) ? form.token : resolve('paymentToken')`);
+it reads the token's own `decimals()`, checks balance/allowance, approves, and calls
+`WagerRegistry.createOpenWager(..., tokenAddr, stakeWei)`. The registry enforces an
+on-chain stake-token allowlist (reverts `NotAllowedToken`, already mapped to the
+friendly message "That stake token is not allowed."). So US3 needs **no contract
+change**: `CreateChallengePanel` simply passes the selected asset's token address as
+`form.token` (defaulting to USDC when the selector's default is chosen).
+
+**Wager selector scoping**: because the stake is pulled via `transferFrom`, the
+stake asset must be an **ERC-20** — so the Wager selector offers ERC-20 holdings
+(stablecoins + tokens), **excludes the native coin** (not a `transferFrom` token)
+and **excludes Bitcoin** (non-EVM). The on-chain `NotAllowedToken` revert remains
+the honest backstop for a held ERC-20 that isn't allowlisted, surfaced via the
+existing friendly error — never a silent failure.
+
+## R7 — Acting-account awareness
+
+**Decision**: `useSelectableAssets` reads the acting account exactly as
+`TransferForm` does (`useActiveAccount` → vault/legacy address → `useAccountAssets`;
+else personal `usePortfolio`), and `RequestPanel` keeps using `useEffectiveAccount`
+for the request recipient. The selector's list follows whose funds are in play.
+
+**Rationale**: Satisfies FR-014 and the "acting as vault/recovered" edge case; avoids
+leaking one account's holdings into another's list (Constitution III network/account
+scoping).
+
+## R8 — Testing approach
+
+**Decision**: Vitest + Testing Library. New tests:
+- `useSelectableAssets`: option assembly, activity scoping (Bitcoin in/out),
+  acting-account source switch, zero-balance defaults, invalid-selection fallback.
+- `UniversalAssetSelect`: renders nested `AssetLogo` per row, symbol+network+balance
+  text, gasless marker, listbox keyboard/a11y roles, empty state.
+- Panel wiring: `PayPanel`/`RequestPanel`/`CreateChallengePanel` use the selector,
+  network-switch gating, Wager excludes Bitcoin & denominates in the selection.
+- `TransferForm`: unchanged asset set, now with nested logos.
+
+**Rationale**: Constitution II (test-first, frontend Vitest for non-trivial logic)
+and SC-006.
+
+## Summary of decisions
+
+| # | Decision |
+|---|----------|
+| R1 | Extract `TransferForm.assetOptions` → `useSelectableAssets` hook |
+| R2 | Reuse `AssetLogo` (Earn nested logo) unchanged; BTC row uses no EVM badge |
+| R3 | Delegate all routing to `useTransfer.send({asset})` + `quoteGaslessForAsset` |
+| R4 | Wrong-chain → "Switch to {network}" via wagmi `useSwitchChain` |
+| R5 | `lib/assets/assetActivity.js` capability profiles filter per activity |
+| R6 | Wager denominates in selected escrow-eligible asset, default USDC |
+| R7 | Acting-account-aware list (personal/vault/legacy) like Transfer today |
+| R8 | Vitest coverage for hook, component, and each rewired surface |
+
+No [NEEDS CLARIFICATION] markers remain. R6's implementation-boundary question was
+resolved directly against `useOpenChallengeCreate.js` + `WagerRegistry` — arbitrary
+allowlisted ERC-20 stake tokens are already supported with no contract change.

--- a/specs/064-universal-asset-selector/spec.md
+++ b/specs/064-universal-asset-selector/spec.md
@@ -1,0 +1,356 @@
+# Feature Specification: Universal Asset Selector
+
+**Feature Branch**: `claude/universal-asset-selector-ytlm7v`
+
+**Created**: 2026-07-23
+
+**Status**: Draft
+
+**Input**: User description: "On the send, request, and wager views on the 'home' the asset dropdown currently only supports matic and usdc. We need to ensure the users are able of leveraging any asset supported by the platform for these activities. The nested asset logos from the earn page provide the best quick view for assets by chain and should be leveraged here. The trade view has the ability to list all assets, however it lacks the nested icon. Create a universal asset selector for these dropdowns ensuring proper wiring for non-EVM assets for functionality supported."
+
+## Overview
+
+The home surface (Pay, Request, Wager) and the trade view each present a way to
+choose which asset an action uses. Today those choices are inconsistent and
+narrow: the home Pay and Request views offer only the connected network's native
+coin and its stablecoin; the home Wager view is hard-locked to USDC; and the
+trade view can list many assets but shows only a plain symbol, with no visual cue
+about which network each asset lives on. Meanwhile the platform already knows a
+much larger set of holdings — a member's whole cross-network portfolio, including
+non-EVM assets like Bitcoin — and the wallet Transfer form already lets a member
+send any of them.
+
+This feature introduces a **single, reusable universal asset selector** used by
+Pay, Request, Wager, and the trade view. It lets a member pick **any
+platform-supported asset the account actually holds**, across **every configured
+network**, and presents each asset with the **nested asset logo** already used on
+the Earn page — the asset's own glyph with a small network sub-badge — so it is
+always obvious at a glance *what* the asset is and *which chain* it lives on. The
+selector honestly reflects what each activity can support: assets an activity
+cannot use (for example, a non-EVM asset in the EVM-only head-to-head Wager
+escrow) are clearly excluded or disabled with an explanation, never silently
+broken.
+
+This is a frontend presentation and wiring feature. It reuses the existing send
+engine, the existing portfolio data, and the existing asset-logo artwork. It
+introduces no new on-chain behavior and no new contracts.
+
+## Clarifications
+
+### Session 2026-07-23
+
+- Q: Should the selector list every asset the platform *knows about*, or only the
+  assets the account *holds*? → A: Only assets the account **holds** (balance
+  > 0), plus the connected network's native + stablecoin always present at zero so
+  the forms stay usable before balances load — matching the wallet Transfer form's
+  existing behavior. A held-only list keeps the picker honest and short.
+- Q: When a chosen asset lives on a network other than the one the wallet is
+  connected to, what happens? → A: The action is **gated behind a network
+  switch** — the same pattern the Transfer form uses. The primary button becomes
+  "Switch to {network}" until the wallet is on the asset's chain; no cross-chain
+  magic is implied.
+- Q: How are activity-incompatible assets presented (e.g. Bitcoin in Wager)? → A:
+  **Excluded from that activity's list entirely** when the activity is
+  categorically EVM-only (Wager, trade), rather than shown-but-disabled — an asset
+  that can never work should not clutter the list. Assets that *could* work but
+  aren't currently sendable (wrong chain) remain visible and switch-gated.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Pay with any held asset (Priority: P1)
+
+A member opens the home **Pay** view. The currency control under the amount is no
+longer a two-item dropdown of native/stablecoin — it is the universal asset
+selector. Opening it shows every asset the account holds across all configured
+networks, each row displaying the nested asset logo (asset glyph + network
+sub-badge), the asset symbol, its network name, and the held balance, with a
+gasless marker where the asset's network supports it. The member picks, say, WBTC
+on Polygon, keys an amount, chooses a recipient, and pays. The transfer runs
+through the existing send engine exactly as a native/stablecoin send does today.
+
+**Why this priority**: Pay is the default home mode and the most-used money
+action. Extending it to the full portfolio is the core of the feature and is a
+viable MVP on its own.
+
+**Independent Test**: Load the home Pay view with an account holding several
+assets on more than one network. Confirm the selector lists all held assets with
+nested logos, pick a non-default asset on the connected chain, complete a
+payment, and verify it settles through the same flow (confirmation, screening, fee
+disclosure, gasless routing) as a stablecoin payment today.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected account holding native, stablecoin, and additional
+   ERC-20 assets across networks, **When** the member opens the Pay currency
+   selector, **Then** every held asset is listed, each with its nested asset logo
+   (glyph + network sub-badge), symbol, network name, and balance.
+2. **Given** the Pay selector is open, **When** the member selects an asset on the
+   currently connected network, **Then** the amount hero, balance line, and
+   gasless/fee disclosure update to that asset and the member can complete the
+   payment through the existing send engine.
+3. **Given** the member selects a held asset that lives on a *different* network
+   than the wallet is connected to, **When** they attempt to pay, **Then** the
+   primary action becomes "Switch to {network}" and only after switching does the
+   payment proceed — no send is ever signed against the wrong chain.
+4. **Given** an asset whose network is configured for gasless sends, **When** it is
+   shown in the list and selected, **Then** a gasless marker is shown for that row
+   and the fee disclosure says gasless; assets without that rail show "network fee
+   applies" — matching the engine's per-asset quote.
+5. **Given** the account holds a non-EVM asset (Bitcoin), **When** the member
+   opens the Pay selector, **Then** Bitcoin appears with its nested logo and, when
+   selected, Pay routes through the existing Bitcoin send path; the fee disclosure
+   honestly states Bitcoin is never gasless.
+
+---
+
+### User Story 2 - Request any held asset (Priority: P2)
+
+A member opens the home **Request** view. The currency control is the same
+universal asset selector, scoped to assets the member can *receive*. The member
+picks an asset (including one on a network other than the connected one, or a
+non-EVM asset like Bitcoin), enters an amount and a note, and generates a payment
+request. The request encodes the correct recipient, amount, asset, and network so
+any compatible wallet can pay it.
+
+**Why this priority**: Request is the second home money action and shares the same
+selector; extending it makes the home surface consistent. It depends on the
+selector from US1 but delivers independent value (asking for any asset, not just
+native/stablecoin).
+
+**Independent Test**: Open the Request view, select a non-stablecoin held asset,
+generate the request, and confirm the resulting payment request/QR encodes that
+asset and its network correctly and is scannable.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Request view, **When** the member opens the asset selector,
+   **Then** it shows the receivable assets with nested logos, symbol, and network,
+   consistent with the Pay selector's presentation.
+2. **Given** a selected asset, **When** the member enters an amount and presses
+   Request, **Then** the generated payment request encodes that asset's identity
+   (recipient, amount, asset/token, network) so a compatible wallet reads the
+   correct asset and chain.
+3. **Given** a non-EVM asset that the request format supports (Bitcoin), **When**
+   the member generates a request for it, **Then** the request is produced in the
+   appropriate form for that asset and the view discloses which account/network it
+   will be paid to.
+4. **Given** the member changes the selected asset or the acting account after a
+   request is displayed, **When** the change occurs, **Then** the previously shown
+   request is invalidated so a stale request can never point at the wrong
+   asset/account.
+
+---
+
+### User Story 3 - Wager with any EVM-supported asset (Priority: P2)
+
+A member opens the home **Wager** (create challenge) view. Instead of a hard-coded
+USDC stake, the stake asset is chosen with the universal asset selector — scoped
+to the assets that the head-to-head wager escrow can actually hold. Non-EVM
+assets (Bitcoin) do not appear in the Wager selector because the escrow is
+EVM-only; the view makes clear that wagers settle in supported on-chain assets.
+The member picks a supported asset, sets the stake, and creates the challenge; the
+stake, escrow, and payout all denominate in the chosen asset.
+
+**Why this priority**: Wager is the third home mode and the feature's namesake
+request ("send, request, and wager"). It shares the selector but carries the most
+constraints (escrow compatibility), so it is scoped after the simpler Pay/Request
+money actions.
+
+**Independent Test**: Open the Wager create view, confirm the selector offers only
+escrow-eligible assets (no Bitcoin), pick a non-USDC eligible asset, and verify
+the created challenge denominates its stake and payout in that asset.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Wager create view, **When** the member opens the stake asset
+   selector, **Then** only assets the head-to-head escrow supports are listed —
+   each with its nested logo — and categorically unsupported assets (non-EVM, e.g.
+   Bitcoin) are excluded.
+2. **Given** an escrow-eligible asset is selected, **When** the member sets a
+   stake and creates the challenge, **Then** the stake, escrow, and payout are
+   denominated in the selected asset rather than a hard-coded USDC.
+3. **Given** an escrow-eligible asset on a network other than the connected one,
+   **When** the member tries to create the challenge, **Then** the action is
+   network-switch gated exactly as Pay is, so the challenge is never created on the
+   wrong chain.
+4. **Given** the platform's existing default (USDC) is available on the connected
+   network, **When** the Wager view first renders, **Then** it defaults to that
+   asset so the common case is unchanged.
+
+---
+
+### User Story 4 - Consistent nested logos in the trade view (Priority: P3)
+
+A member opens the **trade** view, which already lists many assets. The list now
+uses the same universal asset selector presentation, so every asset shows the
+nested asset logo (glyph + network sub-badge) instead of a bare symbol. Behavior
+of the trade view is otherwise unchanged; only the asset presentation becomes
+consistent with the rest of the app.
+
+**Why this priority**: The trade view already lists all assets and works; adding
+the nested icon is a polish/consistency improvement, valuable but lower risk and
+lower urgency than the home money actions.
+
+**Independent Test**: Open the trade view and confirm each listed asset now
+renders with the nested asset logo matching the Earn page and the home selector,
+with no change to which assets are listed or how a trade is executed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the trade view's asset list, **When** it renders, **Then** each asset
+   shows the nested asset logo (asset glyph + network sub-badge) consistent with
+   the Earn page and the home selector.
+2. **Given** the trade view previously listed a set of assets, **When** the
+   selector is adopted, **Then** the same assets remain available and the trade
+   execution flow is unchanged.
+
+---
+
+### Edge Cases
+
+- **Empty portfolio**: The account holds nothing beyond the connected network's
+  native/stablecoin (still shown at zero). The selector renders those defaults and
+  discloses balances are loading or zero; no crash, no empty menu.
+- **Balances still loading**: Before balances resolve, the selector shows the
+  connected network's native + stablecoin so the form is usable, with a loading
+  indicator on balances rather than a blank list.
+- **Asset on an unreachable/unsupported network**: An asset whose network config
+  is missing is not offered; the selector never lists an asset it cannot act on.
+- **Non-EVM asset in an EVM-only activity**: Excluded from Wager and trade lists;
+  present in Pay/Request. The exclusion is by activity capability, applied
+  consistently, never a silent failure at submit time.
+- **Selected asset becomes unavailable**: If the acting account, connected chain,
+  or holdings change so the selected asset is no longer valid, the selector falls
+  back to a sensible default (connected stablecoin → native → first available) and
+  clears any dependent in-progress output (e.g. a generated request).
+- **Acting as a vault or recovered account**: The selector's asset list reflects
+  the account the member is *acting as* (its own holdings on its own chain), not
+  always the connected wallet, consistent with the existing Transfer/Request
+  behavior.
+- **Very long asset lists**: The list remains scannable and scrollable; the nested
+  logos and network labels keep same-symbol assets on different networks
+  distinguishable.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a single reusable asset selector used by the
+  home Pay, home Request, home Wager, and trade views, replacing each view's
+  current asset control.
+- **FR-002**: The selector MUST let a member choose from any platform-supported
+  asset the acting account holds across every configured network, matching the set
+  the wallet Transfer form already surfaces (held balance > 0), while always
+  including the connected network's native coin and stablecoin so the forms are
+  usable before balances load or at zero balance.
+- **FR-003**: Each asset row and the selected-asset display MUST render the nested
+  asset logo used on the Earn page — the asset's primary glyph with its network
+  sub-badge — so the asset's identity and hosting network are clear at a glance.
+- **FR-004**: Each asset row MUST show the asset symbol, its network name, and the
+  held balance; balances that are still loading MUST be shown as pending, not as
+  zero or blank.
+- **FR-005**: The selector MUST indicate, per asset, whether a send of that asset
+  is gasless on its network, using the existing per-asset gasless quote — it MUST
+  NOT re-derive routing itself.
+- **FR-006**: Selecting an asset MUST update the dependent view state (amount
+  denomination, balance line, fee/gasless disclosure, and any generated output) to
+  that asset.
+- **FR-007**: When a selected asset lives on a network other than the one the
+  wallet is connected to, the activity's primary action MUST become a
+  network-switch affordance ("Switch to {network}") and the underlying action MUST
+  NOT be signed until the wallet is on the asset's network.
+- **FR-008**: The system MUST scope each activity's asset list to what that
+  activity can support: Pay and Request MUST include non-EVM assets (Bitcoin) that
+  those flows support; the head-to-head Wager escrow and the trade view MUST
+  exclude categorically unsupported assets (non-EVM), and MUST never present an
+  asset that would fail at submit time as if it were usable.
+- **FR-009**: Pay MUST route a selected asset through the existing send engine
+  using its full asset descriptor (native, network stablecoin, arbitrary ERC-20,
+  or Bitcoin), inheriting the engine's screening, gasless routing, honest
+  lifecycle, and never-stranded fallbacks — no routing logic is reimplemented in
+  the view.
+- **FR-010**: Request MUST encode the selected asset's identity (recipient,
+  amount, asset/token, network) in the generated payment request so a compatible
+  wallet reads the correct asset and chain, and MUST invalidate a displayed
+  request when the selected asset or acting account changes.
+- **FR-011**: Wager MUST denominate the stake, escrow, and payout in the selected
+  escrow-eligible asset instead of a hard-coded USDC, defaulting to the connected
+  network's stablecoin (USDC where available) so the common case is unchanged.
+- **FR-012**: The trade view MUST adopt the selector's nested-logo presentation
+  without changing which assets it lists or how a trade is executed.
+- **FR-013**: When the selected asset becomes invalid (acting account, connected
+  chain, or holdings change), the selector MUST fall back to a sensible default
+  (connected stablecoin → native → first available) and clear dependent in-progress
+  output.
+- **FR-014**: The selector's asset list MUST reflect the account the member is
+  acting as (personal wallet, custody vault, or recovered legacy account),
+  consistent with existing Transfer/Request behavior, and MUST NOT leak one
+  account's holdings into another's list.
+- **FR-015**: The selector MUST be accessible: keyboard-operable, screen-reader
+  labeled, and the decorative nested logos MUST NOT be the sole carrier of meaning
+  (symbol + network text always accompany them).
+- **FR-016**: The system MUST NOT introduce new on-chain behavior, contracts, or
+  network config; it reuses existing portfolio data, the existing send engine, and
+  the existing asset-logo artwork.
+
+### Key Entities *(include if feature involves data)*
+
+- **Selectable Asset**: One choosable option in the selector. Represents a held
+  (or default) asset for the acting account, carrying its identity (symbol, name,
+  underlying), its hosting network (for the nested logo's sub-badge and the
+  network label), its kind (native, ERC-20, or non-EVM/Bitcoin), its held balance,
+  and its per-asset gasless capability. Derived from the existing portfolio
+  holdings and network config — not a new persisted record.
+- **Activity Capability Profile**: The rules that scope which selectable assets an
+  activity may offer (Pay/Request: all supported including Bitcoin; Wager/trade:
+  EVM escrow-eligible only). Used to filter the asset list per activity so
+  unsupported assets never appear where they cannot work.
+- **Nested Asset Logo**: The existing visual — a primary asset glyph plus an
+  optional network sub-badge — reused unchanged to depict each asset's identity
+  and hosting network.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: From the home Pay and Request views, a member can select and act on
+  100% of the assets their account holds across all configured networks — not just
+  the connected network's native coin and stablecoin.
+- **SC-002**: Every asset shown in the Pay, Request, Wager, and trade selectors
+  displays the nested asset logo (glyph + network sub-badge), so a member can
+  distinguish two same-symbol assets on different networks without reading beyond
+  the row.
+- **SC-003**: 100% of network-mismatched selections are gated by a visible "switch
+  network" step; no action is ever submitted against the wrong chain, and no
+  selection results in a silent failure.
+- **SC-004**: Non-EVM assets (Bitcoin) appear and function in Pay and Request, and
+  are absent from Wager and trade — with zero submit-time failures caused by an
+  unsupported asset being offered.
+- **SC-005**: The Wager stake can be denominated in any escrow-eligible asset the
+  account holds, while the default first-render behavior (USDC on the connected
+  network) is unchanged for existing users.
+- **SC-006**: The selector, Pay/Request/Wager wiring, and trade presentation ship
+  with passing frontend tests and no accessibility regressions in CI.
+
+## Assumptions
+
+- The wallet Transfer form's existing cross-network portfolio asset list
+  (including its Bitcoin support and per-asset gasless quoting) is the reference
+  behavior; the universal selector generalizes that same data and presentation,
+  adding the nested logo, and reuses it across the four surfaces.
+- The existing send engine already accepts a full asset descriptor and already
+  routes native, network-stablecoin, arbitrary ERC-20, and Bitcoin sends; this
+  feature wires the selector to it and does not modify routing.
+- The Earn page's nested asset logo artwork is the canonical visual for depicting
+  an asset with its network and is reused as-is.
+- "Trade view" refers to the app's existing surface that already lists all assets;
+  its asset set and execution flow stay as they are — only the asset presentation
+  gains the nested logo.
+- Head-to-head Wager escrow and the trade view are EVM-only for the purposes of
+  asset eligibility; non-EVM assets are scoped out of those activities by design,
+  not by omission.
+- Amounts always start at zero; this feature changes only which asset can be
+  chosen and how it is presented, not the amount-entry or preference behavior
+  established by the home surface feature.
+- The acting-account model (personal / vault / recovered legacy) established by
+  prior features governs whose holdings the selector lists.

--- a/specs/064-universal-asset-selector/tasks.md
+++ b/specs/064-universal-asset-selector/tasks.md
@@ -1,0 +1,145 @@
+---
+description: "Task list for Universal Asset Selector"
+---
+
+# Tasks: Universal Asset Selector
+
+**Input**: Design documents from `specs/064-universal-asset-selector/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/universal-asset-selector.md, quickstart.md
+
+**Tests**: INCLUDED — Constitution II (NON-NEGOTIABLE) requires Vitest coverage for all non-trivial frontend logic; SC-006 requires shipping tests.
+
+**Organization**: Grouped by user story (US1–US4) so each is independently implementable and testable. Frontend-only; no contracts/subgraph/deploy tasks.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no incomplete dependencies)
+- **[Story]**: US1 (Pay), US2 (Request), US3 (Wager), US4 (Trade/Transfer)
+- Paths are repo-relative under `frontend/src/`.
+
+## Path Conventions
+
+Web frontend (React + Vite). New shared code in `components/ui/`, `hooks/`, `lib/assets/`; edits to `components/fairwins/` and `components/wallet/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No new deps or scaffolding needed — verify the reused building blocks exist and behave as the plan assumes.
+
+- [x] T001 Confirm reused modules and their shapes are present and match the plan/contracts: `frontend/src/hooks/useTransfer.js` exports `send({ asset, to, amount })` + `quoteGaslessForAsset`; `frontend/src/components/wallet/AssetLogo.jsx` accepts `symbol`/`chainId`/`showBadge`/`size`; `frontend/src/components/wallet/TransferForm.jsx` `assetOptions` useMemo is the extraction source; `frontend/src/hooks/useOpenChallengeCreate.js` reads `form.token` with USDC fallback. Note any drift in `specs/064-universal-asset-selector/research.md` before coding.
+- [x] T002 [P] Confirm `frontend/src/config/bitcoinNetworks.js` exports `isBitcoinNetworkId` + `getBitcoinNetwork`, and `frontend/src/hooks/useBitcoinWallet.js` exposes `status`/`networkId`/`balances.spendableSats`, so the Bitcoin branch can be wired without new config.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared policy module, the shared data hook, and the shared presentational component that ALL user stories depend on. MUST complete before US1–US4.
+
+⚠️ US1–US4 cannot start until this phase is done.
+
+- [x] T003 [P] Create pure capability-policy module `frontend/src/lib/assets/assetActivity.js` exporting `ASSET_ACTIVITIES`, `allowedKindsForActivity(activity)`, `filterAssetsForActivity(activity, options)`, and `defaultAssetKey(activity, options, { connectedChainId, stableAddress })` per `contracts/universal-asset-selector.md` (wager → `erc20` only; pay/request/transfer → all kinds). No React/chain imports.
+- [x] T004 [P] Write tests `frontend/src/lib/assets/__tests__/assetActivity.test.js`: allowed kinds per activity, Bitcoin+native filtered out of `wager` and kept in `pay`/`request`/`transfer`, default-key precedence (connected stablecoin → native → first; wager → stablecoin → first erc20).
+- [x] T005 Create hook `frontend/src/hooks/useSelectableAssets.js` that returns `{ options, defaultKey, isGasless }` for `{ activity, actingAddress }`, generalizing `TransferForm`'s `assetOptions` assembly (connected native+stable always present; personal `usePortfolio` vs. `useAccountAssets(actingAddress)`; native Bitcoin when `useBitcoinWallet().status === 'ready'` and personal), then applying `filterAssetsForActivity`; `isGasless` delegates to `quoteGaslessForAsset` forcing `false` for `btc-native`; `defaultKey` via `defaultAssetKey`. Depends on T003.
+- [x] T006 Write tests `frontend/src/hooks/__tests__/useSelectableAssets.test.js`: option assembly + connected-chain-first/balance sort, zero-balance defaults kept, non-stable zero rows dropped, acting-account source switch (personal vs vault/legacy), Bitcoin present only when ready+personal, activity scoping (Bitcoin absent for `wager`), `isGasless` BTC→false, invalid selection → fallback default. Depends on T005.
+- [x] T007 Create presentational component `frontend/src/components/ui/UniversalAssetSelect.jsx` + `UniversalAssetSelect.css` per contract: trigger + `role="listbox"`; each row renders nested `AssetLogo` (`showBadge`, EVM `chainId`; no EVM badge for `btc-native`) + symbol + network + balance (null→pending, never `0`) + ⚡ from `isGasless`; keyboard (Enter/Space/Escape) + outside-click close; decorative logo `aria-hidden`; disabled empty state "No assets available". Dark-mode-aware, WCAG 2.1 AA. Depends on T001 (AssetLogo shape).
+- [x] T008 Write tests `frontend/src/components/ui/__tests__/UniversalAssetSelect.test.jsx`: renders one nested `AssetLogo` per option, symbol/network/balance text present, pending balance shown for `null`, ⚡ only when `isGasless` true, listbox/option roles + `aria-selected`, keyboard open/select/close, empty-state disabled trigger. Depends on T007.
+
+**Checkpoint**: Shared selector + hook + policy exist and are green — every user story can now wire them.
+
+---
+
+## Phase 3: User Story 1 — Pay with any held asset (Priority: P1) 🎯 MVP
+
+**Goal**: Home Pay uses the universal selector over the full cross-network portfolio, routes any asset through the existing send engine, gates wrong-chain selections behind a switch, and supports Bitcoin.
+
+**Independent Test**: Load Home→Pay with multi-network holdings; selector lists all held assets with nested logos; pay a non-default connected-chain asset through the normal flow; wrong-chain selection shows "Switch to {network}"; Bitcoin routes the BTC path with a never-gasless fee note.
+
+- [x] T009 [US1] Rewire `frontend/src/components/fairwins/PayPanel.jsx`: replace the two-option `<select>` in the `AmountKeypad` `tokenSlot` with `UniversalAssetSelect` fed by `useSelectableAssets({ activity: 'pay', actingAddress })`; hold the selected option in state with `defaultKey` init + invalid-selection fallback (FR-013); derive `symbol`/`decimals`/`balance`/gasless disclosure from the selected option. Depends on Phase 2.
+- [x] T010 [US1] In `PayPanel.jsx` submit path, call `send({ asset: selectedOption, to: toResolved, amount })` (drop the `kind`-only call), keep confirm/screening/note behavior; map the scanned-payment-request prefill onto a selected-option (match by chain + token/native) instead of the old `kind` toggle. Depends on T009.
+- [x] T011 [US1] Add wrong-chain gating in `PayPanel.jsx`: when `selectedOption.chainId !== connectedChainId`, replace the primary "Pay" with "Switch to {network}" via wagmi `useSwitchChain` (mirror existing `handleSwitch`); guard so no send is signed off-chain (FR-007). Depends on T009.
+- [x] T012 [US1] Wire the Bitcoin branch in `PayPanel.jsx`: when the selected option is `btc-native`, route through the existing Bitcoin send path (as `TransferForm` does via `BitcoinSendPanel`/`useBitcoinWallet`) and show the honest "Bitcoin is never gasless" fee note (FR-009, US1 scenario 5). Depends on T009.
+- [x] T013 [P] [US1] Tests `frontend/src/components/fairwins/__tests__/PayPanel.test.jsx`: selector lists held assets with logos; selecting a connected-chain asset updates denomination + calls `send({ asset })`; wrong-chain → switch button, no send; Bitcoin selected → BTC path + never-gasless note; over-balance/zero-amount gating preserved. Depends on T009–T012.
+
+**Checkpoint**: US1 independently testable — Pay works for the whole portfolio. This is the MVP.
+
+---
+
+## Phase 4: User Story 2 — Request any held asset (Priority: P2)
+
+**Goal**: Home Request uses the same selector; the generated payment request encodes the selected asset + network; changing asset/account invalidates a shown request; Bitcoin supported.
+
+**Independent Test**: Open Request, pick a non-stablecoin asset, generate — the request/QR encodes that asset+network; change asset → prior request invalidated; Bitcoin produces a BTC-appropriate request.
+
+- [x] T014 [US2] Rewire `frontend/src/components/fairwins/RequestPanel.jsx`: replace the `<select>` `currencySelect` with `UniversalAssetSelect` fed by `useSelectableAssets({ activity: 'request', actingAddress: effectiveAddress })`; hold selected option with `defaultKey` init/fallback; derive `symbol` from the option. Depends on Phase 2.
+- [x] T015 [US2] Build the request from the selected option in `RequestPanel.jsx`: pass the option's `tokenAddress`/`decimals`/`chainId`/`kind` to `buildPaymentRequestUri` for EVM assets, and the Bitcoin-request form for a `btc-native` option; keep paid-to disclosure. Depends on T014.
+- [x] T016 [US2] Extend the stale-request guard in `RequestPanel.jsx` (`safeGenerated`) to include the selected asset `key` so changing asset OR acting account nulls a displayed request (FR-010). Depends on T014.
+- [x] T017 [P] [US2] Tests `frontend/src/components/fairwins/__tests__/RequestPanel.test.jsx`: selector shows receivable assets with logos; generated request encodes the selected asset's token/decimals/chain; changing the selected asset invalidates the displayed request; Bitcoin request path produces a BTC-appropriate request + paid-to disclosure. Depends on T014–T016.
+
+**Checkpoint**: US2 independently testable — Request works for any held asset.
+
+---
+
+## Phase 5: User Story 3 — Wager with any EVM-supported asset (Priority: P2)
+
+**Goal**: Wager stake asset chosen via the selector (ERC-20 only; no native, no Bitcoin), denominated via `form.token`; default USDC unchanged; wrong-chain switch-gated; non-allowlisted token surfaces the friendly `NotAllowedToken` error.
+
+**Independent Test**: Open Wager; selector offers only ERC-20 assets (no BTC/native), defaults USDC; create a challenge with a non-USDC allowlisted ERC-20 and verify stake/escrow/payout denominate in it; a non-allowlisted held ERC-20 shows "That stake token is not allowed."
+
+- [x] T018 [US3] Rewire `frontend/src/components/fairwins/CreateChallengePanel.jsx`: replace the hard-coded `token="USDC"` hero with `UniversalAssetSelect` fed by `useSelectableAssets({ activity: 'wager', ... })` (ERC-20 only); default to the connected stablecoin so first-render is unchanged (FR-011, US3 scenario 4). Depends on Phase 2.
+- [x] T019 [US3] Pass the selected asset through create in `CreateChallengePanel.jsx`: set `form.token = selectedOption.address` (and use its `decimals`) in the `createOpenChallenge` payload; when the default USDC is selected, keep passing USDC/zero so behavior is byte-identical to today. Depends on T018.
+- [x] T020 [US3] Add wrong-chain switch-gating to the Wager create action (mirror T011) so a challenge is never created on the wrong chain; surface the existing `NotAllowedToken` → "That stake token is not allowed." error for non-allowlisted ERC-20s (already mapped in `useOpenChallengeCreate`). Depends on T018.
+- [x] T021 [P] [US3] Tests `frontend/src/components/fairwins/__tests__/CreateChallengePanel.test.jsx`: selector excludes native + Bitcoin, offers ERC-20s, defaults USDC; selecting a token passes it as `form.token` to `createOpenChallenge`; wrong-chain → switch-gated; non-allowlisted token surfaces the friendly error. Depends on T018–T020.
+
+**Checkpoint**: US3 independently testable — Wager denominates in any escrow-eligible asset.
+
+---
+
+## Phase 6: User Story 4 — Consistent nested logos in the Trade (Transfer) view (Priority: P3)
+
+**Goal**: The wallet Transfer ("trade") view lists the same assets, now with nested logos, by adopting the shared selector; execution flow unchanged.
+
+**Independent Test**: Open the Transfer view; every listed asset renders the nested logo matching Earn and the home selector; the same assets remain; send flow identical.
+
+- [x] T022 [US4] Refactor `frontend/src/components/wallet/TransferAssetSelect.jsx` to a thin wrapper that renders `UniversalAssetSelect` (mapping its existing `options`/`value`/`onChange`/`isGasless`/`disabled` props through), so the Transfer view gains nested logos with no behavior change; keep the existing export/prop surface so call sites are untouched. Depends on Phase 2.
+- [x] T023 [US4] (Optional consolidation) In `frontend/src/components/wallet/TransferForm.jsx`, swap the inline `assetOptions` useMemo for `useSelectableAssets({ activity: 'transfer', actingAddress })` to converge on one asset-assembly path (verify the asset set + Bitcoin branch + `gaslessForOption` behavior are unchanged). If any divergence appears, keep the inline list and only swap the select — record the decision in research.md. Depends on T022.
+- [x] T024 [P] [US4] Update/extend `frontend/src/components/wallet/__tests__/TransferForm.test.jsx` (and any `TransferAssetSelect` test): assert the asset set is unchanged and each option now renders a nested `AssetLogo`; send flow unaffected. Depends on T022–T023.
+
+**Checkpoint**: All four surfaces share one selector with consistent nested logos.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [x] T025 [P] Accessibility pass on `UniversalAssetSelect` and the four wired surfaces: keyboard traversal, screen-reader labels, decorative-logo `aria-hidden`, focus return; ensure no new axe/Lighthouse violations (Constitution V, SC-006).
+- [x] T026 [P] Run `npm run test:frontend` and `npm run lint` (frontend) — all green, no new ESLint warnings; fix any fallout.
+- [x] T027 [P] Add a short section to `frontend/src/components/fairwins/README.md` (or the relevant component README) documenting the universal asset selector, its activity capability profiles, and that non-EVM assets are scoped per activity.
+- [x] T028 Manual walkthrough of `specs/064-universal-asset-selector/quickstart.md` scenarios A–E; confirm no wrong-chain send, no unsupported asset offered where it can't work, no fake balances.
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (T001–T002)** → no blockers.
+- **Foundational (T003–T008)** → blocks ALL user stories. T003→T004; T003→T005→T006; T007→T008.
+- **US1 (T009–T013)** → depends on Phase 2. MVP.
+- **US2 (T014–T017)**, **US3 (T018–T021)**, **US4 (T022–T024)** → each depends only on Phase 2; independent of one another (different files) and can proceed in parallel after Foundational.
+- **Polish (T025–T028)** → after the stories being polished are done.
+
+## Parallel Opportunities
+
+- Phase 2 kickoff: T003 and T007 (+ their tests T004, T008) touch different files — parallelizable; T005/T006 wait on T003.
+- After Foundational, the three secondary stories run in parallel: one agent per file group —
+  - US2: `RequestPanel.jsx` (+test)
+  - US3: `CreateChallengePanel.jsx` (+test)
+  - US4: `TransferAssetSelect.jsx`/`TransferForm.jsx` (+test)
+- Per-story test tasks (T013, T017, T021, T024) are `[P]` once their implementation tasks land.
+- Polish T025–T027 are `[P]`.
+
+## Implementation Strategy
+
+- **MVP = Phase 1 + Phase 2 + US1 (Pay).** Delivers the core value (pay any held asset with nested logos) and is independently shippable.
+- **Increment 2**: US2 + US3 (Request + Wager) — the rest of the home surface.
+- **Increment 3**: US4 (Trade view logos) — consistency polish.
+- Keep each story behind its own tests; never sign against the wrong chain; never offer an asset an activity can't act on (honest-state).


### PR DESCRIPTION
## Summary

The home surface's asset dropdowns only offered the connected network's native coin and its stablecoin (Wager was hard-locked to USDC), so members couldn't leverage the other assets the platform already supports. This replaces those narrow controls — and upgrades the wallet **Transfer** ("trade") dropdown — with **one reusable `UniversalAssetSelect`** used by Pay, Request, Wager, and Transfer.

Members can now use **any platform-supported asset the acting account holds across every configured network**, each shown with the **Earn-page nested asset logo** (asset glyph + network sub-badge) so it's obvious at a glance *what* the asset is and *which chain* it lives on. Non-EVM assets (Bitcoin) work where supported (Pay, Request) and are cleanly excluded where they can't work (Wager escrow, trade) — never a silent failure.

**Frontend-only. No new on-chain behavior, contracts, or network config.** Built via Spec Kit — spec/plan/tasks/design live under `specs/064-universal-asset-selector/`.

## What changed

**New shared pieces**
- `components/ui/UniversalAssetSelect.jsx` (+ `.css`) — presentational nested-logo listbox: renders `AssetLogo` per row + symbol + network + balance + a ⚡ gasless marker; keyboard/screen-reader operable (`listbox`/`option` roles), decorative logo `aria-hidden`, pending balances shown (never a fake `0`).
- `hooks/useSelectableAssets.js` — activity-scoped, acting-account-aware option list. Generalizes the `assetOptions` assembly previously inlined in `TransferForm`; reuses `usePortfolio`/`useAccountAssets`/`useChainTokens`/`useBitcoinWallet` and the send engine's per-asset gasless quote (never re-derives routing).
- `lib/assets/assetActivity.js` — pure **capability profiles**: `pay`/`request`/`transfer` allow every kind incl. Bitcoin; `wager` is EVM **ERC-20 only** (the escrow pulls the stake via `transferFrom`, so native + non-EVM are excluded by list construction).

**Wiring**
- **PayPanel (US1)** — full-portfolio selector; submits via `send({ asset })` (inherits screening / gasless / honest lifecycle / never-stranded fallbacks); wrong-chain selection becomes a **"Switch to {network}"** action; Bitcoin routes through the existing `BitcoinSendPanel` with an honest "never gasless" note.
- **RequestPanel (US2)** — request any held asset: EIP-681 URI for EVM assets, BIP-21 `bitcoin:` URI for Bitcoin; a shown request is invalidated when the selected asset or acting account changes.
- **CreateChallengePanel (US3)** — stake denominates in any held ERC-20 via `form.token` (already supported by `useOpenChallengeCreate`), **defaulting to USDC so first render is unchanged**; a non-allowlisted token surfaces the existing `NotAllowedToken` message; wrong-chain is switch-gated.
- **TransferAssetSelect (US4)** — now a thin wrapper over `UniversalAssetSelect`, so the trade view gains the nested logo with **no behavior change** (same asset set, same send flow).

## Testing

- New Vitest suites: `assetActivity` (11), `useSelectableAssets` (9), `UniversalAssetSelect` (8), plus rewired `PayPanel`/`RequestPanel`/`CreateChallengePanel` and a `TransferForm` nested-logo assertion.
- Updated the provider-light integration tests that render these panels (claimCode/OpenChallenge, home a11y/axe, acting-account, payment round-trip) to stub the new data hook — the real `UniversalAssetSelect` still renders, so a11y coverage is preserved.
- **220+ tests green** across every file that touches the changed code; `eslint` clean. (The full frontend suite OOMs in this sandbox; validation was run against the complete set of affected files.)

## Notes / follow-ups

- Kept `TransferForm`'s inline `assetOptions` (T023's documented fallback) rather than swapping it to the shared hook, to avoid churn on the more complex Transfer flow — the nested-logo goal is delivered via the `TransferAssetSelect` wrapper.
- Added an honest-state guard: a network mismatch is only claimed when the connected chain is actually known (never gate on an unknown/NaN chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXT7R5hNtNP7HTfeE9wSDx)_