### PR TITLE
feat(request): receive-any asset catalog + Pay balance-line cleanup (spec 064 follow-up)

### DIFF
--- a/frontend/src/components/fairwins/PayPanel.jsx
+++ b/frontend/src/components/fairwins/PayPanel.jsx
@@ -395,16 +395,10 @@ function PayPanel({ onSuccess }) {
         />
       </div>
 
-      <div className="fm-pay-status">
-        <span className="fm-hint">
-          {isConnected
-            ? bal != null
-              ? <>Balance: {bal} {symbol}{gasless ? ' · ⚡ gasless' : ''}</>
-              : 'Loading balance…'
-            : 'Connect a wallet to pay.'}
-        </span>
-      </div>
-
+      {/* The selected asset's balance and its gasless marker now live in the
+          currency selector (trigger + rows), so no separate balance/gasless line
+          is shown above the Pay button. The fee/gasless disclosure still appears
+          honestly on the confirm step. */}
       {blockReason && <div className="fm-error-banner" role="alert">{blockReason}</div>}
       {formError && <div className="fm-error-banner" role="alert">{formError}</div>}
 

--- a/frontend/src/components/fairwins/RequestPanel.jsx
+++ b/frontend/src/components/fairwins/RequestPanel.jsx
@@ -33,7 +33,13 @@ function RequestPanel() {
   const address = effectiveAddress || connectedAddress
 
   const actingAddress = isActingAccount ? effectiveAddress : null
-  const { options, defaultKey } = useSelectableAssets({ activity: ASSET_ACTIVITIES.REQUEST, actingAddress })
+  // Request RECEIVES value, so it offers the full catalog of platform-supported
+  // assets (not just held ones) — a member can request anything. Default stays USDC.
+  const { options, defaultKey } = useSelectableAssets({
+    activity: ASSET_ACTIVITIES.REQUEST,
+    actingAddress,
+    catalog: true,
+  })
   const btc = useBitcoinWallet()
 
   const [selectedKey, setSelectedKey] = useState(null)

--- a/frontend/src/components/ui/README.md
+++ b/frontend/src/components/ui/README.md
@@ -359,8 +359,13 @@ never derives the asset list, eligibility, or routing.
 - `disabled` (bool), `label` (string, default `'Asset'`), `size` (number, logo px)
 
 **Data + activity scoping:**
-- `hooks/useSelectableAssets({ activity, actingAddress })` builds the option list from the
-  acting account's cross-network portfolio (personal / vault / recovered legacy).
+- `hooks/useSelectableAssets({ activity, actingAddress, catalog })` builds the option list
+  from the acting account's cross-network portfolio (personal / vault / recovered legacy).
+- **`catalog: true` (Request only)** — receiving doesn't require holding, so Request unions
+  the list with the full bundled asset registry across every configured network. A member
+  can request **any** platform-supported asset (unheld ones show balance 0); held balances
+  are preserved. Spending activities (Pay/Wager/Transfer) keep the held-only list. The
+  default selection is USDC either way.
 - `lib/assets/assetActivity.js` holds the **activity capability profiles**: `pay`,
   `request`, and `transfer` allow every asset kind **including non-EVM Bitcoin**; `wager`
   is EVM **ERC-20 only** (the escrow pulls the stake via `transferFrom`, so the native

--- a/frontend/src/hooks/__tests__/useSelectableAssets.test.jsx
+++ b/frontend/src/hooks/__tests__/useSelectableAssets.test.jsx
@@ -130,3 +130,35 @@ describe('useSelectableAssets — acting account + gasless + default', () => {
     expect(result.current.defaultKey).toBe(`137:${USDC.toLowerCase()}`)
   })
 })
+
+describe('useSelectableAssets — catalog mode (receive-any)', () => {
+  it('held-only (no catalog) lists just the connected defaults when nothing is held', () => {
+    const { result } = renderHook(() => useSelectableAssets({ activity: ASSET_ACTIVITIES.REQUEST }))
+    // Only the connected chain's native + stablecoin defaults.
+    expect(result.current.options.every((o) => o.chainId === 137)).toBe(true)
+    expect(result.current.options.some((o) => o.symbol === 'WBTC')).toBe(false)
+  })
+
+  it('catalog mode unions the full bundled registry so unheld supported assets appear', () => {
+    const { result } = renderHook(() => useSelectableAssets({ activity: ASSET_ACTIVITIES.REQUEST, catalog: true }))
+    const syms = result.current.options.map((o) => o.symbol)
+    // Polygon (connected) curated registry includes WBTC/WETH even with zero holdings.
+    expect(syms).toContain('WBTC')
+    expect(syms).toContain('WETH')
+    // Cross-network assets are present too (mainnets are in the catalog).
+    expect(result.current.options.some((o) => o.chainId !== 137)).toBe(true)
+    // Default is still the connected stablecoin (USDC), unchanged by catalog mode.
+    expect(result.current.defaultKey).toBe(`137:${USDC.toLowerCase()}`)
+  })
+
+  it('catalog mode preserves a held asset’s real balance (held row wins over the 0 catalog row)', () => {
+    // Canonical Polygon WBTC — same address the bundled registry uses, so the held
+    // row and the catalog row share a key and merge into one.
+    const POLY_WBTC = '0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6'
+    portfolioHoldings = [holding({ address: POLY_WBTC, symbol: 'WBTC', decimals: 8, chainId: 137, balance: 0.5 })]
+    const { result } = renderHook(() => useSelectableAssets({ activity: ASSET_ACTIVITIES.REQUEST, catalog: true }))
+    const wbtc = result.current.options.filter((o) => o.symbol === 'WBTC' && o.chainId === 137)
+    expect(wbtc).toHaveLength(1)
+    expect(wbtc[0].balance).toBe(0.5)
+  })
+})

--- a/frontend/src/hooks/useSelectableAssets.js
+++ b/frontend/src/hooks/useSelectableAssets.js
@@ -6,6 +6,8 @@ import { useBitcoinWallet } from './useBitcoinWallet'
 import usePortfolio from './usePortfolio'
 import { useAccountAssets } from './useAccountAssets'
 import { getBitcoinNetwork } from '../config/bitcoinNetworks'
+import { NETWORKS } from '../config/networks'
+import { getPortfolioRegistry, getPortfolioChainIds } from '../config/assetTaxonomy'
 import { filterAssetsForActivity, defaultAssetKey } from '../lib/assets/assetActivity'
 
 const toNum = (v) => (v == null || v === '' ? null : Number(v))
@@ -32,10 +34,19 @@ const toNum = (v) => (v == null || v === '' ? null : Number(v))
  * Routing is NOT re-derived here: `isGasless(option)` delegates to the send engine's
  * per-asset quote (Bitcoin forced false — never gasless, FR-005).
  *
- * @param {{ activity: 'pay'|'request'|'wager'|'transfer', actingAddress?: string|null }} params
+ * `catalog` mode (spec 064 follow-up) — for RECEIVING, a member should be able to
+ * request ANY platform-supported asset, not just what they currently hold. When
+ * `catalog` is true the list is unioned with the full bundled asset registry
+ * (`getPortfolioRegistry`) across every configured network (mainnets + the connected
+ * chain), so an unheld-but-supported asset appears (balance 0). Held balances are
+ * preserved where known. Non-catalog callers (Pay/Wager/Transfer, which SPEND) keep
+ * the held-only list. The default selection is unchanged either way (connected
+ * stablecoin ⇒ USDC).
+ *
+ * @param {{ activity: 'pay'|'request'|'wager'|'transfer', actingAddress?: string|null, catalog?: boolean }} params
  * @returns {{ options: object[], defaultKey: string|null, isGasless: (o:object)=>boolean }}
  */
-export function useSelectableAssets({ activity, actingAddress = null } = {}) {
+export function useSelectableAssets({ activity, actingAddress = null, catalog = false } = {}) {
   const { chainId } = useWallet()
   const { balanceOf, quoteGaslessForAsset } = useTransfer()
   const tokens = useChainTokens()
@@ -115,15 +126,47 @@ export function useSelectableAssets({ activity, actingAddress = null } = {}) {
       })
     }
 
+    // Catalog union (receive-any): add every bundled-registry asset across all
+    // configured networks so an unheld-but-supported asset can still be requested.
+    // A held option already in the map wins (its real balance is preserved); a
+    // catalog-only asset lands at balance 0 (honest — you hold none yet).
+    if (catalog) {
+      const catalogChainIds = new Set(getPortfolioChainIds())
+      if (Number.isFinite(connectedChainId)) catalogChainIds.add(connectedChainId)
+      for (const cid of catalogChainIds) {
+        const net = NETWORKS[cid]
+        if (!net) continue
+        for (const entry of getPortfolioRegistry(cid)) {
+          if (entry.kind !== 'native' && entry.kind !== 'erc20') continue // no NFTs in a value action
+          const key = `${cid}:${entry.kind === 'native' ? 'native' : String(entry.address).toLowerCase()}`
+          const existing = byKey.get(key)
+          byKey.set(key, {
+            key,
+            chainId: cid,
+            kind: entry.kind,
+            address: entry.address || null,
+            symbol: entry.symbol,
+            name: entry.name,
+            decimals: entry.decimals,
+            networkName: net.name,
+            balance: 0,
+            ...(existing || {}), // a held row (real balance) always wins
+          })
+        }
+      }
+    }
+
     return [...byKey.values()].sort((a, b) => {
       const ac = a.chainId === connectedChainId ? 0 : 1
       const bc = b.chainId === connectedChainId ? 0 : 1
       if (ac !== bc) return ac - bc
-      return (b.balance ?? 0) - (a.balance ?? 0)
+      const bal = (b.balance ?? 0) - (a.balance ?? 0)
+      if (bal !== 0) return bal
+      return (a.symbol || '').localeCompare(b.symbol || '') // stable, readable tiebreak
     })
   }, [
     actingAddress, actingAssets.holdings, portfolio.holdings, tokens, connectedChainId,
-    balanceOf, isConnectedStableAddr, btc.status, btc.networkId, btc.balances?.spendableSats,
+    balanceOf, isConnectedStableAddr, btc.status, btc.networkId, btc.balances?.spendableSats, catalog,
   ])
 
   const options = useMemo(() => filterAssetsForActivity(activity, allOptions), [activity, allOptions])

--- a/specs/064-universal-asset-selector/spec.md
+++ b/specs/064-universal-asset-selector/spec.md
@@ -103,14 +103,22 @@ disclosure, gasless routing) as a stablecoin payment today.
 
 ---
 
-### User Story 2 - Request any held asset (Priority: P2)
+### User Story 2 - Request any supported asset (Priority: P2)
 
 A member opens the home **Request** view. The currency control is the same
-universal asset selector, scoped to assets the member can *receive*. The member
-picks an asset (including one on a network other than the connected one, or a
-non-EVM asset like Bitcoin), enters an amount and a note, and generates a payment
-request. The request encodes the correct recipient, amount, asset, and network so
-any compatible wallet can pay it.
+universal asset selector, but because receiving does not require holding, Request
+offers the **full catalog of platform-supported assets** across every configured
+network — not just what the member currently holds — so they can ask to receive
+anything. The member picks an asset (including one on a network other than the
+connected one, or a non-EVM asset like Bitcoin), enters an amount and a note, and
+generates a payment request. The request encodes the correct recipient, amount,
+asset, and network so any compatible wallet can pay it. The default selection
+remains USDC.
+
+> **Follow-up refinement (post-merge):** Request lists the full supported-asset
+> catalog (via `useSelectableAssets({ catalog: true })`), whereas the other
+> surfaces (Pay/Wager/Transfer, which spend) stay held-only. Unheld catalog assets
+> show a zero balance; held balances are preserved. The USDC default is unchanged.
 
 **Why this priority**: Request is the second home money action and shares the same
 selector; extending it makes the home surface consistent. It depends on the


### PR DESCRIPTION
Follow-up to the merged universal asset selector (#955), addressing two pieces of feedback.

## 1. Request shows the full supported-asset catalog

Receiving value doesn't require holding the asset, so the home **Request** view should let a member ask to receive **any** platform-supported asset — not just what they currently hold.

- Added a `catalog` mode to `useSelectableAssets` that unions the held list with the full bundled asset registry (`getPortfolioRegistry`) across every configured network (mainnets + the connected chain).
- `RequestPanel` now calls `useSelectableAssets({ activity: 'request', catalog: true })`.
- **Pay / Wager / Transfer** (which *spend*) keep the **held-only** list.
- Unheld catalog assets show a **zero balance**; a held row always wins over its 0-balance catalog row (real balances preserved).
- **Default is unchanged** — still the connected stablecoin (USDC).
- Bitcoin keeps its existing readiness gate (shown when the BTC wallet is ready).

## 2. Remove the redundant balance/gasless line on Pay

The selected asset's balance and its gasless ⚡ marker now live in the currency selector (its trigger and rows), so the separate "Balance: X · ⚡ gasless" hint above the Pay button was duplicating what the selector already shows. Removed it — the fee/gasless disclosure still appears honestly on the confirm step.

## Testing

- `useSelectableAssets` suite extended to **12 tests**: catalog union surfaces unheld supported assets (WBTC/WETH on Polygon with zero holdings), cross-network catalog assets present, held balances preserved, USDC default unchanged, held-only mode still minimal.
- `PayPanel` (18), `RequestPanel` (11), payment round-trip, and acting-account Request tests all green; `eslint` clean.

Frontend-only; no new on-chain behavior, contracts, or config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXT7R5hNtNP7HTfeE9wSDx)_