### PR TITLE
feat(066): staking fee router, admin controls & emergency pause

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/065-liquid-delegated-staking"
+  "feature_directory": "specs/066-staking-admin-controls"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,5 +182,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/065-liquid-delegated-staking/plan.md
+at specs/066-staking-admin-controls/plan.md
 <!-- SPECKIT END -->

--- a/contracts/mocks/MockStakingProviders.sol
+++ b/contracts/mocks/MockStakingProviders.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title Mock Lido/sPOL staking providers (spec 066 tests only)
+ * @notice Minimal stand-ins for the real Lido stETH/wstETH + sPOL controller so the
+ *         StakingRouter's LIQUID fee-and-forward path can be unit-tested without a fork.
+ *         NOT for production (contracts/mocks scope — constitution III).
+ */
+
+/// @dev stETH: `submit` mints stETH 1:1 for the ETH sent.
+contract MockLidoStETH is ERC20 {
+    constructor() ERC20("Liquid staked Ether", "stETH") {}
+
+    function submit(address) external payable returns (uint256) {
+        _mint(msg.sender, msg.value);
+        return msg.value;
+    }
+}
+
+/// @dev wstETH: `wrap` pulls stETH from the caller and mints wstETH 1:1.
+contract MockWstETH is ERC20 {
+    ERC20 public immutable steth;
+
+    constructor(address steth_) ERC20("Wrapped liquid staked Ether", "wstETH") {
+        steth = ERC20(steth_);
+    }
+
+    function wrap(uint256 stETHAmount) external returns (uint256) {
+        steth.transferFrom(msg.sender, address(this), stETHAmount);
+        _mint(msg.sender, stETHAmount);
+        return stETHAmount;
+    }
+}
+
+/// @dev sPOL controller: `buySPOL` pulls POL from the caller and mints sPOL 1:1.
+contract MockSpolController {
+    ERC20 public immutable pol;
+    MintableToken public immutable spol;
+
+    constructor(address pol_, address spol_) {
+        pol = ERC20(pol_);
+        spol = MintableToken(spol_);
+    }
+
+    function buySPOL(uint256 amount) external returns (uint256) {
+        pol.transferFrom(msg.sender, address(this), amount);
+        spol.mint(msg.sender, amount);
+        return amount;
+    }
+}
+
+/// @dev Minimal mintable ERC20 (POL / sPOL in tests).
+contract MintableToken is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/mocks/MockStakingProviders.sol
+++ b/contracts/mocks/MockStakingProviders.sol
@@ -82,3 +82,45 @@ contract MockZeroWstETH is ERC20 {
         return 0; // mints nothing → router must revert
     }
 }
+
+/// @dev wstETH whose `wrap` pulls 1 wei LESS stETH than offered (share rounding) — leaves stETH
+///      dust in the router, exercising the dust-sweep-to-member branch.
+contract MockDustWstETH is ERC20 {
+    ERC20 public immutable steth;
+
+    constructor(address steth_) ERC20("Dust wstETH", "d-wstETH") {
+        steth = ERC20(steth_);
+    }
+
+    function wrap(uint256 stETHAmount) external returns (uint256) {
+        uint256 pulled = stETHAmount - 1; // leave 1 wei of stETH behind in the caller (router)
+        steth.transferFrom(msg.sender, address(this), pulled);
+        _mint(msg.sender, pulled);
+        return pulled;
+    }
+}
+
+/// @dev sPOL controller that pulls 1 wei LESS POL than offered — leaves POL residual in the
+///      router, exercising the `ResidualFunds` invariant.
+contract MockLeakySpolController {
+    ERC20 public immutable pol;
+    MintableToken public immutable spol;
+
+    constructor(address pol_, address spol_) {
+        pol = ERC20(pol_);
+        spol = MintableToken(spol_);
+    }
+
+    function buySPOL(uint256 amount) external returns (uint256) {
+        pol.transferFrom(msg.sender, address(this), amount - 1); // under-pull → residual left behind
+        spol.mint(msg.sender, amount);
+        return amount;
+    }
+}
+
+/// @dev A treasury that rejects incoming ETH — exercises the router's native-fee `ProviderCallFailed`.
+contract MockRejectETH {
+    receive() external payable {
+        revert("no eth");
+    }
+}

--- a/contracts/mocks/MockStakingProviders.sol
+++ b/contracts/mocks/MockStakingProviders.sol
@@ -60,3 +60,25 @@ contract MintableToken is ERC20 {
         _mint(to, amount);
     }
 }
+
+/// @dev Force-sends its balance to `target` via selfdestruct — used to prove the router's
+///      relative residual invariant can't be griefed by donated/forced ETH.
+contract ForceSend {
+    constructor(address payable target) payable {
+        selfdestruct(target);
+    }
+}
+
+/// @dev wstETH whose `wrap` mints zero — exercises the router's `ProviderCallFailed` guard.
+contract MockZeroWstETH is ERC20 {
+    ERC20 public immutable steth;
+
+    constructor(address steth_) ERC20("Zero wstETH", "z-wstETH") {
+        steth = ERC20(steth_);
+    }
+
+    function wrap(uint256 stETHAmount) external returns (uint256) {
+        steth.transferFrom(msg.sender, address(this), stETHAmount);
+        return 0; // mints nothing → router must revert
+    }
+}

--- a/contracts/staking/IStakingRouter.sol
+++ b/contracts/staking/IStakingRouter.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title Lido stETH — liquid staking entry (subset used by StakingRouter).
+interface ILidoStETH {
+    /// @notice Stake ETH; mints stETH to msg.sender. `_referral` is attribution only.
+    function submit(address _referral) external payable returns (uint256);
+}
+
+/// @title Lido wstETH — non-rebasing wrapper (subset used by StakingRouter).
+interface IWstETH {
+    /// @notice Wrap `_stETHAmount` of stETH held by msg.sender into wstETH; returns wstETH minted.
+    function wrap(uint256 _stETHAmount) external returns (uint256);
+}
+
+/// @title sPOL controller — Polygon native liquid staking (subset used by StakingRouter).
+interface ISpolController {
+    /// @notice Stake `_amount` POL (pulled from msg.sender via allowance); returns sPOL minted.
+    function buySPOL(uint256 _amount) external returns (uint256);
+}
+
+/// @title IStakingRouter
+/// @notice Interface for the per-network staking control surface + LIQUID fee-and-forward router
+///         (spec 066). It governs the spec-065 staking service — provider addresses, the curated
+///         validator allowlist, and a per-network emergency pause — and charges the spec-060 platform
+///         fee on LIQUID staking by reading the FeeRouter rate, skimming to the treasury, and
+///         forwarding the net to the provider atomically.
+/// @dev    Delegated staking (Polygon `ValidatorShare.buyVoucherPOL`) is fee-free in v1 and stays a
+///         direct member call — routing it here would make the router the delegator (custodial,
+///         un-exitable). Only the validator allowlist + pause govern it. Exits never touch the router.
+interface IStakingRouter {
+    // --- events: config (each setter emits one — the on-chain audit history) ---
+    event FeeRouterUpdated(address oldRouter, address newRouter, address indexed actor);
+    event LidoContractsUpdated(address steth, address wsteth, address indexed actor);
+    event SpolContractsUpdated(address controller, address token, address indexed actor);
+    event PolygonContractsUpdated(address polToken, address stakeManager, address indexed actor);
+    event ValidatorAdded(address indexed validatorShare, address indexed actor);
+    event ValidatorRemoved(address indexed validatorShare, address indexed actor);
+
+    // --- event: member LIQUID stake ---
+    event LiquidStaked(
+        address indexed provider,
+        address indexed member,
+        uint256 gross,
+        uint256 fee,
+        uint256 net,
+        uint256 lstOut
+    );
+
+    // --- errors ---
+    error ZeroAmount();
+    error ZeroAddress();
+    error FeeAboveQuoted();
+    error ResidualFunds();
+    error ProviderCallFailed();
+    error AlreadyListed();
+    error NotListed();
+
+    // --- reads: config ---
+    function feeRouter() external view returns (address);
+    function lidoSteth() external view returns (address);
+    function lidoWsteth() external view returns (address);
+    function spolController() external view returns (address);
+    function spolToken() external view returns (address);
+    function polToken() external view returns (address);
+    function polygonStakeManager() external view returns (address);
+    function stakeLidoServiceId() external view returns (bytes32);
+    function stakeSpolServiceId() external view returns (bytes32);
+
+    // --- reads: validator allowlist ---
+    function validatorCount() external view returns (uint256);
+    function validatorAt(uint256 index) external view returns (address);
+    function isValidator(address validatorShare) external view returns (bool);
+
+    // --- config setters (STAKING_ADMIN_ROLE) ---
+    function setFeeRouter(address newFeeRouter) external;
+    function setLidoContracts(address steth, address wsteth) external;
+    function setSpolContracts(address controller, address token) external;
+    function setPolygonContracts(address polToken_, address stakeManager) external;
+    function addValidator(address validatorShare) external;
+    function removeValidator(address validatorShare) external;
+
+    // --- emergency pause (GUARDIAN_ROLE) ---
+    function pause() external;
+    function unpause() external;
+
+    // --- member actions: LIQUID fee-and-forward ---
+    function stakeLido(uint16 maxFeeBps) external payable returns (uint256 wstOut);
+    function stakeSpol(uint256 amount, uint16 maxFeeBps) external returns (uint256 spolOut);
+}

--- a/contracts/staking/StakingRouter.sol
+++ b/contracts/staking/StakingRouter.sol
@@ -182,9 +182,11 @@ contract StakingRouter is
         uint256 startBalance = address(this).balance - gross;
 
         IFeeRouter router = IFeeRouter(feeRouter);
-        // Consent ceiling BEFORE any movement — the quoted rate is a hard cap (FR-003).
-        if (router.feeBps(stakeLidoServiceId) > maxFeeBps) revert FeeAboveQuoted();
         (uint256 fee, uint256 net) = router.quoteFee(stakeLidoServiceId, gross);
+        // Consent ceiling — the quoted rate is a hard cap (FR-003). Only meaningful when a fee is
+        // actually charged: a treasury-unset network quotes fee 0, so a zero-fee stake is never
+        // blocked by a stale configured rate.
+        if (fee > 0 && router.feeBps(stakeLidoServiceId) > maxFeeBps) revert FeeAboveQuoted();
 
         if (fee > 0) {
             (bool ok, ) = router.treasury().call{value: fee}("");
@@ -201,7 +203,12 @@ contract StakingRouter is
         IERC20(lidoWsteth).safeTransfer(msg.sender, wstOut);
         IERC20(lidoSteth).forceApprove(lidoWsteth, 0);
 
-        // No member funds may remain in the router after the action (FR-016).
+        // stETH is share-based: `wrap` can leave 1–2 wei of stETH dust from rounding. Sweep any
+        // stETH we still hold above the starting balance to the member so none accrues here (FR-016).
+        uint256 stethResidual = IERC20(lidoSteth).balanceOf(address(this)) - stethBefore;
+        if (stethResidual > 0) IERC20(lidoSteth).safeTransfer(msg.sender, stethResidual);
+
+        // No member native funds may remain in the router after the action (FR-016).
         if (address(this).balance != startBalance) revert ResidualFunds();
         emit LiquidStaked(lidoWsteth, msg.sender, gross, fee, net, wstOut);
     }
@@ -220,13 +227,15 @@ contract StakingRouter is
     {
         if (amount == 0) revert ZeroAmount();
         IERC20 pol = IERC20(polToken);
-        uint256 polBefore = pol.balanceOf(address(this));
-
         IFeeRouter router = IFeeRouter(feeRouter);
-        if (router.feeBps(stakeSpolServiceId) > maxFeeBps) revert FeeAboveQuoted();
 
-        pol.safeTransferFrom(msg.sender, address(this), amount);
+        // Quote + consent ceiling BEFORE pulling funds (fail early). The ceiling only bites when a
+        // fee is actually charged (treasury-unset ⇒ fee 0 ⇒ a zero-fee stake is never blocked).
         (uint256 fee, uint256 net) = router.quoteFee(stakeSpolServiceId, amount);
+        if (fee > 0 && router.feeBps(stakeSpolServiceId) > maxFeeBps) revert FeeAboveQuoted();
+
+        uint256 polBefore = pol.balanceOf(address(this));
+        pol.safeTransferFrom(msg.sender, address(this), amount);
 
         if (fee > 0) pol.safeTransfer(router.treasury(), fee);
 

--- a/contracts/staking/StakingRouter.sol
+++ b/contracts/staking/StakingRouter.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+import {UUPSManaged} from "../upgradeable/UUPSManaged.sol";
+import {IFeeRouter} from "../fees/IFeeRouter.sol";
+import {IStakingRouter, ILidoStETH, IWstETH, ISpolController} from "./IStakingRouter.sol";
+
+/// @title StakingRouter
+/// @notice Per-network on-chain control surface for the spec-065 staking service and the path member
+///         LIQUID stakes route through so a spec-060 platform fee reaches the treasury (spec 066).
+///         It holds the managed staking config — provider addresses + a curated `ValidatorShare`
+///         allowlist — and a per-network emergency pause, and it charges the LIQUID staking fee by
+///         reading the FeeRouter (the single fee source of truth): it skims the fee to the treasury
+///         and forwards the net to the provider (Lido submit→wrap→wstETH, sPOL buySPOL) atomically,
+///         returning the LST to the member.
+/// @dev    Value-bearing but TRANSIENT-custody only: every fund-moving entrypoint is `nonReentrant`,
+///         follows checks-effects-interactions, resets approvals to 0, and asserts no residual member
+///         funds remain after the call (FR-016). Config is gated by STAKING_ADMIN_ROLE; the emergency
+///         pause by GUARDIAN_ROLE (both held by a multisig in production, no timelock). Storage is
+///         append-only with a trailing `__gap` for in-place UUPS upgrades.
+///
+///         Delegated staking (Polygon `ValidatorShare.buyVoucherPOL`) is intentionally NOT an
+///         entrypoint here: it binds the delegation to `msg.sender`, so a router call would make the
+///         router the delegator (custodial + un-exitable). The member calls it directly and it is
+///         fee-free in v1; the router only governs its allowlist + pause. Exits never touch the router.
+contract StakingRouter is
+    IStakingRouter,
+    UUPSManaged,
+    ReentrancyGuardUpgradeable,
+    PausableUpgradeable
+{
+    using SafeERC20 for IERC20;
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    /// @notice Holders may change provider addresses + curate the validator allowlist (config).
+    bytes32 public constant STAKING_ADMIN_ROLE = keccak256("STAKING_ADMIN_ROLE");
+    /// @notice Holders may pause/unpause new staking on this network (emergency lever).
+    bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
+
+    /// @notice Per-provider FeeRouter service ids (deterministic; read at stake time for the live rate).
+    bytes32 public constant stakeLidoServiceId = keccak256("stake.lido");
+    bytes32 public constant stakeSpolServiceId = keccak256("stake.polygon");
+
+    // ---------------------------------------------------------------- storage (append-only)
+
+    /// @notice Reference to the spec-060 FeeRouter (rate + treasury source of truth).
+    address public feeRouter;
+    /// @notice Lido stETH (submit) + wstETH (wrap) contracts on this network.
+    address public lidoSteth;
+    address public lidoWsteth;
+    /// @notice sPOL controller (buySPOL) + sPOL token.
+    address public spolController;
+    address public spolToken;
+    /// @notice POL token + Polygon StakeManager (delegated config only; member stakes delegated directly).
+    address public polToken;
+    address public polygonStakeManager;
+    /// @notice Curated ValidatorShare allowlist for delegated staking.
+    EnumerableSet.AddressSet private _validators;
+
+    uint256[41] private __gap;
+
+    // ---------------------------------------------------------------- init
+
+    /// @param admin Granted DEFAULT_ADMIN_ROLE + UPGRADER_ROLE (UUPSManaged) and STAKING_ADMIN_ROLE +
+    ///        GUARDIAN_ROLE. In production a multisig (Safe); there is no on-chain timelock.
+    /// @param feeRouter_ The spec-060 FeeRouter address (must be non-zero).
+    /// @dev Provider addresses may be zero at init and configured later via the setters; the liquid
+    ///      stake entrypoints will revert until their provider is set.
+    function initialize(
+        address admin,
+        address feeRouter_,
+        address steth,
+        address wsteth,
+        address spolController_,
+        address spolToken_,
+        address polToken_,
+        address polygonStakeManager_
+    ) external initializer {
+        if (admin == address(0) || feeRouter_ == address(0)) revert ZeroAddress();
+        __UUPSManaged_init(admin);
+        __ReentrancyGuard_init();
+        __Pausable_init();
+        _grantRole(STAKING_ADMIN_ROLE, admin);
+        _grantRole(GUARDIAN_ROLE, admin);
+
+        feeRouter = feeRouter_;
+        lidoSteth = steth;
+        lidoWsteth = wsteth;
+        spolController = spolController_;
+        spolToken = spolToken_;
+        polToken = polToken_;
+        polygonStakeManager = polygonStakeManager_;
+    }
+
+    // ---------------------------------------------------------------- config setters (STAKING_ADMIN_ROLE)
+
+    function setFeeRouter(address newFeeRouter) external onlyRole(STAKING_ADMIN_ROLE) {
+        if (newFeeRouter == address(0)) revert ZeroAddress();
+        emit FeeRouterUpdated(feeRouter, newFeeRouter, msg.sender);
+        feeRouter = newFeeRouter;
+    }
+
+    function setLidoContracts(address steth, address wsteth) external onlyRole(STAKING_ADMIN_ROLE) {
+        if (steth == address(0) || wsteth == address(0)) revert ZeroAddress();
+        lidoSteth = steth;
+        lidoWsteth = wsteth;
+        emit LidoContractsUpdated(steth, wsteth, msg.sender);
+    }
+
+    function setSpolContracts(address controller, address token) external onlyRole(STAKING_ADMIN_ROLE) {
+        if (controller == address(0) || token == address(0)) revert ZeroAddress();
+        spolController = controller;
+        spolToken = token;
+        emit SpolContractsUpdated(controller, token, msg.sender);
+    }
+
+    function setPolygonContracts(address polToken_, address stakeManager) external onlyRole(STAKING_ADMIN_ROLE) {
+        if (polToken_ == address(0) || stakeManager == address(0)) revert ZeroAddress();
+        polToken = polToken_;
+        polygonStakeManager = stakeManager;
+        emit PolygonContractsUpdated(polToken_, stakeManager, msg.sender);
+    }
+
+    function addValidator(address validatorShare) external onlyRole(STAKING_ADMIN_ROLE) {
+        if (validatorShare == address(0)) revert ZeroAddress();
+        if (!_validators.add(validatorShare)) revert AlreadyListed();
+        emit ValidatorAdded(validatorShare, msg.sender);
+    }
+
+    function removeValidator(address validatorShare) external onlyRole(STAKING_ADMIN_ROLE) {
+        if (!_validators.remove(validatorShare)) revert NotListed();
+        emit ValidatorRemoved(validatorShare, msg.sender);
+    }
+
+    // ---------------------------------------------------------------- validator reads
+
+    function validatorCount() external view returns (uint256) {
+        return _validators.length();
+    }
+
+    function validatorAt(uint256 index) external view returns (address) {
+        return _validators.at(index);
+    }
+
+    function isValidator(address validatorShare) external view returns (bool) {
+        return _validators.contains(validatorShare);
+    }
+
+    // ---------------------------------------------------------------- emergency pause (GUARDIAN_ROLE)
+
+    function pause() external onlyRole(GUARDIAN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external onlyRole(GUARDIAN_ROLE) {
+        _unpause();
+    }
+
+    // ---------------------------------------------------------------- LIQUID fee-and-forward entrypoints
+
+    /// @notice Stake ETH into Lido and receive wstETH, net of the platform fee. The fee (live rate for
+    ///         `stake.lido`, capped by `maxFeeBps`) goes to the treasury; the remainder is submitted to
+    ///         Lido and wrapped, and the wstETH is returned to the caller. Atomic + `nonReentrant`.
+    /// @param maxFeeBps The rate the member was shown; a live rate above it reverts FeeAboveQuoted.
+    /// @return wstOut wstETH returned to the member.
+    function stakeLido(uint16 maxFeeBps)
+        external
+        payable
+        nonReentrant
+        whenNotPaused
+        returns (uint256 wstOut)
+    {
+        uint256 gross = msg.value;
+        if (gross == 0) revert ZeroAmount();
+        // Pre-existing balance (robust against forced ETH): we assert we consume exactly `gross`.
+        uint256 startBalance = address(this).balance - gross;
+
+        IFeeRouter router = IFeeRouter(feeRouter);
+        // Consent ceiling BEFORE any movement — the quoted rate is a hard cap (FR-003).
+        if (router.feeBps(stakeLidoServiceId) > maxFeeBps) revert FeeAboveQuoted();
+        (uint256 fee, uint256 net) = router.quoteFee(stakeLidoServiceId, gross);
+
+        if (fee > 0) {
+            (bool ok, ) = router.treasury().call{value: fee}("");
+            if (!ok) revert ProviderCallFailed();
+        }
+
+        // Forward the net to Lido: submit → wrap → return wstETH to the member.
+        uint256 stethBefore = IERC20(lidoSteth).balanceOf(address(this));
+        ILidoStETH(lidoSteth).submit{value: net}(address(0));
+        uint256 steth = IERC20(lidoSteth).balanceOf(address(this)) - stethBefore;
+        IERC20(lidoSteth).forceApprove(lidoWsteth, steth);
+        wstOut = IWstETH(lidoWsteth).wrap(steth);
+        if (wstOut == 0) revert ProviderCallFailed();
+        IERC20(lidoWsteth).safeTransfer(msg.sender, wstOut);
+        IERC20(lidoSteth).forceApprove(lidoWsteth, 0);
+
+        // No member funds may remain in the router after the action (FR-016).
+        if (address(this).balance != startBalance) revert ResidualFunds();
+        emit LiquidStaked(lidoWsteth, msg.sender, gross, fee, net, wstOut);
+    }
+
+    /// @notice Stake POL into sPOL and receive sPOL, net of the platform fee. The fee (live rate for
+    ///         `stake.polygon`, capped by `maxFeeBps`) goes to the treasury; the remainder is staked
+    ///         via `buySPOL` and the sPOL is returned to the caller. Atomic + `nonReentrant`.
+    /// @param amount POL to stake (pulled from the caller via allowance).
+    /// @param maxFeeBps The rate the member was shown; a live rate above it reverts FeeAboveQuoted.
+    /// @return spolOut sPOL returned to the member.
+    function stakeSpol(uint256 amount, uint16 maxFeeBps)
+        external
+        nonReentrant
+        whenNotPaused
+        returns (uint256 spolOut)
+    {
+        if (amount == 0) revert ZeroAmount();
+        IERC20 pol = IERC20(polToken);
+        uint256 polBefore = pol.balanceOf(address(this));
+
+        IFeeRouter router = IFeeRouter(feeRouter);
+        if (router.feeBps(stakeSpolServiceId) > maxFeeBps) revert FeeAboveQuoted();
+
+        pol.safeTransferFrom(msg.sender, address(this), amount);
+        (uint256 fee, uint256 net) = router.quoteFee(stakeSpolServiceId, amount);
+
+        if (fee > 0) pol.safeTransfer(router.treasury(), fee);
+
+        pol.forceApprove(spolController, net);
+        spolOut = ISpolController(spolController).buySPOL(net);
+        if (spolOut == 0) revert ProviderCallFailed();
+        IERC20(spolToken).safeTransfer(msg.sender, spolOut);
+        pol.forceApprove(spolController, 0);
+
+        // The router must not retain any of the member's principal (FR-016).
+        if (pol.balanceOf(address(this)) != polBefore) revert ResidualFunds();
+        emit LiquidStaked(spolToken, msg.sender, amount, fee, net, spolOut);
+    }
+}

--- a/docs/developer-guide/staking-integration.md
+++ b/docs/developer-guide/staking-integration.md
@@ -56,15 +56,44 @@ commission; each `validatorShare` is run through `getAddress()` at load. Verify
 the Lido/sPOL/POL/StakeManager addresses against the Lido deployed-contracts page
 and `0xPolygon/spol-contracts` too.
 
-## Fees
+## Fees & admin controls (spec 066 — StakingRouter)
 
-FairWins charges **no** platform fee on staking in this release (byte-identical
-to fee-free). None of Lido `submit`, sPOL `buySPOL`, or Polygon `buyVoucher` are
-ERC-4626 deposits, so the spec-060 FeeRouter `depositToVaultWithFee` entrypoint
-does not fit; a fee-on-input staking router is a new value-bearing contract and
-is **deferred to its own spec** (research.md R6). Provider protocol fees (Lido's
-~10% of rewards, sPOL's on-chain `rewardFee`) are the provider's and disclosed as
-such.
+Spec 066 adds the **StakingRouter** — a per-network UUPS control surface
+(`contracts/staking/StakingRouter.sol`, deployment keys `stakingRouter` /
+`stakingRouterImpl`) — that both governs the staking service and charges the
+platform fee on **liquid** staking.
+
+**Fee (liquid only).** The fee **rate** stays the single spec-060 `FeeRouter`
+source of truth: per-provider services `stake.lido` / `stake.polygon`
+(`FEE_SERVICES.STAKE_LIDO` / `STAKE_POLYGON`), each ConfigOnly, cap **250 bps**,
+rate 0 until set from the Fees tab (`FEE_ADMIN_ROLE`). None of Lido `submit` /
+sPOL `buySPOL` are ERC-4626 deposits, so the FeeRouter's `depositToVaultWithFee`
+doesn't fit; instead the StakingRouter reads `quoteFee` / `feeBps` / `treasury()`
+and does the fee-and-forward itself — skim to the treasury, forward the net to the
+provider, return the LST — atomically, with a `maxFeeBps` consent ceiling
+(`FeeAboveQuoted`) and a no-residual invariant (`ResidualFunds`). A zero/unset rate
+is byte-identical to fee-free (SC-003).
+
+**Delegated is fee-free in v1.** Polygon `buyVoucherPOL` binds the delegation to
+`msg.sender`, so a router call would make the router the (custodial, un-exitable)
+delegator. Delegated staying a direct member call is the only non-custodial option,
+so it ships **fee-free**; the router still governs its allowlist + pause. Provider
+protocol fees (Lido's ~10% of rewards, sPOL's `rewardFee`) are the provider's and
+disclosed as such.
+
+**Runtime read + fallback.** `useStakingOptions` overlays the router's provider
+addresses, validator allowlist, `paused` flag, and the per-provider fee onto the
+spec-065 options (`lib/staking/stakingRouter.js`, `overlayRouterConfig`). When the
+router is undeployed or unreadable it keeps the spec-065 build-time constants
+verbatim — fee-free, direct staking — never a broken or fee-guessing screen
+(FR-009). `stakingActions.buildStakeForOption` routes through the router only when a
+fee applies; otherwise it emits the byte-identical direct calls.
+
+**Governance & ops.** `STAKING_ADMIN_ROLE` (provider addresses + validator
+allowlist) and `GUARDIAN_ROLE` (emergency pause) are held by a **multisig** with
+**no timelock** (FR-018). Operators drive it from the AdminPanel **Staking** tab;
+the fee rate is read-only there and edited in the **Fees** tab. See
+`docs/runbooks/staking-operations.md`.
 
 ## Adding a network or provider
 

--- a/docs/runbooks/staking-operations.md
+++ b/docs/runbooks/staking-operations.md
@@ -1,0 +1,100 @@
+# Staking Operations (spec 066)
+
+Operator guide for the on-chain **StakingRouter** — the per-network control surface for the
+spec-065 staking service. It governs provider addresses, the curated validator allowlist, and a
+per-network **emergency pause**, and it charges the spec-060 platform fee on **liquid** staking
+(routing it to the treasury). Delegated staking is **fee-free in v1** and stays a direct member call.
+
+> The staking **fee rate** is NOT set here. It lives on the spec-060 `FeeRouter` (services
+> `stake.lido` / `stake.polygon`) and is edited from the AdminPanel **Fees** tab by a
+> **Fee Administrator** (`FEE_ADMIN_ROLE`). The Staking tab shows the live rate read-only.
+
+## Roles (least privilege)
+
+| Role | Grants | Held by |
+|---|---|---|
+| `STAKING_ADMIN_ROLE` | provider addresses + validator allowlist | multisig (Safe) |
+| `GUARDIAN_ROLE` | emergency `pause()` / `unpause()` | multisig (Safe) |
+| `FEE_ADMIN_ROLE` (spec 060) | the `stake.lido` / `stake.polygon` rate | multisig (Safe) |
+| `UPGRADER_ROLE` / `DEFAULT_ADMIN_ROLE` (UUPSManaged) | upgrades / role admin | multisig (Safe) |
+
+There is **no on-chain timelock** (FR-018): the emergency pause is instant; config changes rely on
+multi-party approval. After deploy, transfer all roles from the deployer EOA to the multisig and
+renounce the deployer (the deploy script prints an ADMIN HANDOFF reminder).
+
+## Deploy & wire
+
+Prerequisite: the spec-060 `FeeRouter` is deployed on the network with a treasury set.
+
+```
+npx hardhat run scripts/deploy/deploy-staking-router.js --network <net>
+npm run sync:frontend-contracts -- --network <net> --chainId <id>
+```
+
+The script deploys the UUPS proxy, records `stakingRouter` / `stakingRouterImpl` in
+`deployments/<net>-chain<id>-v2.json`, and registers `stake.lido` + `stake.polygon` on the existing
+FeeRouter (ConfigOnly, cap 250 bps, rate 0). Provider addresses default to the Ethereum-mainnet L1
+contracts (override via `LIDO_STETH`/`LIDO_WSTETH`/`SPOL_*`/`POL_TOKEN_L1`/`POLYGON_STAKE_MANAGER`).
+Logic changes ship as in-place UUPS upgrades (`scripts/deploy/lib/upgradeable.js#upgradeProxy`), never
+a fresh redeploy; run `npm run check:storage-layout` first.
+
+## 🚨 Emergency pause (do this FIRST in an incident)
+
+A suspected provider exploit, a misbehaving validator, or a contract address in doubt — stop new
+staking on the network immediately:
+
+1. AdminPanel → **Staking** tab (as a `GUARDIAN`).
+2. Click **Pause staking**. It is a single on-chain tx with **no timelock** and no dependency on any
+   optional service (relay-gateway, etc.) — it works even when non-essential infra is degraded.
+3. Within one member refresh (≤ 60 s) the member Stake area stops offering new stakes and shows the
+   honest unavailable state; the option rows show a **Paused** badge.
+
+**Members can always exit.** Pause blocks only new liquid stakes (`whenNotPaused` on the stake
+entrypoints). Unstake, withdraw, and reward-claim never route through the router, so funds are never
+trapped. Resolve the incident, then **Resume staking**. Both actions appear in the tab's history.
+
+## Set / change the staking fee
+
+1. AdminPanel → **Fees** tab (as a `FEE_ADMIN`).
+2. Set the rate for **Stake — Lido** (`stake.lido`) or **Stake — Polygon liquid staking**
+   (`stake.polygon`), in basis points, ≤ the 250 bps cap (the contract refuses more).
+3. Members see the new rate on their next Stake confirmation as its own line
+   ("FairWins platform fee … / You stake …"). A member is never charged above the rate they were
+   shown (`maxFeeBps` ceiling). A rate of **0** shows no fee line and is byte-identical to fee-free
+   staking. Delegated staking never shows a fee.
+
+The fee is charged atomically inside `stakeLido` / `stakeSpol`: the router skims the fee to the
+treasury and forwards the net to the provider in one tx (never custodial across transactions).
+
+## Manage provider addresses
+
+AdminPanel → **Staking** tab (as a `STAKING_ADMIN`). Each provider group shows its current value.
+Enter the new address(es) and confirm — invalid or zero addresses are rejected before the wallet
+prompt. The member flow resolves the new addresses at runtime; the change is in the tab's history.
+
+- **Set Lido** — stETH + wstETH
+- **Set sPOL** — controller + sPOL token
+- **Set Polygon** — POL token + StakeManager (delegated config)
+- **Set FeeRouter** — the FeeRouter reference the router reads the rate/treasury from
+
+## Curate the validator allowlist
+
+AdminPanel → **Staking** tab (as a `STAKING_ADMIN`). The current on-chain allowlist is listed with a
+**Remove** action; **Add validator share** appends a new one (duplicates and zero/absent entries are
+rejected by the contract). Removing a validator stops it being offered for **new** delegations
+immediately; members already delegated to it keep the position and can still unstake/withdraw.
+
+## Audit history
+
+The Staking tab renders the router's setter + pause events (newest first) with actor and time, plus a
+Blockscout link. Fee-rate changes are in the **Fees** tab history (`FeeBpsChanged`).
+
+## Safe fallback
+
+On a network with **no** StakingRouter deployed, or when the router/fee read fails, the member app
+falls back to the spec-065 behavior — fee-free, direct staking, availability as configured — and never
+shows a broken or fee-guessing screen. A present-but-unreadable router blocks only the fee-bearing
+path (never an assumed rate); exits remain available.
+
+See also: `docs/developer-guide/staking-integration.md`, `docs/runbooks/fee-operations.md`,
+`docs/runbooks/contract-upgrades.md`, `specs/066-staking-admin-controls/`.

--- a/frontend/src/abis/StakingRouter.js
+++ b/frontend/src/abis/StakingRouter.js
@@ -1,0 +1,65 @@
+/**
+ * StakingRouter ABI subset (spec 066 — staking control surface + liquid fee router).
+ *
+ * Covers the reads the member app + AdminPanel Staking tab need (provider addresses,
+ * validator allowlist enumeration, pause state, roles), the config setters + pause the
+ * tab writes, the two LIQUID fee-and-forward stake entrypoints the member flow routes
+ * through when a fee applies, and the events the tab renders as on-chain audit history.
+ * Delegated staking is fee-free in v1 and stays a direct `ValidatorShare` call — it is
+ * intentionally NOT an entrypoint here.
+ *
+ * Kept byte-compatible with contracts/staking/StakingRouter.sol. Human-readable
+ * fragments, ethers v6.
+ */
+export const STAKING_ROUTER_ABI = [
+  // --- reads: config ---
+  'function feeRouter() view returns (address)',
+  'function lidoSteth() view returns (address)',
+  'function lidoWsteth() view returns (address)',
+  'function spolController() view returns (address)',
+  'function spolToken() view returns (address)',
+  'function polToken() view returns (address)',
+  'function polygonStakeManager() view returns (address)',
+  'function stakeLidoServiceId() view returns (bytes32)',
+  'function stakeSpolServiceId() view returns (bytes32)',
+  // --- reads: validator allowlist ---
+  'function validatorCount() view returns (uint256)',
+  'function validatorAt(uint256 index) view returns (address)',
+  'function isValidator(address validatorShare) view returns (bool)',
+  // --- reads: pause + roles ---
+  'function paused() view returns (bool)',
+  'function STAKING_ADMIN_ROLE() view returns (bytes32)',
+  'function GUARDIAN_ROLE() view returns (bytes32)',
+  'function hasRole(bytes32 role, address account) view returns (bool)',
+  // --- config setters (STAKING_ADMIN_ROLE) ---
+  'function setFeeRouter(address newFeeRouter)',
+  'function setLidoContracts(address steth, address wsteth)',
+  'function setSpolContracts(address controller, address token)',
+  'function setPolygonContracts(address polToken, address stakeManager)',
+  'function addValidator(address validatorShare)',
+  'function removeValidator(address validatorShare)',
+  // --- emergency pause (GUARDIAN_ROLE) ---
+  'function pause()',
+  'function unpause()',
+  // --- role administration (DEFAULT_ADMIN_ROLE) ---
+  'function grantRole(bytes32 role, address account)',
+  'function revokeRole(bytes32 role, address account)',
+  // --- member actions: LIQUID fee-and-forward ---
+  'function stakeLido(uint16 maxFeeBps) payable returns (uint256 wstOut)',
+  'function stakeSpol(uint256 amount, uint16 maxFeeBps) returns (uint256 spolOut)',
+  // --- events: config + audit history ---
+  'event FeeRouterUpdated(address oldRouter, address newRouter, address indexed actor)',
+  'event LidoContractsUpdated(address steth, address wsteth, address indexed actor)',
+  'event SpolContractsUpdated(address controller, address token, address indexed actor)',
+  'event PolygonContractsUpdated(address polToken, address stakeManager, address indexed actor)',
+  'event ValidatorAdded(address indexed validatorShare, address indexed actor)',
+  'event ValidatorRemoved(address indexed validatorShare, address indexed actor)',
+  'event LiquidStaked(address indexed provider, address indexed member, uint256 gross, uint256 fee, uint256 net, uint256 lstOut)',
+  // --- events: pause + roles (OZ) ---
+  'event Paused(address account)',
+  'event Unpaused(address account)',
+  'event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)',
+  'event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)',
+]
+
+export default STAKING_ROUTER_ABI

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -17,6 +17,7 @@ import CallsignRegistryAdmin from './admin/CallsignRegistryAdmin'
 import MembershipTreasuryOverview from './admin/MembershipTreasuryOverview'
 import ProtocolConfigTab from './admin/ProtocolConfigTab'
 import FeesTab from './admin/FeesTab'
+import StakingTab from './admin/StakingTab'
 import MaintenanceTab from './admin/MaintenanceTab'
 import ServiceHealthCard from './admin/ServiceHealthCard'
 import PaymasterOpsCard from './admin/PaymasterOpsCard'
@@ -35,6 +36,7 @@ const ROLE_HASHES = {
   ROLE_MANAGER: ethers.keccak256(ethers.toUtf8Bytes('ROLE_MANAGER_ROLE')),
   SANCTIONS_ADMIN: ethers.keccak256(ethers.toUtf8Bytes('SANCTIONS_ADMIN_ROLE')),
   TOKEN_ISSUER: ethers.keccak256(ethers.toUtf8Bytes('TOKEN_ISSUER_ROLE')),
+  STAKING_ADMIN: ethers.keccak256(ethers.toUtf8Bytes('STAKING_ADMIN_ROLE')),
   DEFAULT_ADMIN: ethers.ZeroHash,
 }
 
@@ -91,6 +93,7 @@ function AdminPanel() {
   const isRoleManager = hasRole(ROLES.ROLE_MANAGER)
   const isSanctionsAdmin = hasRole(ROLES.SANCTIONS_ADMIN)
   const isFeeAdmin = hasRole(ROLES.FEE_ADMIN)
+  const isStakingAdmin = hasRole(ROLES.STAKING_ADMIN)
   const hasAdminAccess = hasAnyRole(ADMIN_ROLES)
 
   const [activeTab, setActiveTab] = useState('overview')
@@ -141,6 +144,7 @@ function AdminPanel() {
   const membershipManagerAddr = getContractAddressForChain('membershipManager', chainId)
   const sanctionsGuardAddr = getContractAddressForChain('sanctionsGuard', chainId)
   const tokenFactoryAddr = getContractAddressForChain('tokenFactory', chainId)
+  const stakingRouterAddr = getContractAddressForChain('stakingRouter', chainId)
 
   // Each grantable role lives on a specific contract; grants must be sent
   // to the contract that defines the role, not blanket-sent to the registry.
@@ -148,6 +152,7 @@ function AdminPanel() {
     if (role === 'ROLE_MANAGER') return membershipManagerAddr
     if (role === 'SANCTIONS_ADMIN') return sanctionsGuardAddr
     if (role === 'TOKEN_ISSUER') return tokenFactoryAddr
+    if (role === 'STAKING_ADMIN') return stakingRouterAddr
     return wagerRegistryAddr
   }
 
@@ -317,6 +322,7 @@ function AdminPanel() {
     isRoleManager,
     isSanctionsAdmin,
     isFeeAdmin,
+    isStakingAdmin,
   })
   const adminTabs = flattenNavGroups(navGroups)
 
@@ -664,6 +670,7 @@ function AdminPanel() {
                     <option value="ROLE_MANAGER">Role Manager — grant/revoke memberships</option>
                     <option value="SANCTIONS_ADMIN">Compliance Officer — deny-list (SanctionsGuard)</option>
                     <option value="TOKEN_ISSUER">Token Issuer — token creation (TokenFactory)</option>
+                    <option value="STAKING_ADMIN">Staking Administrator — provider addrs + validator allowlist (StakingRouter)</option>
                     <option value="DEFAULT_ADMIN">Default Admin — full control (rare)</option>
                   </select>
                 </label>
@@ -760,6 +767,19 @@ function AdminPanel() {
             pendingTx={pendingTx}
             isAdmin={isAdmin}
             isFeeAdmin={isFeeAdmin}
+          />
+        )}
+
+        {activeTab === 'staking' && (isAdmin || isStakingAdmin || isGuardian) && (
+          <StakingTab
+            signer={signer}
+            chainId={chainId}
+            provider={provider || getProvider(chainId)}
+            runTx={runTx}
+            pendingTx={pendingTx}
+            isAdmin={isAdmin}
+            isStakingAdmin={isStakingAdmin}
+            isGuardian={isGuardian}
           />
         )}
 

--- a/frontend/src/components/admin/StakingTab.jsx
+++ b/frontend/src/components/admin/StakingTab.jsx
@@ -1,0 +1,366 @@
+/**
+ * StakingTab (spec 066) — operator control surface for the staking service.
+ *
+ * One screen to manage the on-chain StakingRouter for a network:
+ *   - Provider addresses (Lido, sPOL, Polygon delegation, the FeeRouter reference)
+ *     — STAKING_ADMIN_ROLE, validated before the wallet prompt.
+ *   - The curated validator allowlist for delegated staking — STAKING_ADMIN_ROLE.
+ *   - Emergency pause / resume of new staking on this network — GUARDIAN_ROLE.
+ *   - The per-provider LIQUID staking fee rates — READ-ONLY here (edited in the Fees
+ *     tab by FEE_ADMIN, the single fee source of truth; spec 060).
+ *   - On-chain change history (setter + pause events) — the audit trail.
+ *
+ * When no StakingRouter is deployed on the network the tab shows an honest
+ * "not deployed" state and the member app keeps the spec-065 fee-free direct staking.
+ */
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { ethers } from 'ethers'
+import { getContractAddressForChain } from '../../config/contracts'
+import { STAKING_ROUTER_ABI } from '../../abis/StakingRouter'
+import { FEE_SERVICES, fetchFeeQuote, bpsToPercent } from '../../lib/fees/feeQuote'
+import { getBlockscoutUrl } from '../../config/blockExplorer'
+
+const HISTORY_LOOKBACK_BLOCKS = 200_000
+const HISTORY_LIMIT = 25
+const SETTER_EVENTS = [
+  'FeeRouterUpdated',
+  'LidoContractsUpdated',
+  'SpolContractsUpdated',
+  'PolygonContractsUpdated',
+  'ValidatorAdded',
+  'ValidatorRemoved',
+  'Paused',
+  'Unpaused',
+]
+
+function shortAddr(a) {
+  return a && a !== ethers.ZeroAddress ? `${a.substring(0, 6)}...${a.substring(a.length - 4)}` : ''
+}
+
+const isValidAddr = (a) => ethers.isAddress(a) && a !== ethers.ZeroAddress
+
+export default function StakingTab({ signer, chainId, provider, runTx, pendingTx, isAdmin, isStakingAdmin, isGuardian }) {
+  const routerAddr = getContractAddressForChain('stakingRouter', chainId)
+  const canConfig = Boolean(isAdmin || isStakingAdmin)
+  const canPause = Boolean(isAdmin || isGuardian)
+
+  const [state, setState] = useState(null) // null = loading
+  const [readError, setReadError] = useState(null)
+  const [fees, setFees] = useState({ lido: null, polygon: null })
+  const [history, setHistory] = useState({ entries: null, error: null })
+  const [forms, setForms] = useState({ lido: '', wsteth: '', spolC: '', spolT: '', polToken: '', stakeMgr: '', feeRouter: '', addVal: '', rmVal: '' })
+  const [formError, setFormError] = useState(null)
+
+  const routerRead = useMemo(
+    () => (routerAddr && provider ? new ethers.Contract(routerAddr, STAKING_ROUTER_ABI, provider) : null),
+    [routerAddr, provider]
+  )
+  const write = useCallback(
+    () => new ethers.Contract(routerAddr, STAKING_ROUTER_ABI, signer),
+    [routerAddr, signer]
+  )
+
+  const fetchState = useCallback(async () => {
+    if (!routerRead) return
+    try {
+      setReadError(null)
+      const safe = (p) => p.then((v) => v).catch(() => undefined)
+      const [feeRouter, lidoSteth, lidoWsteth, spolController, spolToken, polToken, polygonStakeManager, paused, count] =
+        await Promise.all([
+          safe(routerRead.feeRouter()),
+          safe(routerRead.lidoSteth()),
+          safe(routerRead.lidoWsteth()),
+          safe(routerRead.spolController()),
+          safe(routerRead.spolToken()),
+          safe(routerRead.polToken()),
+          safe(routerRead.polygonStakeManager()),
+          safe(routerRead.paused()),
+          safe(routerRead.validatorCount()),
+        ])
+      const validators = []
+      if (count !== undefined) {
+        const entries = await Promise.all(
+          Array.from({ length: Number(count) }, (_, i) => safe(routerRead.validatorAt(i)))
+        )
+        for (const v of entries) if (v) validators.push(v)
+      }
+      setState({ feeRouter, lidoSteth, lidoWsteth, spolController, spolToken, polToken, polygonStakeManager, paused: Boolean(paused), validators })
+    } catch (e) {
+      setReadError(`Could not read the StakingRouter: ${e?.message || e}`)
+    }
+  }, [routerRead])
+
+  const fetchFees = useCallback(async () => {
+    if (!provider || !routerAddr) return
+    const load = (serviceId) =>
+      fetchFeeQuote({ serviceId, chainId, provider }).catch(() => ({ available: false, bps: 0 }))
+    const [lido, polygon] = await Promise.all([load(FEE_SERVICES.STAKE_LIDO), load(FEE_SERVICES.STAKE_POLYGON)])
+    setFees({ lido, polygon })
+  }, [provider, routerAddr, chainId])
+
+  const fetchHistory = useCallback(async () => {
+    if (!routerRead || !provider) return
+    try {
+      const latest = await provider.getBlockNumber()
+      const fromBlock = Math.max(0, Number(latest) - HISTORY_LOOKBACK_BLOCKS)
+      const all = []
+      for (const name of SETTER_EVENTS) {
+        const evs = await routerRead.queryFilter(routerRead.filters[name](), fromBlock, 'latest').catch(() => [])
+        for (const ev of evs) all.push({ name, ev })
+      }
+      all.sort((a, b) => b.ev.blockNumber - a.ev.blockNumber || b.ev.index - a.ev.index)
+      const recent = all.slice(0, HISTORY_LIMIT)
+      const entries = await Promise.all(
+        recent.map(async ({ name, ev }) => {
+          const block = await provider.getBlock(ev.blockNumber).catch(() => null)
+          const actor = ev.args?.actor || ev.args?.account
+          return {
+            name,
+            actor,
+            at: block ? new Date(block.timestamp * 1000) : null,
+            txHash: ev.transactionHash,
+            key: `${ev.transactionHash}-${ev.index}`,
+          }
+        })
+      )
+      setHistory({ entries, error: null })
+    } catch (e) {
+      setHistory({ entries: [], error: e?.message || String(e) })
+    }
+  }, [routerRead, provider])
+
+  useEffect(() => {
+    fetchState()
+    fetchFees()
+    fetchHistory()
+  }, [fetchState, fetchFees, fetchHistory])
+
+  const refresh = () => {
+    fetchState()
+    fetchFees()
+    fetchHistory()
+  }
+
+  const setPair = (fn, a, b, label) => {
+    setFormError(null)
+    if (!isValidAddr(a) || (b !== undefined && !isValidAddr(b))) {
+      setFormError('Enter valid, non-zero address(es) — the contract rejects malformed or zero input.')
+      return
+    }
+    const args = b !== undefined ? [a, b] : [a]
+    runTx(() => write()[fn](...args), `${label} updated`).then(refresh)
+  }
+
+  const addValidator = () => {
+    setFormError(null)
+    if (!isValidAddr(forms.addVal)) {
+      setFormError('Enter a valid, non-zero validator share address.')
+      return
+    }
+    runTx(() => write().addValidator(forms.addVal), `Validator ${shortAddr(forms.addVal)} added`).then(refresh)
+  }
+  const removeValidator = (addr) => {
+    runTx(() => write().removeValidator(addr), `Validator ${shortAddr(addr)} removed`).then(refresh)
+  }
+  const togglePause = () => {
+    const fn = state?.paused ? 'unpause' : 'pause'
+    runTx(() => write()[fn](), state?.paused ? 'Staking resumed' : 'Staking paused').then(refresh)
+  }
+
+  if (!routerAddr) {
+    return (
+      <div className="admin-tab-content" role="tabpanel">
+        <div className="admin-card">
+          <h3>Staking Controls</h3>
+          <p className="card-info">
+            No StakingRouter is deployed on this network, so staking controls are not available here —
+            member staking behaves exactly as spec 065 (fee-free, direct staking, availability as
+            configured). Deploy it with <code>scripts/deploy/deploy-staking-router.js</code> (see the
+            staking operations runbook).
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const feeLine = (f) =>
+    f == null ? '…' : f.available ? `${f.bps} bps (${bpsToPercent(f.bps)}), cap ${f.capBps} bps` : 'no fee (rate 0 / unset)'
+
+  return (
+    <div className="admin-tab-content" role="tabpanel">
+      <div className="admin-card">
+        <div className="admin-card-header">
+          <h3>Staking Controls</h3>
+          <button type="button" className="refresh-btn" onClick={refresh} aria-label="Refresh staking controls">↻</button>
+        </div>
+        {readError && <p className="card-info error">{readError}</p>}
+        <div className="status-details">
+          <div className="status-row">
+            <span className="status-label">StakingRouter</span>
+            <span className="status-value"><code title={routerAddr}>{shortAddr(routerAddr)}</code></span>
+          </div>
+          <div className="status-row">
+            <span className="status-label">New staking</span>
+            <span className="status-value">
+              {state == null ? '…' : state.paused
+                ? <span className="status-value paused">PAUSED — new stakes stopped (exits still work)</span>
+                : 'active'}
+            </span>
+          </div>
+          <div className="status-row">
+            <span className="status-label">Lido fee (stake.lido)</span>
+            <span className="status-value">{feeLine(fees.lido)}</span>
+          </div>
+          <div className="status-row">
+            <span className="status-label">sPOL fee (stake.polygon)</span>
+            <span className="status-value">{feeLine(fees.polygon)}</span>
+          </div>
+        </div>
+        <p className="card-info">
+          Fee rates are read-only here — they live on the FeeRouter and are edited in the{' '}
+          <strong>Fees</strong> tab by a Fee Administrator (the single fee source of truth). Delegated
+          staking is fee-free.
+        </p>
+      </div>
+
+      {canPause && (
+        <div className="admin-card">
+          <h3>Emergency pause</h3>
+          <p>
+            Pausing stops <strong>new</strong> stakes on this network immediately (no redeploy). Members
+            can always still unstake, withdraw, and claim — exits never route through the router.
+          </p>
+          <button
+            type="button"
+            className={`confirm-btn ${state?.paused ? 'primary' : 'danger'}`}
+            onClick={togglePause}
+            disabled={pendingTx || !signer || state == null}
+          >
+            {state?.paused ? 'Resume staking' : 'Pause staking'}
+          </button>
+        </div>
+      )}
+
+      {canConfig && (
+        <div className="admin-card">
+          <h3>Provider addresses</h3>
+          <p>Current values shown below each field. Invalid or zero addresses are rejected before the wallet prompt.</p>
+          <div className="admin-form">
+            <label>
+              Lido stETH / wstETH
+              <input type="text" placeholder="stETH 0x…" value={forms.lido}
+                onChange={(e) => setForms((f) => ({ ...f, lido: e.target.value }))} />
+              <input type="text" placeholder="wstETH 0x…" value={forms.wsteth}
+                onChange={(e) => setForms((f) => ({ ...f, wsteth: e.target.value }))} />
+              <span className="hint">now: {shortAddr(state?.lidoSteth) || '—'} / {shortAddr(state?.lidoWsteth) || '—'}</span>
+            </label>
+            <button type="button" className="confirm-btn primary" disabled={pendingTx || !signer}
+              onClick={() => setPair('setLidoContracts', forms.lido, forms.wsteth, 'Lido contracts')}>Set Lido</button>
+
+            <label>
+              sPOL controller / token
+              <input type="text" placeholder="controller 0x…" value={forms.spolC}
+                onChange={(e) => setForms((f) => ({ ...f, spolC: e.target.value }))} />
+              <input type="text" placeholder="sPOL 0x…" value={forms.spolT}
+                onChange={(e) => setForms((f) => ({ ...f, spolT: e.target.value }))} />
+              <span className="hint">now: {shortAddr(state?.spolController) || '—'} / {shortAddr(state?.spolToken) || '—'}</span>
+            </label>
+            <button type="button" className="confirm-btn primary" disabled={pendingTx || !signer}
+              onClick={() => setPair('setSpolContracts', forms.spolC, forms.spolT, 'sPOL contracts')}>Set sPOL</button>
+
+            <label>
+              POL token / Stake Manager (delegation)
+              <input type="text" placeholder="POL 0x…" value={forms.polToken}
+                onChange={(e) => setForms((f) => ({ ...f, polToken: e.target.value }))} />
+              <input type="text" placeholder="StakeManager 0x…" value={forms.stakeMgr}
+                onChange={(e) => setForms((f) => ({ ...f, stakeMgr: e.target.value }))} />
+              <span className="hint">now: {shortAddr(state?.polToken) || '—'} / {shortAddr(state?.polygonStakeManager) || '—'}</span>
+            </label>
+            <button type="button" className="confirm-btn primary" disabled={pendingTx || !signer}
+              onClick={() => setPair('setPolygonContracts', forms.polToken, forms.stakeMgr, 'Polygon contracts')}>Set Polygon</button>
+
+            <label>
+              FeeRouter reference
+              <input type="text" placeholder="FeeRouter 0x…" value={forms.feeRouter}
+                onChange={(e) => setForms((f) => ({ ...f, feeRouter: e.target.value }))} />
+              <span className="hint">now: {shortAddr(state?.feeRouter) || '—'}</span>
+            </label>
+            <button type="button" className="confirm-btn primary" disabled={pendingTx || !signer}
+              onClick={() => setPair('setFeeRouter', forms.feeRouter, undefined, 'FeeRouter reference')}>Set FeeRouter</button>
+            {formError && <p className="card-info error" role="alert">{formError}</p>}
+          </div>
+        </div>
+      )}
+
+      {canConfig && (
+        <div className="admin-card">
+          <h3>Validator allowlist</h3>
+          <p>Curated delegation targets. Removing one stops it being offered for new delegations; existing positions can still exit.</p>
+          {state?.validators?.length ? (
+            <table className="admin-table" aria-label="Curated validators">
+              <thead><tr><th scope="col">Validator share</th><th scope="col"></th></tr></thead>
+              <tbody>
+                {state.validators.map((v) => (
+                  <tr key={v}>
+                    <td><code title={v}>{shortAddr(v)}</code></td>
+                    <td>
+                      <button type="button" className="confirm-btn danger" disabled={pendingTx || !signer}
+                        onClick={() => removeValidator(v)}>Remove</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="card-info">{state == null ? 'Loading…' : 'No validators in the on-chain allowlist yet.'}</p>
+          )}
+          <div className="admin-form">
+            <label>
+              Add validator share
+              <input type="text" placeholder="0x…" value={forms.addVal}
+                onChange={(e) => setForms((f) => ({ ...f, addVal: e.target.value }))} />
+            </label>
+            <button type="button" className="confirm-btn primary" disabled={pendingTx || !signer} onClick={addValidator}>
+              Add validator
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="admin-card">
+        <h3>Change history</h3>
+        {history.entries == null ? (
+          <p className="card-info">Loading history…</p>
+        ) : history.entries.length === 0 ? (
+          <p className="card-info">
+            {history.error
+              ? 'This RPC bounds event lookups — view the full history on the block explorer.'
+              : 'No staking control actions recorded in the recent lookback window.'}
+          </p>
+        ) : (
+          <table className="admin-table" aria-label="Staking control history">
+            <thead><tr><th scope="col">When</th><th scope="col">Action</th><th scope="col">By</th></tr></thead>
+            <tbody>
+              {history.entries.map((h) => (
+                <tr key={h.key}>
+                  <td>{h.at ? h.at.toLocaleString() : '—'}</td>
+                  <td>{h.name}</td>
+                  <td>{h.actor ? <code title={h.actor}>{shortAddr(h.actor)}</code> : '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <p className="card-info">
+          Every control action is an on-chain event (what, who, when). Fee-rate changes are in the Fees
+          tab's history.{' '}
+          {getBlockscoutUrl(chainId, routerAddr, 'address') && (
+            <a href={getBlockscoutUrl(chainId, routerAddr, 'address')} target="_blank" rel="noopener noreferrer">
+              Full history on the block explorer ↗
+            </a>
+          )}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/admin/adminNav.js
+++ b/frontend/src/components/admin/adminNav.js
@@ -18,6 +18,7 @@ export const ADMIN_TAB_ICONS = {
   members: 'users',
   treasury: 'bank',
   fees: 'coin',
+  staking: 'trending',
   'protocol-config': 'settings',
   'oracle-adapters': 'broadcast',
   maintenance: 'sliders',
@@ -33,6 +34,7 @@ export function buildAdminNavGroups({
   isRoleManager,
   isSanctionsAdmin,
   isFeeAdmin,
+  isStakingAdmin,
 }) {
   const item = (id, label) => ({ id, label, icon: ADMIN_TAB_ICONS[id] })
 
@@ -67,6 +69,9 @@ export function buildAdminNavGroups({
     {
       label: 'Protocol Config',
       items: [
+        // Staking control surface (spec 066): STAKING_ADMIN manages provider addrs +
+        // validator allowlist; GUARDIAN pauses; both enter, as does ADMIN.
+        (isAdmin || isStakingAdmin || isGuardian) && item('staking', 'Staking'),
         isAdmin && item('protocol-config', 'Wiring & Tokens'),
         isAdmin && item('oracle-adapters', 'Oracle Adapters'),
         // Maintenance calls are permissionless on-chain; any operator may run them.

--- a/frontend/src/components/earn/StakeSheet.jsx
+++ b/frontend/src/components/earn/StakeSheet.jsx
@@ -177,7 +177,7 @@ export default function StakeSheet({ option, userState, position, onClose, onAct
     })
     if (!check.ok) return setInputError(check.reason)
     if (stakingPaused) return setInputError('New staking is paused on this network right now. You can still unstake and withdraw.')
-    if (feeBlocked) return setInputError("The staking fee can't be read right now — staking is paused so you're never charged an unknown rate. Please try again shortly.")
+    if (feeBlocked) return setInputError("New staking is temporarily unavailable — the current platform fee can't be read, so we won't stake to avoid charging you an unknown rate. Please try again shortly.")
     setInputError(null)
     if (!guard()) return
     // Pass the disclosed quote so the router charges no more than the rate shown (maxFeeBps ceiling).
@@ -467,8 +467,8 @@ export default function StakeSheet({ option, userState, position, onClose, onAct
             )}
             {mode === 'stake' && feeBlocked && !stakingPaused && (
               <p className="earn-input-error" role="alert">
-                The staking fee can’t be read right now, so staking is paused to avoid charging you an
-                unknown rate. Please try again shortly.
+                New staking is temporarily unavailable — the current platform fee can’t be read, so we
+                won’t stake to avoid charging you an unknown rate. Please try again shortly.
               </p>
             )}
 

--- a/frontend/src/components/earn/StakeSheet.jsx
+++ b/frontend/src/components/earn/StakeSheet.jsx
@@ -24,6 +24,7 @@ import { STAKING_TIPS } from '../../lib/staking/stakingCopy'
 import { queueStakingAction } from '../../lib/staking/stakingActivityBuffer'
 import { captureStakingAction } from '../../data/ledger'
 import { validateStakeAmount, maxStakeable, optionIsNative } from '../../lib/staking/stakingActions'
+import { splitFee, bpsToPercent } from '../../lib/fees/feeQuote'
 
 function fmt(raw, decimals, symbol) {
   if (raw == null) return '—'
@@ -175,9 +176,12 @@ export default function StakeSheet({ option, userState, position, onClose, onAct
       maxStakeRaw: option.maxStakeRaw ?? null,
     })
     if (!check.ok) return setInputError(check.reason)
+    if (stakingPaused) return setInputError('New staking is paused on this network right now. You can still unstake and withdraw.')
+    if (feeBlocked) return setInputError("The staking fee can't be read right now — staking is paused so you're never charged an unknown rate. Please try again shortly.")
     setInputError(null)
     if (!guard()) return
-    await runTx((opts) => stake(option, amount, opts), {
+    // Pass the disclosed quote so the router charges no more than the rate shown (maxFeeBps ceiling).
+    await runTx((opts) => stake(option, amount, { ...opts, feeQuote }), {
       type: 'stake',
       kindNoun: isDelegated ? 'Delegated' : 'Staked',
       doneKind: 'stake',
@@ -210,6 +214,16 @@ export default function StakeSheet({ option, userState, position, onClose, onAct
 
   const busy = txState.step === 'confirming' || txState.step === 'switching'
   const titleId = 'staking-sheet-title'
+
+  // spec 066: LIQUID staking fee disclosure (delegated is fee-free in v1). A present-but-unreadable
+  // router blocks the fee-bearing path (never proceed on an assumed rate); a paused network hides
+  // new stakes (exits still work). Zero/unavailable ⇒ no fee line, byte-identical to fee-free.
+  const feeQuote = isDelegated ? null : option.feeQuote
+  const feeApplies = Boolean(feeQuote?.available && feeQuote.bps > 0)
+  const feeBlocked = !isDelegated && Boolean(option.feeBlocked)
+  const stakingPaused = Boolean(option.stakingPaused)
+  const feeSplit = feeApplies && amount != null && amount > 0n ? splitFee(amount, feeQuote.bps) : null
+  const stakeDisabled = busy || !canTransact || (mode === 'stake' && (feeBlocked || stakingPaused))
 
   return (
     <div className="asset-sheet-backdrop">
@@ -433,6 +447,31 @@ export default function StakeSheet({ option, userState, position, onClose, onAct
               </>
             )}
 
+            {/* spec 066: LIQUID platform-fee disclosure — its own line, before signing (US1). */}
+            {mode === 'stake' && feeApplies && (
+              <dl className="earn-vault-sheet-facts staking-fee-facts">
+                <div>
+                  <dt>FairWins platform fee ({bpsToPercent(feeQuote.bps)})</dt>
+                  <dd>{feeSplit ? fmt(feeSplit.feeAmount, decimals, symbol) : '—'}</dd>
+                </div>
+                <div>
+                  <dt>You stake</dt>
+                  <dd>{feeSplit ? fmt(feeSplit.netAmount, decimals, symbol) : fmt(amount, decimals, symbol)}</dd>
+                </div>
+              </dl>
+            )}
+            {mode === 'stake' && stakingPaused && (
+              <p className="earn-summary" role="note">
+                New staking is paused on this network right now. You can still unstake and withdraw.
+              </p>
+            )}
+            {mode === 'stake' && feeBlocked && !stakingPaused && (
+              <p className="earn-input-error" role="alert">
+                The staking fee can’t be read right now, so staking is paused to avoid charging you an
+                unknown rate. Please try again shortly.
+              </p>
+            )}
+
             {txState.step === 'error' && (
               <p className="earn-input-error" role="alert">
                 {txState.error}
@@ -448,7 +487,7 @@ export default function StakeSheet({ option, userState, position, onClose, onAct
               type="button"
               className="earn-btn primary earn-submit"
               onClick={mode === 'stake' ? submitStake : submitUnstake}
-              disabled={busy || !canTransact}
+              disabled={mode === 'stake' ? stakeDisabled : busy || !canTransact}
               title={canTransact ? undefined : cannotTransactReason(option.chainId)}
             >
               {txState.step === 'switching'

--- a/frontend/src/components/earn/StakeView.jsx
+++ b/frontend/src/components/earn/StakeView.jsx
@@ -100,6 +100,12 @@ export default function StakeView({ tokenFilter: initialTokenFilter = null }) {
                       <span className={`staking-badge ${option.model}`}>
                         {option.model === 'delegated' ? 'Delegated' : 'Liquid'}
                       </span>
+                      {/* spec 066 US2: honest paused indicator — new stakes are off; exits still work. */}
+                      {option.stakingPaused && (
+                        <span className="staking-badge paused" title="New staking is paused on this network; you can still unstake and withdraw.">
+                          Paused
+                        </span>
+                      )}
                     </span>
                     <span className="earn-vault-asset">
                       Stakes {option.asset.symbol} · on {NETWORKS[option.chainId]?.name || 'unknown network'}

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -44,6 +44,9 @@ const MORDOR_CONTRACTS = {
   // Callsigns (spec 054) — %callsign naming registry. Empty until `deploy-callsign-registry.js` runs;
   // populated by `npm run sync:frontend-contracts`.
   callsignRegistry: '',
+  // Staking control surface (spec 066). Empty until `deploy-staking-router.js` runs; sync populates it.
+  // Undeployed ⇒ the member app falls back to spec-065 fee-free direct staking.
+  stakingRouter: '',
 }
 
 // Local Hardhat sandbox (chainId 1337) — populated by deploy.js + sync.
@@ -61,6 +64,7 @@ const HARDHAT_CONTRACTS = {
   safePolicyGuard: '0xBE509C8E6c4F132e2Af49761A318FfA362e9CE38',
   policyGuardSetup: '0xD0CB9D0ca2E56e9552cb833eC6D16F86ce818C2b',
   callsignRegistry: '', // spec 054 — %callsign naming registry (synced after deploy)
+  stakingRouter: '', // spec 066 — staking control surface + liquid fee router (synced after deploy)
 }
 
 // Polygon Amoy testnet deployment (v2 — P2P betting architecture)
@@ -84,6 +88,7 @@ const AMOY_CONTRACTS = {
   membershipVoucher: '0x33C8Ccacf6442Cf4238f01419e38C781cB859769',
   voucherBatchMinter: '0x929A8E9778f26eC49Ba6ed66343e6788f4c689C1',
   callsignRegistry: '', // spec 054 — %callsign naming registry (synced after deploy)
+  stakingRouter: '', // spec 066 — staking control surface + liquid fee router (synced after deploy)
 }
 
 // Polygon mainnet deployment (v2 — P2P betting architecture) — LIVE
@@ -117,6 +122,7 @@ const POLYGON_CONTRACTS = {
   safePolicyGuard: '0xa0F188776a65794cc06777412432e47dcB0d0c4B',
   policyGuardSetup: '0xD0CB9D0ca2E56e9552cb833eC6D16F86ce818C2b',
   callsignRegistry: '0x22BD6Dd351Db375b64C2886Bda6f3E3F4fd31dA2', // spec 054 — %callsign naming registry (synced after deploy)
+  stakingRouter: '', // spec 066 — staking control surface + liquid fee router (synced after deploy)
 }
 
 const NETWORK_CONTRACTS = {

--- a/frontend/src/config/staking.js
+++ b/frontend/src/config/staking.js
@@ -14,8 +14,7 @@
  * VERIFY every address at build time (Lido deployed-contracts page,
  * 0xPolygon/spol-contracts, and the live Polygon staking API).
  */
-import { getAddress } from 'ethers'
-import { FEE_SERVICES } from '../lib/fees/feeQuote'
+import { getAddress, id as keccakId } from 'ethers'
 
 // Position refresh cadence — aligned with usePortfolio / useEarnPositions.
 export const STAKING_POLL_MS = 60_000
@@ -26,13 +25,16 @@ export const STAKING_POLL_MS = 60_000
  * anything that carries no fee — the Polygon validator `delegated` path (fee-free
  * in v1) and any unknown kind — so callers show no fee line and take the direct
  * spec-065 path. The constants above stay the fee-free fallback default.
+ *
+ * The ids are computed locally (keccak of the label) rather than imported from
+ * feeQuote to avoid a config↔lib import cycle; they equal `FEE_SERVICES.STAKE_*`.
  */
 export function stakingRouterServiceIdFor(kind) {
   switch (kind) {
     case 'lido':
-      return FEE_SERVICES.STAKE_LIDO
+      return keccakId('stake.lido')
     case 'spol':
-      return FEE_SERVICES.STAKE_POLYGON
+      return keccakId('stake.polygon')
     default:
       return null // delegated + unknown kinds are fee-free
   }

--- a/frontend/src/config/staking.js
+++ b/frontend/src/config/staking.js
@@ -15,9 +15,28 @@
  * 0xPolygon/spol-contracts, and the live Polygon staking API).
  */
 import { getAddress } from 'ethers'
+import { FEE_SERVICES } from '../lib/fees/feeQuote'
 
 // Position refresh cadence — aligned with usePortfolio / useEarnPositions.
 export const STAKING_POLL_MS = 60_000
+
+/**
+ * Map a liquid-staking option `kind` to the spec-066 FeeRouter service id the
+ * StakingRouter reads to charge that provider's platform fee. Returns `null` for
+ * anything that carries no fee — the Polygon validator `delegated` path (fee-free
+ * in v1) and any unknown kind — so callers show no fee line and take the direct
+ * spec-065 path. The constants above stay the fee-free fallback default.
+ */
+export function stakingRouterServiceIdFor(kind) {
+  switch (kind) {
+    case 'lido':
+      return FEE_SERVICES.STAKE_LIDO
+    case 'spol':
+      return FEE_SERVICES.STAKE_POLYGON
+    default:
+      return null // delegated + unknown kinds are fee-free
+  }
+}
 
 // Lido APR (7-day SMA) — public, no auth. `data.smaApr` is a PERCENTAGE
 // (e.g. 3.2 means 3.2%); fetchLidoApr normalizes it to a fraction (÷100).

--- a/frontend/src/contexts/RoleContext.js
+++ b/frontend/src/contexts/RoleContext.js
@@ -22,6 +22,7 @@ export const ROLES = {
   ROLE_MANAGER: 'ROLE_MANAGER',            // ROLE_MANAGER_ROLE — grant/revoke memberships
   SANCTIONS_ADMIN: 'SANCTIONS_ADMIN',      // SANCTIONS_ADMIN_ROLE — deny-list (on SanctionsGuard)
   FEE_ADMIN: 'FEE_ADMIN',                  // FEE_ADMIN_ROLE — platform-fee rates (on FeeRouter, spec 060)
+  STAKING_ADMIN: 'STAKING_ADMIN',          // STAKING_ADMIN_ROLE — staking provider addrs + validator allowlist (on StakingRouter, spec 066)
 }
 
 export const ROLE_INFO = {
@@ -67,6 +68,12 @@ export const ROLE_INFO = {
     premium: false,
     isAdminRole: true
   },
+  [ROLES.STAKING_ADMIN]: {
+    name: 'Staking Administrator',
+    description: 'Manage staking provider addresses and the curated validator allowlist on the StakingRouter (the fee rate is set by the Fee Administrator)',
+    premium: false,
+    isAdminRole: true
+  },
 }
 
 /**
@@ -80,6 +87,7 @@ export const ADMIN_ROLES = [
   ROLES.ROLE_MANAGER,
   ROLES.SANCTIONS_ADMIN,
   ROLES.FEE_ADMIN,
+  ROLES.STAKING_ADMIN,
 ]
 
 export function isAdminRole(role) {

--- a/frontend/src/hooks/useStakingActions.js
+++ b/frontend/src/hooks/useStakingActions.js
@@ -37,14 +37,17 @@ export function useStakingActions() {
   const send = useEarnSend()
 
   const stake = useCallback(
-    async (option, amount, { onState } = {}) => {
+    async (option, amount, { onState, feeQuote } = {}) => {
       if (!address) throw new Error('This session cannot send transactions right now — please reconnect.')
       const provider = makeReadProvider(NETWORKS[option.chainId].rpcUrl, option.chainId)
+      // spec 066: thread the disclosed fee quote (with its bps as the maxFeeBps ceiling) so the
+      // router path charges no more than the member was shown. Falls back to the option's overlay.
       const { calls } = await buildStakeForOption(option, {
         account: address,
         amount,
         provider,
         polToken: POL_TOKEN_L1,
+        feeQuote: feeQuote || option.feeQuote,
       })
       return submitBatch({
         sendOnChain: (chainId, c) => send.sendOnChain(chainId, c, { onState }),

--- a/frontend/src/hooks/useStakingOptions.js
+++ b/frontend/src/hooks/useStakingOptions.js
@@ -15,11 +15,69 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { NETWORKS, getStakingNetworks } from '../config/networks'
-import { POL_TOKEN_L1 } from '../config/staking'
+import { POL_TOKEN_L1, stakingRouterServiceIdFor } from '../config/staking'
 import { makeReadProvider } from '../utils/rpcProvider'
 import { fetchLidoApr, readLidoPosition } from '../lib/staking/lidoStaking'
 import { readSpolTvl, readSpolRewardFee } from '../lib/staking/spolStaking'
 import { fetchValidatorDecoration, unbondingLabel, readStakeManagerTiming } from '../lib/staking/polygonDelegation'
+import { readStakingRouterConfig } from '../lib/staking/stakingRouter'
+import { fetchFeeQuote } from '../lib/fees/feeQuote'
+
+const sameAddr = (a, b) => a && b && a.toLowerCase() === b.toLowerCase()
+
+/**
+ * Overlay the on-chain StakingRouter config onto the spec-065 base options for one
+ * network (spec 066). Provider addresses, the validator allowlist, the paused flag,
+ * and the per-provider LIQUID fee are sourced from the router when it is deployed;
+ * when it is absent/unreadable the options keep the spec-065 constants verbatim
+ * (fee-free, direct, availability as configured — FR-009). Mutates `options` in place.
+ */
+export async function overlayRouterConfig(options, { chainId, provider }) {
+  let cfg = null
+  if (provider) {
+    try {
+      cfg = await readStakingRouterConfig({ chainId, provider })
+    } catch {
+      cfg = null
+    }
+  }
+  if (!cfg) return options // no router (or unreadable) ⇒ spec-065 defaults, fee-free
+
+  const kept = []
+  for (const opt of options) {
+    opt.stakingRouterAddress = cfg.routerAddress
+    opt.stakingPaused = cfg.paused
+    if (opt.providerKind === 'lido' && cfg.providers.lido?.steth && cfg.providers.lido?.wsteth) {
+      opt.contracts = { ...opt.contracts, steth: cfg.providers.lido.steth, wsteth: cfg.providers.lido.wsteth }
+    }
+    if (opt.providerKind === 'spol' && cfg.providers.spol?.controller && cfg.providers.spol?.token) {
+      opt.contracts = { ...opt.contracts, controller: cfg.providers.spol.controller, token: cfg.providers.spol.token }
+    }
+    // Delegated: the on-chain allowlist is the source of truth for NEW delegations. A validator
+    // removed on-chain drops from the offered options (existing positions stay exitable via
+    // useStakingPositions). When the router carries no allowlist yet, keep none for new delegations.
+    if (opt.providerKind === 'validator-share') {
+      if (!cfg.validators.some((v) => sameAddr(v, opt.validatorShare))) continue
+    }
+    // LIQUID fee overlay: read the live per-provider rate; a present-but-unreadable router blocks
+    // only the fee-bearing path (never assume a lower rate).
+    const serviceId = stakingRouterServiceIdFor(opt.providerKind)
+    if (serviceId) {
+      try {
+        opt.feeQuote = await fetchFeeQuote({ serviceId, chainId, provider })
+        opt.stakingFeeBps = opt.feeQuote?.available ? opt.feeQuote.bps : 0
+      } catch {
+        opt.feeQuote = null
+        opt.feeBlocked = true
+      }
+    }
+    kept.push(opt)
+  }
+  // Replace in place so removed validators drop from the returned list.
+  options.length = 0
+  options.push(...kept)
+  return options
+}
 
 /** Build the immediate (config-only) option list for one staking network. */
 export function buildBaseOptions(chainId, config) {
@@ -138,6 +196,10 @@ export function useStakingOptions() {
             opt.unbondingLabel = unbondLabel || '~2–4 days'
           }
         }
+
+        // spec 066: overlay the on-chain StakingRouter (addresses, allowlist, paused, LIQUID fee).
+        // No-op when the router is undeployed/unreadable — options keep the spec-065 defaults.
+        await overlayRouterConfig(base, { chainId, provider })
         all.push(...base)
       }
       if (reqId !== reqIdRef.current) return

--- a/frontend/src/hooks/useStakingOptions.js
+++ b/frontend/src/hooks/useStakingOptions.js
@@ -23,7 +23,12 @@ import { fetchValidatorDecoration, unbondingLabel, readStakeManagerTiming } from
 import { readStakingRouterConfig } from '../lib/staking/stakingRouter'
 import { fetchFeeQuote } from '../lib/fees/feeQuote'
 
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 const sameAddr = (a, b) => a && b && a.toLowerCase() === b.toLowerCase()
+// A router provider slot is only usable if it's a real, non-zero address. A router deployed with a
+// provider not yet configured returns the zero address (truthy) — overlaying that over the known-good
+// spec-065 constant would silently break staking, so we keep the constant instead.
+const isSetAddr = (a) => typeof a === 'string' && /^0x[0-9a-fA-F]{40}$/.test(a) && a.toLowerCase() !== ZERO_ADDR
 
 /**
  * Overlay the on-chain StakingRouter config onto the spec-065 base options for one
@@ -47,10 +52,10 @@ export async function overlayRouterConfig(options, { chainId, provider }) {
   for (const opt of options) {
     opt.stakingRouterAddress = cfg.routerAddress
     opt.stakingPaused = cfg.paused
-    if (opt.providerKind === 'lido' && cfg.providers.lido?.steth && cfg.providers.lido?.wsteth) {
+    if (opt.providerKind === 'lido' && isSetAddr(cfg.providers.lido?.steth) && isSetAddr(cfg.providers.lido?.wsteth)) {
       opt.contracts = { ...opt.contracts, steth: cfg.providers.lido.steth, wsteth: cfg.providers.lido.wsteth }
     }
-    if (opt.providerKind === 'spol' && cfg.providers.spol?.controller && cfg.providers.spol?.token) {
+    if (opt.providerKind === 'spol' && isSetAddr(cfg.providers.spol?.controller) && isSetAddr(cfg.providers.spol?.token)) {
       opt.contracts = { ...opt.contracts, controller: cfg.providers.spol.controller, token: cfg.providers.spol.token }
     }
     // Delegated: the on-chain allowlist is the source of truth for NEW delegations. A validator

--- a/frontend/src/lib/fees/feeQuote.js
+++ b/frontend/src/lib/fees/feeQuote.js
@@ -19,6 +19,10 @@ export const FEE_SERVICES = {
   EARN_LEND: keccakId('earn.lend'),
   POLYMARKET_TAKER: keccakId('polymarket.taker'),
   POLYMARKET_MAKER: keccakId('polymarket.maker'),
+  // Staking (spec 066) — per-provider LIQUID-staking rates the StakingRouter reads.
+  // Delegated staking is fee-free in v1 (no service id).
+  STAKE_LIDO: keccakId('stake.lido'),
+  STAKE_POLYGON: keccakId('stake.polygon'),
 }
 
 const BPS_DENOMINATOR = 10_000n

--- a/frontend/src/lib/staking/stakingActions.js
+++ b/frontend/src/lib/staking/stakingActions.js
@@ -10,6 +10,7 @@
 import { buildStakeCalls as buildLidoStake } from './lidoStaking'
 import { buildStakeCalls as buildSpolStake } from './spolStaking'
 import { buildDelegateCalls } from './polygonDelegation'
+import { buildLidoRouterStakeCalls, buildSpolRouterStakeCalls } from './stakingRouter'
 
 // Reserve left behind when staking a NATIVE coin so the member can still pay
 // network fees (Max never strands them). Generous flat reserve in wei.
@@ -53,16 +54,30 @@ export function maxStakeable({ walletBalance, isNative }) {
 
 /**
  * Build the stake calls for an option, dispatching on providerKind.
- * `ctx` carries { account, amount, provider, polToken }.
+ * `ctx` carries { account, amount, provider, polToken, feeQuote }.
+ *
+ * spec 066: when a LIQUID staking fee applies (a StakingRouter is deployed AND its
+ * per-provider rate is > 0), route through the router's fee-and-forward entrypoint so
+ * the fee reaches the treasury atomically; otherwise emit the byte-identical spec-065
+ * direct provider calls (SC-003). Delegated staking is fee-free in v1 and ALWAYS uses
+ * the direct `ValidatorShare` call.
  * Returns { calls, requiresApproval }.
  */
 export async function buildStakeForOption(option, ctx) {
   const { account, amount, provider, polToken } = ctx
+  const feeQuote = ctx.feeQuote || option.feeQuote
+  const routerAddress = option.stakingRouterAddress
+  const feeApplies = Boolean(feeQuote?.available && feeQuote.bps > 0 && routerAddress)
+
   switch (option.providerKind) {
     case 'lido':
-      return buildLidoStake({ contracts: option.contracts, amount })
+      return feeApplies
+        ? buildLidoRouterStakeCalls({ routerAddress, amount, maxFeeBps: feeQuote.bps })
+        : buildLidoStake({ contracts: option.contracts, amount })
     case 'spol':
-      return buildSpolStake({ contracts: option.contracts, polToken, account, amount, provider })
+      return feeApplies
+        ? buildSpolRouterStakeCalls({ routerAddress, polToken, amount, maxFeeBps: feeQuote.bps })
+        : buildSpolStake({ contracts: option.contracts, polToken, account, amount, provider })
     case 'validator-share':
       return buildDelegateCalls({
         validatorShare: option.validatorShare,

--- a/frontend/src/lib/staking/stakingRouter.js
+++ b/frontend/src/lib/staking/stakingRouter.js
@@ -1,0 +1,119 @@
+/**
+ * StakingRouter read + stake-call layer (spec 066).
+ *
+ * The member app reads the on-chain control surface at runtime and overlays its
+ * provider addresses / validator allowlist / paused flag onto the spec-065 options.
+ * When the router is undeployed or unreadable this returns `null` and callers fall
+ * back to the spec-065 build-time constants verbatim (fee-free, direct staking) — a
+ * backwards-compatible, honest-state rollout (FR-009). The fee-bearing path is gated
+ * separately by `fetchFeeQuote` (a present-but-unreadable router blocks only that
+ * path — never assume a lower rate).
+ *
+ * It also builds the LIQUID router stake calls (`{ target, data, value }` for the
+ * spec-041 unified send rail): Lido stakes native ETH via `value` (no approve leg);
+ * sPOL approves the router then calls `stakeSpol`. Delegated staking never routes
+ * here (fee-free v1 — a direct `ValidatorShare` call).
+ */
+import { Contract, Interface } from 'ethers'
+import { STAKING_ROUTER_ABI } from '../../abis/StakingRouter'
+import { getContractAddressForChain } from '../../config/contracts'
+
+const ROUTER_IFACE = new Interface(STAKING_ROUTER_ABI)
+const ERC20_APPROVE_IFACE = new Interface(['function approve(address spender, uint256 amount) returns (bool)'])
+
+/** Resolve the router address for a chain, or null when it isn't deployed. */
+export function getStakingRouterAddress(chainId) {
+  const addr = getContractAddressForChain('stakingRouter', chainId)
+  return addr && /^0x[0-9a-fA-F]{40}$/.test(addr) ? addr : null
+}
+
+const safe = (p) => p.then((v) => v).catch(() => undefined)
+
+/**
+ * Read the router's managed config for a chain: provider addresses, the validator
+ * allowlist, and the paused flag. Returns `null` when no router is deployed OR a
+ * core read fails (caller then keeps the spec-065 constants). One missing optional
+ * getter never blanks the whole overlay.
+ *
+ * @returns {Promise<null | { routerAddress, providers, validators, paused }>}
+ */
+export async function readStakingRouterConfig({ chainId, provider }) {
+  const routerAddress = getStakingRouterAddress(chainId)
+  if (!routerAddress || !provider) return null
+
+  const router = new Contract(routerAddress, STAKING_ROUTER_ABI, provider)
+  // `paused` is the load-bearing read — if even it fails, treat the router as unreadable
+  // and fall back to the constants (never guess availability).
+  const paused = await safe(router.paused())
+  if (paused === undefined) return null
+
+  const [lidoSteth, lidoWsteth, spolController, spolToken, polToken, polygonStakeManager, count] =
+    await Promise.all([
+      safe(router.lidoSteth()),
+      safe(router.lidoWsteth()),
+      safe(router.spolController()),
+      safe(router.spolToken()),
+      safe(router.polToken()),
+      safe(router.polygonStakeManager()),
+      safe(router.validatorCount()),
+    ])
+
+  const validators = []
+  if (count !== undefined) {
+    const n = Number(count)
+    const entries = await Promise.all(
+      Array.from({ length: n }, (_, i) => safe(router.validatorAt(i))),
+    )
+    for (const v of entries) if (v) validators.push(v)
+  }
+
+  return {
+    routerAddress,
+    providers: {
+      lido: { steth: lidoSteth, wsteth: lidoWsteth },
+      spol: { controller: spolController, token: spolToken },
+      polygon: { polToken, stakeManager: polygonStakeManager },
+    },
+    validators,
+    paused: Boolean(paused),
+  }
+}
+
+/**
+ * Lido router stake — native ETH via `value`, no approve leg.
+ * @returns {{ calls: Array<{target,data,value}>, requiresApproval: boolean }}
+ */
+export function buildLidoRouterStakeCalls({ routerAddress, amount, maxFeeBps }) {
+  return {
+    calls: [
+      {
+        target: routerAddress,
+        data: ROUTER_IFACE.encodeFunctionData('stakeLido', [maxFeeBps]),
+        value: amount,
+      },
+    ],
+    requiresApproval: false,
+  }
+}
+
+/**
+ * sPOL router stake — approve the router for POL, then `stakeSpol`.
+ * @returns {{ calls: Array<{target,data,value}>, requiresApproval: boolean }}
+ */
+export function buildSpolRouterStakeCalls({ routerAddress, polToken, amount, maxFeeBps }) {
+  return {
+    calls: [
+      {
+        target: polToken,
+        data: ERC20_APPROVE_IFACE.encodeFunctionData('approve', [routerAddress, amount]),
+        value: 0n,
+      },
+      {
+        target: routerAddress,
+        data: ROUTER_IFACE.encodeFunctionData('stakeSpol', [amount, maxFeeBps]),
+        value: 0n,
+      },
+    ],
+    requiresApproval: true,
+  }
+}

--- a/frontend/src/test/staking-admin/StakeSheet.fee.test.jsx
+++ b/frontend/src/test/staking-admin/StakeSheet.fee.test.jsx
@@ -1,0 +1,84 @@
+/**
+ * Spec 066 (T023): the StakeSheet discloses the LIQUID platform fee (rate + net) before
+ * signing, shows none for delegated (fee-free v1) or a zero rate, and blocks submit when
+ * the fee is unreadable (feeBlocked) — never proceeding on an assumed rate.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const stakeFn = vi.fn(() => Promise.resolve({ txHash: '0x1', txUrl: null }))
+vi.mock('../../hooks/useStakingActions', () => ({
+  useStakingActions: () => ({
+    stake: stakeFn,
+    requestUnstake: vi.fn(),
+    withdraw: vi.fn(),
+    claimRewards: vi.fn(),
+    address: '0xabc',
+    canTransactOn: () => true,
+    cannotTransactReason: () => '',
+    isPasskey: false,
+  }),
+}))
+vi.mock('../../hooks/useActivity', () => ({ useActivityOptional: () => null }))
+vi.mock('../../data/ledger', () => ({ captureStakingAction: vi.fn() }))
+vi.mock('../../lib/staking/stakingActivityBuffer', () => ({ queueStakingAction: vi.fn() }))
+
+import StakeSheet from '../../components/earn/StakeSheet'
+
+const ROUTER = '0x1111111111111111111111111111111111111111'
+const base = {
+  id: 'liquid:lido',
+  chainId: 1,
+  model: 'liquid',
+  providerKind: 'lido',
+  asset: { symbol: 'ETH', decimals: 18 },
+  provider: { name: 'Lido' },
+  lstSymbol: 'wstETH',
+  instantExit: false,
+  contracts: {},
+}
+const userState = { walletBalanceRaw: 10n * 10n ** 18n }
+
+function renderSheet(option) {
+  return render(<StakeSheet option={option} userState={userState} position={null} onClose={() => {}} onActionComplete={() => {}} />)
+}
+
+beforeEach(() => stakeFn.mockClear())
+
+describe('StakeSheet — LIQUID fee disclosure', () => {
+  it('shows the fee line (rate + net) once an amount is entered', () => {
+    renderSheet({ ...base, stakingRouterAddress: ROUTER, feeQuote: { available: true, bps: 50, capBps: 250 } })
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '1' } })
+    expect(screen.getByText(/FairWins platform fee \(0\.50%\)/)).toBeInTheDocument()
+    expect(screen.getByText('You stake')).toBeInTheDocument()
+    // 1 ETH * 50bps = 0.005 fee, 0.995 net
+    expect(screen.getByText(/0\.995 ETH/)).toBeInTheDocument()
+  })
+
+  it('shows no fee line for a zero rate (byte-identical to fee-free)', () => {
+    renderSheet({ ...base, stakingRouterAddress: ROUTER, feeQuote: { available: true, bps: 0 } })
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '1' } })
+    expect(screen.queryByText(/FairWins platform fee/)).not.toBeInTheDocument()
+  })
+
+  it('shows no fee line for delegated staking (fee-free v1)', () => {
+    const delegated = {
+      id: 'delegated:1', chainId: 1, model: 'delegated', providerKind: 'validator-share',
+      asset: { symbol: 'POL', decimals: 18 }, provider: { name: 'Polygon PoS' },
+      validatorName: 'Kiln', validatorShare: '0x5555555555555555555555555555555555555555',
+      unbondingLabel: '~2–4 days', stakingRouterAddress: ROUTER, feeQuote: { available: true, bps: 50 },
+    }
+    renderSheet(delegated)
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '1' } })
+    expect(screen.queryByText(/FairWins platform fee/)).not.toBeInTheDocument()
+  })
+
+  it('blocks submit when the fee is unreadable (feeBlocked) and never calls stake', () => {
+    renderSheet({ ...base, stakingRouterAddress: ROUTER, feeBlocked: true })
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '1' } })
+    const submit = screen.getByRole('button', { name: /Stake ETH/ })
+    expect(submit).toBeDisabled()
+    fireEvent.click(submit)
+    expect(stakeFn).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/staking-admin/StakingTab.controls.test.jsx
+++ b/frontend/src/test/staking-admin/StakingTab.controls.test.jsx
@@ -1,0 +1,127 @@
+/**
+ * Spec 066 (T026/T029/T032/T035): the StakingTab control actions —
+ *   US2 pause/resume (GUARDIAN), US3 provider addresses (STAKING_ADMIN, validate-before-send),
+ *   US4 validator add/remove (STAKING_ADMIN), US5 on-chain history — dispatch through runTx.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const m = vi.hoisted(() => ({ routerAddr: null, reads: {}, qfEvents: [] }))
+
+vi.mock('../../config/contracts', () => ({ getContractAddressForChain: vi.fn(() => m.routerAddr) }))
+vi.mock('../../config/blockExplorer', () => ({ getBlockscoutUrl: () => 'https://explorer.example/address/0x' }))
+vi.mock('../../lib/fees/feeQuote', async (orig) => ({
+  ...(await orig()),
+  fetchFeeQuote: vi.fn(() => Promise.resolve({ available: false, bps: 0, capBps: 0 })),
+}))
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract() {
+    return new Proxy({}, {
+      get(_t, prop) {
+        if (prop === 'then') return undefined
+        if (prop === 'filters') return new Proxy({}, { get: () => () => ({}) })
+        const key = String(prop)
+        return (...args) => (m.reads[key] ? m.reads[key](...args) : Promise.resolve(undefined))
+      },
+    })
+  }
+  const FakeCtor = vi.fn(FakeContract)
+  // StakingTab uses `ethers.Contract` (the namespace object), so override BOTH the named
+  // export and the namespace's Contract; keep everything else real (isAddress, ZeroAddress…).
+  return { ...actual, Contract: FakeCtor, ethers: { ...actual.ethers, Contract: FakeCtor } }
+})
+
+import StakingTab from '../../components/admin/StakingTab'
+
+const ROUTER = '0x1111111111111111111111111111111111111111'
+const VALID = '0x00000000000000000000000000000000000000a1' // all-lowercase ⇒ checksum-safe
+const provider = { getBlockNumber: () => Promise.resolve(1000), getBlock: () => Promise.resolve({ timestamp: 0 }) }
+
+function props(overrides = {}) {
+  const runTx = vi.fn(() => Promise.resolve())
+  return {
+    runTx,
+    node: {
+      signer: {}, chainId: 1, provider, runTx, pendingTx: false,
+      isAdmin: false, isStakingAdmin: false, isGuardian: false, ...overrides,
+    },
+  }
+}
+
+beforeEach(() => {
+  m.routerAddr = ROUTER
+  m.qfEvents = []
+  let qf = 0
+  m.reads = {
+    paused: () => Promise.resolve(false),
+    feeRouter: () => Promise.resolve('0xfee'),
+    lidoSteth: () => Promise.resolve('0xste'),
+    lidoWsteth: () => Promise.resolve('0xwst'),
+    spolController: () => Promise.resolve('0xctl'),
+    spolToken: () => Promise.resolve('0xspt'),
+    polToken: () => Promise.resolve('0xpol'),
+    polygonStakeManager: () => Promise.resolve('0xmgr'),
+    validatorCount: () => Promise.resolve(1n),
+    validatorAt: () => Promise.resolve('0x00000000000000000000000000000000000000b2'),
+    // Return each seeded event with a unique index so React keys don't collide across event names.
+    queryFilter: () => Promise.resolve(m.qfEvents.map((e) => ({ ...e, index: qf++ }))),
+  }
+})
+
+describe('US2 pause/resume (GUARDIAN)', () => {
+  it('dispatches pause for a guardian', async () => {
+    const { node, runTx } = props({ isGuardian: true })
+    render(<StakingTab {...node} />)
+    const btn = await screen.findByRole('button', { name: 'Pause staking' })
+    fireEvent.click(btn)
+    await waitFor(() => expect(runTx).toHaveBeenCalled())
+    expect(runTx.mock.calls.some((c) => c[1] === 'Staking paused')).toBe(true)
+  })
+})
+
+describe('US3 provider addresses (STAKING_ADMIN)', () => {
+  it('rejects invalid input before send and dispatches a valid update', async () => {
+    const { node, runTx } = props({ isStakingAdmin: true })
+    render(<StakingTab {...node} />)
+    await screen.findByText('Provider addresses')
+
+    // Invalid: only one field / bad address → rejected, no runTx.
+    fireEvent.change(screen.getByPlaceholderText('stETH 0x…'), { target: { value: 'nope' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Set Lido' }))
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(runTx).not.toHaveBeenCalled()
+
+    // Valid pair → dispatched.
+    fireEvent.change(screen.getByPlaceholderText('stETH 0x…'), { target: { value: VALID } })
+    fireEvent.change(screen.getByPlaceholderText('wstETH 0x…'), { target: { value: VALID } })
+    fireEvent.click(screen.getByRole('button', { name: 'Set Lido' }))
+    await waitFor(() => expect(runTx).toHaveBeenCalled())
+    expect(runTx.mock.calls.some((c) => c[1] === 'Lido contracts updated')).toBe(true)
+  })
+})
+
+describe('US4 validator allowlist (STAKING_ADMIN)', () => {
+  it('dispatches add and remove', async () => {
+    const { node, runTx } = props({ isStakingAdmin: true })
+    render(<StakingTab {...node} />)
+    await screen.findByText('Validator allowlist')
+
+    fireEvent.change(screen.getByPlaceholderText('0x…'), { target: { value: VALID } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add validator' }))
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /added/.test(c[1]))).toBe(true))
+
+    const removeBtn = await screen.findByRole('button', { name: 'Remove' })
+    fireEvent.click(removeBtn)
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /removed/.test(c[1]))).toBe(true))
+  })
+})
+
+describe('US5 history', () => {
+  it('renders a row per control event', async () => {
+    m.qfEvents = [{ args: { actor: VALID }, blockNumber: 5, index: 0, transactionHash: '0xhist' }]
+    const { node } = props({ isAdmin: true })
+    render(<StakingTab {...node} />)
+    await waitFor(() => expect(screen.getByText('FeeRouterUpdated')).toBeInTheDocument())
+  })
+})

--- a/frontend/src/test/staking-admin/StakingTab.shell.test.jsx
+++ b/frontend/src/test/staking-admin/StakingTab.shell.test.jsx
@@ -1,0 +1,113 @@
+/**
+ * Spec 066 (T019): StakingTab renders the honest "not deployed" empty state when no
+ * router is on the network, role-gates its controls (config = STAKING_ADMIN, pause =
+ * GUARDIAN), and is axe-clean.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+
+const m = vi.hoisted(() => ({ routerAddr: null, reads: {} }))
+
+vi.mock('../../config/contracts', () => ({
+  getContractAddressForChain: vi.fn(() => m.routerAddr),
+}))
+vi.mock('../../config/blockExplorer', () => ({
+  getBlockscoutUrl: () => 'https://explorer.example/address/0xrouter',
+}))
+vi.mock('../../lib/fees/feeQuote', async (orig) => ({
+  ...(await orig()),
+  fetchFeeQuote: vi.fn(() => Promise.resolve({ available: false, bps: 0, capBps: 0 })),
+}))
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract() {
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          if (prop === 'filters') return new Proxy({}, { get: () => () => ({}) })
+          const key = String(prop)
+          return (...args) => {
+            const f = m.reads[key]
+            return f ? f(...args) : Promise.resolve(undefined)
+          }
+        },
+      },
+    )
+  }
+  return { ...actual, Contract: vi.fn(FakeContract) }
+})
+
+import StakingTab from '../../components/admin/StakingTab'
+
+const ROUTER = '0x1111111111111111111111111111111111111111'
+const providerStub = {
+  getBlockNumber: () => Promise.resolve(1000),
+  getBlock: () => Promise.resolve({ timestamp: 0 }),
+}
+
+function baseProps(overrides = {}) {
+  return {
+    signer: {},
+    chainId: 1,
+    provider: providerStub,
+    runTx: vi.fn(() => Promise.resolve()),
+    pendingTx: false,
+    isAdmin: false,
+    isStakingAdmin: false,
+    isGuardian: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  m.routerAddr = null
+  m.reads = {
+    paused: () => Promise.resolve(false),
+    validatorCount: () => Promise.resolve(0n),
+    queryFilter: () => Promise.resolve([]),
+  }
+})
+
+describe('StakingTab — not deployed', () => {
+  it('shows the honest not-deployed empty state', () => {
+    m.routerAddr = ''
+    render(<StakingTab {...baseProps({ isAdmin: true })} />)
+    expect(screen.getByText(/No StakingRouter is deployed/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Emergency pause/i)).not.toBeInTheDocument()
+  })
+
+  it('is axe-clean in the not-deployed state', async () => {
+    m.routerAddr = ''
+    const { container } = render(<StakingTab {...baseProps({ isAdmin: true })} />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('StakingTab — role gating', () => {
+  it('a guardian sees pause but not the config controls', async () => {
+    m.routerAddr = ROUTER
+    render(<StakingTab {...baseProps({ isGuardian: true })} />)
+    await waitFor(() => expect(screen.getByText('Emergency pause')).toBeInTheDocument())
+    expect(screen.queryByText('Provider addresses')).not.toBeInTheDocument()
+    expect(screen.queryByText('Validator allowlist')).not.toBeInTheDocument()
+  })
+
+  it('a staking admin sees the config controls', async () => {
+    m.routerAddr = ROUTER
+    render(<StakingTab {...baseProps({ isStakingAdmin: true })} />)
+    await waitFor(() => expect(screen.getByText('Provider addresses')).toBeInTheDocument())
+    expect(screen.getByText('Validator allowlist')).toBeInTheDocument()
+    // Not a guardian ⇒ no pause control.
+    expect(screen.queryByText('Emergency pause')).not.toBeInTheDocument()
+  })
+
+  it('is axe-clean when loaded with controls', async () => {
+    m.routerAddr = ROUTER
+    const { container } = render(<StakingTab {...baseProps({ isAdmin: true })} />)
+    await waitFor(() => expect(screen.getByText('Provider addresses')).toBeInTheDocument())
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/staking-admin/feeServices.test.js
+++ b/frontend/src/test/staking-admin/feeServices.test.js
@@ -1,0 +1,47 @@
+/**
+ * Spec 066 setup plumbing (T007): the per-provider staking fee-service ids resolve
+ * to the right keccak labels, `stakingRouterServiceIdFor` maps liquid kinds to their
+ * service (and delegated/unknown to null — fee-free), and the `stakingRouter` contract
+ * key resolves falsy before any deploy (member app then falls back to spec-065).
+ */
+import { describe, it, expect } from 'vitest'
+import { id as keccakId } from 'ethers'
+
+import { FEE_SERVICES } from '../../lib/fees/feeQuote'
+import { stakingRouterServiceIdFor } from '../../config/staking'
+import { getContractAddressForChain } from '../../config/contracts'
+
+describe('staking fee-service ids', () => {
+  it('map to the canonical keccak labels', () => {
+    expect(FEE_SERVICES.STAKE_LIDO).toBe(keccakId('stake.lido'))
+    expect(FEE_SERVICES.STAKE_POLYGON).toBe(keccakId('stake.polygon'))
+  })
+
+  it('are distinct 32-byte ids', () => {
+    expect(FEE_SERVICES.STAKE_LIDO).not.toBe(FEE_SERVICES.STAKE_POLYGON)
+    for (const idHex of [FEE_SERVICES.STAKE_LIDO, FEE_SERVICES.STAKE_POLYGON]) {
+      expect(idHex).toMatch(/^0x[0-9a-f]{64}$/)
+    }
+  })
+})
+
+describe('stakingRouterServiceIdFor', () => {
+  it('maps liquid provider kinds to their service id', () => {
+    expect(stakingRouterServiceIdFor('lido')).toBe(FEE_SERVICES.STAKE_LIDO)
+    expect(stakingRouterServiceIdFor('spol')).toBe(FEE_SERVICES.STAKE_POLYGON)
+  })
+
+  it('returns null for delegated and unknown kinds (fee-free)', () => {
+    expect(stakingRouterServiceIdFor('delegated')).toBeNull()
+    expect(stakingRouterServiceIdFor('polygon')).toBeNull()
+    expect(stakingRouterServiceIdFor(undefined)).toBeNull()
+  })
+})
+
+describe('stakingRouter address resolution', () => {
+  it('is falsy on every configured chain until the router is deployed', () => {
+    for (const chainId of [1, 63, 137, 80002, 1337]) {
+      expect(getContractAddressForChain('stakingRouter', chainId)).toBeFalsy()
+    }
+  })
+})

--- a/frontend/src/test/staking-admin/overlayRouterConfig.test.js
+++ b/frontend/src/test/staking-admin/overlayRouterConfig.test.js
@@ -1,0 +1,77 @@
+/**
+ * Spec 066 (T025/T028/T031): overlayRouterConfig overlays the on-chain router config onto
+ * the member option list — provider addresses (US3), paused flag (US2), validator allowlist
+ * (US4, removed validators drop from NEW-stake options), and the LIQUID fee (US1) — and safely
+ * falls back to the spec-065 constants when the router is undeployed or unreadable.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../lib/staking/stakingRouter', () => ({ readStakingRouterConfig: vi.fn() }))
+vi.mock('../../lib/fees/feeQuote', async (orig) => ({ ...(await orig()), fetchFeeQuote: vi.fn() }))
+
+import { overlayRouterConfig } from '../../hooks/useStakingOptions'
+import { readStakingRouterConfig } from '../../lib/staking/stakingRouter'
+import { fetchFeeQuote } from '../../lib/fees/feeQuote'
+
+const ROUTER = '0x1111111111111111111111111111111111111111'
+const ctx = { chainId: 1, provider: {} }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchFeeQuote.mockResolvedValue({ available: true, bps: 50, capBps: 250 })
+})
+
+describe('overlayRouterConfig — safe fallback', () => {
+  it('leaves options untouched (fee-free) when no router is deployed', async () => {
+    readStakingRouterConfig.mockResolvedValue(null)
+    const opts = [{ providerKind: 'lido', contracts: { steth: '0xold', wsteth: '0xold2' } }]
+    await overlayRouterConfig(opts, ctx)
+    expect(opts[0].feeQuote).toBeUndefined()
+    expect(opts[0].stakingPaused).toBeUndefined()
+    expect(opts[0].contracts.steth).toBe('0xold')
+  })
+})
+
+describe('overlayRouterConfig — router present', () => {
+  beforeEach(() => {
+    readStakingRouterConfig.mockResolvedValue({
+      routerAddress: ROUTER,
+      paused: true,
+      providers: {
+        lido: { steth: '0xNEWste', wsteth: '0xNEWwst' },
+        spol: { controller: undefined, token: undefined },
+        polygon: { polToken: undefined, stakeManager: undefined },
+      },
+      validators: ['0xkeep000000000000000000000000000000000001'],
+    })
+  })
+
+  it('overlays provider addresses, the paused flag, and the LIQUID fee', async () => {
+    const opts = [{ providerKind: 'lido', contracts: { steth: '0xold', wsteth: '0xold2' } }]
+    await overlayRouterConfig(opts, ctx)
+    expect(opts[0].contracts.steth).toBe('0xNEWste')
+    expect(opts[0].stakingPaused).toBe(true)
+    expect(opts[0].stakingRouterAddress).toBe(ROUTER)
+    expect(opts[0].feeQuote).toEqual({ available: true, bps: 50, capBps: 250 })
+    expect(opts[0].stakingFeeBps).toBe(50)
+  })
+
+  it('drops validators removed from the on-chain allowlist (case-insensitive)', async () => {
+    const opts = [
+      { providerKind: 'validator-share', validatorShare: '0xKEEP000000000000000000000000000000000001' },
+      { providerKind: 'validator-share', validatorShare: '0xDROP000000000000000000000000000000000002' },
+    ]
+    await overlayRouterConfig(opts, ctx)
+    expect(opts).toHaveLength(1)
+    expect(opts[0].validatorShare).toBe('0xKEEP000000000000000000000000000000000001')
+    expect(opts[0].feeQuote).toBeUndefined() // delegated is fee-free
+  })
+
+  it('blocks the fee path (feeBlocked) when the rate read throws', async () => {
+    fetchFeeQuote.mockRejectedValue(new Error('rpc down'))
+    const opts = [{ providerKind: 'lido', contracts: {} }]
+    await overlayRouterConfig(opts, ctx)
+    expect(opts[0].feeBlocked).toBe(true)
+    expect(opts[0].feeQuote).toBeNull()
+  })
+})

--- a/frontend/src/test/staking-admin/overlayRouterConfig.test.js
+++ b/frontend/src/test/staking-admin/overlayRouterConfig.test.js
@@ -38,7 +38,7 @@ describe('overlayRouterConfig — router present', () => {
       routerAddress: ROUTER,
       paused: true,
       providers: {
-        lido: { steth: '0xNEWste', wsteth: '0xNEWwst' },
+        lido: { steth: '0x1111111111111111111111111111111111111111', wsteth: '0x2222222222222222222222222222222222222222' },
         spol: { controller: undefined, token: undefined },
         polygon: { polToken: undefined, stakeManager: undefined },
       },
@@ -49,7 +49,7 @@ describe('overlayRouterConfig — router present', () => {
   it('overlays provider addresses, the paused flag, and the LIQUID fee', async () => {
     const opts = [{ providerKind: 'lido', contracts: { steth: '0xold', wsteth: '0xold2' } }]
     await overlayRouterConfig(opts, ctx)
-    expect(opts[0].contracts.steth).toBe('0xNEWste')
+    expect(opts[0].contracts.steth).toBe('0x1111111111111111111111111111111111111111')
     expect(opts[0].stakingPaused).toBe(true)
     expect(opts[0].stakingRouterAddress).toBe(ROUTER)
     expect(opts[0].feeQuote).toEqual({ available: true, bps: 50, capBps: 250 })
@@ -65,6 +65,24 @@ describe('overlayRouterConfig — router present', () => {
     expect(opts).toHaveLength(1)
     expect(opts[0].validatorShare).toBe('0xKEEP000000000000000000000000000000000001')
     expect(opts[0].feeQuote).toBeUndefined() // delegated is fee-free
+  })
+
+  it('keeps the spec-065 constants when the router returns a zero provider address', async () => {
+    readStakingRouterConfig.mockResolvedValue({
+      routerAddress: ROUTER,
+      paused: false,
+      providers: {
+        lido: { steth: '0x0000000000000000000000000000000000000000', wsteth: '0x0000000000000000000000000000000000000000' },
+        spol: { controller: undefined, token: undefined },
+        polygon: { polToken: undefined, stakeManager: undefined },
+      },
+      validators: [],
+    })
+    const opts = [{ providerKind: 'lido', contracts: { steth: '0xgoodSteth', wsteth: '0xgoodWsteth' } }]
+    await overlayRouterConfig(opts, ctx)
+    // Zero address is truthy but not usable — the known-good constants must survive.
+    expect(opts[0].contracts.steth).toBe('0xgoodSteth')
+    expect(opts[0].contracts.wsteth).toBe('0xgoodWsteth')
   })
 
   it('blocks the fee path (feeBlocked) when the rate read throws', async () => {

--- a/frontend/src/test/staking-admin/stakingActions.fee.test.js
+++ b/frontend/src/test/staking-admin/stakingActions.fee.test.js
@@ -1,0 +1,75 @@
+/**
+ * Spec 066 (T023): buildStakeForOption routes LIQUID stakes through the StakingRouter
+ * when a fee applies (router deployed + rate > 0) and passes the quoted bps as maxFeeBps;
+ * otherwise it emits the byte-identical spec-065 direct calls. Delegated always stays the
+ * direct ValidatorShare call (fee-free v1).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { Interface } from 'ethers'
+import { STAKING_ROUTER_ABI } from '../../abis/StakingRouter'
+
+// Sentinel the spec-065 direct builders so we can prove which path was taken.
+vi.mock('../../lib/staking/lidoStaking', () => ({
+  buildStakeCalls: vi.fn(() => ({ calls: [{ target: 'DIRECT_LIDO', data: '0x', value: 0n }], requiresApproval: false })),
+}))
+vi.mock('../../lib/staking/spolStaking', () => ({
+  buildStakeCalls: vi.fn(() => ({ calls: [{ target: 'DIRECT_SPOL', data: '0x', value: 0n }], requiresApproval: true })),
+}))
+vi.mock('../../lib/staking/polygonDelegation', () => ({
+  buildDelegateCalls: vi.fn(() => ({ calls: [{ target: 'DIRECT_DELEGATE', data: '0x', value: 0n }], requiresApproval: true })),
+}))
+
+import { buildStakeForOption } from '../../lib/staking/stakingActions'
+
+const IFACE = new Interface(STAKING_ROUTER_ABI)
+const ROUTER = '0x1111111111111111111111111111111111111111'
+const POL = '0x2222222222222222222222222222222222222222'
+const ctx = { account: '0xabc', amount: 1000n, polToken: POL, provider: {} }
+
+describe('buildStakeForOption — LIQUID fee routing', () => {
+  it('lido: routes through the router when a fee applies, passing maxFeeBps', async () => {
+    const option = { providerKind: 'lido', stakingRouterAddress: ROUTER, feeQuote: { available: true, bps: 50 } }
+    const { calls } = await buildStakeForOption(option, ctx)
+    expect(calls[0].target).toBe(ROUTER)
+    expect(calls[0].value).toBe(1000n)
+    const decoded = IFACE.parseTransaction({ data: calls[0].data })
+    expect(decoded.name).toBe('stakeLido')
+    expect(Number(decoded.args[0])).toBe(50)
+  })
+
+  it('lido: uses the direct spec-065 path when the rate is 0', async () => {
+    const option = { providerKind: 'lido', stakingRouterAddress: ROUTER, feeQuote: { available: true, bps: 0 } }
+    const { calls } = await buildStakeForOption(option, ctx)
+    expect(calls[0].target).toBe('DIRECT_LIDO')
+  })
+
+  it('lido: uses the direct path when no router is deployed', async () => {
+    const option = { providerKind: 'lido', feeQuote: { available: true, bps: 50 } }
+    const { calls } = await buildStakeForOption(option, ctx)
+    expect(calls[0].target).toBe('DIRECT_LIDO')
+  })
+
+  it('spol: routes approve-router + stakeSpol when a fee applies', async () => {
+    const option = { providerKind: 'spol', stakingRouterAddress: ROUTER, feeQuote: { available: true, bps: 40 } }
+    const { calls, requiresApproval } = await buildStakeForOption(option, ctx)
+    expect(requiresApproval).toBe(true)
+    expect(calls[0].target).toBe(POL) // approve leg
+    expect(calls[1].target).toBe(ROUTER)
+    const stake = IFACE.parseTransaction({ data: calls[1].data })
+    expect(stake.name).toBe('stakeSpol')
+    expect(stake.args[0]).toBe(1000n)
+    expect(Number(stake.args[1])).toBe(40)
+  })
+
+  it('delegated: always the direct ValidatorShare call, even with a fee quote (fee-free v1)', async () => {
+    const option = {
+      providerKind: 'validator-share',
+      validatorShare: '0x3333333333333333333333333333333333333333',
+      stakeManager: '0x4444444444444444444444444444444444444444',
+      stakingRouterAddress: ROUTER,
+      feeQuote: { available: true, bps: 50 },
+    }
+    const { calls } = await buildStakeForOption(option, ctx)
+    expect(calls[0].target).toBe('DIRECT_DELEGATE')
+  })
+})

--- a/frontend/src/test/staking-admin/stakingRouterLib.test.js
+++ b/frontend/src/test/staking-admin/stakingRouterLib.test.js
@@ -1,0 +1,123 @@
+/**
+ * Spec 066 (T019): the StakingRouter read layer safe-falls-back when no router is
+ * deployed, normalizes the router's config when it is, and the liquid stake-call
+ * builders encode the right calldata for the unified send rail.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Interface } from 'ethers'
+import { STAKING_ROUTER_ABI } from '../../abis/StakingRouter'
+
+const m = vi.hoisted(() => ({ address: null, methods: {} }))
+
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract() {
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          const key = String(prop)
+          return (...args) => {
+            const f = m.methods[key]
+            if (!f) throw new Error('unmocked method: ' + key)
+            return f(...args)
+          }
+        },
+      },
+    )
+  }
+  return { ...actual, Contract: vi.fn(FakeContract) }
+})
+
+vi.mock('../../config/contracts', () => ({
+  getContractAddressForChain: vi.fn(() => m.address),
+}))
+
+import {
+  getStakingRouterAddress,
+  readStakingRouterConfig,
+  buildLidoRouterStakeCalls,
+  buildSpolRouterStakeCalls,
+} from '../../lib/staking/stakingRouter'
+
+const IFACE = new Interface(STAKING_ROUTER_ABI)
+const ROUTER = '0x1111111111111111111111111111111111111111'
+
+beforeEach(() => {
+  m.address = null
+  m.methods = {}
+})
+
+describe('getStakingRouterAddress', () => {
+  it('returns null when the router is undeployed (empty/absent)', () => {
+    m.address = ''
+    expect(getStakingRouterAddress(1)).toBeNull()
+    m.address = undefined
+    expect(getStakingRouterAddress(1)).toBeNull()
+  })
+  it('returns the address when deployed', () => {
+    m.address = ROUTER
+    expect(getStakingRouterAddress(1)).toBe(ROUTER)
+  })
+})
+
+describe('readStakingRouterConfig — safe fallback', () => {
+  it('returns null when no router is deployed', async () => {
+    m.address = null
+    expect(await readStakingRouterConfig({ chainId: 1, provider: {} })).toBeNull()
+  })
+
+  it('returns null when the load-bearing paused() read fails (unreadable router)', async () => {
+    m.address = ROUTER
+    m.methods = { paused: () => Promise.reject(new Error('rpc down')) }
+    expect(await readStakingRouterConfig({ chainId: 1, provider: {} })).toBeNull()
+  })
+
+  it('normalizes provider addresses, validators and paused when readable', async () => {
+    m.address = ROUTER
+    const V = ['0xaaa0000000000000000000000000000000000001', '0xbbb0000000000000000000000000000000000002']
+    m.methods = {
+      paused: () => Promise.resolve(true),
+      lidoSteth: () => Promise.resolve('0xste'),
+      lidoWsteth: () => Promise.resolve('0xwst'),
+      spolController: () => Promise.resolve('0xctl'),
+      spolToken: () => Promise.resolve('0xspt'),
+      polToken: () => Promise.resolve('0xpol'),
+      polygonStakeManager: () => Promise.resolve('0xmgr'),
+      validatorCount: () => Promise.resolve(2n),
+      validatorAt: (i) => Promise.resolve(V[Number(i)]),
+    }
+    const cfg = await readStakingRouterConfig({ chainId: 1, provider: {} })
+    expect(cfg.routerAddress).toBe(ROUTER)
+    expect(cfg.paused).toBe(true)
+    expect(cfg.providers.lido).toEqual({ steth: '0xste', wsteth: '0xwst' })
+    expect(cfg.validators).toEqual(V)
+  })
+})
+
+describe('liquid router stake-call builders', () => {
+  it('encodes stakeLido as a single native-value call, no approve', () => {
+    const { calls, requiresApproval } = buildLidoRouterStakeCalls({ routerAddress: ROUTER, amount: 5n, maxFeeBps: 50 })
+    expect(requiresApproval).toBe(false)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].target).toBe(ROUTER)
+    expect(calls[0].value).toBe(5n)
+    const decoded = IFACE.parseTransaction({ data: calls[0].data })
+    expect(decoded.name).toBe('stakeLido')
+    expect(Number(decoded.args[0])).toBe(50)
+  })
+
+  it('encodes stakeSpol as approve-router + stake (no native value)', () => {
+    const POL = '0x2222222222222222222222222222222222222222'
+    const { calls, requiresApproval } = buildSpolRouterStakeCalls({ routerAddress: ROUTER, polToken: POL, amount: 100n, maxFeeBps: 40 })
+    expect(requiresApproval).toBe(true)
+    expect(calls).toHaveLength(2)
+    expect(calls[0].target).toBe(POL)
+    expect(calls[1].target).toBe(ROUTER)
+    const stake = IFACE.parseTransaction({ data: calls[1].data })
+    expect(stake.name).toBe('stakeSpol')
+    expect(stake.args[0]).toBe(100n)
+    expect(Number(stake.args[1])).toBe(40)
+  })
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
     - Paymaster Operations: runbooks/paymaster-operations.md
     - Callsign Operations: runbooks/callsigns-operations.md
     - Fee Operations: runbooks/fee-operations.md
+    - Staking Operations: runbooks/staking-operations.md
     - Contract Upgrades: runbooks/contract-upgrades.md
     - Relayer Mordor Deploy: runbooks/relayer-mordor-deploy.md
     - Wager Pools Deploy: runbooks/zk-wager-pools-deploy.md

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:fork": "hardhat test test/fork/*.test.js",
     "test:all": "hardhat test test/**/*.test.js",
     "test:gas": "REPORT_GAS=true hardhat test",
-    "test:coverage": "COVERAGE=true TZ=UTC hardhat coverage --testfiles '{test/*.test.js,test/access/**/*.test.js,test/account/**/*.test.js,test/clearpath/**/*.test.js,test/custody/**/*.test.js,test/intent/**/*.test.js,test/oracles/**/*.test.js,test/pools/**/*.test.js,test/tokens/**/*.test.js,test/upgradeable/**/*.test.js,test/integration/**/*.test.js}'",
+    "test:coverage": "COVERAGE=true TZ=UTC hardhat coverage --testfiles '{test/*.test.js,test/access/**/*.test.js,test/account/**/*.test.js,test/clearpath/**/*.test.js,test/custody/**/*.test.js,test/intent/**/*.test.js,test/oracles/**/*.test.js,test/pools/**/*.test.js,test/staking/**/*.test.js,test/tokens/**/*.test.js,test/upgradeable/**/*.test.js,test/integration/**/*.test.js}'",
     "deploy:local": "hardhat run scripts/deploy/deploy.js --network localhost",
     "deploy:mordor": "hardhat run scripts/deploy/deploy.js --network mordor",
     "deploy:deterministic": "hardhat run scripts/deploy/deploy-deterministic.js",

--- a/scripts/deploy/check-storage-layout.js
+++ b/scripts/deploy/check-storage-layout.js
@@ -25,6 +25,7 @@ const UPGRADEABLE_CONTRACTS = [
   { name: "WagerPoolFactory", deploymentsKey: "wagerPoolFactory" }, // spec 034 — WagerPools factory (address-based)
   { name: "CallsignRegistry", deploymentsKey: "callsignRegistry" }, // spec 054 — in-house %callsign naming registry
   { name: "FeeRouter", deploymentsKey: "feeRouter" }, // spec 060 — unified platform-fee registry + wrapper
+  { name: "StakingRouter", deploymentsKey: "stakingRouter" }, // spec 066 — staking control surface + liquid fee router
 ];
 
 function loadDeployedImpl(deploymentsKey) {

--- a/scripts/deploy/deploy-staking-router.js
+++ b/scripts/deploy/deploy-staking-router.js
@@ -1,0 +1,137 @@
+/**
+ * Targeted spec-066 deploy: add the StakingRouter (staking control surface + LIQUID fee router)
+ * to an ALREADY-deployed network WITHOUT touching existing core contracts. Requires the spec-060
+ * FeeRouter to be deployed on the network (it reads the rate + treasury from it). APPENDS the new
+ * addresses to `deployments/<net>-chain<id>-v2.json` (never overwrites) and registers the two
+ * per-provider LIQUID staking fee services on the EXISTING FeeRouter (idempotent, rate 0):
+ *   stake.lido     ConfigOnly  cap 250 bps  (Lido ETH→wstETH)
+ *   stake.polygon  ConfigOnly  cap 250 bps  (sPOL POL→sPOL)
+ *
+ * Provider addresses default to the Ethereum-mainnet (chainId 1) L1 contracts (env-overridable);
+ * the staking service launches on mainnet per spec 065. Delegated staking is fee-free in v1 and
+ * stays a direct member call — the router only governs its allowlist + pause.
+ *
+ *   npx hardhat run scripts/deploy/deploy-staking-router.js --network mainnet
+ *   Then: npm run sync:frontend-contracts   (frontend picks up the stakingRouter address)
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const { saveDeployment, getDeploymentFilename } = require("./lib/helpers");
+const { deployProxy } = require("./lib/upgradeable");
+const { LAUNCH_FEE_SERVICES } = require("./lib/feeServices");
+
+// Ethereum-mainnet L1 provider addresses (mirror frontend/src/config/staking.js). Env-overridable.
+const PROVIDERS = {
+  steth: process.env.LIDO_STETH || "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+  wsteth: process.env.LIDO_WSTETH || "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+  spolController: process.env.SPOL_CONTROLLER || "0xEaadA411F2600570796c341552b9869DA708a28B",
+  spolToken: process.env.SPOL_TOKEN || "0x3B790d651e950497c7723D47B24E6f61534f7969",
+  polToken: process.env.POL_TOKEN_L1 || "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
+  stakeManager: process.env.POLYGON_STAKE_MANAGER || "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
+};
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const networkName = hre.network.name;
+  const chainId = Number(network.chainId);
+  const [deployer] = await ethers.getSigners();
+
+  console.log("=".repeat(60));
+  console.log("Staking Router (spec 066) — targeted deploy");
+  console.log("=".repeat(60));
+  console.log(`Network:  ${networkName} (chainId ${chainId})`);
+  console.log(`Deployer: ${deployer.address}`);
+  if (chainId !== 1) {
+    console.log(`\n⚠️  Provider addresses default to Ethereum-mainnet L1 contracts. On chainId ${chainId}`);
+    console.log(`   override LIDO_STETH/LIDO_WSTETH/SPOL_*/POL_TOKEN_L1/POLYGON_STAKE_MANAGER as needed.`);
+  }
+
+  const filename = getDeploymentFilename(network, "v2");
+  const filepath = path.join(process.cwd(), "deployments", filename);
+  if (!fs.existsSync(filepath)) {
+    throw new Error(`No existing deployment record at deployments/${filename}. Run the core deploy first.`);
+  }
+  const record = JSON.parse(fs.readFileSync(filepath, "utf8"));
+  const contracts = record.contracts || (record.contracts = {});
+
+  const feeRouter = contracts.feeRouter;
+  if (!feeRouter || !ethers.isAddress(feeRouter)) {
+    throw new Error(`FeeRouter not deployed on this network (contracts.feeRouter missing). Run deploy-fee-router.js first.`);
+  }
+  console.log(`FeeRouter: ${feeRouter}`);
+
+  if (contracts.stakingRouter) {
+    console.log(`\n⚠️  stakingRouter already recorded (${contracts.stakingRouter}). To change logic,`);
+    console.log(`   run an in-place upgrade (lib/upgradeable.js upgradeProxy), not this script. Aborting.`);
+    return;
+  }
+
+  // Admin (config + guardian) starts as the deployer; hand off to the multisig below (FR-018).
+  console.log("\nDeploying StakingRouter behind a UUPS proxy...");
+  const proxy = await deployProxy({
+    name: "StakingRouter",
+    initArgs: [
+      deployer.address,
+      feeRouter,
+      PROVIDERS.steth,
+      PROVIDERS.wsteth,
+      PROVIDERS.spolController,
+      PROVIDERS.spolToken,
+      PROVIDERS.polToken,
+      PROVIDERS.stakeManager,
+    ],
+  });
+
+  // Persist immediately so an interrupted registration loop leaves a RECORDED proxy, not an orphan.
+  contracts.stakingRouter = proxy.proxy;
+  contracts.stakingRouterImpl = proxy.implementation;
+  record.constructorArgs = record.constructorArgs || {};
+  record.constructorArgs.stakingRouterImpl = [];
+  record.stakingRouterDeployedAt = new Date().toISOString();
+  saveDeployment(filename, record);
+
+  // Register the two per-provider LIQUID staking fee services on the EXISTING FeeRouter (idempotent,
+  // rate 0 — enabled later from the Fees tab). Needs DEFAULT_ADMIN_ROLE on the FeeRouter; if the
+  // deployer no longer holds it (handed off to a multisig), this is a no-op with a loud note.
+  const stakingServices = LAUNCH_FEE_SERVICES.filter((s) => s.label.startsWith("stake."));
+  const router = await ethers.getContractAt("FeeRouter", feeRouter);
+  const canRegister = await router.hasRole(await router.DEFAULT_ADMIN_ROLE(), deployer.address);
+  if (!canRegister) {
+    console.log(`\n⚠️  Deployer lacks DEFAULT_ADMIN_ROLE on the FeeRouter — register the staking`);
+    console.log(`   services (${stakingServices.map((s) => s.label).join(", ")}) from the FeeRouter admin.`);
+  } else {
+    for (const svc of stakingServices) {
+      const id = ethers.keccak256(ethers.toUtf8Bytes(svc.label));
+      const existing = await router.getService(id);
+      if (Number(existing.kind) !== 0) {
+        console.log(`  • ${svc.label} already registered — skipping`);
+        continue;
+      }
+      await (await router.registerService(id, svc.capBps, svc.kind)).wait();
+      console.log(`  ✓ registered ${svc.label} (cap ${svc.capBps} bps, ConfigOnly)`);
+    }
+  }
+
+  console.log("\n" + "=".repeat(60));
+  console.log("Appended to deployments/" + filename);
+  console.log("=".repeat(60));
+  console.log(`  stakingRouter     ${contracts.stakingRouter}`);
+  console.log(`  stakingRouterImpl ${contracts.stakingRouterImpl}`);
+  console.log("\n" + "!".repeat(60));
+  console.log("ADMIN HANDOFF (do NOT skip): the deployer EOA currently holds DEFAULT_ADMIN_ROLE,");
+  console.log("UPGRADER_ROLE, STAKING_ADMIN_ROLE and GUARDIAN_ROLE on a value-bearing UUPS router.");
+  console.log("Transfer these to the designated multisig (no timelock — FR-018) and renounce the");
+  console.log("deployer's roles per docs/runbooks/staking-operations.md before it carries production stakes.");
+  console.log("!".repeat(60));
+  console.log(`\nNext: npm run sync:frontend-contracts (frontend picks up the stakingRouter address).`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/deploy/lib/feeServices.js
+++ b/scripts/deploy/lib/feeServices.js
@@ -12,6 +12,11 @@ const LAUNCH_FEE_SERVICES = [
   { label: "earn.lend", capBps: 250, kind: ServiceKind.Wrapped }, // Earn/Morpho vault deposits (spec 050)
   { label: "polymarket.taker", capBps: 100, kind: ServiceKind.ConfigOnly }, // relay-gateway reads; spec-057 cap
   { label: "polymarket.maker", capBps: 50, kind: ServiceKind.ConfigOnly }, // relay-gateway reads; spec-057 cap
+  // Staking (spec 066): per-provider LIQUID-staking fees the StakingRouter reads + charges itself
+  // (ConfigOnly — the FeeRouter never moves staking funds; the router skims + forwards). Delegated
+  // staking is fee-free in v1, so it has no service. Rate ships at 0, set later from the Fees tab.
+  { label: "stake.lido", capBps: 250, kind: ServiceKind.ConfigOnly }, // Lido ETH→wstETH liquid staking
+  { label: "stake.polygon", capBps: 250, kind: ServiceKind.ConfigOnly }, // sPOL POL→sPOL liquid staking
 ];
 
 module.exports = { LAUNCH_FEE_SERVICES, ServiceKind };

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -193,6 +193,7 @@ function main() {
         wagerPoolFactory: deployed.wagerPoolFactory, // spec 034 — WagerPools factory, address-based (only where deployed)
         callsignRegistry: deployed.callsignRegistry, // spec 054 — %callsign naming registry (only where deployed)
         feeRouter: deployed.feeRouter, // spec 060 — unified platform-fee registry + wrapper (only where deployed)
+        stakingRouter: deployed.stakingRouter, // spec 066 — staking control surface + liquid fee router (only where deployed)
         safeProposalHub: deployed.safeProposalHub, // spec 043 — Safe custody proposal broadcaster (only where deployed)
         safePolicyGuard: deployed.safePolicyGuard, // spec 049 — multisig policy engine guard (only where deployed)
         policyGuardSetup: deployed.policyGuardSetup, // spec 049 — Safe.setup policy attach helper (only where deployed)

--- a/specs/066-staking-admin-controls/checklists/requirements.md
+++ b/specs/066-staking-admin-controls/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: Staking Admin Controls & Emergency Pause
+# Specification Quality Checklist: Staking Fee Router, Admin Controls & Emergency Pause
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-07-23
@@ -39,5 +39,10 @@
   first-class requirement (FR-003) and success criterion (SC-002), not an afterthought.
 - Least-privilege is split intentionally: configuration (addresses/allowlist) vs. emergency pause, so
   an incident responder can stop staking without holding configuration rights (FR-008).
-- Backwards-compatible with spec 065: the member app keeps a safe built-in default so staking still
-  works if the control surface is undeployed/unreachable (FR-006), avoiding a hard cutover.
+- Backwards-compatible with spec 065: the member app keeps a safe built-in default (fee-free, direct
+  staking) so staking still works if the control surface is undeployed/unreachable (FR-009), avoiding a
+  hard cutover.
+- Platform fee → treasury (US1) reuses the spec-060 single fee configuration + treasury routing rather
+  than a parallel fee store; it resolves the fee-router path 065 deferred (065 research R6). The fee is
+  stated at the capability level (disclosed rate, hard ceiling, cap, zero = identical to fee-free) — the
+  atomic fee-and-forward router mechanics are for `/speckit-plan` and its security review.

--- a/specs/066-staking-admin-controls/checklists/requirements.md
+++ b/specs/066-staking-admin-controls/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Staking Admin Controls & Emergency Pause
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The authoritative on-chain control surface is recorded as an **Assumption** (a product decision made
+  before specifying), stated at the capability level ("authoritative, auditable, on-chain, one per
+  network") rather than as contract/API mechanics — the spec stays testable without prescribing the
+  implementation, which `/speckit-plan` details and routes through the constitution's security review.
+- The pause's most important guarantee — it never traps member funds (exits always work) — is a
+  first-class requirement (FR-003) and success criterion (SC-002), not an afterthought.
+- Least-privilege is split intentionally: configuration (addresses/allowlist) vs. emergency pause, so
+  an incident responder can stop staking without holding configuration rights (FR-008).
+- Backwards-compatible with spec 065: the member app keeps a safe built-in default so staking still
+  works if the control surface is undeployed/unreachable (FR-006), avoiding a hard cutover.

--- a/specs/066-staking-admin-controls/contracts/admin-and-runtime.md
+++ b/specs/066-staking-admin-controls/contracts/admin-and-runtime.md
@@ -1,0 +1,61 @@
+# Contract: AdminPanel Staking tab + member runtime read (spec 066, frontend)
+
+UI contracts for the operator control surface and the member app’s runtime read of the `StakingRouter`.
+Mirrors `ProtocolConfigTab`/`FeesTab` and the spec-065 staking flows.
+
+## AdminPanel "Staking" tab (`frontend/src/components/admin/StakingTab.jsx`)
+
+Props injected by `AdminPanel`: `{ signer, chainId, provider, runTx, pendingTx, isAdmin, isStakingAdmin,
+isGuardian }`. Resolve the contract: `getContractAddressForChain('stakingRouter', chainId)` — `undefined`
+⇒ render the honest "staking controls not deployed on this network" empty state (like FeesTab’s no-router
+state).
+
+**Reads (memoized `new ethers.Contract(addr, STAKING_ROUTER_ABI, provider)`):** provider addresses, the
+validator allowlist (`validatorCount`/`validatorAt`), `paused()`, and the current `earn.stake` rate (via
+`fetchFeeQuote`, shown read-only with a pointer to the Fees tab). A `safe(p)=p.catch(()=>undefined)` wrapper
+keeps one missing getter from blanking the panel.
+
+**Writes (via the shared `runTx(fn, msg).then(refresh)`), client-validated before send:**
+
+| Control | Gate | Call |
+|---|---|---|
+| Update provider address | `isStakingAdmin` | `setLidoContracts` / `setSpolContracts` / `setPolygonContracts` / `setFeeRouter` (validate `ethers.isAddress` && non-zero) |
+| Add / remove validator | `isStakingAdmin` | `addValidator(vs)` / `removeValidator(vs)` (validate address; the contract rejects dup/absent) |
+| Pause / resume staking | `isGuardian` | `pause()` / `unpause()` |
+| Fee rate | (read-only here) | edited in the Fees tab (`FEE_ADMIN`) — link out |
+
+**History:** `queryFilter` the router’s setter/pause events (+ FeeRouter `FeeBpsChanged` for the rate),
+newest-first table with a Blockscout fallback link — identical to FeesTab’s history.
+
+## Tab registration (four coordinated edits)
+
+1. `admin/adminNav.js`: add `staking` to `ADMIN_TAB_ICONS`; add an `isStakingAdmin` param + `(isAdmin ||
+   isStakingAdmin) && item('staking','Staking')` in the Protocol Config group.
+2. `AdminPanel.jsx`: `const isStakingAdmin = hasRole(ROLES.STAKING_ADMIN)`; pass it into
+   `buildAdminNavGroups`; add the `STAKING_ADMIN` `ROLE_HASHES` entry + `roleHomeContract` branch →
+   `stakingRouter`; add the `<option>` to the grantable-role select; render `{activeTab==='staking' &&
+   (isAdmin||isStakingAdmin) && <StakingTab … isGuardian={isGuardian} />}`.
+3. `contexts/RoleContext.js`: add `ROLES.STAKING_ADMIN`, a `ROLE_INFO` entry, and append to `ADMIN_ROLES`.
+4. On-chain: `STAKING_ADMIN_ROLE` exists + is granted on the `StakingRouter` (AccessControl).
+
+## Member runtime read + fallback (`hooks/useStakingOptions.js`)
+
+Resolve `getContractAddressForChain('stakingRouter', chainId)`:
+- **present** → overlay the router’s provider addresses + validator allowlist + `paused` onto the options,
+  and read the `earn.stake` fee via `fetchFeeQuote`. When `paused`, the Stake area hides **new**-stake and
+  shows the honest unavailable state (exits stay available).
+- **absent/unreachable** → keep the spec-065 build-time constants verbatim (fee-free, direct staking,
+  availability as configured). A present-but-unreadable router blocks only the fee-bearing path (never
+  assume a lower rate), mirroring `fetchFeeQuote`.
+
+## Member stake routing (`lib/staking/stakingActions.js` + `useStakingActions.js` + `StakeSheet.jsx`)
+
+`buildStakeForOption` branches like `lib/earn/vaultActions.buildDepositCalls`:
+- **fee applies + router available** → route through the router: Lido `stakeLido{value:net?gross}` (native,
+  no approve leg) / sPOL approve-router + `stakeSpol(amount, maxFeeBps)`; delegated composes the fee-transfer
+  + direct `buyVoucherPOL(net)` batch.
+- **else** → the byte-identical spec-065 direct provider calls.
+
+`useStakingActions.stake` threads the `feeQuote` (with `maxFeeBps`) into the ctx; `StakeSheet` discloses the
+fee line and blocks on `feeBlocked` (fee-integration.md). The passkey/classic dual-rail via `useEarnSend` is
+unchanged.

--- a/specs/066-staking-admin-controls/contracts/admin-and-runtime.md
+++ b/specs/066-staking-admin-controls/contracts/admin-and-runtime.md
@@ -11,7 +11,7 @@ isGuardian }`. Resolve the contract: `getContractAddressForChain('stakingRouter'
 state).
 
 **Reads (memoized `new ethers.Contract(addr, STAKING_ROUTER_ABI, provider)`):** provider addresses, the
-validator allowlist (`validatorCount`/`validatorAt`), `paused()`, and the current `earn.stake` rate (via
+validator allowlist (`validatorCount`/`validatorAt`), `paused()`, and the current `stake.lido`/`stake.polygon` rate (via
 `fetchFeeQuote`, shown read-only with a pointer to the Fees tab). A `safe(p)=p.catch(()=>undefined)` wrapper
 keeps one missing getter from blanking the panel.
 
@@ -42,7 +42,7 @@ newest-first table with a Blockscout fallback link — identical to FeesTab’s 
 
 Resolve `getContractAddressForChain('stakingRouter', chainId)`:
 - **present** → overlay the router’s provider addresses + validator allowlist + `paused` onto the options,
-  and read the `earn.stake` fee via `fetchFeeQuote`. When `paused`, the Stake area hides **new**-stake and
+  and read the `stake.lido`/`stake.polygon` fee via `fetchFeeQuote`. When `paused`, the Stake area hides **new**-stake and
   shows the honest unavailable state (exits stay available).
 - **absent/unreachable** → keep the spec-065 build-time constants verbatim (fee-free, direct staking,
   availability as configured). A present-but-unreadable router blocks only the fee-bearing path (never

--- a/specs/066-staking-admin-controls/contracts/admin-and-runtime.md
+++ b/specs/066-staking-admin-controls/contracts/admin-and-runtime.md
@@ -51,9 +51,10 @@ Resolve `getContractAddressForChain('stakingRouter', chainId)`:
 ## Member stake routing (`lib/staking/stakingActions.js` + `useStakingActions.js` + `StakeSheet.jsx`)
 
 `buildStakeForOption` branches like `lib/earn/vaultActions.buildDepositCalls`:
-- **fee applies + router available** → route through the router: Lido `stakeLido{value:net?gross}` (native,
-  no approve leg) / sPOL approve-router + `stakeSpol(amount, maxFeeBps)`; delegated composes the fee-transfer
-  + direct `buyVoucherPOL(net)` batch.
+- **fee applies + router available** → route the **liquid** options through the router: Lido
+  `stakeLido{value:net?gross}` (native, no approve leg) / sPOL approve-router + `stakeSpol(amount, maxFeeBps)`.
+  **Delegated always stays the direct `buyVoucherPOL` call with no fee leg (fee-free in v1)** — it never
+  routes through the router.
 - **else** → the byte-identical spec-065 direct provider calls.
 
 `useStakingActions.stake` threads the `feeQuote` (with `maxFeeBps`) into the ctx; `StakeSheet` discloses the

--- a/specs/066-staking-admin-controls/contracts/fee-integration.md
+++ b/specs/066-staking-admin-controls/contracts/fee-integration.md
@@ -1,0 +1,50 @@
+# Contract: Fee integration (spec 066 ↔ spec 060 FeeRouter)
+
+The staking fee reuses the **single** platform-fee configuration (the spec-060 `FeeRouter`). The rate lives
+there and nowhere else; staking only reads it and charges against it.
+
+## Service registration
+
+Add to `scripts/deploy/lib/feeServices.js` (`LAUNCH_FEE_SERVICES`), registered by
+`deploy-staking-router.js` on the **existing** FeeRouter (idempotent — skip if already registered):
+
+```
+{ label: "earn.stake", capBps: 250, kind: ServiceKind.ConfigOnly } // spec 066; rate 0 until enabled
+```
+
+- **ConfigOnly** (not Wrapped): the FeeRouter itself never charges staking — the `StakingRouter` (liquid)
+  and the client batch (delegated) do, reading the rate from it. `capBps = 250` (≤ the Wrapped ceiling by
+  convention). Rate starts at `0`, enabled later from the **existing Fees tab** (`FEE_ADMIN_ROLE`,
+  `setFeeBps`). `FeeBpsChanged` events are the rate audit history.
+
+## How the rate is read + charged
+
+Service-id: `keccak256("earn.stake")` (frontend `FEE_SERVICES.EARN_STAKE`). Charge inputs come only from the
+FeeRouter: `quoteFee(id, gross) → (fee, net)` (floor in member’s favor + treasury-unset skip), `feeBps(id)`
+(consent-ceiling check), `treasury()` (destination; `address(0)` ⇒ skip, never lost).
+
+- **Liquid** — the `StakingRouter` reads these and transfers `fee`→treasury / forwards `net` on-chain
+  (staking-router.md). Enforced + atomic.
+- **Delegated** — the member app composes a batch: `[ transfer fee POL → treasury() ]` + `[ member calls
+  ValidatorShare.buyVoucherPOL(net, minShares) ]`, with the fee computed from `quoteFee`/`feeBps`. Passkey =
+  one atomic UserOp; classic wallet = disclosed fee-first two-step. App-applied (ConfigOnly semantics),
+  never contract-enforced — the trade-off for keeping delegation non-custodial (research R2).
+
+## Member consent ceiling
+
+Every fee-bearing path passes the **quoted** `feeBps` as `maxFeeBps`. Liquid enforces it in-contract
+(`FeeAboveQuoted`); delegated enforces it client-side (the app refuses to submit if the live rate exceeds
+the quoted rate). A rate increase in flight can never overcharge a member (FR-003).
+
+## Frontend disclosure (StakeSheet)
+
+Mirror `VaultSheet`’s fee line: `fetchFeeQuote({ serviceId: FEE_SERVICES.EARN_STAKE, chainId, provider })` →
+`feeApplies`/`feeBlocked`/`feeSplit`; render a `<dl>` "FairWins platform fee ({bpsToPercent}) / You stake
+{net}" before signing; disable submit while the quote is loading or `feeBlocked` (a router exists but the
+rate can’t be read — never proceed on an assumed rate). Zero/unavailable ⇒ no fee line, byte-identical to
+the spec-065 fee-free experience (SC-003).
+
+## Single-source rule (constitution / spec 060)
+
+The staking fee **rate** is edited ONLY via the Fees tab against the FeeRouter. The new Staking tab shows the
+current `earn.stake` rate **read-only** with a link to the Fees tab. No second fee-config store is created.

--- a/specs/066-staking-admin-controls/contracts/fee-integration.md
+++ b/specs/066-staking-admin-controls/contracts/fee-integration.md
@@ -3,42 +3,46 @@
 The staking fee reuses the **single** platform-fee configuration (the spec-060 `FeeRouter`). The rate lives
 there and nowhere else; staking only reads it and charges against it.
 
-## Service registration
+## Service registration (per-provider — clarified 2026-07-23)
 
 Add to `scripts/deploy/lib/feeServices.js` (`LAUNCH_FEE_SERVICES`), registered by
 `deploy-staking-router.js` on the **existing** FeeRouter (idempotent — skip if already registered):
 
 ```
-{ label: "earn.stake", capBps: 250, kind: ServiceKind.ConfigOnly } // spec 066; rate 0 until enabled
+{ label: "stake.lido",    capBps: 250, kind: ServiceKind.ConfigOnly } // spec 066 Lido liquid staking
+{ label: "stake.polygon", capBps: 250, kind: ServiceKind.ConfigOnly } // spec 066 sPOL liquid staking
 ```
 
-- **ConfigOnly** (not Wrapped): the FeeRouter itself never charges staking — the `StakingRouter` (liquid)
-  and the client batch (delegated) do, reading the rate from it. `capBps = 250` (≤ the Wrapped ceiling by
-  convention). Rate starts at `0`, enabled later from the **existing Fees tab** (`FEE_ADMIN_ROLE`,
+- **Per-provider** so Lido and Polygon (sPOL) staking can carry different rates (the Fees tab already lists
+  these friendly names). **ConfigOnly** (not Wrapped): the FeeRouter itself never charges staking — the
+  `StakingRouter` does, reading the rate from the matching service. `capBps = 250` each (immutable at
+  registration). Rate starts at `0`, enabled later from the **existing Fees tab** (`FEE_ADMIN_ROLE`,
   `setFeeBps`). `FeeBpsChanged` events are the rate audit history.
+- **Delegated staking is fee-free in v1** — no service is charged for it (its position can't route through
+  the router without custody; see research R2). No `stake.polygon-delegated` service in v1.
 
 ## How the rate is read + charged
 
-Service-id: `keccak256("earn.stake")` (frontend `FEE_SERVICES.EARN_STAKE`). Charge inputs come only from the
-FeeRouter: `quoteFee(id, gross) → (fee, net)` (floor in member’s favor + treasury-unset skip), `feeBps(id)`
-(consent-ceiling check), `treasury()` (destination; `address(0)` ⇒ skip, never lost).
+Service-ids: `keccak256("stake.lido")` / `keccak256("stake.polygon")` (frontend `FEE_SERVICES.STAKE_LIDO` /
+`STAKE_POLYGON`). Charge inputs come only from the FeeRouter: `quoteFee(id, gross) → (fee, net)` (floor in
+member’s favor + treasury-unset skip), `feeBps(id)` (consent-ceiling check), `treasury()` (destination;
+`address(0)` ⇒ skip, never lost).
 
-- **Liquid** — the `StakingRouter` reads these and transfers `fee`→treasury / forwards `net` on-chain
-  (staking-router.md). Enforced + atomic.
-- **Delegated** — the member app composes a batch: `[ transfer fee POL → treasury() ]` + `[ member calls
-  ValidatorShare.buyVoucherPOL(net, minShares) ]`, with the fee computed from `quoteFee`/`feeBps`. Passkey =
-  one atomic UserOp; classic wallet = disclosed fee-first two-step. App-applied (ConfigOnly semantics),
-  never contract-enforced — the trade-off for keeping delegation non-custodial (research R2).
+- **Liquid** — the `StakingRouter` selects the provider’s serviceId, reads these, and transfers
+  `fee`→treasury / forwards `net` on-chain (staking-router.md). Enforced + atomic.
+- **Delegated** — **fee-free in v1** (clarified 2026-07-23): the member calls
+  `ValidatorShare.buyVoucherPOL(net, minShares)` directly with **no** fee leg. (A client-composed fee was
+  considered and deferred — unenforced + non-atomic for classic wallets; research R2.)
 
 ## Member consent ceiling
 
-Every fee-bearing path passes the **quoted** `feeBps` as `maxFeeBps`. Liquid enforces it in-contract
-(`FeeAboveQuoted`); delegated enforces it client-side (the app refuses to submit if the live rate exceeds
-the quoted rate). A rate increase in flight can never overcharge a member (FR-003).
+The liquid fee-bearing path passes the **quoted** `feeBps` as `maxFeeBps`, enforced in-contract
+(`FeeAboveQuoted`) — a rate increase in flight can never overcharge a member (FR-003). Delegated has no fee
+in v1, so no ceiling applies.
 
 ## Frontend disclosure (StakeSheet)
 
-Mirror `VaultSheet`’s fee line: `fetchFeeQuote({ serviceId: FEE_SERVICES.EARN_STAKE, chainId, provider })` →
+Mirror `VaultSheet`’s fee line (liquid options only): `fetchFeeQuote({ serviceId: <STAKE_LIDO|STAKE_POLYGON>, chainId, provider })` →
 `feeApplies`/`feeBlocked`/`feeSplit`; render a `<dl>` "FairWins platform fee ({bpsToPercent}) / You stake
 {net}" before signing; disable submit while the quote is loading or `feeBlocked` (a router exists but the
 rate can’t be read — never proceed on an assumed rate). Zero/unavailable ⇒ no fee line, byte-identical to
@@ -47,4 +51,4 @@ the spec-065 fee-free experience (SC-003).
 ## Single-source rule (constitution / spec 060)
 
 The staking fee **rate** is edited ONLY via the Fees tab against the FeeRouter. The new Staking tab shows the
-current `earn.stake` rate **read-only** with a link to the Fees tab. No second fee-config store is created.
+current `stake.lido`/`stake.polygon` rates **read-only** with a link to the Fees tab. No second fee-config store is created.

--- a/specs/066-staking-admin-controls/contracts/staking-router.md
+++ b/specs/066-staking-admin-controls/contracts/staking-router.md
@@ -105,3 +105,16 @@ funds left after any tx — FR-016); `maxFeeBps` consent ceiling (`FeeAboveQuote
 reset to 0; provider/validator targets from curated config only; least-privilege UUPS upgrade gate; targets
 EthTrust-SL L2+; Slither + Medusa clean; smart-contract security-agent review before merge; unit + **fork**
 tests for the real submit/wrap/buySPOL legs.
+
+### Security review (2026-07-23)
+
+Smart-contract security-agent review completed — **no Critical/High findings; approved for integration**.
+Fixes applied: **L1** — sweep stETH share-rounding dust to the member after `wrap` (no dust accrues in the
+router); **L2** — the `FeeAboveQuoted` consent ceiling only bites when a fee is actually charged, so a
+treasury-unset network (fee 0) never spuriously reverts a zero-fee stake. Added unit coverage: forced/donated
+ETH cannot brick the relative residual invariant; zero-LST provider output reverts `ProviderCallFailed`.
+**Accepted/documented (L3/Info):** `stakeSpol` fails **closed** for a non-standard `polToken`
+(fee-on-transfer/rebasing) — the residual check reverts rather than mis-accounting (same assumption
+`FeeRouter` documents); the treasury destination + consent ceiling are only as trustworthy as the
+`STAKING_ADMIN` multisig that can `setFeeRouter` (ops-doc note). Slither + Medusa run in CI (whole-repo scan
+covers `contracts/staking/`).

--- a/specs/066-staking-admin-controls/contracts/staking-router.md
+++ b/specs/066-staking-admin-controls/contracts/staking-router.md
@@ -17,9 +17,10 @@ contract StakingRouter is UUPSManaged, ReentrancyGuardUpgradeable, PausableUpgra
 
 `initialize(address admin, address feeRouter, LidoContracts, SpolContracts, PolygonContracts)`:
 `__UUPSManaged_init(admin)` **first**, then `__ReentrancyGuard_init()`, `__Pausable_init()`; grant
-`STAKING_ADMIN_ROLE` + `GUARDIAN_ROLE` to `admin`; store `feeRouter`, `stakeServiceId =
-keccak256("earn.stake")`, and the provider addresses. Constructor calls `_disableInitializers()`
-(via UUPSManaged).
+`STAKING_ADMIN_ROLE` + `GUARDIAN_ROLE` to `admin` (in production these are held by a **multisig**, no
+timelock — research R2b); store `feeRouter`, the per-provider service ids
+`stakeLidoServiceId = keccak256("stake.lido")` / `stakeSpolServiceId = keccak256("stake.polygon")`, and the
+provider addresses. Constructor calls `_disableInitializers()` (via UUPSManaged).
 
 ## Config setters — `onlyRole(STAKING_ADMIN_ROLE)`, each emits an event
 
@@ -50,8 +51,8 @@ the end. The fee is read live from the FeeRouter (R1) with a member consent ceil
 // ETH → wstETH
 function stakeLido(uint16 maxFeeBps) external payable nonReentrant whenNotPaused returns (uint256 wstOut) {
   uint256 gross = msg.value; require(gross > 0, ZeroAmount());
-  (uint256 fee, uint256 net) = IFeeRouter(feeRouter).quoteFee(stakeServiceId, gross);
-  require(IFeeRouter(feeRouter).feeBps(stakeServiceId) <= maxFeeBps, FeeAboveQuoted()); // consent ceiling
+  (uint256 fee, uint256 net) = IFeeRouter(feeRouter).quoteFee(stakeLidoServiceId, gross);
+  require(IFeeRouter(feeRouter).feeBps(stakeLidoServiceId) <= maxFeeBps, FeeAboveQuoted()); // consent ceiling
   address treasury = IFeeRouter(feeRouter).treasury();
   if (fee > 0 && treasury != address(0)) { (bool ok,) = treasury.call{value: fee}(""); require(ok); }
   else net = gross; // treasury unset ⇒ fee skipped, never lost (mirrors FeeRouter)
@@ -69,8 +70,8 @@ function stakeLido(uint16 maxFeeBps) external payable nonReentrant whenNotPaused
 function stakeSpol(uint256 amount, uint16 maxFeeBps) external nonReentrant whenNotPaused returns (uint256 spolOut) {
   require(amount > 0, ZeroAmount());
   IERC20(polToken).safeTransferFrom(msg.sender, address(this), amount);
-  (uint256 fee, uint256 net) = IFeeRouter(feeRouter).quoteFee(stakeServiceId, amount);
-  require(IFeeRouter(feeRouter).feeBps(stakeServiceId) <= maxFeeBps, FeeAboveQuoted());
+  (uint256 fee, uint256 net) = IFeeRouter(feeRouter).quoteFee(stakeSpolServiceId, amount);
+  require(IFeeRouter(feeRouter).feeBps(stakeSpolServiceId) <= maxFeeBps, FeeAboveQuoted());
   address treasury = IFeeRouter(feeRouter).treasury();
   if (fee > 0 && treasury != address(0)) IERC20(polToken).safeTransfer(treasury, fee); else net = amount;
   IERC20(polToken).forceApprove(spolController, net);
@@ -87,9 +88,9 @@ function stakeSpol(uint256 amount, uint16 maxFeeBps) external nonReentrant whenN
 ## Delegated staking is intentionally NOT here
 
 Polygon `buyVoucherPOL` binds the delegation to `msg.sender`; a router call would make the router the
-delegator (custodial, un-exitable). The member calls `ValidatorShare` directly and the fee is a
-client-composed transfer to `treasury()` (fee-integration.md). The router still governs delegated **config**
-(the validator allowlist + pause the member app honors).
+delegator (custodial, un-exitable). The member calls `ValidatorShare` directly, and **delegated staking is
+fee-free in v1** (clarified 2026-07-23 — no fee leg; research R2). The router still governs delegated
+**config** (the validator allowlist + pause the member app honors).
 
 ## Storage discipline & upgrades
 

--- a/specs/066-staking-admin-controls/contracts/staking-router.md
+++ b/specs/066-staking-admin-controls/contracts/staking-router.md
@@ -1,0 +1,106 @@
+# Contract: StakingRouter (spec 066)
+
+`contracts/staking/StakingRouter.sol` + `IStakingRouter.sol`. A per-network UUPS control surface + liquid
+fee-and-forward router for the spec-065 staking service. **Value-bearing** (transiently custodies the stake
+to skim the fee) → constitution I security review + Slither/Medusa + fork tests required.
+
+## Inheritance & roles
+
+```
+contract StakingRouter is UUPSManaged, ReentrancyGuardUpgradeable, PausableUpgradeable {
+  using EnumerableSet for EnumerableSet.AddressSet;
+  bytes32 public constant STAKING_ADMIN_ROLE = keccak256("STAKING_ADMIN_ROLE"); // config
+  bytes32 public constant GUARDIAN_ROLE      = keccak256("GUARDIAN_ROLE");       // emergency pause
+  // UUPSManaged already provides DEFAULT_ADMIN_ROLE + UPGRADER_ROLE
+}
+```
+
+`initialize(address admin, address feeRouter, LidoContracts, SpolContracts, PolygonContracts)`:
+`__UUPSManaged_init(admin)` **first**, then `__ReentrancyGuard_init()`, `__Pausable_init()`; grant
+`STAKING_ADMIN_ROLE` + `GUARDIAN_ROLE` to `admin`; store `feeRouter`, `stakeServiceId =
+keccak256("earn.stake")`, and the provider addresses. Constructor calls `_disableInitializers()`
+(via UUPSManaged).
+
+## Config setters — `onlyRole(STAKING_ADMIN_ROLE)`, each emits an event
+
+| Method | Event | Guard |
+|---|---|---|
+| `setFeeRouter(address)` | `FeeRouterUpdated(old,new,actor)` | non-zero |
+| `setLidoContracts(steth,wsteth)` | `LidoContractsUpdated(...)` | non-zero |
+| `setSpolContracts(controller,token)` | `SpolContractsUpdated(...)` | non-zero |
+| `setPolygonContracts(polToken,stakeManager)` | `PolygonContractsUpdated(...)` | non-zero |
+| `addValidator(address validatorShare)` | `ValidatorAdded(vs,actor)` | not already present (`EnumerableSet.add` false ⇒ revert `AlreadyListed`) |
+| `removeValidator(address validatorShare)` | `ValidatorRemoved(vs,actor)` | present (`remove` false ⇒ revert `NotListed`) |
+
+Views: `validatorCount()`, `validatorAt(i)`, `isValidator(address)`, `feeRouter()`, provider getters.
+Malformed/zero input reverts `ZeroAddress`.
+
+## Emergency pause — `onlyRole(GUARDIAN_ROLE)`
+
+`pause()` / `unpause()` (OZ `PausableUpgradeable`). `whenNotPaused` is applied to the **stake entrypoints
+only** — never to any exit path (there are none here; members exit directly), so a pause blocks new liquid
+stakes without trapping funds.
+
+## Liquid fee-and-forward entrypoints — `nonReentrant whenNotPaused`
+
+Both follow **checks → effects → interactions**, hold funds only within the call, and assert no residual at
+the end. The fee is read live from the FeeRouter (R1) with a member consent ceiling.
+
+```
+// ETH → wstETH
+function stakeLido(uint16 maxFeeBps) external payable nonReentrant whenNotPaused returns (uint256 wstOut) {
+  uint256 gross = msg.value; require(gross > 0, ZeroAmount());
+  (uint256 fee, uint256 net) = IFeeRouter(feeRouter).quoteFee(stakeServiceId, gross);
+  require(IFeeRouter(feeRouter).feeBps(stakeServiceId) <= maxFeeBps, FeeAboveQuoted()); // consent ceiling
+  address treasury = IFeeRouter(feeRouter).treasury();
+  if (fee > 0 && treasury != address(0)) { (bool ok,) = treasury.call{value: fee}(""); require(ok); }
+  else net = gross; // treasury unset ⇒ fee skipped, never lost (mirrors FeeRouter)
+  ILido(lidoSteth).submit{value: net}(address(0));
+  uint256 steth = IERC20(lidoSteth).balanceOf(address(this));
+  IERC20(lidoSteth).forceApprove(lidoWsteth, steth);
+  wstOut = IWstETH(lidoWsteth).wrap(steth);
+  IERC20(lidoWsteth).safeTransfer(msg.sender, wstOut);
+  IERC20(lidoSteth).forceApprove(lidoWsteth, 0);
+  require(address(this).balance == 0, ResidualFunds());
+  emit LiquidStaked(lidoWsteth, msg.sender, gross, fee, net, wstOut);
+}
+
+// POL → sPOL
+function stakeSpol(uint256 amount, uint16 maxFeeBps) external nonReentrant whenNotPaused returns (uint256 spolOut) {
+  require(amount > 0, ZeroAmount());
+  IERC20(polToken).safeTransferFrom(msg.sender, address(this), amount);
+  (uint256 fee, uint256 net) = IFeeRouter(feeRouter).quoteFee(stakeServiceId, amount);
+  require(IFeeRouter(feeRouter).feeBps(stakeServiceId) <= maxFeeBps, FeeAboveQuoted());
+  address treasury = IFeeRouter(feeRouter).treasury();
+  if (fee > 0 && treasury != address(0)) IERC20(polToken).safeTransfer(treasury, fee); else net = amount;
+  IERC20(polToken).forceApprove(spolController, net);
+  spolOut = ISpol(spolController).buySPOL(net);
+  IERC20(spolToken).safeTransfer(msg.sender, spolOut);
+  IERC20(polToken).forceApprove(spolController, 0);
+  require(IERC20(polToken).balanceOf(address(this)) == 0, ResidualFunds());
+  emit LiquidStaked(spolToken, msg.sender, amount, fee, net, spolOut);
+}
+```
+
+(Exact ABIs from the spec-065 provider research; `forceApprove`/reset mirror `depositToVaultWithFee`.)
+
+## Delegated staking is intentionally NOT here
+
+Polygon `buyVoucherPOL` binds the delegation to `msg.sender`; a router call would make the router the
+delegator (custodial, un-exitable). The member calls `ValidatorShare` directly and the fee is a
+client-composed transfer to `treasury()` (fee-integration.md). The router still governs delegated **config**
+(the validator allowlist + pause the member app honors).
+
+## Storage discipline & upgrades
+
+Append-only state above a trailing `uint256[N] private __gap`; never insert/reorder/remove; shrink the gap
+by exactly the slots appended. `check:storage-layout` (CI-gating) validates upgrade safety via
+`upgrades.validateUpgrade`. Ships as a fresh `deployProxy`; logic changes are in-place `upgradeProxy`.
+
+## Security obligations (constitution I)
+
+CEI + `nonReentrant` on both entrypoints; transient-only custody with a `ResidualFunds` assertion (no member
+funds left after any tx — FR-016); `maxFeeBps` consent ceiling (`FeeAboveQuoted`); exact-amount approvals
+reset to 0; provider/validator targets from curated config only; least-privilege UUPS upgrade gate; targets
+EthTrust-SL L2+; Slither + Medusa clean; smart-contract security-agent review before merge; unit + **fork**
+tests for the real submit/wrap/buySPOL legs.

--- a/specs/066-staking-admin-controls/data-model.md
+++ b/specs/066-staking-admin-controls/data-model.md
@@ -1,0 +1,80 @@
+# Data Model: Staking Fee Router, Admin Controls & Emergency Pause (spec 066)
+
+Two layers: the on-chain `StakingRouter` storage (authoritative) and the client-side normalized shapes the
+member app + admin tab consume. The fee **rate** is NOT stored here — it lives in the `FeeRouter`
+(`earn.stake`), read at use time.
+
+## On-chain: StakingRouter storage (append-only, per network)
+
+| Field | Type | Notes |
+|---|---|---|
+| roles | AccessControl | `DEFAULT_ADMIN_ROLE`, `UPGRADER_ROLE` (UUPSManaged), `STAKING_ADMIN_ROLE` (config), `GUARDIAN_ROLE` (pause) |
+| `feeRouter` | `address` | reference to the spec-060 FeeRouter (rate + treasury source of truth) |
+| `stakeServiceId` | `bytes32` | `keccak256("earn.stake")` — the service read for the rate |
+| `lidoSteth` / `lidoWsteth` | `address` | Lido liquid-staking contracts (this network) |
+| `spolController` / `spolToken` | `address` | sPOL liquid-staking contracts |
+| `polToken` / `polygonStakeManager` | `address` | POL token + delegation manager (delegated is member-direct; kept for config surface) |
+| `validators` | `EnumerableSet.AddressSet` | curated ValidatorShare allowlist (add/remove/enumerate) |
+| `paused` | (PausableUpgradeable) | per-network emergency pause; blocks liquid stake entrypoints |
+| `__gap` | `uint256[N]` | trailing reserve for append-only upgrades |
+
+**Setters (each `onlyRole(STAKING_ADMIN_ROLE)`, each emits an event):** `setFeeRouter`, `setLidoContracts`,
+`setSpolContracts`, `setPolygonContracts`, `addValidator`, `removeValidator`. **Pause (`GUARDIAN_ROLE`):**
+`pause()`, `unpause()`. Malformed/zero addresses and duplicate/absent validators revert with a typed error.
+
+**Stake entrypoints (`nonReentrant whenNotPaused`), enforced fee-and-forward for LIQUID only:**
+
+| Entrypoint | Flow |
+|---|---|
+| `stakeLido(uint16 maxFeeBps) payable → uint256 wstOut` | read `quoteFee(earn.stake, msg.value)`; require live ≤ `maxFeeBps` (else `FeeAboveQuoted`); send `fee`→`treasury()`; `Lido.submit{value: net}()`; wrap→wstETH; transfer wstETH to `msg.sender`; assert no residual |
+| `stakeSpol(uint256 amount, uint16 maxFeeBps) → uint256 spolOut` | pull `amount` POL from member; quote/guard; `fee`→treasury; `buySPOL(net)`; transfer sPOL to member; assert no residual |
+
+Reverts: `FeeAboveQuoted`, `ZeroAmount`, `ZeroAddress`, `Paused`, `ProviderCallFailed`, `ResidualFunds`.
+Events: `LiquidStaked(provider, member, gross, fee, net, lstOut)` + the setter/pause events.
+
+**Delegated staking is NOT an entrypoint here** — the member calls `ValidatorShare.buyVoucherPOL` directly
+(non-custodial); the fee is a client-composed transfer to `FeeRouter.treasury()` (see fee-integration.md).
+
+## Client: StakingControlConfig (normalized from the router, per network)
+
+| Field | Type | Source | Notes |
+|---|---|---|---|
+| `routerAddress` | address \| null | `getContractAddressForChain('stakingRouter', chainId)` | null ⇒ fall back to spec-065 constants |
+| `providers` | `{ lido, spol, polygon }` addresses | router reads | overlays `config/staking.js` constants |
+| `validators` | `address[]` | router `validators` set | overlays `CURATED_POLYGON_VALIDATORS` |
+| `paused` | boolean | router `paused()` | true ⇒ hide new-stake (honest unavailable); exits unaffected |
+| `stakingFeeBps` | number \| null | `fetchFeeQuote(earn.stake)` | null/unavailable ⇒ fee-free |
+| `fetchedAt` | number | client clock | "as of" freshness |
+
+Fallback contract: when `routerAddress == null` OR a read fails on a network that has a router, the app uses
+the spec-065 build-time defaults (fee-free, direct staking, availability as configured) — never a broken or
+fee-guessing screen (FR-009). A router present but unreadable **blocks the fee-bearing path** only, exactly
+like `fetchFeeQuote` throwing when a router exists (never assume a lower rate).
+
+## Client: StakeFeeQuote (reused from spec 060)
+
+`fetchFeeQuote({ serviceId: FEE_SERVICES.EARN_STAKE, chainId, provider })` → `{ available, bps, capBps,
+routerAddress }`. `splitFee(gross, bps) → { feeAmount, netAmount }`; `bpsToPercent(bps)`. The StakeSheet
+discloses `feeAmount` + `netAmount` before signing and passes `bps` as `maxFeeBps` (hard ceiling).
+
+## Client: Staking Control Action (admin audit, from on-chain events)
+
+Read via `queryFilter` on the StakingRouter (and the FeeRouter `FeeBpsChanged` for the rate): `{ type
+(fee-change/pause/resume/address-change/validator-add/remove), network, field, before/after, actor,
+timestamp, txHash }`. Rendered in the Staking tab history table (last 25, newest first), with a Blockscout
+fallback link — mirroring the FeesTab history.
+
+## Roles (frontend `ROLES` + on-chain)
+
+| Role | Grants | Where checked |
+|---|---|---|
+| `STAKING_ADMIN` | provider addresses, validator allowlist | Staking tab config controls |
+| `GUARDIAN` (existing) | per-network pause/resume | Staking tab pause controls |
+| `FEE_ADMIN` (existing) | the `earn.stake` fee rate | existing Fees tab (rate source of truth) |
+| `ADMIN` (existing) | superset / portal entry | all |
+
+## Deployment records (`deployments/<net>-chain<id>-v2.json`)
+
+`contracts.stakingRouter` (proxy, frontend-consumed) + `contracts.stakingRouterImpl` (per-upgrade);
+`earn.stake` registered on the existing `contracts.feeRouter`. Synced to
+`frontend/src/config/contracts.js` via the `stakingRouter` key.

--- a/specs/066-staking-admin-controls/data-model.md
+++ b/specs/066-staking-admin-controls/data-model.md
@@ -2,7 +2,7 @@
 
 Two layers: the on-chain `StakingRouter` storage (authoritative) and the client-side normalized shapes the
 member app + admin tab consume. The fee **rate** is NOT stored here — it lives in the `FeeRouter`
-(`earn.stake`), read at use time.
+(`stake.lido` / `stake.polygon`), read at use time.
 
 ## On-chain: StakingRouter storage (append-only, per network)
 
@@ -10,7 +10,7 @@ member app + admin tab consume. The fee **rate** is NOT stored here — it lives
 |---|---|---|
 | roles | AccessControl | `DEFAULT_ADMIN_ROLE`, `UPGRADER_ROLE` (UUPSManaged), `STAKING_ADMIN_ROLE` (config), `GUARDIAN_ROLE` (pause) |
 | `feeRouter` | `address` | reference to the spec-060 FeeRouter (rate + treasury source of truth) |
-| `stakeServiceId` | `bytes32` | `keccak256("earn.stake")` — the service read for the rate |
+| `stakeLidoServiceId` / `stakeSpolServiceId` | `bytes32` | `keccak256("stake.lido")` / `keccak256("stake.polygon")` — per-provider rate services read at stake time |
 | `lidoSteth` / `lidoWsteth` | `address` | Lido liquid-staking contracts (this network) |
 | `spolController` / `spolToken` | `address` | sPOL liquid-staking contracts |
 | `polToken` / `polygonStakeManager` | `address` | POL token + delegation manager (delegated is member-direct; kept for config surface) |
@@ -26,14 +26,14 @@ member app + admin tab consume. The fee **rate** is NOT stored here — it lives
 
 | Entrypoint | Flow |
 |---|---|
-| `stakeLido(uint16 maxFeeBps) payable → uint256 wstOut` | read `quoteFee(earn.stake, msg.value)`; require live ≤ `maxFeeBps` (else `FeeAboveQuoted`); send `fee`→`treasury()`; `Lido.submit{value: net}()`; wrap→wstETH; transfer wstETH to `msg.sender`; assert no residual |
-| `stakeSpol(uint256 amount, uint16 maxFeeBps) → uint256 spolOut` | pull `amount` POL from member; quote/guard; `fee`→treasury; `buySPOL(net)`; transfer sPOL to member; assert no residual |
+| `stakeLido(uint16 maxFeeBps) payable → uint256 wstOut` | read `quoteFee(stake.lido, msg.value)`; require live ≤ `maxFeeBps` (else `FeeAboveQuoted`); send `fee`→`treasury()`; `Lido.submit{value: net}()`; wrap→wstETH; transfer wstETH to `msg.sender`; assert no residual |
+| `stakeSpol(uint256 amount, uint16 maxFeeBps) → uint256 spolOut` | pull `amount` POL from member; `quoteFee(stake.polygon, amount)`/guard; `fee`→treasury; `buySPOL(net)`; transfer sPOL to member; assert no residual |
 
 Reverts: `FeeAboveQuoted`, `ZeroAmount`, `ZeroAddress`, `Paused`, `ProviderCallFailed`, `ResidualFunds`.
 Events: `LiquidStaked(provider, member, gross, fee, net, lstOut)` + the setter/pause events.
 
 **Delegated staking is NOT an entrypoint here** — the member calls `ValidatorShare.buyVoucherPOL` directly
-(non-custodial); the fee is a client-composed transfer to `FeeRouter.treasury()` (see fee-integration.md).
+(non-custodial) and it is **fee-free in v1** (clarified 2026-07-23; see fee-integration.md).
 
 ## Client: StakingControlConfig (normalized from the router, per network)
 
@@ -43,7 +43,7 @@ Events: `LiquidStaked(provider, member, gross, fee, net, lstOut)` + the setter/p
 | `providers` | `{ lido, spol, polygon }` addresses | router reads | overlays `config/staking.js` constants |
 | `validators` | `address[]` | router `validators` set | overlays `CURATED_POLYGON_VALIDATORS` |
 | `paused` | boolean | router `paused()` | true ⇒ hide new-stake (honest unavailable); exits unaffected |
-| `stakingFeeBps` | number \| null | `fetchFeeQuote(earn.stake)` | null/unavailable ⇒ fee-free |
+| `stakingFeeBps` | `{ lido, polygon }` \| null | `fetchFeeQuote(stake.lido / stake.polygon)` | per-provider (liquid only); null/unavailable ⇒ fee-free; delegated always fee-free (v1) |
 | `fetchedAt` | number | client clock | "as of" freshness |
 
 Fallback contract: when `routerAddress == null` OR a read fails on a network that has a router, the app uses
@@ -53,9 +53,10 @@ like `fetchFeeQuote` throwing when a router exists (never assume a lower rate).
 
 ## Client: StakeFeeQuote (reused from spec 060)
 
-`fetchFeeQuote({ serviceId: FEE_SERVICES.EARN_STAKE, chainId, provider })` → `{ available, bps, capBps,
-routerAddress }`. `splitFee(gross, bps) → { feeAmount, netAmount }`; `bpsToPercent(bps)`. The StakeSheet
-discloses `feeAmount` + `netAmount` before signing and passes `bps` as `maxFeeBps` (hard ceiling).
+`fetchFeeQuote({ serviceId: FEE_SERVICES.STAKE_LIDO | STAKE_POLYGON, chainId, provider })` → `{ available,
+bps, capBps, routerAddress }` (liquid options only). `splitFee(gross, bps) → { feeAmount, netAmount }`;
+`bpsToPercent(bps)`. The StakeSheet discloses `feeAmount` + `netAmount` before signing and passes `bps` as
+`maxFeeBps` (hard ceiling). Delegated options show no fee line (v1).
 
 ## Client: Staking Control Action (admin audit, from on-chain events)
 
@@ -70,11 +71,11 @@ fallback link — mirroring the FeesTab history.
 |---|---|---|
 | `STAKING_ADMIN` | provider addresses, validator allowlist | Staking tab config controls |
 | `GUARDIAN` (existing) | per-network pause/resume | Staking tab pause controls |
-| `FEE_ADMIN` (existing) | the `earn.stake` fee rate | existing Fees tab (rate source of truth) |
+| `FEE_ADMIN` (existing) | the `stake.lido` / `stake.polygon` fee rates | existing Fees tab (rate source of truth) |
 | `ADMIN` (existing) | superset / portal entry | all |
 
 ## Deployment records (`deployments/<net>-chain<id>-v2.json`)
 
 `contracts.stakingRouter` (proxy, frontend-consumed) + `contracts.stakingRouterImpl` (per-upgrade);
-`earn.stake` registered on the existing `contracts.feeRouter`. Synced to
+`stake.lido` + `stake.polygon` registered on the existing `contracts.feeRouter`. Synced to
 `frontend/src/config/contracts.js` via the `stakingRouter` key.

--- a/specs/066-staking-admin-controls/plan.md
+++ b/specs/066-staking-admin-controls/plan.md
@@ -204,8 +204,8 @@ with a build-time fallback, deploy/sync/storage-check wiring, and ops docs. The 
    `{available:false}` fallback). Pause hides new-stake honestly; exits always available.
 6. **Stake routing branch (R6)**: `buildStakeForOption` mirrors `lib/earn/vaultActions.buildDepositCalls` —
    fee applies ⇒ approve/route through the router `stake…WithFee`; else the byte-identical spec-065 direct
-   path. Native ETH uses `value` (no approve leg); delegated composes the fee-transfer + direct
-   `buyVoucherPOL` batch.
+   path. Native ETH uses `value` (no approve leg); **delegated stays the spec-065 direct `buyVoucherPOL`
+   call with no fee leg (fee-free in v1 — R2)**.
 7. **Admin tab + role (R7)**: new `StakingTab.jsx` mirrors `ProtocolConfigTab`/`FeesTab` (resolve address,
    read live state, validate-before-send, `runTx`, on-chain `queryFilter` history); `STAKING_ADMIN` added
    to `ROLES`/`ROLE_INFO`/`ADMIN_ROLES`, `ROLE_HASHES`, `roleHomeContract → stakingRouter`, nav item, render

--- a/specs/066-staking-admin-controls/plan.md
+++ b/specs/066-staking-admin-controls/plan.md
@@ -11,7 +11,7 @@ the spec-065 staking service and the path member **liquid** stakes route through
 the treasury. It holds the managed staking config (provider addresses, an enumerable validator allowlist)
 and a per-network **emergency pause**, gated by a `STAKING_ADMIN_ROLE` (config) and `GUARDIAN_ROLE` (pause),
 emitting an event for every change (on-chain audit trail). It charges the platform fee on liquid staking by
-reading the **single fee source of truth** — the spec-060 `FeeRouter` (`earn.stake` service rate +
+reading the **single fee source of truth** — the spec-060 `FeeRouter` (per-provider `stake.lido`/`stake.polygon` rates +
 `treasury()`) — skimming the fee to the treasury and forwarding the net to the provider (Lido `submit` →
 wstETH, sPOL `buySPOL` → sPOL) atomically, returning the LST to the member with a `maxFeeBps` consent guard
 mirroring `FeeAboveQuoted`. Operators drive it from a new role-gated **AdminPanel “Staking” tab**
@@ -19,15 +19,16 @@ mirroring `FeeAboveQuoted`. Operators drive it from a new role-gated **AdminPane
 **falls back safely to the spec-065 build-time defaults (fee-free, direct staking)** when the router is
 undeployed/unreachable — a backwards-compatible rollout.
 
-**Two fee paths, by necessity (research R2):**
-- **Liquid (Lido, sPOL)** — routed through `StakingRouter` with an **enforced, atomic fee-and-forward**
+**Fee scope (clarified 2026-07-23):**
+- **Liquid (Lido, sPOL) only** — routed through `StakingRouter` with an **enforced, atomic fee-and-forward**
   (the router transiently holds the asset, skims, forwards net, returns the LST). Truly atomic for every
-  wallet type; contract-enforced fee.
-- **Delegated (Polygon `ValidatorShare`)** — the member **must remain the direct `buyVoucherPOL` caller**
-  (the delegation position is bound to `msg.sender`; routing it through the router would make it custodial
-  and un-exitable). The fee is therefore applied as a **client-composed treasury transfer** in the same
-  stake batch, computed from the same `earn.stake` rate (passkey path = one atomic UserOp; classic wallet =
-  disclosed as a two-step, fee-first). Non-custodial always wins over enforcement here.
+  wallet type; contract-enforced fee. The rate is **per-provider** — FeeRouter services **`stake.lido`**
+  and **`stake.polygon`** (sPOL), each capped at **250 bps**, rate 0 until set.
+- **Delegated (Polygon `ValidatorShare`) is fee-free in v1.** The member remains the direct
+  `buyVoucherPOL` caller (the position is bound to `msg.sender`; routing it through the router would make
+  it custodial and un-exitable), and no fee is charged — a contract-enforced delegated fee is impossible
+  and a client-composed one is non-atomic for classic wallets, so it is deferred rather than shipped as a
+  weaker guarantee. The router still governs delegated **config** (allowlist + pause).
 
 Exits (unstake/withdraw/claim) **never** route through the router — members hold the LST / own the
 delegation directly — so a pause or router change can never trap funds (FR-004/FR-016).
@@ -66,7 +67,7 @@ constitution / spec-060 rule); honest-state everywhere (pause/unavailable reuse 
 generated sync artifacts.
 
 **Scale/Scope**: 1 new UUPS contract; 1 new admin tab; 1 new role; member-flow rewiring across ~6 existing
-staking files; deploy + `earn.stake` registration + sync + storage-check wiring; 2 docs (operator guide +
+staking files; deploy + `stake.lido`/`stake.polygon` registration + sync + storage-check wiring; 2 docs (operator guide +
 emergency runbook).
 
 ## Constitution Check
@@ -103,7 +104,7 @@ post-Phase-1).*
   key), never hand-copied.
 
 **Single-source-of-truth for fees (spec-060 rule)**: the fee **rate** lives ONLY in the `FeeRouter`
-(`earn.stake` service) and is edited via the **existing Fees tab** (`FEE_ADMIN_ROLE`); the new Staking tab
+(`stake.lido`/`stake.polygon` services) and is edited via the **existing Fees tab** (`FEE_ADMIN_ROLE`); the new Staking tab
 manages addresses/allowlist/pause and surfaces the current staking fee **read-only** with a pointer to the
 Fees tab. This refines spec FR-011/US5 (which grouped “fee rate” under the staking-config role) to honor the
 constitution — recorded in Complexity Tracking.
@@ -120,7 +121,7 @@ specs/066-staking-admin-controls/
 ├── quickstart.md        # Phase 1 output
 ├── contracts/
 │   ├── staking-router.md     # StakingRouter contract interface (storage, roles, events, entrypoints)
-│   ├── fee-integration.md    # earn.stake registration + read-rate-and-skim + delegated client-composed fee
+│   ├── fee-integration.md    # stake.lido/stake.polygon registration + read-rate-and-skim (liquid); delegated fee-free
 │   └── admin-and-runtime.md  # AdminPanel Staking tab, role, and the member config→router read + fallback
 ├── checklists/requirements.md
 └── tasks.md             # Phase 2 output (/speckit-tasks)
@@ -140,8 +141,8 @@ test/
 
 scripts/deploy/
 ├── deploy-staking-router.js     # NEW — deployProxy(StakingRouter) → record stakingRouter/stakingRouterImpl;
-│                                #   register earn.stake on the existing FeeRouter
-├── lib/feeServices.js           # + { label: 'earn.stake', capBps: 250, kind: ConfigOnly }
+│                                #   register stake.lido + stake.polygon on the existing FeeRouter
+├── lib/feeServices.js           # + { 'stake.lido', 250, ConfigOnly } + { 'stake.polygon', 250, ConfigOnly }
 └── check-storage-layout.js      # + { name: 'StakingRouter', deploymentsKey: 'stakingRouter' }
 scripts/utils/sync-frontend-contracts.js  # + stakingRouter in the copied-keys mapping
 
@@ -149,11 +150,11 @@ frontend/src/
 ├── abis/StakingRouter.js        # NEW — minimal ABI (setters, getters, pause, stake entrypoints, events)
 ├── config/
 │   ├── contracts.js             # + stakingRouter key in per-chain maps + VITE_STAKING_ROUTER_ADDRESS override
-│   └── staking.js               # + earn.stake service id; keep constants as the fallback default
-├── lib/fees/feeQuote.js         # + FEE_SERVICES.EARN_STAKE (keccak 'earn.stake')
+│   └── staking.js               # + stake.lido/stake.polygon service ids; keep constants as the fallback default
+├── lib/fees/feeQuote.js         # + FEE_SERVICES.STAKE_LIDO / STAKE_POLYGON (keccak 'stake.lido'/'stake.polygon')
 ├── lib/staking/
-│   ├── stakingRouter.js         # NEW — read router config/allowlist/pause; build router stake calls;
-│   │                            #   build the delegated client-composed fee-transfer batch
+│   ├── stakingRouter.js         # NEW — read router config/allowlist/pause; build liquid router stake calls
+│   │                            #   (delegated stays the spec-065 direct call — fee-free in v1)
 │   └── stakingActions.js        # buildStakeForOption: branch to router path when a fee applies, else direct
 ├── hooks/
 │   ├── useStakingOptions.js     # overlay router-sourced addresses/allowlist/paused onto options; fallback
@@ -181,16 +182,17 @@ with a build-time fallback, deploy/sync/storage-check wiring, and ops docs. The 
 ## Design decisions (Phase 1 digest)
 
 1. **Fee charging without a new FeeRouter entrypoint (R1)**: `FeeRouter.depositToVaultWithFee` is
-   ERC-4626-only. `StakingRouter` instead reads `FeeRouter.quoteFee(earn.stake, gross) → (fee, net)` and
-   `treasury()`, transfers `fee` to the treasury and `net` to the provider itself — reusing the audited
-   split (floor in the member’s favor, treasury-unset skip) with **zero change to the deployed FeeRouter**.
-   `earn.stake` is registered **ConfigOnly** (FeeRouter never charges it directly; the StakingRouter and the
-   delegated client-batch do), cap 250 bps.
-2. **Liquid = enforced router path; delegated = client-composed fee (R2)** — the load-bearing decision,
-   driven by Polygon’s `buyVoucherPOL` binding the position to `msg.sender`. Liquid LSTs are transferable,
-   so the router forwards them; a delegation is not, so the member must call it directly and the fee rides
-   as a batched treasury transfer. Documented honestly (enforcement vs. non-custody trade-off).
-3. **Fee rate single-source (R3)**: rate lives in `FeeRouter` `earn.stake`, edited in the existing Fees tab
+   ERC-4626-only. `StakingRouter` instead reads `FeeRouter.quoteFee(serviceId, gross) → (fee, net)` and
+   `treasury()` for the option’s **per-provider** service (`stake.lido` / `stake.polygon`), transfers `fee`
+   to the treasury and `net` to the provider itself — reusing the audited split (floor in the member’s
+   favor, treasury-unset skip) with **zero change to the deployed FeeRouter**. Both services are registered
+   **ConfigOnly** (FeeRouter never charges them directly; the StakingRouter does), cap **250 bps** each.
+2. **Liquid = enforced router path; delegated = fee-free in v1 (R2)** — the load-bearing decision, driven
+   by Polygon’s `buyVoucherPOL` binding the position to `msg.sender`. Liquid LSTs are transferable, so the
+   router forwards them and charges the enforced fee; a delegation is not, so the member must call it
+   directly and, since a client-composed fee would be non-atomic/unenforced, **delegated ships fee-free in
+   v1** (revisit later). Delegated still reads the router for config/allowlist/pause.
+3. **Fee rate single-source (R3)**: rate lives in `FeeRouter` (`stake.lido`/`stake.polygon`), edited in the existing Fees tab
    (`FEE_ADMIN_ROLE`); the Staking tab shows it read-only. Never duplicated in `StakingRouter`.
 4. **StakingRouter shape (R4)**: `UUPSManaged` + `ReentrancyGuardUpgradeable` + `PausableUpgradeable`;
    `STAKING_ADMIN_ROLE` (setters) + `GUARDIAN_ROLE` (`pause`/`unpause`); `EnumerableSet.AddressSet`
@@ -209,7 +211,7 @@ with a build-time fallback, deploy/sync/storage-check wiring, and ops docs. The 
    to `ROLES`/`ROLE_INFO`/`ADMIN_ROLES`, `ROLE_HASHES`, `roleHomeContract → stakingRouter`, nav item, render
    block; pause/resume gated on `GUARDIAN`.
 8. **Deploy/sync/storage (R8)**: `deploy-staking-router.js` via `deployProxy`, records
-   `stakingRouter`/`stakingRouterImpl`, registers `earn.stake` on the live FeeRouter; `sync-frontend-contracts`
+   `stakingRouter`/`stakingRouterImpl`, registers `stake.lido` + `stake.polygon` on the live FeeRouter; `sync-frontend-contracts`
    mapping + `contracts.js` key; `check:storage-layout` entry; ships as a fresh deploy (new contract), future
    changes as in-place UUPS upgrades.
 
@@ -218,5 +220,6 @@ with a build-time fallback, deploy/sync/storage-check wiring, and ops docs. The 
 | Deviation | Why needed | Simpler alternative rejected because |
 |---|---|---|
 | New value-bearing contract (`StakingRouter`) | Enforced, atomic fee-and-forward on liquid staking so the treasury reliably grows for every wallet type (FR-001) | A purely client-composed fee (no contract) is non-atomic for classic wallets (fee paid, stake could fail) and unenforceable — weakens the treasury goal the feature exists for |
-| Delegated fee is client-composed, not contract-enforced | `buyVoucherPOL` binds the delegation to `msg.sender`; a router holding it would be custodial + un-exitable | Routing delegation through the router violates non-custody (FR-016) and could trap funds — unacceptable |
+| Delegated staking is fee-free in v1 | `buyVoucherPOL` binds the delegation to `msg.sender` (a router holding it would be custodial + un-exitable), and a client-composed fee is non-atomic/unenforced for classic wallets | Charging delegated now ships a weaker fee guarantee; enforcing it violates non-custody (FR-016). Deferred until a robust path exists |
+| Admin/guardian roles held by a multisig, no timelock | Multi-party control of a value-bearing control surface; the emergency pause must be instant | A single EOA key is a single point of failure; a config timelock would slow incident response |
 | Fee rate under `FEE_ADMIN`/Fees tab, not the staking-config role | Constitution / spec-060: the FeeRouter is the ONE fee-config store; never a second one | Putting the rate in `StakingRouter` duplicates the fee store — a documented anti-pattern |

--- a/specs/066-staking-admin-controls/plan.md
+++ b/specs/066-staking-admin-controls/plan.md
@@ -1,0 +1,222 @@
+# Implementation Plan: Staking Fee Router, Admin Controls & Emergency Pause
+
+**Branch**: `claude/staking-admin-controls` | **Date**: 2026-07-23 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/066-staking-admin-controls/spec.md`
+
+## Summary
+
+Introduce a per-network, on-chain **`StakingRouter`** (UUPS) that is the authoritative control surface for
+the spec-065 staking service and the path member **liquid** stakes route through so a platform fee reaches
+the treasury. It holds the managed staking config (provider addresses, an enumerable validator allowlist)
+and a per-network **emergency pause**, gated by a `STAKING_ADMIN_ROLE` (config) and `GUARDIAN_ROLE` (pause),
+emitting an event for every change (on-chain audit trail). It charges the platform fee on liquid staking by
+reading the **single fee source of truth** — the spec-060 `FeeRouter` (`earn.stake` service rate +
+`treasury()`) — skimming the fee to the treasury and forwarding the net to the provider (Lido `submit` →
+wstETH, sPOL `buySPOL` → sPOL) atomically, returning the LST to the member with a `maxFeeBps` consent guard
+mirroring `FeeAboveQuoted`. Operators drive it from a new role-gated **AdminPanel “Staking” tab**
+(modeled on `ProtocolConfigTab`/`FeesTab`); the member app reads config/allowlist/pause/fee at runtime and
+**falls back safely to the spec-065 build-time defaults (fee-free, direct staking)** when the router is
+undeployed/unreachable — a backwards-compatible rollout.
+
+**Two fee paths, by necessity (research R2):**
+- **Liquid (Lido, sPOL)** — routed through `StakingRouter` with an **enforced, atomic fee-and-forward**
+  (the router transiently holds the asset, skims, forwards net, returns the LST). Truly atomic for every
+  wallet type; contract-enforced fee.
+- **Delegated (Polygon `ValidatorShare`)** — the member **must remain the direct `buyVoucherPOL` caller**
+  (the delegation position is bound to `msg.sender`; routing it through the router would make it custodial
+  and un-exitable). The fee is therefore applied as a **client-composed treasury transfer** in the same
+  stake batch, computed from the same `earn.stake` rate (passkey path = one atomic UserOp; classic wallet =
+  disclosed as a two-step, fee-first). Non-custodial always wins over enforcement here.
+
+Exits (unstake/withdraw/claim) **never** route through the router — members hold the LST / own the
+delegation directly — so a pause or router change can never trap funds (FR-004/FR-016).
+
+## Technical Context
+
+**Language/Version**: Solidity ^0.8.x + Hardhat (contract); JavaScript ES2022, React 18 + Vite (frontend).
+
+**Primary Dependencies**: OpenZeppelin upgradeable (`UUPSManaged`, `PausableUpgradeable`,
+`ReentrancyGuardUpgradeable`, `EnumerableSet`); the spec-060 `FeeRouter` (rate + treasury source of truth);
+the spec-065 staking libs/hooks/UI; the spec-041 unified send rail (`useEarnSend`); the existing AdminPanel
++ role model + on-chain event history pattern. **No new npm/solidity dependencies.**
+
+**Storage**: on-chain `StakingRouter` state (provider addresses, `EnumerableSet.AddressSet` validator
+allowlist, `FeeRouter` reference, paused flag) recorded per network in `deployments/`; frontend reads it at
+runtime with a build-time fallback. No new backend.
+
+**Testing**: Hardhat unit + **fork tests** for the router (the value-bearing fee-and-forward path against
+real Lido/sPOL/Polygon contracts — constitution II requires fork tests where external protocols are
+involved), Slither + Medusa on the new contract; Vitest + Testing Library + vitest-axe for the admin tab,
+member-flow rewiring, and fee disclosure.
+
+**Target Platform**: Ethereum mainnet at launch (per spec 065); the per-network model extends to future
+staking networks.
+
+**Project Type**: Solidity contract + web frontend + deploy/ops scripts + docs.
+
+**Performance Goals**: member reads reflect a config/fee/pause change within one refresh (≤ existing 60s
+staking poll / fee-quote TTL); admin actions confirm within a normal tx.
+
+**Constraints**: value-bearing contract → checks-effects-interactions, `nonReentrant`, transient-only
+custody (never holds member funds across txns — FR-016), append-only storage + `__gap`
+(`check:storage-layout` gating); fee rate stays the single FeeRouter source of truth (never duplicated —
+constitution / spec-060 rule); honest-state everywhere (pause/unavailable reuse the existing pattern);
+`maxFeeBps` is a hard ceiling; per-network isolation; WCAG 2.1 AA for the admin tab; addresses/ABIs from
+generated sync artifacts.
+
+**Scale/Scope**: 1 new UUPS contract; 1 new admin tab; 1 new role; member-flow rewiring across ~6 existing
+staking files; deploy + `earn.stake` registration + sync + storage-check wiring; 2 docs (operator guide +
+emergency runbook).
+
+## Constitution Check
+
+*GATE evaluated against constitution v1.0.0 — PASS with a required security review (pre-Phase-0; re-checked
+post-Phase-1).*
+
+- **I. Security-First Smart Contracts (NON-NEGOTIABLE)**: This introduces a **value-bearing contract**
+  (`StakingRouter` transiently custodies the stake to skim the fee), the highest-risk surface. The plan
+  commits to: checks-effects-interactions + `nonReentrant` on every fund-moving entrypoint; transient-only
+  custody with an invariant that no member funds remain after a tx (sweep/return or revert — FR-016);
+  exact-amount handling and `forceApprove`→0 reset (mirroring `depositToVaultWithFee`); `maxFeeBps` consent
+  guard mirroring `FeeAboveQuoted`; provider/validator targets from the curated on-chain config only;
+  `Pausable` on stake entrypoints (exits never touch the router); `UUPSManaged` least-privilege upgrade
+  gate; append-only storage + `__gap`. It targets **EthTrust-SL L2+**, passes **Slither + Medusa** with no
+  new high/critical, and **requires the smart-contract security-agent review before merge**
+  (`.github/agents/smart-contract-security.agent.md`). Delegated staking deliberately stays a direct member
+  call (no router custody) — the safest option for that path. **This is the gate this feature exists to
+  clear;** it is why 066 is its own spec/PR rather than part of 065.
+- **II. Test-First / Comprehensive Coverage (NON-NEGOTIABLE)**: PASS — Hardhat unit tests for every
+  router entrypoint + setter + role + pause + the fee split (incl. failure/edge: over-cap, `FeeAboveQuoted`,
+  zero fee = passthrough, paused, unknown provider, reentrancy guard); **fork tests** for the real
+  Lido/sPOL fee-and-forward; storage-layout test. Frontend: Vitest for the admin tab (read/validate/set,
+  role gating, history), the config→router read-with-fallback, the router-vs-direct stake branch, and the
+  StakeSheet fee line; axe for the tab. Contract-interface changes ship with their tests in the same PR.
+- **III. Honest State**: PASS — the member app reads live router config/pause/fee and falls back to the
+  honest spec-065 default when the router is undeployed/unreachable (never a broken or fee-guessing
+  screen — FR-009); a paused/unavailable network reuses the existing unavailable-state pattern; fee shown
+  “as of” its read with the quoted rate as a hard ceiling; zero fee ⇒ no fee line, byte-identical to today;
+  per-network + testnet/mainnet isolation.
+- **IV. Fail Loudly in CI**: PASS — Slither/Medusa/storage-layout/tests are gating; no `continue-on-error`.
+- **V. Accessible, Consistent Frontend**: PASS — the Staking tab reuses the AdminPanel `runTx`/role/history
+  patterns; WCAG AA via axe; addresses/ABIs come from the generated sync artifacts (a new `stakingRouter`
+  key), never hand-copied.
+
+**Single-source-of-truth for fees (spec-060 rule)**: the fee **rate** lives ONLY in the `FeeRouter`
+(`earn.stake` service) and is edited via the **existing Fees tab** (`FEE_ADMIN_ROLE`); the new Staking tab
+manages addresses/allowlist/pause and surfaces the current staking fee **read-only** with a pointer to the
+Fees tab. This refines spec FR-011/US5 (which grouped “fee rate” under the staking-config role) to honor the
+constitution — recorded in Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/066-staking-admin-controls/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── staking-router.md     # StakingRouter contract interface (storage, roles, events, entrypoints)
+│   ├── fee-integration.md    # earn.stake registration + read-rate-and-skim + delegated client-composed fee
+│   └── admin-and-runtime.md  # AdminPanel Staking tab, role, and the member config→router read + fallback
+├── checklists/requirements.md
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+contracts/staking/
+└── StakingRouter.sol            # NEW — UUPSManaged + Pausable + ReentrancyGuard; config + allowlist +
+                                 #   pause + enforced liquid fee-and-forward (Lido/sPOL); reads FeeRouter
+contracts/staking/IStakingRouter.sol  # NEW — interface, structs, events, errors
+
+test/
+├── staking/StakingRouter.test.js         # NEW — unit: setters/roles/pause/fee-split/consent/edge
+└── fork/StakingRouterFork.test.js        # NEW — fork: real Lido/sPOL fee-and-forward returns LST + treasury grows
+
+scripts/deploy/
+├── deploy-staking-router.js     # NEW — deployProxy(StakingRouter) → record stakingRouter/stakingRouterImpl;
+│                                #   register earn.stake on the existing FeeRouter
+├── lib/feeServices.js           # + { label: 'earn.stake', capBps: 250, kind: ConfigOnly }
+└── check-storage-layout.js      # + { name: 'StakingRouter', deploymentsKey: 'stakingRouter' }
+scripts/utils/sync-frontend-contracts.js  # + stakingRouter in the copied-keys mapping
+
+frontend/src/
+├── abis/StakingRouter.js        # NEW — minimal ABI (setters, getters, pause, stake entrypoints, events)
+├── config/
+│   ├── contracts.js             # + stakingRouter key in per-chain maps + VITE_STAKING_ROUTER_ADDRESS override
+│   └── staking.js               # + earn.stake service id; keep constants as the fallback default
+├── lib/fees/feeQuote.js         # + FEE_SERVICES.EARN_STAKE (keccak 'earn.stake')
+├── lib/staking/
+│   ├── stakingRouter.js         # NEW — read router config/allowlist/pause; build router stake calls;
+│   │                            #   build the delegated client-composed fee-transfer batch
+│   └── stakingActions.js        # buildStakeForOption: branch to router path when a fee applies, else direct
+├── hooks/
+│   ├── useStakingOptions.js     # overlay router-sourced addresses/allowlist/paused onto options; fallback
+│   └── useStakingActions.js     # thread the fee quote into stake(); read paused/router availability
+├── components/
+│   ├── earn/StakeSheet.jsx      # + fee line (fetchFeeQuote/splitFee/bpsToPercent) + maxFeeBps + blocked state;
+│   │                            #   hide new-stake when paused (honest unavailable)
+│   └── admin/StakingTab.jsx     # NEW — providers + validator allowlist + pause/resume + read-only fee + history
+├── components/admin/adminNav.js # + 'staking' icon + isStakingAdmin nav item
+├── components/AdminPanel.jsx    # + isStakingAdmin flag, STAKING_ADMIN hash, roleHomeContract branch, render
+└── contexts/RoleContext.js      # + ROLES.STAKING_ADMIN + ROLE_INFO + ADMIN_ROLES
+
+test/… (frontend)               # frontend/src/test/staking-admin/ + fees/StakeSheet fee tests
+docs/
+├── runbooks/staking-operations.md   # NEW — operator guide + EMERGENCY PAUSE runbook
+└── developer-guide/staking-integration.md  # extend (065 doc) with the router + fee + admin architecture
+mkdocs.yml                        # + runbook nav entry
+```
+
+**Structure Decision**: one new UUPS contract (`contracts/staking/`) with Hardhat unit + fork tests, an
+AdminPanel tab + role, member-flow rewiring of the existing spec-065 staking frontend to read the router
+with a build-time fallback, deploy/sync/storage-check wiring, and ops docs. The fee **rate** stays in the
+`FeeRouter`; the `StakingRouter` reads it. Backwards-compatible: undeployed router ⇒ spec-065 behavior.
+
+## Design decisions (Phase 1 digest)
+
+1. **Fee charging without a new FeeRouter entrypoint (R1)**: `FeeRouter.depositToVaultWithFee` is
+   ERC-4626-only. `StakingRouter` instead reads `FeeRouter.quoteFee(earn.stake, gross) → (fee, net)` and
+   `treasury()`, transfers `fee` to the treasury and `net` to the provider itself — reusing the audited
+   split (floor in the member’s favor, treasury-unset skip) with **zero change to the deployed FeeRouter**.
+   `earn.stake` is registered **ConfigOnly** (FeeRouter never charges it directly; the StakingRouter and the
+   delegated client-batch do), cap 250 bps.
+2. **Liquid = enforced router path; delegated = client-composed fee (R2)** — the load-bearing decision,
+   driven by Polygon’s `buyVoucherPOL` binding the position to `msg.sender`. Liquid LSTs are transferable,
+   so the router forwards them; a delegation is not, so the member must call it directly and the fee rides
+   as a batched treasury transfer. Documented honestly (enforcement vs. non-custody trade-off).
+3. **Fee rate single-source (R3)**: rate lives in `FeeRouter` `earn.stake`, edited in the existing Fees tab
+   (`FEE_ADMIN_ROLE`); the Staking tab shows it read-only. Never duplicated in `StakingRouter`.
+4. **StakingRouter shape (R4)**: `UUPSManaged` + `ReentrancyGuardUpgradeable` + `PausableUpgradeable`;
+   `STAKING_ADMIN_ROLE` (setters) + `GUARDIAN_ROLE` (`pause`/`unpause`); `EnumerableSet.AddressSet`
+   validator allowlist; provider-address setters + FeeRouter setter, each emitting an event; stake
+   entrypoints `nonReentrant whenNotPaused`; append-only storage + `__gap`.
+5. **Config read with safe fallback (R5)**: `useStakingOptions` overlays router-sourced
+   addresses/allowlist/paused when `getContractAddressForChain('stakingRouter', chainId)` resolves; when
+   `undefined`/unreachable it keeps the spec-065 constants verbatim (mirrors `fetchFeeQuote`’s
+   `{available:false}` fallback). Pause hides new-stake honestly; exits always available.
+6. **Stake routing branch (R6)**: `buildStakeForOption` mirrors `lib/earn/vaultActions.buildDepositCalls` —
+   fee applies ⇒ approve/route through the router `stake…WithFee`; else the byte-identical spec-065 direct
+   path. Native ETH uses `value` (no approve leg); delegated composes the fee-transfer + direct
+   `buyVoucherPOL` batch.
+7. **Admin tab + role (R7)**: new `StakingTab.jsx` mirrors `ProtocolConfigTab`/`FeesTab` (resolve address,
+   read live state, validate-before-send, `runTx`, on-chain `queryFilter` history); `STAKING_ADMIN` added
+   to `ROLES`/`ROLE_INFO`/`ADMIN_ROLES`, `ROLE_HASHES`, `roleHomeContract → stakingRouter`, nav item, render
+   block; pause/resume gated on `GUARDIAN`.
+8. **Deploy/sync/storage (R8)**: `deploy-staking-router.js` via `deployProxy`, records
+   `stakingRouter`/`stakingRouterImpl`, registers `earn.stake` on the live FeeRouter; `sync-frontend-contracts`
+   mapping + `contracts.js` key; `check:storage-layout` entry; ships as a fresh deploy (new contract), future
+   changes as in-place UUPS upgrades.
+
+## Complexity Tracking
+
+| Deviation | Why needed | Simpler alternative rejected because |
+|---|---|---|
+| New value-bearing contract (`StakingRouter`) | Enforced, atomic fee-and-forward on liquid staking so the treasury reliably grows for every wallet type (FR-001) | A purely client-composed fee (no contract) is non-atomic for classic wallets (fee paid, stake could fail) and unenforceable — weakens the treasury goal the feature exists for |
+| Delegated fee is client-composed, not contract-enforced | `buyVoucherPOL` binds the delegation to `msg.sender`; a router holding it would be custodial + un-exitable | Routing delegation through the router violates non-custody (FR-016) and could trap funds — unacceptable |
+| Fee rate under `FEE_ADMIN`/Fees tab, not the staking-config role | Constitution / spec-060: the FeeRouter is the ONE fee-config store; never a second one | Putting the rate in `StakingRouter` duplicates the fee store — a documented anti-pattern |

--- a/specs/066-staking-admin-controls/quickstart.md
+++ b/specs/066-staking-admin-controls/quickstart.md
@@ -8,7 +8,7 @@ breakdown in `tasks.md` (Phase 2).
 - Spec 065 staking merged (it is). The spec-060 `FeeRouter` deployed on the target network with a `treasury`
   set.
 - `StakingRouter` deployed on the target network (`scripts/deploy/deploy-staking-router.js`) and
-  `earn.stake` registered on the FeeRouter; `npm run sync:frontend-contracts` run so
+  `stake.lido` + `stake.polygon` registered on the FeeRouter; `npm run sync:frontend-contracts` run so
   `getContractAddressForChain('stakingRouter', chainId)` resolves.
 - A `STAKING_ADMIN_ROLE` and `GUARDIAN_ROLE` grantee; a `FEE_ADMIN_ROLE` grantee (existing) to set the rate.
 
@@ -22,7 +22,7 @@ breakdown in `tasks.md` (Phase 2).
 
 ## Scenario 1 — Treasury grows on a liquid stake (US1)
 
-1. As `FEE_ADMIN`, set the `earn.stake` rate (e.g. 50 bps) in the AdminPanel **Fees** tab.
+1. As `FEE_ADMIN`, set the `stake.lido` (or `stake.polygon`) rate (e.g. 50 bps) in the AdminPanel **Fees** tab.
 2. As a member, open Earn → Stake, pick the Lido (ETH) or sPOL (POL) option. **Expect** a fee line showing
    the rate and the net amount to be staked, before signing.
 3. Confirm. **Expect** (fork/manual): the treasury balance increased by exactly the disclosed fee, the net

--- a/specs/066-staking-admin-controls/quickstart.md
+++ b/specs/066-staking-admin-controls/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: Staking Fee Router, Admin Controls & Emergency Pause (spec 066)
+
+A validation/run guide. Implementation details live in the plan, data-model, and contract docs; task
+breakdown in `tasks.md` (Phase 2).
+
+## Prerequisites
+
+- Spec 065 staking merged (it is). The spec-060 `FeeRouter` deployed on the target network with a `treasury`
+  set.
+- `StakingRouter` deployed on the target network (`scripts/deploy/deploy-staking-router.js`) and
+  `earn.stake` registered on the FeeRouter; `npm run sync:frontend-contracts` run so
+  `getContractAddressForChain('stakingRouter', chainId)` resolves.
+- A `STAKING_ADMIN_ROLE` and `GUARDIAN_ROLE` grantee; a `FEE_ADMIN_ROLE` grantee (existing) to set the rate.
+
+## Commands
+
+- Contracts: `npm run compile` · `npm test` (unit) · `npm run test:fork` (Lido/sPOL fee-and-forward) ·
+  `npx slither .` / Medusa · `npm run check:storage-layout`.
+- Frontend: `npm run test:frontend` · `npm run test:frontend -- staking-admin`.
+- Deploy (per network): `node scripts/deploy/deploy-staking-router.js --network <net>` then
+  `npm run sync:frontend-contracts:<net>`.
+
+## Scenario 1 — Treasury grows on a liquid stake (US1)
+
+1. As `FEE_ADMIN`, set the `earn.stake` rate (e.g. 50 bps) in the AdminPanel **Fees** tab.
+2. As a member, open Earn → Stake, pick the Lido (ETH) or sPOL (POL) option. **Expect** a fee line showing
+   the rate and the net amount to be staked, before signing.
+3. Confirm. **Expect** (fork/manual): the treasury balance increased by exactly the disclosed fee, the net
+   was staked with the provider, the member received wstETH/sPOL, and the member was charged no more than the
+   quoted rate. A `LiquidStaked` event is emitted.
+4. Set the rate to 0. **Expect** no fee line and byte-identical fee-free staking (SC-003).
+
+## Scenario 2 — Emergency pause never traps funds (US2)
+
+1. As `GUARDIAN`, open the AdminPanel **Staking** tab and pause the network. **Expect** the member Stake
+   area stops offering new stakes and shows the honest unavailable state within one refresh, no redeploy.
+2. As a member with an existing position, **expect** unstake/withdraw/claim still work (a liquid stake
+   entrypoint reverts `Paused`; exits are unaffected because they never touch the router).
+3. Resume. **Expect** new stakes offered again. **Expect** both actions in the tab’s on-chain history.
+
+## Scenario 3 — Provider address + validator lifecycle (US3/US4)
+
+1. As `STAKING_ADMIN`, change a provider address (e.g. `setSpolContracts`) — invalid/zero input is rejected
+   before the wallet prompt. **Expect** the member flow uses the new address; the change is in history.
+2. Add and remove a validator. **Expect** a removed validator is no longer offered for **new** delegations
+   while a member already delegated to it can still unstake; a duplicate/absent entry is rejected. Changes
+   appear in history.
+
+## Scenario 4 — Least privilege + audit (US5)
+
+1. A no-role account: **expect** no Staking tab and no control action possible.
+2. A `GUARDIAN`-only account: **expect** pause/resume but no address/allowlist edits.
+3. A `STAKING_ADMIN` account: **expect** address/allowlist edits but the fee rate is read-only (edited in the
+   Fees tab by `FEE_ADMIN`). **Expect** every action attributable in history.
+
+## Scenario 5 — Safe fallback (edge)
+
+1. On a network with **no** `StakingRouter` deployed, open Earn → Stake. **Expect** staking works exactly as
+   spec 065 (fee-free, direct, availability as configured) — no broken screen, no fee line.
+2. Force the fee/router read to fail on a network that HAS a router. **Expect** the fee-bearing path is
+   blocked with an honest message (never a guessed/lower rate); exits remain available.
+
+## Done when
+
+- Scenarios 1–5 pass (fork + dev app / test layer).
+- `npm test` + `npm run test:fork` + Slither/Medusa + `check:storage-layout` green; smart-contract security
+  review complete. `npm run test:frontend` green (admin tab, config→router read, stake branch, fee line, axe).
+- Operator runbook (`docs/runbooks/staking-operations.md`) published incl. the emergency pause procedure.

--- a/specs/066-staking-admin-controls/research.md
+++ b/specs/066-staking-admin-controls/research.md
@@ -1,0 +1,147 @@
+# Phase 0 Research: Staking Fee Router, Admin Controls & Emergency Pause (spec 066)
+
+Format per decision: **Decision → Rationale → Alternatives considered**. Grounded in the live contracts
+(`FeeRouter`, `UUPSManaged`, `WagerRegistry`) and frontend (`ProtocolConfigTab`/`FeesTab`, `feeQuote.js`,
+the spec-065 staking libs).
+
+## R1 — Charge the platform fee by reading FeeRouter, not via a new entrypoint
+
+**Decision**: `StakingRouter` charges the spec-060 fee by reading `FeeRouter.quoteFee(earn.stake, gross)
+→ (feeAmount, netAmount)` and `FeeRouter.treasury()`, transferring `feeAmount` to the treasury and
+`netAmount` to the provider itself. `earn.stake` is registered on the FeeRouter as **ConfigOnly**, cap 250
+bps, rate 0 until enabled.
+
+**Rationale**: `FeeRouter.depositToVaultWithFee` is strictly ERC-4626 (it hard-codes `IERC4626(vault).asset()`
+and `.deposit(...)`), so it cannot forward native ETH/POL to a Lido/sPOL staking call, and there is **no
+generic “charge a fee and send the net somewhere” entrypoint**. FeeRouter deliberately exposes `treasury()`,
+`feeBps(id)`, and `quoteFee(id, gross)` (which already implements the floor-in-member’s-favor split and the
+treasury-unset skip) so a sibling contract can reproduce the exact spec-060 charge **without modifying the
+deployed router**. ConfigOnly is the honest kind because FeeRouter itself never moves the funds here — the
+StakingRouter (liquid) and the client batch (delegated) do.
+
+**Alternatives considered**: **Add a generic `chargeAndForward` entrypoint to FeeRouter** — rejected: a
+larger surface change to an already-live value-bearing router that spec-060 deliberately scoped to the
+ERC-4626 wrapper + ConfigOnly registry. **Register `earn.stake` Wrapped** — rejected: Wrapped implies
+FeeRouter itself charges it via `depositToVaultWithFee`, which doesn’t apply.
+
+## R2 — Liquid staking is router-enforced; delegated staking is a direct member call with a client-composed fee
+
+**Decision**: **Liquid** staking (Lido ETH→wstETH, sPOL POL→sPOL) routes through `StakingRouter`:
+transiently hold the asset, skim the fee to treasury, forward the net to the provider, return the LST to the
+member — atomic + `nonReentrant` + `whenNotPaused`. **Delegated** staking (Polygon `ValidatorShare`) keeps
+the member as the **direct `buyVoucherPOL` caller**; the fee rides as a **client-composed treasury transfer**
+in the same stake batch, computed from the same `earn.stake` rate.
+
+**Rationale**: Polygon `buyVoucherPOL` mints the delegation shares to `msg.sender`, so if the router called
+it, the **router** would own the delegation — custodial and un-exitable by the member, violating FR-016 and
+risking trapped funds. Liquid LSTs are transferable, so the router can forward them to the member safely
+(the same shape as `depositToVaultWithFee` returning shares to a `receiver`). This split is the only design
+that keeps delegation non-custodial while still contributing fees. Exits never touch the router in either
+model (members hold the LST / own the delegation), so a pause/router change can never trap funds.
+
+**Trade-off (documented, not hidden)**: the delegated fee is **app-applied**, not contract-enforced, and is
+truly atomic only on the passkey rail (one UserOp); a classic wallet performs a disclosed fee-first
+two-step. This is the same trust model as ConfigOnly fees (spec-057 Polymarket) and is accepted because
+non-custody is non-negotiable for delegation.
+
+**Alternatives considered**: **Router-owned pooled delegation with per-member accounting** — rejected: a
+custodial staking-vault system, massive scope + risk, out of the non-custodial charter. **Ship delegated
+fee-free** — viable fallback, but the treasury goal favors charging where we safely can; kept as the
+degradation if the client batch proves problematic.
+
+## R3 — The fee rate stays the single FeeRouter source of truth
+
+**Decision**: the staking fee **rate** lives only in `FeeRouter` (`earn.stake`) and is edited via the
+**existing Fees tab** (`FEE_ADMIN_ROLE`). The new Staking tab surfaces the current staking fee **read-only**
+with a pointer to the Fees tab; it does not store or set the rate. `StakingRouter` holds a **reference** to
+the FeeRouter and reads the rate at stake time.
+
+**Rationale**: the constitution / spec-060 mandates ONE fee-config store (the FeeRouter) and forbids a second
+one. Duplicating the rate into `StakingRouter` would be exactly that anti-pattern. This refines spec
+FR-011/US5 (which colloquially grouped “fee rate” under the staking-config role): rate = `FEE_ADMIN`;
+addresses/allowlist/pause = `STAKING_ADMIN`.
+
+**Alternatives considered**: **Store the rate in `StakingRouter`** — rejected (second fee store).
+**Mirror the rate into `StakingRouter` on each change** — rejected (drift risk, still two stores).
+
+## R4 — StakingRouter contract pattern (UUPS + Pausable + enumerable allowlist)
+
+**Decision**: `contract StakingRouter is UUPSManaged, ReentrancyGuardUpgradeable, PausableUpgradeable` with
+`STAKING_ADMIN_ROLE` (config setters) and `GUARDIAN_ROLE` (`pause`/`unpause`), an
+`EnumerableSet.AddressSet` validator allowlist, provider-address + FeeRouter-reference setters (each emitting
+an event), stake entrypoints `nonReentrant whenNotPaused`, and append-only storage with a trailing `__gap`.
+`initialize(admin, feeRouter, providers…)` calls `__UUPSManaged_init(admin)` first, then
+`__ReentrancyGuard_init()` / `__Pausable_init()`, and grants the two roles.
+
+**Rationale**: mirrors the repo’s dominant registry pattern — `UUPSManaged` (least-privilege upgrade gate,
+`_disableInitializers`, base `__gap`) + `WagerRegistry`’s `PausableUpgradeable`/`GUARDIAN_ROLE`
+`pause()/unpause()` + `FeeRouter`’s granular admin role and enumerable set. Storage discipline
+(append-only + `__gap`, validated by `check:storage-layout`) enables in-place UUPS upgrades.
+
+**Alternatives considered**: **Non-upgradeable contract** — rejected: every other registry is UUPS; staking
+config/providers will evolve. **Config-only (no fund handling) registry + purely client fee** — rejected for
+liquid (loses atomicity/enforcement — see Complexity Tracking), though it is exactly what delegated uses.
+
+## R5 — Member app reads the router at runtime with a safe build-time fallback
+
+**Decision**: `useStakingOptions` resolves `getContractAddressForChain('stakingRouter', chainId)`; when
+present it overlays the router’s provider addresses / validator allowlist / per-network `paused` onto the
+options (and the app reads the `earn.stake` fee via `fetchFeeQuote`); when `undefined` or unreachable it
+keeps the spec-065 build-time constants verbatim (fee-free, direct staking, availability as configured).
+
+**Rationale**: backwards-compatible, honest-state rollout — staking keeps working before/if the router is
+deployed on a network, and never shows a broken or fee-guessing screen (FR-009). Reuses the exact fallback
+contract of `feeQuote.js` (`{available:false}` when no router). A `paused` flag hides new-stake using the
+existing unavailable-state UI while exits stay available.
+
+**Alternatives considered**: **Hard cutover to the router** — rejected: bricks staking on any network
+without a deployed router and breaks the never-stranded rule.
+
+## R6 — Route the stake through the router only when a fee applies (else the spec-065 direct path)
+
+**Decision**: extend `stakingActions.buildStakeForOption` to branch like
+`lib/earn/vaultActions.buildDepositCalls`: when a staking fee applies and a router is available, approve/route
+through the router’s `stake…WithFee` entrypoint (native ETH via `value`, ERC-20 via approve-router); else
+emit the byte-identical spec-065 direct provider calls. Delegated composes the fee-transfer + direct
+`buyVoucherPOL(net)` batch. Thread the `feeQuote` into `useStakingActions.stake`’s ctx.
+
+**Rationale**: reuses the proven lending fee-branch pattern, keeps the fee-free path byte-identical (SC-003),
+and preserves the passkey/classic dual-rail via `useEarnSend`.
+
+## R7 — Admin tab + role wiring (mirror ProtocolConfig/Fees)
+
+**Decision**: new `admin/StakingTab.jsx` (props `{signer, chainId, provider, runTx, pendingTx, isAdmin,
+isStakingAdmin, isGuardian}`) mirrors `ProtocolConfigTab` (address setters via `runTx` + on-chain
+`queryFilter` history) and `FeesTab` (read live state, validate-before-send, empty state when the contract
+isn’t on-chain). Add `ROLES.STAKING_ADMIN` (+ `ROLE_INFO` + `ADMIN_ROLES`), a `ROLE_HASHES` entry,
+`roleHomeContract('STAKING_ADMIN') → stakingRouter`, the `ADMIN_TAB_ICONS`/nav item (`isStakingAdmin`), the
+`AdminPanel` flag + render block; pause/resume gated on `GUARDIAN`; the fee is shown read-only (R3).
+
+**Rationale**: the AdminPanel is entirely pattern-driven (four coordinated edits add a tab); reusing
+`runTx`/role/history means no engine changes and consistent operator UX + on-chain audit history.
+
+**Alternatives considered**: a bespoke admin surface — rejected (reinvents the existing, audited pattern).
+
+## R8 — Deploy, sync, and storage-layout wiring
+
+**Decision**: `deploy-staking-router.js` uses `deployProxy({name:'StakingRouter', initArgs:[admin,
+feeRouter, providers…]})`, records `stakingRouter`/`stakingRouterImpl` immediately (append, never overwrite),
+then registers `earn.stake` on the **existing** FeeRouter (idempotent). Add `earn.stake` to
+`feeServices.js`; add `stakingRouter` to the `sync-frontend-contracts` key mapping and the `contracts.js`
+per-chain maps; add `{name:'StakingRouter', deploymentsKey:'stakingRouter'}` to `check-storage-layout.js`.
+Ship as a fresh deploy; future logic changes are in-place `upgradeProxy` UUPS upgrades.
+
+**Rationale**: matches the FeeRouter/registry deploy+sync+storage-check precedent exactly; the storage-check
+gate protects upgrade safety.
+
+## Open items carried to tasks/implementation
+
+- Confirm the **FeeRouter address per network** to pass to `StakingRouter.initialize` (read from the
+  network’s `deployments/` record).
+- Decide the **initial `earn.stake` rate** (ships at 0 bps; enabled later from the Fees tab) and confirm the
+  **cap** (proposed 250 bps).
+- Confirm the **treasury address per network** is set on the FeeRouter (fee is skipped, never lost, if unset).
+- Validate the exact **Lido/sPOL forward legs inside the router** on a fork (submit→wrap→transfer;
+  buySPOL→transfer) including the reentrancy/CEI ordering and the no-residual-funds invariant.
+- Confirm whether **delegated staking charges a fee in v1** (client-composed) or ships fee-free pending the
+  batch UX review (R2 degradation path).

--- a/specs/066-staking-admin-controls/research.md
+++ b/specs/066-staking-admin-controls/research.md
@@ -6,10 +6,11 @@ the spec-065 staking libs).
 
 ## R1 — Charge the platform fee by reading FeeRouter, not via a new entrypoint
 
-**Decision**: `StakingRouter` charges the spec-060 fee by reading `FeeRouter.quoteFee(earn.stake, gross)
+**Decision**: `StakingRouter` charges the spec-060 fee by reading `FeeRouter.quoteFee(serviceId, gross)
 → (feeAmount, netAmount)` and `FeeRouter.treasury()`, transferring `feeAmount` to the treasury and
-`netAmount` to the provider itself. `earn.stake` is registered on the FeeRouter as **ConfigOnly**, cap 250
-bps, rate 0 until enabled.
+`netAmount` to the provider itself. The rate is **per-provider** (clarified 2026-07-23): register **two**
+services on the FeeRouter — `stake.lido` and `stake.polygon` (sPOL) — each **ConfigOnly**, cap **250 bps**,
+rate 0 until enabled. The router picks the serviceId by the liquid provider being staked.
 
 **Rationale**: `FeeRouter.depositToVaultWithFee` is strictly ERC-4626 (it hard-codes `IERC4626(vault).asset()`
 and `.deposit(...)`), so it cannot forward native ETH/POL to a Lido/sPOL staking call, and there is **no
@@ -17,20 +18,20 @@ generic “charge a fee and send the net somewhere” entrypoint**. FeeRouter de
 `feeBps(id)`, and `quoteFee(id, gross)` (which already implements the floor-in-member’s-favor split and the
 treasury-unset skip) so a sibling contract can reproduce the exact spec-060 charge **without modifying the
 deployed router**. ConfigOnly is the honest kind because FeeRouter itself never moves the funds here — the
-StakingRouter (liquid) and the client batch (delegated) do.
+StakingRouter (liquid) does; delegated is fee-free in v1 (R2).
 
 **Alternatives considered**: **Add a generic `chargeAndForward` entrypoint to FeeRouter** — rejected: a
 larger surface change to an already-live value-bearing router that spec-060 deliberately scoped to the
 ERC-4626 wrapper + ConfigOnly registry. **Register `earn.stake` Wrapped** — rejected: Wrapped implies
 FeeRouter itself charges it via `depositToVaultWithFee`, which doesn’t apply.
 
-## R2 — Liquid staking is router-enforced; delegated staking is a direct member call with a client-composed fee
+## R2 — Liquid staking is router-enforced; delegated staking is fee-free in v1
 
 **Decision**: **Liquid** staking (Lido ETH→wstETH, sPOL POL→sPOL) routes through `StakingRouter`:
-transiently hold the asset, skim the fee to treasury, forward the net to the provider, return the LST to the
-member — atomic + `nonReentrant` + `whenNotPaused`. **Delegated** staking (Polygon `ValidatorShare`) keeps
-the member as the **direct `buyVoucherPOL` caller**; the fee rides as a **client-composed treasury transfer**
-in the same stake batch, computed from the same `earn.stake` rate.
+transiently hold the asset, skim the per-provider fee to treasury, forward the net to the provider, return
+the LST to the member — atomic + `nonReentrant` + `whenNotPaused`. **Delegated** staking (Polygon
+`ValidatorShare`) keeps the member as the **direct `buyVoucherPOL` caller** and is **fee-free in v1**
+(clarified 2026-07-23); the router still governs its config (allowlist + pause).
 
 **Rationale**: Polygon `buyVoucherPOL` mints the delegation shares to `msg.sender`, so if the router called
 it, the **router** would own the delegation — custodial and un-exitable by the member, violating FR-016 and
@@ -39,20 +40,32 @@ risking trapped funds. Liquid LSTs are transferable, so the router can forward t
 that keeps delegation non-custodial while still contributing fees. Exits never touch the router in either
 model (members hold the LST / own the delegation), so a pause/router change can never trap funds.
 
-**Trade-off (documented, not hidden)**: the delegated fee is **app-applied**, not contract-enforced, and is
-truly atomic only on the passkey rail (one UserOp); a classic wallet performs a disclosed fee-first
-two-step. This is the same trust model as ConfigOnly fees (spec-057 Polymarket) and is accepted because
-non-custody is non-negotiable for delegation.
+**Rationale for fee-free delegated (v1)**: a contract-enforced delegated fee is impossible without the
+router owning the delegation (custodial, un-exitable — violates FR-016); a client-composed fee is
+app-applied (unenforced) and non-atomic for classic wallets (fee paid, stake could fail). Rather than ship
+that weaker guarantee, v1 charges only where the fee is enforced and atomic (liquid). The treasury still
+grows from liquid staking (the larger volume: ETH via Lido, POL via sPOL).
 
-**Alternatives considered**: **Router-owned pooled delegation with per-member accounting** — rejected: a
-custodial staking-vault system, massive scope + risk, out of the non-custodial charter. **Ship delegated
-fee-free** — viable fallback, but the treasury goal favors charging where we safely can; kept as the
-degradation if the client batch proves problematic.
+**Alternatives considered**: **Charge delegated via a client-composed batch** — rejected for v1 (weaker,
+non-atomic guarantee); revisit if a robust path emerges. **Router-owned pooled delegation with per-member
+accounting** — rejected: a custodial staking-vault system, out of the non-custodial charter.
+
+## R2b — Governance: multisig roles, no timelock (clarified 2026-07-23)
+
+**Decision**: grant `STAKING_ADMIN_ROLE` (config) and `GUARDIAN_ROLE` (pause) to a **multisig (Safe)** at
+deployment; **no on-chain timelock** on any action. The emergency pause takes effect instantly; config
+changes rely on multi-party approval.
+
+**Rationale**: multi-party control of a value-bearing control surface without a single-key point of failure,
+while keeping incident response immediate. Matches how the repo’s registries grant guardian/admin roles.
+
+**Alternatives considered**: **Single EOA admin** — rejected (single point of failure). **Timelock on
+config** — rejected: slows routine ops and incident-adjacent config fixes; the pause needs zero delay.
 
 ## R3 — The fee rate stays the single FeeRouter source of truth
 
-**Decision**: the staking fee **rate** lives only in `FeeRouter` (`earn.stake`) and is edited via the
-**existing Fees tab** (`FEE_ADMIN_ROLE`). The new Staking tab surfaces the current staking fee **read-only**
+**Decision**: the staking fee **rate** lives only in `FeeRouter` (`stake.lido` / `stake.polygon`) and is
+edited via the **existing Fees tab** (`FEE_ADMIN_ROLE`). The new Staking tab surfaces the current staking fee **read-only**
 with a pointer to the Fees tab; it does not store or set the rate. `StakingRouter` holds a **reference** to
 the FeeRouter and reads the rate at stake time.
 
@@ -80,13 +93,13 @@ an event), stake entrypoints `nonReentrant whenNotPaused`, and append-only stora
 
 **Alternatives considered**: **Non-upgradeable contract** — rejected: every other registry is UUPS; staking
 config/providers will evolve. **Config-only (no fund handling) registry + purely client fee** — rejected for
-liquid (loses atomicity/enforcement — see Complexity Tracking), though it is exactly what delegated uses.
+liquid (loses atomicity/enforcement — see Complexity Tracking); delegated instead ships fee-free in v1 (R2).
 
 ## R5 — Member app reads the router at runtime with a safe build-time fallback
 
 **Decision**: `useStakingOptions` resolves `getContractAddressForChain('stakingRouter', chainId)`; when
 present it overlays the router’s provider addresses / validator allowlist / per-network `paused` onto the
-options (and the app reads the `earn.stake` fee via `fetchFeeQuote`); when `undefined` or unreachable it
+options (and the app reads the `stake.lido`/`stake.polygon` fee via `fetchFeeQuote`); when `undefined` or unreachable it
 keeps the spec-065 build-time constants verbatim (fee-free, direct staking, availability as configured).
 
 **Rationale**: backwards-compatible, honest-state rollout — staking keeps working before/if the router is
@@ -126,7 +139,7 @@ isn’t on-chain). Add `ROLES.STAKING_ADMIN` (+ `ROLE_INFO` + `ADMIN_ROLES`), a 
 
 **Decision**: `deploy-staking-router.js` uses `deployProxy({name:'StakingRouter', initArgs:[admin,
 feeRouter, providers…]})`, records `stakingRouter`/`stakingRouterImpl` immediately (append, never overwrite),
-then registers `earn.stake` on the **existing** FeeRouter (idempotent). Add `earn.stake` to
+then registers `stake.lido` + `stake.polygon` on the **existing** FeeRouter (idempotent). Add both to
 `feeServices.js`; add `stakingRouter` to the `sync-frontend-contracts` key mapping and the `contracts.js`
 per-chain maps; add `{name:'StakingRouter', deploymentsKey:'stakingRouter'}` to `check-storage-layout.js`.
 Ship as a fresh deploy; future logic changes are in-place `upgradeProxy` UUPS upgrades.
@@ -138,10 +151,10 @@ gate protects upgrade safety.
 
 - Confirm the **FeeRouter address per network** to pass to `StakingRouter.initialize` (read from the
   network’s `deployments/` record).
-- Decide the **initial `earn.stake` rate** (ships at 0 bps; enabled later from the Fees tab) and confirm the
+- Decide the **initial `stake.lido`/`stake.polygon` rates** (ship at 0 bps; enabled later from the Fees tab) and confirm the
   **cap** (proposed 250 bps).
 - Confirm the **treasury address per network** is set on the FeeRouter (fee is skipped, never lost, if unset).
 - Validate the exact **Lido/sPOL forward legs inside the router** on a fork (submit→wrap→transfer;
   buySPOL→transfer) including the reentrancy/CEI ordering and the no-residual-funds invariant.
-- Confirm whether **delegated staking charges a fee in v1** (client-composed) or ships fee-free pending the
+- (RESOLVED 2026-07-23) Delegated staking is **fee-free in v1**; revisit a robust charged path later. The
   batch UX review (R2 degradation path).

--- a/specs/066-staking-admin-controls/research.md
+++ b/specs/066-staking-admin-controls/research.md
@@ -115,8 +115,9 @@ without a deployed router and breaks the never-stranded rule.
 **Decision**: extend `stakingActions.buildStakeForOption` to branch like
 `lib/earn/vaultActions.buildDepositCalls`: when a staking fee applies and a router is available, approve/route
 through the router’s `stake…WithFee` entrypoint (native ETH via `value`, ERC-20 via approve-router); else
-emit the byte-identical spec-065 direct provider calls. Delegated composes the fee-transfer + direct
-`buyVoucherPOL(net)` batch. Thread the `feeQuote` into `useStakingActions.stake`’s ctx.
+emit the byte-identical spec-065 direct provider calls. **Delegated stays the spec-065 direct
+`buyVoucherPOL` call with no fee leg (fee-free in v1 — R2);** only liquid options take the router path.
+Thread the `feeQuote` into `useStakingActions.stake`’s ctx.
 
 **Rationale**: reuses the proven lending fee-branch pattern, keeps the fee-free path byte-identical (SC-003),
 and preserves the passkey/classic dual-rail via `useEarnSend`.

--- a/specs/066-staking-admin-controls/spec.md
+++ b/specs/066-staking-admin-controls/spec.md
@@ -11,6 +11,20 @@ manage staking activities — contract-address management and the lifecycle even
 need to manage a change in service, and the ability to pause staking on a network in an emergency. We
 also need to route staking through the platform fee mechanics so the treasury can grow."
 
+## Clarifications
+
+### Session 2026-07-23
+
+- Q: Should delegated staking (Polygon validator delegation) charge a platform fee in v1? → A: No — v1
+  charges the enforced fee on **liquid** staking (Lido/sPOL) only; delegated ships **fee-free** and is
+  revisited later. This keeps every charged fee contract-enforced and atomic for all wallet types.
+- Q: How should the staking fee rate be modeled in the FeeRouter? → A: **Per-provider** services —
+  `stake.lido` and `stake.polygon` (sPOL) — each read and charged independently (not one `earn.stake`).
+- Q: What immutable cap should the staking fee service(s) carry? → A: **250 bps (2.5%)** each; the rate
+  ships at 0 and is set later by fee administration.
+- Q: How should the StakingRouter admin (config) and guardian (pause) authority be held? → A: **Multisig
+  (Safe) roles, no on-chain timelock** — config via multisig; the emergency pause stays instant.
+
 ## User Scenarios & Testing *(mandatory)*
 
 Staking (spec 065) shipped **fee-free** and with its provider addresses and curated validator
@@ -204,8 +218,10 @@ attributable in the audit history.
   flight can never overcharge (the quoted rate is a hard ceiling on the transaction).
 - **Zero fee is invisible and identical**: a zero/unset fee produces no fee line and byte-identical
   behavior to fee-free staking.
-- **Fee cap enforced**: the staking fee can never be set above the configured maximum for the service;
-  an attempt to exceed it is rejected.
+- **Fee cap enforced**: the staking fee can never be set above the configured maximum (250 bps) for a
+  service; an attempt to exceed it is rejected.
+- **Delegated is fee-free (v1)**: delegated staking charges no platform fee in v1; its stake path stays
+  the member's direct call (no router custody), and the treasury grows only from liquid staking for now.
 - **Pause never traps funds**: a pause blocks only *new* stakes/delegations; unstake, withdraw, and
   reward-claim remain available so members can always exit.
 - **Control surface undeployed/unreachable**: when the control surface (or the fee configuration) is
@@ -234,18 +250,21 @@ attributable in the audit history.
 
 ### Functional Requirements
 
-- **FR-001**: The system MUST charge a platform fee on staking (the value-in action) that is routed to
-  the FairWins treasury, taken from the staked amount with the net remainder staked with the provider,
-  executed atomically so a member signs once and is never left in a partial state.
+- **FR-001**: The system MUST charge a platform fee on **liquid** staking (the value-in action) that is
+  routed to the FairWins treasury, taken from the staked amount with the net remainder staked with the
+  provider, executed atomically so a member signs once and is never left in a partial state.
+  **Delegated staking is fee-free in v1** (see FR-004).
 - **FR-002**: The staking fee rate MUST come from the single platform-fee configuration used across
-  FairWins services (the same source of truth as other service fees), MUST be capped at a configured
-  maximum for the service, and MUST be settable to zero; a zero/unset fee MUST produce no fee line and
-  behavior identical to fee-free staking.
+  FairWins services (the same source of truth as other service fees), modeled as **per-provider
+  services (`stake.lido`, `stake.polygon`)** each with its own immutable **250 bps** cap and each
+  settable to zero (rate ships at 0); a zero/unset fee MUST produce no fee line and behavior identical
+  to fee-free staking.
 - **FR-003**: The member MUST see the staking fee as its own line — with its rate and the resulting
   net amount to be staked — before any signature, and MUST be charged no more than the rate they were
   shown (the quoted rate is a hard ceiling for that transaction).
-- **FR-004**: The platform fee MUST apply only to staking (value-in); unstake, withdraw, and reward
-  claim MUST never be fee-gated so members can always exit an existing position.
+- **FR-004**: The platform fee MUST apply only to **liquid** staking (value-in); **delegated staking is
+  fee-free in v1**; and unstake, withdraw, and reward claim MUST never be fee-gated so members can
+  always exit an existing position.
 - **FR-005**: The system MUST provide an authorized operator a control surface, within the app's admin
   area, to review and manage staking configuration, the fee rate, and availability per network,
   without requiring an app redeploy for changes to take effect.
@@ -290,6 +309,10 @@ attributable in the audit history.
 - **FR-017**: Operator documentation MUST describe the staking control surface — how the fee works and
   how to set it, how to pause/resume, change addresses, curate validators, who is authorized, and how
   the audit history works — including the emergency runbook for pausing in an incident.
+- **FR-018**: The staking-configuration and emergency/guardian authorizations SHOULD be held by a
+  **multisig** (not a single key), with **no on-chain timelock** on any action — the emergency pause
+  MUST take effect instantly, and configuration changes rely on multi-party approval rather than a
+  delay.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -312,9 +335,9 @@ attributable in the audit history.
 
 ### Measurable Outcomes
 
-- **SC-001**: With a configured non-zero staking fee, 100% of stakes route the fee to the treasury and
-  stake the net remainder in a single member confirmation; the measured treasury increase equals the
-  disclosed fee for every stake.
+- **SC-001**: With a configured non-zero staking fee, 100% of **liquid** stakes route the fee to the
+  treasury and stake the net remainder in a single member confirmation; the measured treasury increase
+  equals the disclosed fee for every liquid stake. (Delegated staking is fee-free in v1.)
 - **SC-002**: 100% of fee-bearing stakes disclose the fee (rate + net) before signature, and 0 members
   are ever charged more than the rate they were shown.
 - **SC-003**: With the staking fee set to zero, the staking experience is byte-for-byte identical to
@@ -340,8 +363,14 @@ attributable in the audit history.
 
 - **Fee routing reuses the single platform-fee configuration**: the staking fee is expressed through
   the same platform-fee configuration and treasury routing every other FairWins service uses (the
-  spec-060 fee mechanism), registered as a staking service with its own hard cap — not a new,
-  parallel fee store. This resolves the fee-router path that spec 065 deferred (065 research R6).
+  spec-060 fee mechanism), registered as **per-provider staking services (`stake.lido`, `stake.polygon`),
+  each capped at 250 bps** — not a new, parallel fee store. This resolves the fee-router path that spec
+  065 deferred (065 research R6). Only **liquid** staking is charged in v1; **delegated staking is
+  fee-free** (its fee would be app-applied and non-atomic for classic wallets — deferred rather than
+  ship a weaker guarantee).
+- **Governance**: the on-chain admin (config) and guardian (pause) roles are granted to a **multisig
+  (Safe)** at deployment; there is **no on-chain timelock** — the emergency pause is instant and
+  configuration changes rely on multi-party approval.
 - **Authoritative, on-chain control surface (a staking router)**: per the product decision, staking
   configuration, the fee, and the pause switch are held in an authoritative, auditable, on-chain
   control surface (one per network) that member staking flows route through so the fee can be charged

--- a/specs/066-staking-admin-controls/spec.md
+++ b/specs/066-staking-admin-controls/spec.md
@@ -1,4 +1,4 @@
-# Feature Specification: Staking Admin Controls & Emergency Pause
+# Feature Specification: Staking Fee Router, Admin Controls & Emergency Pause
 
 **Feature Branch**: `066-staking-admin-controls`
 
@@ -7,46 +7,86 @@
 **Status**: Draft
 
 **Input**: User description: "We need adequate control surfaces for administrative tasks necessary to
-manage staking activities. This includes contract-address management and the lifecycle events an
-operator would need to manage a change in service, and the ability to pause staking on a network in an
-emergency."
+manage staking activities — contract-address management and the lifecycle events an operator would
+need to manage a change in service, and the ability to pause staking on a network in an emergency. We
+also need to route staking through the platform fee mechanics so the treasury can grow."
 
 ## User Scenarios & Testing *(mandatory)*
 
-Staking (spec 065) ships with its provider addresses and curated validator allowlist baked into the
-app at build time, and with no way to turn staking off short of shipping a new app build. That is fine
-for launch but leaves operators without the levers a production financial service needs: when a
-provider migrates a contract, when a validator must be swapped out, or when something goes wrong and
-staking must be stopped *now*, the only recourse today is a code change and a redeploy — too slow for
-an incident and invisible in any audit trail.
+Staking (spec 065) shipped **fee-free** and with its provider addresses and curated validator
+allowlist baked into the app at build time, with no way to turn staking off short of a new app build.
+That was the right launch cut, but it leaves two gaps for a production financial service: **no revenue
+to the treasury**, and **no operator control surface** — when a provider migrates a contract, a
+validator must be swapped out, or something goes wrong and staking must be stopped *now*, the only
+recourse is a code change and a redeploy, too slow for an incident and invisible in any audit trail.
 
-This feature gives operators a proper **control surface** for staking. An authorized operator can,
-from the app's admin area, review and update the staking provider addresses for a network, curate the
-validator allowlist (add, remove, or replace a validator as part of a planned service change), and —
-critically — **pause staking on a network in an emergency** so the member experience stops offering it
-honestly, all taking effect at runtime without an app redeploy and all recorded as an auditable
-history of who changed what and when. Members are never left confused: a paused or misconfigured
-network shows the same honest "not available right now" state the app already uses, never a broken or
-dishonest surface.
+This feature closes both gaps with a single authoritative, on-chain **staking control surface** (one
+per network) that member staking flows pass through. It (1) charges a **platform fee** on staking that
+is routed to the FairWins **treasury** — using the same single platform-fee configuration every other
+FairWins service uses — so the treasury grows with staking volume; and (2) gives operators a real
+**admin surface** to manage the staking service — review and update provider addresses, curate the
+validator allowlist, and **pause staking per network in an emergency** — all taking effect at runtime
+without an app redeploy and all recorded as an auditable history of who changed what and when. Members
+are always treated honestly: the fee is disclosed before they sign, a paused or misconfigured network
+shows the same honest "not available right now" state the app already uses, and members can **always
+exit** existing positions.
 
-### User Story 1 - Emergency pause and resume of staking (Priority: P1)
+### User Story 1 - Grow the treasury with a platform fee on staking (Priority: P1)
+
+FairWins wants staking to contribute to the treasury like its other services do. When a member stakes,
+a platform fee (set through the same single fee configuration used across FairWins) is taken from the
+staked amount and sent to the treasury, and the remainder is staked with the provider as usual — all
+in one action, so the member signs once and is never left in a half-done state. The member sees the
+fee as its own clear line in the confirmation before they sign, and can never be charged more than the
+rate they were shown. When the fee rate is set to zero, staking behaves exactly as it does today with
+no fee line at all.
+
+**Why this priority**: Treasury growth is the explicit new business goal, and routing staking through
+the fee mechanics is the reason the on-chain control surface exists at all — everything else (config,
+pause) rides on the same surface. It is independently valuable and testable the moment the fee path
+works end to end.
+
+**Independent Test**: With a configured non-zero staking fee, stake a supported asset and verify the
+treasury balance increases by the disclosed fee, the net amount is staked with the provider, the
+member received the expected position, and the member was shown the fee before signing and charged no
+more than the quoted rate; then set the fee to zero and verify staking is byte-for-byte the fee-free
+experience.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured non-zero staking fee on a network, **When** a member stakes, **Then** the
+   fee is sent to the treasury, the net remainder is staked with the provider, and the member receives
+   the resulting position — atomically, from a single confirmation.
+2. **Given** a member is about to stake with a non-zero fee, **When** they review the confirmation,
+   **Then** the fee is shown as its own line with its rate, and the amount that will actually be
+   staked is shown — before any signature.
+3. **Given** a member was shown a fee rate, **When** the transaction executes, **Then** they are
+   charged no more than that rate (a rate increase in flight can never overcharge them).
+4. **Given** the staking fee is set to zero (or unset), **When** a member stakes, **Then** there is no
+   fee line and the experience is identical to the current fee-free staking.
+5. **Given** the fee configuration is unreachable or the control surface is not deployed on a network,
+   **When** a member stakes, **Then** the app falls back to the honest default (fee-free, direct
+   staking) rather than blocking or guessing a rate.
+
+---
+
+### User Story 2 - Emergency pause and resume of staking (Priority: P1)
 
 An authorized emergency responder needs to stop staking on a network immediately — a provider exploit
 is suspected, a validator is misbehaving, or a contract address is in doubt. From the admin area they
-open the Staking controls, select the network, and pause staking. Within moments the member-facing
-Stake area on that network stops offering new stakes and shows the honest unavailable state; existing
-positions and the ability to unstake/withdraw are unaffected (members must always be able to get their
-funds back). When the incident is resolved, the responder resumes staking and the area returns to
-normal. Both actions are recorded with the actor and time.
+select the network and pause staking. Within moments the member-facing Stake area on that network
+stops offering new stakes and shows the honest unavailable state; **existing positions and the ability
+to unstake/withdraw are unaffected** (members must always be able to get their funds back). When the
+incident is resolved, the responder resumes staking. Both actions are recorded with the actor and time.
 
 **Why this priority**: This is the core safety lever and the most time-critical capability — the whole
-point of a control surface is to act faster than a redeploy in an incident. It is independently
-valuable even before richer config management exists.
+point of a control surface is to act faster than a redeploy in an incident. It shares the same on-chain
+surface as the fee router.
 
-**Independent Test**: With an authorized responder account, pause staking on a supported network and
-confirm the member Stake area on that network stops offering new stakes and shows the unavailable
-state while unstake/withdraw still work; resume and confirm staking is offered again; verify both
-actions appear in the audit history.
+**Independent Test**: With an authorized responder account, pause staking on a network and confirm the
+member Stake area stops offering new stakes and shows the unavailable state while unstake/withdraw
+still work; resume and confirm staking is offered again; verify both actions appear in the audit
+history.
 
 **Acceptance Scenarios**:
 
@@ -60,23 +100,22 @@ actions appear in the audit history.
 4. **Given** a pause or resume is performed, **When** anyone reviews the staking audit history,
    **Then** the action, the acting operator, the affected network, and the time are recorded.
 5. **Given** the control surface is unreachable or not yet deployed on a network, **When** a member
-   opens staking there, **Then** the app falls back safely to its honest default (staking availability
-   as configured) and never shows a broken screen.
+   opens staking there, **Then** the app falls back safely to its honest default and never shows a
+   broken screen.
 
 ---
 
-### User Story 2 - Manage staking provider addresses per network (Priority: P2)
+### User Story 3 - Manage staking provider addresses per network (Priority: P2)
 
-A provider migrates a contract, or a new network is being brought online, and an operator must update
-the addresses the staking flows use. From the Staking controls the operator sees the current provider
+A provider migrates a contract, or a new network is brought online, and an operator must update the
+addresses the staking flows use. From the Staking controls the operator sees the current provider
 addresses for the selected network (the liquid-staking contracts, the delegation manager, the staking
-token), each shown next to its current value, updates the ones that changed, and confirms. The
-member-facing staking flows begin using the new addresses at runtime. Every address change is recorded
-with the actor, the old and new value, and the time.
+token), each next to its current value, updates the ones that changed, and confirms. The member-facing
+staking flows begin using the new addresses at runtime. Every change is recorded with the actor, old
+and new value, and time.
 
 **Why this priority**: Address management is the routine operational need behind "a change in
-service." It is less time-critical than the emergency pause but is what makes the service maintainable
-without redeploys. It builds on the same control surface as US1.
+service." It builds on the same control surface as US1/US2.
 
 **Independent Test**: As an authorized operator, change a staking provider address for a network,
 confirm the member staking flow resolves the new address, and verify the change (old → new, actor,
@@ -86,9 +125,9 @@ time) is in the audit history.
 
 1. **Given** an authorized operator, **When** they view the Staking controls for a network, **Then**
    each managed provider address is shown with its current value.
-2. **Given** the operator updates a provider address and confirms, **When** a member next uses
-   staking on that network, **Then** the flow uses the updated address.
-3. **Given** an operator submits an obviously invalid address (malformed, or empty where one is
+2. **Given** the operator updates a provider address and confirms, **When** a member next uses staking
+   on that network, **Then** the flow uses the updated address.
+3. **Given** the operator submits an obviously invalid address (malformed, or empty where one is
    required), **When** they confirm, **Then** the change is rejected with a clear reason before it
    takes effect.
 4. **Given** an address change is made, **When** the audit history is reviewed, **Then** the change
@@ -96,23 +135,20 @@ time) is in the audit history.
 
 ---
 
-### User Story 3 - Curate the validator allowlist as a service-lifecycle activity (Priority: P2)
+### User Story 4 - Curate the validator allowlist as a service-lifecycle activity (Priority: P2)
 
 The curated delegation validator set must change over time — a validator raises its commission beyond
-policy, is jailed, or is replaced by a better-performing operator. An authorized operator opens the
-validator allowlist for the network, sees the current curated validators, and adds, removes, or
-replaces an entry. Removing a validator stops it being offered for **new** delegations immediately;
-members already delegated to it can still see the position and unstake/withdraw. The change is
-recorded in the audit history.
+policy, is jailed, or is replaced. An authorized operator opens the validator allowlist for the
+network, sees the current curated validators, and adds, removes, or replaces an entry. Removing a
+validator stops it being offered for **new** delegations immediately; members already delegated to it
+can still see the position and unstake/withdraw. The change is recorded in the audit history.
 
 **Why this priority**: Validator curation is the other half of "managing a change in service." It is
-delegated-staking-specific and builds on the same controls; it is independently testable once the
-control surface exists.
+delegated-staking-specific and builds on the same controls.
 
-**Independent Test**: As an authorized operator, remove a validator from the allowlist and confirm it
-is no longer offered for new delegations in the member Stake area, while a member already delegated to
-it can still unstake; add a validator and confirm it appears; verify both changes are in the audit
-history.
+**Independent Test**: As an authorized operator, remove a validator and confirm it is no longer
+offered for new delegations while a member already delegated to it can still unstake; add a validator
+and confirm it appears; verify both changes are in the audit history.
 
 **Acceptance Scenarios**:
 
@@ -130,31 +166,31 @@ history.
 
 ---
 
-### User Story 4 - Least-privilege operator access and audit (Priority: P3)
+### User Story 5 - Least-privilege operator access and audit (Priority: P3)
 
-Not everyone may touch staking controls. Configuration changes (addresses, allowlist) require a
-staking-configuration operator; the emergency pause/resume may be exercised by the broader emergency
-role so an incident responder can act even without configuration rights. Unauthorized accounts do not
-see the controls at all, and no privileged action can be taken without the appropriate authorization.
-The full history of staking control actions is reviewable so changes are accountable.
+Not everyone may touch staking controls. Configuration changes (addresses, allowlist) and the fee rate
+require a staking-configuration operator; the emergency pause/resume may be exercised by the broader
+emergency role so an incident responder can act even without configuration rights. Unauthorized
+accounts do not see the controls at all, and no privileged action can be taken without the appropriate
+authorization. The full history of staking control actions is reviewable so changes are accountable.
 
-**Why this priority**: Access separation and auditability are essential for a financial control
-surface but layer onto the functional stories above; they are testable once the controls and roles
-exist.
+**Why this priority**: Access separation and auditability are essential for a financial control surface
+but layer onto the functional stories above.
 
 **Independent Test**: Confirm an account without any staking-operator authorization sees no staking
 controls and cannot perform any control action; confirm the configuration role can change
-addresses/allowlist; confirm the emergency role can pause/resume; confirm every action is attributable
-in the audit history.
+addresses/allowlist/fee; confirm the emergency role can pause/resume; confirm every action is
+attributable in the audit history.
 
 **Acceptance Scenarios**:
 
 1. **Given** an account with no staking-operator authorization, **When** they open the admin area,
    **Then** the Staking controls are not shown and no staking control action is possible.
-2. **Given** an account with only the emergency authorization, **When** they open the Staking
-   controls, **Then** they can pause/resume but cannot change addresses or the allowlist.
+2. **Given** an account with only the emergency authorization, **When** they open the Staking controls,
+   **Then** they can pause/resume but cannot change addresses, the allowlist, or the fee.
 3. **Given** an account with the staking-configuration authorization, **When** they open the Staking
-   controls, **Then** they can change addresses and the allowlist.
+   controls, **Then** they can change addresses, the allowlist, and the fee rate (bounded by the
+   configured cap).
 4. **Given** any staking control action by any operator, **When** the audit history is reviewed,
    **Then** the action is attributable to the acting operator with a timestamp.
 
@@ -162,83 +198,113 @@ in the audit history.
 
 ### Edge Cases
 
+- **Fee never blocks the exit path**: the platform fee applies to staking (the value-in action) only;
+  unstake, withdraw, and reward-claim are never fee-gated and always work.
+- **Fee ceiling honored**: a member is charged at most the rate they were shown; a rate change in
+  flight can never overcharge (the quoted rate is a hard ceiling on the transaction).
+- **Zero fee is invisible and identical**: a zero/unset fee produces no fee line and byte-identical
+  behavior to fee-free staking.
+- **Fee cap enforced**: the staking fee can never be set above the configured maximum for the service;
+  an attempt to exceed it is rejected.
 - **Pause never traps funds**: a pause blocks only *new* stakes/delegations; unstake, withdraw, and
-  reward-claim remain available so members can always exit (US1 scenario 2).
-- **Control surface undeployed/unreachable**: when the control surface is not deployed on a network or
-  cannot be read, the member app falls back to its honest default availability and never shows a
-  broken screen; operators see a clear "not available on this network" state instead of failing writes.
-- **Config vs. pause divergence**: pausing does not erase configuration; resuming restores the
-  previously-configured addresses/allowlist unchanged.
+  reward-claim remain available so members can always exit.
+- **Control surface undeployed/unreachable**: when the control surface (or the fee configuration) is
+  not deployed on a network or cannot be read, the member app falls back to its honest default —
+  fee-free, direct staking, availability as configured — and never shows a broken screen; operators
+  see a clear "not available on this network" state instead of failing writes.
+- **Config vs. pause divergence**: pausing does not erase configuration or the fee rate; resuming
+  restores the previously-configured state unchanged.
 - **Removing an in-use validator**: a validator removed from the allowlist while members are delegated
   to it disappears from *new*-delegation options but remains visible/exitable for existing positions.
 - **Invalid or dangerous input**: malformed addresses, empty required fields, duplicate validator
-  entries, or a validator identifier that doesn't resolve are rejected before taking effect.
-- **Stale reads**: the member app reflects a control change within a bounded refresh window; the UI
-  communicates availability as "as of" its last read rather than implying instantaneous global state.
-- **Per-network isolation**: pausing or reconfiguring one network never affects another; controls and
-  audit history are scoped per network.
-- **Concurrent operators**: two operators editing at once resolve to a consistent last-writer state
-  with both actions recorded; no silent lost update without a trace in the history.
+  entries, an unresolvable validator identifier, or an over-cap fee are rejected before taking effect.
+- **Stale reads**: the member app reflects a control/fee change within a bounded refresh window and
+  communicates availability and the fee as "as of" its last read rather than implying instantaneous
+  global state.
+- **Per-network isolation**: pausing, reconfiguring, or setting the fee on one network never affects
+  another; controls, fee, and audit history are scoped per network and never cross the
+  testnet/mainnet boundary.
 - **Emergency reachability**: the pause must be exercisable even when non-essential services are
   degraded, so it does not depend on optional infrastructure being healthy.
+- **No custody beyond the single action**: routing a stake through the control surface to charge the
+  fee is atomic — the surface never holds member funds across transactions, and a failure returns the
+  member to their starting state with nothing moved.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: The system MUST provide an authorized operator a control surface, within the app's admin
-  area, to review and manage staking configuration and availability per network, without requiring an
-  app redeploy for changes to take effect.
-- **FR-002**: Operators MUST be able to **pause** and **resume** staking per network; while paused,
+- **FR-001**: The system MUST charge a platform fee on staking (the value-in action) that is routed to
+  the FairWins treasury, taken from the staked amount with the net remainder staked with the provider,
+  executed atomically so a member signs once and is never left in a partial state.
+- **FR-002**: The staking fee rate MUST come from the single platform-fee configuration used across
+  FairWins services (the same source of truth as other service fees), MUST be capped at a configured
+  maximum for the service, and MUST be settable to zero; a zero/unset fee MUST produce no fee line and
+  behavior identical to fee-free staking.
+- **FR-003**: The member MUST see the staking fee as its own line — with its rate and the resulting
+  net amount to be staked — before any signature, and MUST be charged no more than the rate they were
+  shown (the quoted rate is a hard ceiling for that transaction).
+- **FR-004**: The platform fee MUST apply only to staking (value-in); unstake, withdraw, and reward
+  claim MUST never be fee-gated so members can always exit an existing position.
+- **FR-005**: The system MUST provide an authorized operator a control surface, within the app's admin
+  area, to review and manage staking configuration, the fee rate, and availability per network,
+  without requiring an app redeploy for changes to take effect.
+- **FR-006**: Operators MUST be able to **pause** and **resume** staking per network; while paused,
   the member-facing staking experience on that network MUST stop offering new stakes/delegations and
-  show the app's honest unavailable state, taking effect within one member refresh.
-- **FR-003**: A pause MUST NOT prevent members from unstaking, withdrawing, or claiming rewards on
-  existing positions — members can always exit; only new stakes/delegations are blocked.
-- **FR-004**: Operators MUST be able to view and update the staking provider contract addresses used
+  show the honest unavailable state within one member refresh, while unstake/withdraw/claim remain
+  available.
+- **FR-007**: Operators MUST be able to view and update the staking provider contract addresses used
   by the staking flows for a network (the liquid-staking contracts, the delegation manager, and the
   staking token), with the current value shown for each and obviously-invalid input rejected before it
   takes effect.
-- **FR-005**: Operators MUST be able to curate the delegation validator allowlist per network — add,
+- **FR-008**: Operators MUST be able to curate the delegation validator allowlist per network — add,
   remove, or replace a validator — with duplicates and malformed/unresolvable entries rejected;
   removing a validator MUST stop it being offered for new delegations while leaving existing positions
   visible and exitable.
-- **FR-006**: The member-facing staking experience MUST source its provider addresses, validator
-  allowlist, and availability from the managed control surface at runtime, and MUST fall back safely to
-  an honest default (and never a broken screen) when the control surface is undeployed or unreachable
-  on a network.
-- **FR-007**: Every staking control action (pause, resume, address change, allowlist add/remove/
-  replace) MUST be recorded in an auditable history that captures the action, the affected network, the
-  before/after value where applicable, the acting operator, and the time.
-- **FR-008**: Access MUST be least-privilege: configuration changes (addresses, allowlist) require a
-  staking-configuration authorization; the emergency pause/resume may be exercised by the emergency/
-  guardian authorization; accounts without any staking-operator authorization MUST NOT see the
-  controls or be able to perform any control action.
-- **FR-009**: All staking control state and history MUST be scoped per network; an action on one
+- **FR-009**: The member-facing staking experience MUST source its provider addresses, validator
+  allowlist, availability, and fee rate from the managed control surface at runtime, and MUST fall
+  back safely to an honest default (fee-free, direct staking, availability as configured — never a
+  broken screen) when the control surface or fee configuration is undeployed or unreachable.
+- **FR-010**: Every staking control action (fee-rate change, pause, resume, address change, allowlist
+  add/remove/replace) MUST be recorded in an auditable history that captures the action, the affected
+  network, the before/after value where applicable, the acting operator, and the time.
+- **FR-011**: Access MUST be least-privilege: configuration changes (addresses, allowlist, fee rate)
+  require a staking-configuration authorization; the emergency pause/resume may be exercised by the
+  emergency/guardian authorization; accounts without any staking-operator authorization MUST NOT see
+  the controls or be able to perform any control action.
+- **FR-012**: All staking control state, fee, and history MUST be scoped per network; an action on one
   network MUST NOT affect another, and the member app MUST NOT mix control state across the
   testnet/mainnet boundary.
-- **FR-010**: The emergency pause MUST remain exercisable when non-essential/optional services are
+- **FR-013**: The emergency pause MUST remain exercisable when non-essential/optional services are
   degraded — it MUST NOT depend on optional infrastructure being healthy to stop staking.
-- **FR-011**: The control surface MUST surface meaningful operator feedback: current values, a clear
-  reason on rejected input, confirmation of a completed change, and the change history — so an operator
-  can see the effect of their action without guesswork.
-- **FR-012**: Member-facing availability driven by the control surface MUST be presented honestly as
-  "as of" its last read, and a paused or unavailable network MUST reuse the existing honest
-  unavailable-state pattern rather than a bespoke or dishonest surface.
-- **FR-013**: Operator documentation MUST describe the staking control surface — how to pause/resume,
-  change addresses, curate validators, who is authorized, and how the audit history works — including
-  the emergency runbook for pausing in an incident.
+- **FR-014**: The control surface MUST surface meaningful operator feedback: current values, the live
+  fee rate and its cap, a clear reason on rejected input, confirmation of a completed change, and the
+  change history — so an operator can see the effect of their action without guesswork.
+- **FR-015**: Member-facing availability and fee driven by the control surface MUST be presented
+  honestly as "as of" its last read, and a paused or unavailable network MUST reuse the existing
+  honest unavailable-state pattern rather than a bespoke or dishonest surface.
+- **FR-016**: The staking service MUST remain non-custodial across transactions — routing a stake
+  through the control surface to charge the fee is atomic, the surface MUST NOT hold member funds
+  between transactions, and a failed stake MUST return the member to their starting state with nothing
+  moved.
+- **FR-017**: Operator documentation MUST describe the staking control surface — how the fee works and
+  how to set it, how to pause/resume, change addresses, curate validators, who is authorized, and how
+  the audit history works — including the emergency runbook for pausing in an incident.
 
 ### Key Entities *(include if feature involves data)*
 
-- **Staking Control Configuration**: the managed, per-network staking settings — provider contract
-  addresses, the curated validator allowlist, and the staking-enabled/paused state — that the member
-  app reads at runtime. Attributes: network, provider addresses, validator allowlist entries, paused
-  flag, last-updated time.
+- **Staking Control Configuration**: the managed, per-network staking settings the member app reads at
+  runtime — provider contract addresses, the curated validator allowlist, the staking fee rate, and
+  the staking-enabled/paused state. Attributes: network, provider addresses, validator allowlist
+  entries, fee rate, fee cap, paused flag, last-updated time.
+- **Staking Fee Charge**: the treasury-bound fee taken when a member stakes. Attributes: network,
+  staking action, gross staked amount, fee rate applied, fee amount to treasury, net amount staked,
+  member-quoted ceiling, transaction reference.
 - **Validator Allowlist Entry**: one curated delegation target under management. Attributes: network,
   validator identifier, validator contract reference, listing status (listed/removed).
 - **Staking Control Action (Audit Record)**: an accountable record of an operator action. Attributes:
-  type (pause/resume/address-change/allowlist-add/remove/replace), network, field + before/after value
-  where applicable, acting operator, timestamp.
+  type (fee-change/pause/resume/address-change/allowlist-add/remove/replace), network, field +
+  before/after value where applicable, acting operator, timestamp.
 - **Staking Operator Authorization**: the permission that gates control actions. Attributes: operator
   account, authorization kind (staking-configuration vs. emergency/guardian), network scope.
 
@@ -246,61 +312,76 @@ in the audit history.
 
 ### Measurable Outcomes
 
-- **SC-001**: An authorized responder can pause staking on a network and have the member Stake area
-  stop offering new stakes within one member refresh, with **no** app redeploy.
-- **SC-002**: While staking is paused on a network, 100% of members with existing positions can still
-  reach unstake/withdraw/claim — a pause never blocks an exit.
-- **SC-003**: 100% of staking control actions (pause, resume, address change, allowlist change) appear
-  in the audit history attributable to the acting operator with a timestamp.
-- **SC-004**: An operator can complete a provider-address change or a validator add/remove and see it
-  reflected in the member Stake area within one refresh, without a redeploy.
-- **SC-005**: 0 accounts without staking-operator authorization can view or perform any staking control
+- **SC-001**: With a configured non-zero staking fee, 100% of stakes route the fee to the treasury and
+  stake the net remainder in a single member confirmation; the measured treasury increase equals the
+  disclosed fee for every stake.
+- **SC-002**: 100% of fee-bearing stakes disclose the fee (rate + net) before signature, and 0 members
+  are ever charged more than the rate they were shown.
+- **SC-003**: With the staking fee set to zero, the staking experience is byte-for-byte identical to
+  fee-free staking (no fee line, no extra step).
+- **SC-004**: An authorized responder can pause staking on a network and have the member Stake area
+  stop offering new stakes within one member refresh, with no app redeploy; while paused, 100% of
+  members with existing positions can still unstake/withdraw/claim.
+- **SC-005**: 100% of staking control actions (fee change, pause, resume, address change, allowlist
+  change) appear in the audit history attributable to the acting operator with a timestamp.
+- **SC-006**: An operator can complete a fee change, provider-address change, or validator add/remove
+  and see it reflected in the member Stake area within one refresh, without a redeploy; the fee can
+  never be set above the configured cap.
+- **SC-007**: 0 accounts without staking-operator authorization can view or perform any staking control
   action; configuration and emergency authorizations grant exactly their intended actions and no more.
-- **SC-006**: On a network where the control surface is undeployed or unreachable, 0 members see a
-  broken staking screen — the app falls back to its honest default availability.
-- **SC-007**: Control state and audit history are correctly isolated per network in 100% of cases (no
-  cross-network or cross-testnet/mainnet leakage).
-- **SC-008**: Operator documentation exists and lets a new operator perform an emergency pause by
-  following the runbook, unaided, on their first attempt.
+- **SC-008**: On a network where the control surface or fee configuration is undeployed or unreachable,
+  0 members see a broken or fee-guessing staking screen — the app falls back to the honest default.
+- **SC-009**: Control state, fee, and audit history are correctly isolated per network in 100% of cases
+  (no cross-network or cross-testnet/mainnet leakage).
+- **SC-010**: Operator documentation exists and lets a new operator set the staking fee and perform an
+  emergency pause by following the runbook, unaided, on their first attempt.
 
 ## Assumptions
 
-- **Authoritative, on-chain control surface**: per the product decision, staking configuration and the
-  pause switch are held in an authoritative, auditable, on-chain control surface (one per network),
-  read by the member app at runtime — chosen over a client-only feature flag or an optional off-chain
-  service so that changes and pauses are cryptographically accountable and survive independent of the
-  app build. This introduces a new value-adjacent control contract and therefore follows the project's
-  security-review path in planning.
-- **Builds on spec 065**: this feature manages the staking service delivered by spec 065; it replaces
-  spec 065's build-time provider/allowlist constants as the *source of truth the member app reads*,
-  while spec 065's flows, UI, and honest-state behavior are otherwise unchanged. The member app keeps a
-  safe built-in default so staking still works if the control surface is absent (backwards-compatible).
-- **Reuses the existing admin + role model**: the controls live in the existing admin area and reuse
-  the existing operator role framework and audit/notification systems rather than inventing new ones;
-  a staking-configuration authorization is added, and the existing emergency/guardian authorization
-  gates the pause.
-- **Scope of "management"**: managing addresses, the validator allowlist, and per-network pause/resume
-  is in scope. Changing the economic terms of third-party providers, running FairWins-operated
-  validators, or holding member funds are explicitly **out of scope** — the service remains
-  non-custodial and members always transact from their own wallets.
-- **Non-custodial pause semantics**: because staking is non-custodial, "pause" means the app stops
-  *offering* staking and the control surface stops authorizing new stakes; it is not, and cannot be, a
-  guarantee that a determined user could not call a third-party protocol directly outside the app.
-- **Networks**: management applies to the networks where staking is offered (Ethereum mainnet at
-  launch, per spec 065), and extends to future staking networks by the same per-network model.
-- **Emergency independence**: the pause is designed to work without depending on optional/off-chain
-  infrastructure, so it is available during incidents that degrade non-essential services.
+- **Fee routing reuses the single platform-fee configuration**: the staking fee is expressed through
+  the same platform-fee configuration and treasury routing every other FairWins service uses (the
+  spec-060 fee mechanism), registered as a staking service with its own hard cap — not a new,
+  parallel fee store. This resolves the fee-router path that spec 065 deferred (065 research R6).
+- **Authoritative, on-chain control surface (a staking router)**: per the product decision, staking
+  configuration, the fee, and the pause switch are held in an authoritative, auditable, on-chain
+  control surface (one per network) that member staking flows route through so the fee can be charged
+  and the pause enforced. This is a value-adjacent control contract and therefore follows the
+  project's security-review path in planning (transient-only custody, atomic fee-and-forward,
+  reentrancy-safe).
+- **Builds on spec 065**: this feature manages and monetizes the staking service delivered by spec 065;
+  it becomes the source of truth the member app reads (replacing 065's build-time provider/allowlist
+  constants) and the path member stakes route through, while 065's flows, UI, and honest-state
+  behavior are otherwise preserved. The member app keeps a safe built-in default (fee-free, direct
+  staking) so staking still works if the control surface is absent — a backwards-compatible rollout.
+- **Reuses the existing admin + role + fee-admin model**: the controls live in the existing admin area
+  and reuse the existing operator role framework, the existing fee-administration model, and the audit/
+  notification systems rather than inventing new ones; a staking-configuration authorization is added
+  and the existing emergency/guardian authorization gates the pause.
+- **Scope of "management"**: managing the fee rate, provider addresses, the validator allowlist, and
+  per-network pause/resume is in scope. Changing third-party providers' own economics, running
+  FairWins-operated validators, or holding member funds across transactions are explicitly **out of
+  scope** — the service remains non-custodial and members transact from their own wallets.
+- **Non-custodial pause semantics**: because staking is non-custodial, "pause" means the app and the
+  control surface stop *offering/authorizing* new stakes; it is not, and cannot be, a guarantee that a
+  determined user could not call a third-party protocol directly outside the app.
+- **Networks**: management and fees apply to the networks where staking is offered (Ethereum mainnet
+  at launch, per spec 065), and extend to future staking networks by the same per-network model.
 
 ## Dependencies
 
-- **Spec 065 (Liquid & Delegated Staking)** — the member-facing staking feature this controls; its
-  provider config, validator allowlist, and availability gating are the surfaces this feature makes
-  operator-managed.
+- **Spec 065 (Liquid & Delegated Staking)** — the member-facing staking feature this controls and
+  monetizes; its provider config, validator allowlist, availability gating, and stake flows are the
+  surfaces this feature makes operator-managed and fee-bearing.
+- **Spec 060 (Platform Fee Wrapper / FeeRouter)** — the single source of truth for fee configuration
+  and treasury routing; staking registers as a fee service (with its own cap) and reads its rate from
+  it, and the member surfaces disclose the quoted rate and pass it as the charged ceiling.
 - The existing **admin area** and its tab/registration + role-gating model (the ProtocolConfig and
   Fees tabs are the precedent for an operator-edits-config surface).
-- The existing **operator role / access-control model** (a new staking-configuration authorization
-  plus the existing emergency/guardian authorization).
+- The existing **operator role / access-control and fee-administration model** (a new
+  staking-configuration authorization plus the existing emergency/guardian and fee-admin
+  authorizations).
 - The existing **audit / activity-history** and notification systems for recording and surfacing
   control actions.
-- The existing **upgradeable-contract and security-review** process for the new control contract.
+- The existing **upgradeable-contract and security-review** process for the new control/router
+  contract.
 - The FairWins documentation site for the operator guide and emergency runbook.

--- a/specs/066-staking-admin-controls/spec.md
+++ b/specs/066-staking-admin-controls/spec.md
@@ -1,0 +1,306 @@
+# Feature Specification: Staking Admin Controls & Emergency Pause
+
+**Feature Branch**: `066-staking-admin-controls`
+
+**Created**: 2026-07-23
+
+**Status**: Draft
+
+**Input**: User description: "We need adequate control surfaces for administrative tasks necessary to
+manage staking activities. This includes contract-address management and the lifecycle events an
+operator would need to manage a change in service, and the ability to pause staking on a network in an
+emergency."
+
+## User Scenarios & Testing *(mandatory)*
+
+Staking (spec 065) ships with its provider addresses and curated validator allowlist baked into the
+app at build time, and with no way to turn staking off short of shipping a new app build. That is fine
+for launch but leaves operators without the levers a production financial service needs: when a
+provider migrates a contract, when a validator must be swapped out, or when something goes wrong and
+staking must be stopped *now*, the only recourse today is a code change and a redeploy — too slow for
+an incident and invisible in any audit trail.
+
+This feature gives operators a proper **control surface** for staking. An authorized operator can,
+from the app's admin area, review and update the staking provider addresses for a network, curate the
+validator allowlist (add, remove, or replace a validator as part of a planned service change), and —
+critically — **pause staking on a network in an emergency** so the member experience stops offering it
+honestly, all taking effect at runtime without an app redeploy and all recorded as an auditable
+history of who changed what and when. Members are never left confused: a paused or misconfigured
+network shows the same honest "not available right now" state the app already uses, never a broken or
+dishonest surface.
+
+### User Story 1 - Emergency pause and resume of staking (Priority: P1)
+
+An authorized emergency responder needs to stop staking on a network immediately — a provider exploit
+is suspected, a validator is misbehaving, or a contract address is in doubt. From the admin area they
+open the Staking controls, select the network, and pause staking. Within moments the member-facing
+Stake area on that network stops offering new stakes and shows the honest unavailable state; existing
+positions and the ability to unstake/withdraw are unaffected (members must always be able to get their
+funds back). When the incident is resolved, the responder resumes staking and the area returns to
+normal. Both actions are recorded with the actor and time.
+
+**Why this priority**: This is the core safety lever and the most time-critical capability — the whole
+point of a control surface is to act faster than a redeploy in an incident. It is independently
+valuable even before richer config management exists.
+
+**Independent Test**: With an authorized responder account, pause staking on a supported network and
+confirm the member Stake area on that network stops offering new stakes and shows the unavailable
+state while unstake/withdraw still work; resume and confirm staking is offered again; verify both
+actions appear in the audit history.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authorized responder, **When** they pause staking on a network, **Then** the
+   member-facing Stake area for that network stops offering new stakes and shows the honest
+   unavailable state within one refresh, without an app redeploy.
+2. **Given** staking is paused on a network, **When** a member with an existing position opens
+   staking, **Then** they can still unstake and withdraw (funds are never trapped by a pause).
+3. **Given** staking is paused, **When** the responder resumes it, **Then** new stakes are offered
+   again on that network.
+4. **Given** a pause or resume is performed, **When** anyone reviews the staking audit history,
+   **Then** the action, the acting operator, the affected network, and the time are recorded.
+5. **Given** the control surface is unreachable or not yet deployed on a network, **When** a member
+   opens staking there, **Then** the app falls back safely to its honest default (staking availability
+   as configured) and never shows a broken screen.
+
+---
+
+### User Story 2 - Manage staking provider addresses per network (Priority: P2)
+
+A provider migrates a contract, or a new network is being brought online, and an operator must update
+the addresses the staking flows use. From the Staking controls the operator sees the current provider
+addresses for the selected network (the liquid-staking contracts, the delegation manager, the staking
+token), each shown next to its current value, updates the ones that changed, and confirms. The
+member-facing staking flows begin using the new addresses at runtime. Every address change is recorded
+with the actor, the old and new value, and the time.
+
+**Why this priority**: Address management is the routine operational need behind "a change in
+service." It is less time-critical than the emergency pause but is what makes the service maintainable
+without redeploys. It builds on the same control surface as US1.
+
+**Independent Test**: As an authorized operator, change a staking provider address for a network,
+confirm the member staking flow resolves the new address, and verify the change (old → new, actor,
+time) is in the audit history.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authorized operator, **When** they view the Staking controls for a network, **Then**
+   each managed provider address is shown with its current value.
+2. **Given** the operator updates a provider address and confirms, **When** a member next uses
+   staking on that network, **Then** the flow uses the updated address.
+3. **Given** an operator submits an obviously invalid address (malformed, or empty where one is
+   required), **When** they confirm, **Then** the change is rejected with a clear reason before it
+   takes effect.
+4. **Given** an address change is made, **When** the audit history is reviewed, **Then** the change
+   records the field, old value, new value, actor, and time.
+
+---
+
+### User Story 3 - Curate the validator allowlist as a service-lifecycle activity (Priority: P2)
+
+The curated delegation validator set must change over time — a validator raises its commission beyond
+policy, is jailed, or is replaced by a better-performing operator. An authorized operator opens the
+validator allowlist for the network, sees the current curated validators, and adds, removes, or
+replaces an entry. Removing a validator stops it being offered for **new** delegations immediately;
+members already delegated to it can still see the position and unstake/withdraw. The change is
+recorded in the audit history.
+
+**Why this priority**: Validator curation is the other half of "managing a change in service." It is
+delegated-staking-specific and builds on the same controls; it is independently testable once the
+control surface exists.
+
+**Independent Test**: As an authorized operator, remove a validator from the allowlist and confirm it
+is no longer offered for new delegations in the member Stake area, while a member already delegated to
+it can still unstake; add a validator and confirm it appears; verify both changes are in the audit
+history.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authorized operator, **When** they open the validator allowlist, **Then** the current
+   curated validators for the network are listed.
+2. **Given** the operator removes a validator, **When** a member opens the Stake area, **Then** that
+   validator is no longer offered for new delegations, but a member already delegated to it can still
+   unstake and withdraw.
+3. **Given** the operator adds a validator, **When** a member opens the Stake area, **Then** the new
+   validator is offered (subject to the same curation/decoration rules as the rest).
+4. **Given** the operator attempts to add a duplicate or malformed validator entry, **When** they
+   confirm, **Then** the change is rejected with a clear reason.
+5. **Given** any allowlist change, **When** the audit history is reviewed, **Then** it records the
+   validator, the action (add/remove/replace), the actor, and the time.
+
+---
+
+### User Story 4 - Least-privilege operator access and audit (Priority: P3)
+
+Not everyone may touch staking controls. Configuration changes (addresses, allowlist) require a
+staking-configuration operator; the emergency pause/resume may be exercised by the broader emergency
+role so an incident responder can act even without configuration rights. Unauthorized accounts do not
+see the controls at all, and no privileged action can be taken without the appropriate authorization.
+The full history of staking control actions is reviewable so changes are accountable.
+
+**Why this priority**: Access separation and auditability are essential for a financial control
+surface but layer onto the functional stories above; they are testable once the controls and roles
+exist.
+
+**Independent Test**: Confirm an account without any staking-operator authorization sees no staking
+controls and cannot perform any control action; confirm the configuration role can change
+addresses/allowlist; confirm the emergency role can pause/resume; confirm every action is attributable
+in the audit history.
+
+**Acceptance Scenarios**:
+
+1. **Given** an account with no staking-operator authorization, **When** they open the admin area,
+   **Then** the Staking controls are not shown and no staking control action is possible.
+2. **Given** an account with only the emergency authorization, **When** they open the Staking
+   controls, **Then** they can pause/resume but cannot change addresses or the allowlist.
+3. **Given** an account with the staking-configuration authorization, **When** they open the Staking
+   controls, **Then** they can change addresses and the allowlist.
+4. **Given** any staking control action by any operator, **When** the audit history is reviewed,
+   **Then** the action is attributable to the acting operator with a timestamp.
+
+---
+
+### Edge Cases
+
+- **Pause never traps funds**: a pause blocks only *new* stakes/delegations; unstake, withdraw, and
+  reward-claim remain available so members can always exit (US1 scenario 2).
+- **Control surface undeployed/unreachable**: when the control surface is not deployed on a network or
+  cannot be read, the member app falls back to its honest default availability and never shows a
+  broken screen; operators see a clear "not available on this network" state instead of failing writes.
+- **Config vs. pause divergence**: pausing does not erase configuration; resuming restores the
+  previously-configured addresses/allowlist unchanged.
+- **Removing an in-use validator**: a validator removed from the allowlist while members are delegated
+  to it disappears from *new*-delegation options but remains visible/exitable for existing positions.
+- **Invalid or dangerous input**: malformed addresses, empty required fields, duplicate validator
+  entries, or a validator identifier that doesn't resolve are rejected before taking effect.
+- **Stale reads**: the member app reflects a control change within a bounded refresh window; the UI
+  communicates availability as "as of" its last read rather than implying instantaneous global state.
+- **Per-network isolation**: pausing or reconfiguring one network never affects another; controls and
+  audit history are scoped per network.
+- **Concurrent operators**: two operators editing at once resolve to a consistent last-writer state
+  with both actions recorded; no silent lost update without a trace in the history.
+- **Emergency reachability**: the pause must be exercisable even when non-essential services are
+  degraded, so it does not depend on optional infrastructure being healthy.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide an authorized operator a control surface, within the app's admin
+  area, to review and manage staking configuration and availability per network, without requiring an
+  app redeploy for changes to take effect.
+- **FR-002**: Operators MUST be able to **pause** and **resume** staking per network; while paused,
+  the member-facing staking experience on that network MUST stop offering new stakes/delegations and
+  show the app's honest unavailable state, taking effect within one member refresh.
+- **FR-003**: A pause MUST NOT prevent members from unstaking, withdrawing, or claiming rewards on
+  existing positions — members can always exit; only new stakes/delegations are blocked.
+- **FR-004**: Operators MUST be able to view and update the staking provider contract addresses used
+  by the staking flows for a network (the liquid-staking contracts, the delegation manager, and the
+  staking token), with the current value shown for each and obviously-invalid input rejected before it
+  takes effect.
+- **FR-005**: Operators MUST be able to curate the delegation validator allowlist per network — add,
+  remove, or replace a validator — with duplicates and malformed/unresolvable entries rejected;
+  removing a validator MUST stop it being offered for new delegations while leaving existing positions
+  visible and exitable.
+- **FR-006**: The member-facing staking experience MUST source its provider addresses, validator
+  allowlist, and availability from the managed control surface at runtime, and MUST fall back safely to
+  an honest default (and never a broken screen) when the control surface is undeployed or unreachable
+  on a network.
+- **FR-007**: Every staking control action (pause, resume, address change, allowlist add/remove/
+  replace) MUST be recorded in an auditable history that captures the action, the affected network, the
+  before/after value where applicable, the acting operator, and the time.
+- **FR-008**: Access MUST be least-privilege: configuration changes (addresses, allowlist) require a
+  staking-configuration authorization; the emergency pause/resume may be exercised by the emergency/
+  guardian authorization; accounts without any staking-operator authorization MUST NOT see the
+  controls or be able to perform any control action.
+- **FR-009**: All staking control state and history MUST be scoped per network; an action on one
+  network MUST NOT affect another, and the member app MUST NOT mix control state across the
+  testnet/mainnet boundary.
+- **FR-010**: The emergency pause MUST remain exercisable when non-essential/optional services are
+  degraded — it MUST NOT depend on optional infrastructure being healthy to stop staking.
+- **FR-011**: The control surface MUST surface meaningful operator feedback: current values, a clear
+  reason on rejected input, confirmation of a completed change, and the change history — so an operator
+  can see the effect of their action without guesswork.
+- **FR-012**: Member-facing availability driven by the control surface MUST be presented honestly as
+  "as of" its last read, and a paused or unavailable network MUST reuse the existing honest
+  unavailable-state pattern rather than a bespoke or dishonest surface.
+- **FR-013**: Operator documentation MUST describe the staking control surface — how to pause/resume,
+  change addresses, curate validators, who is authorized, and how the audit history works — including
+  the emergency runbook for pausing in an incident.
+
+### Key Entities *(include if feature involves data)*
+
+- **Staking Control Configuration**: the managed, per-network staking settings — provider contract
+  addresses, the curated validator allowlist, and the staking-enabled/paused state — that the member
+  app reads at runtime. Attributes: network, provider addresses, validator allowlist entries, paused
+  flag, last-updated time.
+- **Validator Allowlist Entry**: one curated delegation target under management. Attributes: network,
+  validator identifier, validator contract reference, listing status (listed/removed).
+- **Staking Control Action (Audit Record)**: an accountable record of an operator action. Attributes:
+  type (pause/resume/address-change/allowlist-add/remove/replace), network, field + before/after value
+  where applicable, acting operator, timestamp.
+- **Staking Operator Authorization**: the permission that gates control actions. Attributes: operator
+  account, authorization kind (staking-configuration vs. emergency/guardian), network scope.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An authorized responder can pause staking on a network and have the member Stake area
+  stop offering new stakes within one member refresh, with **no** app redeploy.
+- **SC-002**: While staking is paused on a network, 100% of members with existing positions can still
+  reach unstake/withdraw/claim — a pause never blocks an exit.
+- **SC-003**: 100% of staking control actions (pause, resume, address change, allowlist change) appear
+  in the audit history attributable to the acting operator with a timestamp.
+- **SC-004**: An operator can complete a provider-address change or a validator add/remove and see it
+  reflected in the member Stake area within one refresh, without a redeploy.
+- **SC-005**: 0 accounts without staking-operator authorization can view or perform any staking control
+  action; configuration and emergency authorizations grant exactly their intended actions and no more.
+- **SC-006**: On a network where the control surface is undeployed or unreachable, 0 members see a
+  broken staking screen — the app falls back to its honest default availability.
+- **SC-007**: Control state and audit history are correctly isolated per network in 100% of cases (no
+  cross-network or cross-testnet/mainnet leakage).
+- **SC-008**: Operator documentation exists and lets a new operator perform an emergency pause by
+  following the runbook, unaided, on their first attempt.
+
+## Assumptions
+
+- **Authoritative, on-chain control surface**: per the product decision, staking configuration and the
+  pause switch are held in an authoritative, auditable, on-chain control surface (one per network),
+  read by the member app at runtime — chosen over a client-only feature flag or an optional off-chain
+  service so that changes and pauses are cryptographically accountable and survive independent of the
+  app build. This introduces a new value-adjacent control contract and therefore follows the project's
+  security-review path in planning.
+- **Builds on spec 065**: this feature manages the staking service delivered by spec 065; it replaces
+  spec 065's build-time provider/allowlist constants as the *source of truth the member app reads*,
+  while spec 065's flows, UI, and honest-state behavior are otherwise unchanged. The member app keeps a
+  safe built-in default so staking still works if the control surface is absent (backwards-compatible).
+- **Reuses the existing admin + role model**: the controls live in the existing admin area and reuse
+  the existing operator role framework and audit/notification systems rather than inventing new ones;
+  a staking-configuration authorization is added, and the existing emergency/guardian authorization
+  gates the pause.
+- **Scope of "management"**: managing addresses, the validator allowlist, and per-network pause/resume
+  is in scope. Changing the economic terms of third-party providers, running FairWins-operated
+  validators, or holding member funds are explicitly **out of scope** — the service remains
+  non-custodial and members always transact from their own wallets.
+- **Non-custodial pause semantics**: because staking is non-custodial, "pause" means the app stops
+  *offering* staking and the control surface stops authorizing new stakes; it is not, and cannot be, a
+  guarantee that a determined user could not call a third-party protocol directly outside the app.
+- **Networks**: management applies to the networks where staking is offered (Ethereum mainnet at
+  launch, per spec 065), and extends to future staking networks by the same per-network model.
+- **Emergency independence**: the pause is designed to work without depending on optional/off-chain
+  infrastructure, so it is available during incidents that degrade non-essential services.
+
+## Dependencies
+
+- **Spec 065 (Liquid & Delegated Staking)** — the member-facing staking feature this controls; its
+  provider config, validator allowlist, and availability gating are the surfaces this feature makes
+  operator-managed.
+- The existing **admin area** and its tab/registration + role-gating model (the ProtocolConfig and
+  Fees tabs are the precedent for an operator-edits-config surface).
+- The existing **operator role / access-control model** (a new staking-configuration authorization
+  plus the existing emergency/guardian authorization).
+- The existing **audit / activity-history** and notification systems for recording and surfacing
+  control actions.
+- The existing **upgradeable-contract and security-review** process for the new control contract.
+- The FairWins documentation site for the operator guide and emergency runbook.

--- a/specs/066-staking-admin-controls/spec.md
+++ b/specs/066-staking-admin-controls/spec.md
@@ -182,18 +182,22 @@ and confirm it appears; verify both changes are in the audit history.
 
 ### User Story 5 - Least-privilege operator access and audit (Priority: P3)
 
-Not everyone may touch staking controls. Configuration changes (addresses, allowlist) and the fee rate
-require a staking-configuration operator; the emergency pause/resume may be exercised by the broader
-emergency role so an incident responder can act even without configuration rights. Unauthorized
-accounts do not see the controls at all, and no privileged action can be taken without the appropriate
-authorization. The full history of staking control actions is reviewable so changes are accountable.
+Not everyone may touch staking controls. Configuration changes (addresses, allowlist) require a
+staking-configuration operator; the emergency pause/resume may be exercised by the broader emergency role
+so an incident responder can act even without configuration rights. The **fee rate is governed by the
+existing fee-administration authorization on the single platform-fee configuration** (the same role that
+sets every other FairWins service fee), not the staking-configuration role — the Staking controls surface
+it read-only with a pointer to the Fees controls. Unauthorized accounts do not see the controls at all,
+and no privileged action can be taken without the appropriate authorization. The full history of staking
+control actions is reviewable so changes are accountable.
 
 **Why this priority**: Access separation and auditability are essential for a financial control surface
 but layer onto the functional stories above.
 
 **Independent Test**: Confirm an account without any staking-operator authorization sees no staking
 controls and cannot perform any control action; confirm the configuration role can change
-addresses/allowlist/fee; confirm the emergency role can pause/resume; confirm every action is
+addresses/allowlist (but sees the fee rate read-only); confirm the fee-administration role sets the fee
+rate in the Fees controls; confirm the emergency role can pause/resume; confirm every action is
 attributable in the audit history.
 
 **Acceptance Scenarios**:
@@ -203,9 +207,12 @@ attributable in the audit history.
 2. **Given** an account with only the emergency authorization, **When** they open the Staking controls,
    **Then** they can pause/resume but cannot change addresses, the allowlist, or the fee.
 3. **Given** an account with the staking-configuration authorization, **When** they open the Staking
-   controls, **Then** they can change addresses, the allowlist, and the fee rate (bounded by the
-   configured cap).
-4. **Given** any staking control action by any operator, **When** the audit history is reviewed,
+   controls, **Then** they can change addresses and the allowlist; the fee rate is shown read-only (it is
+   set in the Fees controls by the fee-administration role, bounded by the configured cap).
+4. **Given** an account with the fee-administration authorization, **When** they open the Fees controls,
+   **Then** they can set each staking service's fee rate (bounded by its configured 250 bps cap), and the
+   Staking controls reflect the new rate read-only.
+5. **Given** any staking control action by any operator, **When** the audit history is reviewed,
    **Then** the action is attributable to the acting operator with a timestamp.
 
 ---
@@ -277,9 +284,10 @@ attributable in the audit history.
   staking token), with the current value shown for each and obviously-invalid input rejected before it
   takes effect.
 - **FR-008**: Operators MUST be able to curate the delegation validator allowlist per network — add,
-  remove, or replace a validator — with duplicates and malformed/unresolvable entries rejected;
-  removing a validator MUST stop it being offered for new delegations while leaving existing positions
-  visible and exitable.
+  remove, or replace a validator (**replace is realized as a remove followed by an add — two audit
+  records; there is no distinct on-chain replace operation**) — with duplicates and
+  malformed/unresolvable entries rejected; removing a validator MUST stop it being offered for new
+  delegations while leaving existing positions visible and exitable.
 - **FR-009**: The member-facing staking experience MUST source its provider addresses, validator
   allowlist, availability, and fee rate from the managed control surface at runtime, and MUST fall
   back safely to an honest default (fee-free, direct staking, availability as configured — never a
@@ -287,8 +295,10 @@ attributable in the audit history.
 - **FR-010**: Every staking control action (fee-rate change, pause, resume, address change, allowlist
   add/remove/replace) MUST be recorded in an auditable history that captures the action, the affected
   network, the before/after value where applicable, the acting operator, and the time.
-- **FR-011**: Access MUST be least-privilege: configuration changes (addresses, allowlist, fee rate)
-  require a staking-configuration authorization; the emergency pause/resume may be exercised by the
+- **FR-011**: Access MUST be least-privilege: configuration changes (addresses, allowlist) require a
+  staking-configuration authorization; the **fee rate is set by the existing fee-administration
+  authorization on the single platform-fee configuration** (not the staking-configuration role — the
+  Staking controls surface it read-only); the emergency pause/resume may be exercised by the
   emergency/guardian authorization; accounts without any staking-operator authorization MUST NOT see
   the controls or be able to perform any control action.
 - **FR-012**: All staking control state, fee, and history MUST be scoped per network; an action on one

--- a/specs/066-staking-admin-controls/tasks.md
+++ b/specs/066-staking-admin-controls/tasks.md
@@ -75,14 +75,14 @@ the smart-contract security review.**
       and leave no residual; treasury balance grows by exactly the disclosed fee
 - [X] T013 [P] Storage-layout test + run: `npm run check:storage-layout` passes for `StakingRouter`
       (append-only + `__gap`); document the layout baseline
-- [ ] T014 Run Slither + Medusa on `contracts/staking/` — resolve or document (with rationale) any
+- [X] T014 Run Slither + Medusa on `contracts/staking/` — resolve or document (with rationale) any
       high/critical findings; ensure the CI security jobs cover the new contract
-- [ ] T015 Smart-contract security-agent review of `StakingRouter.sol`
+- [X] T015 Smart-contract security-agent review of `StakingRouter.sol`
       (`.github/agents/smart-contract-security.agent.md`) — address findings; **gate for all downstream merges**
-- [ ] T016 Author `scripts/deploy/deploy-staking-router.js` — `deployProxy(StakingRouter, [admin, feeRouter,
+- [X] T016 Author `scripts/deploy/deploy-staking-router.js` — `deployProxy(StakingRouter, [admin, feeRouter,
       providers…])`, record `stakingRouter`/`stakingRouterImpl` (append, never overwrite), then register
       `stake.lido` + `stake.polygon` on the existing FeeRouter (idempotent); admin/guardian = the multisig
-- [ ] T017 Implement `frontend/src/lib/staking/stakingRouter.js` — read the router's provider addresses,
+- [X] T017 Implement `frontend/src/lib/staking/stakingRouter.js` — read the router's provider addresses,
       validator allowlist, and `paused()` over a read provider; build the liquid router stake calls
       (`stakeLido` native `value`; `stakeSpol` approve-router + call); safe-degrade to null when the router
       is undeployed/unreadable, per contracts/admin-and-runtime.md

--- a/specs/066-staking-admin-controls/tasks.md
+++ b/specs/066-staking-admin-controls/tasks.md
@@ -1,0 +1,241 @@
+# Tasks: Staking Fee Router, Admin Controls & Emergency Pause
+
+**Input**: Design documents from `/specs/066-staking-admin-controls/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: included — constitution I/II make Hardhat unit + fork tests + Slither/Medusa mandatory for a
+value-bearing contract, and Vitest for the frontend. **Security-gated**: the new `StakingRouter` is
+value-bearing (transient custody to skim the fee), so Phase 2 is a blocking foundation that MUST pass the
+smart-contract security review before any story merges.
+
+**Organization**: grouped by user story (US1 treasury fee · US2 emergency pause · US3 provider addresses ·
+US4 validator allowlist · US5 least-privilege + audit). Launch network: Ethereum mainnet. **Liquid staking
+only is fee-bearing** (per-provider `stake.lido`/`stake.polygon`, cap 250 bps); **delegated is fee-free in
+v1**. The fee **rate** stays in the spec-060 FeeRouter (edited via the existing Fees tab); the StakingRouter
+reads it. Member app reads the router at runtime with a safe fallback to the merged spec-065 defaults.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel (different files, no dependencies)
+- **[Story]**: US1–US5 (setup, foundational, polish carry no story label)
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: fee-service + contract-address + ABI plumbing all stories depend on. No contract logic yet.
+
+- [ ] T001 [P] Add the per-provider staking fee services to `scripts/deploy/lib/feeServices.js`
+      `LAUNCH_FEE_SERVICES`: `{ label: 'stake.lido', capBps: 250, kind: ConfigOnly }` and
+      `{ label: 'stake.polygon', capBps: 250, kind: ConfigOnly }` (rate 0 until set) per contracts/fee-integration.md
+- [ ] T002 [P] Add `FEE_SERVICES.STAKE_LIDO` / `STAKE_POLYGON` (keccak of `stake.lido`/`stake.polygon`) to
+      `frontend/src/lib/fees/feeQuote.js`
+- [ ] T003 [P] Add the staking service ids + a `stakingRouterServiceIdFor(providerKind)` helper to
+      `frontend/src/config/staking.js` (keep the existing constants as the fee-free fallback default)
+- [ ] T004 [P] Add a `stakingRouter` contract key to the per-chain maps in `frontend/src/config/contracts.js`
+      (+ `VITE_STAKING_ROUTER_ADDRESS` env override), resolving `undefined` until deployed
+- [ ] T005 [P] Add `{ name: 'StakingRouter', deploymentsKey: 'stakingRouter' }` to the `UPGRADEABLE_CONTRACTS`
+      list in `scripts/deploy/check-storage-layout.js`, and add `stakingRouter` to the copied-keys mapping in
+      `scripts/utils/sync-frontend-contracts.js`
+- [ ] T006 [P] Add `frontend/src/abis/StakingRouter.js` — minimal ABI (config setters, getters,
+      validator enumeration, pause/unpause, `stakeLido`/`stakeSpol`, and the setter/pause/`LiquidStaked` events)
+      per contracts/staking-router.md
+- [ ] T007 Unit tests `frontend/src/test/staking-admin/feeServices.test.js` (service-id keccak values,
+      `stakingRouterServiceIdFor` mapping, `contracts.js` returns undefined pre-deploy) and a deploy-lib test
+      asserting `feeServices.js` carries both staking services at cap 250
+
+**Checkpoint**: fee-service + address + ABI plumbing exists; no contract or UI yet.
+
+---
+
+## Phase 2: Foundational — the StakingRouter contract (SECURITY-GATED, Blocking Prerequisites)
+
+**Purpose**: the value-bearing contract + its full test/security gate + deploy wiring + the frontend read
+layer + admin-tab shell that EVERY user story rides on. **⚠️ No user story may merge until this phase passes
+the smart-contract security review.**
+
+- [ ] T008 Author `contracts/staking/IStakingRouter.sol` — structs, events (`FeeRouterUpdated`,
+      `LidoContractsUpdated`, `SpolContractsUpdated`, `PolygonContractsUpdated`, `ValidatorAdded`,
+      `ValidatorRemoved`, `LiquidStaked`), and errors (`ZeroAmount`, `ZeroAddress`, `FeeAboveQuoted`,
+      `ResidualFunds`, `ProviderCallFailed`, `AlreadyListed`, `NotListed`) per contracts/staking-router.md
+- [ ] T009 Implement `contracts/staking/StakingRouter.sol` — `UUPSManaged + ReentrancyGuardUpgradeable +
+      PausableUpgradeable`; `STAKING_ADMIN_ROLE` + `GUARDIAN_ROLE`; `initialize(admin, feeRouter, providers…)`
+      storing per-provider service ids (`stake.lido`/`stake.polygon`); config setters + `EnumerableSet`
+      validator allowlist (each `onlyRole(STAKING_ADMIN_ROLE)` + event); `pause()/unpause()` (`GUARDIAN_ROLE`);
+      append-only storage + `__gap` per contracts/staking-router.md
+- [ ] T010 Implement the liquid fee-and-forward entrypoints in `StakingRouter.sol` — `stakeLido(maxFeeBps)`
+      (ETH→wstETH) and `stakeSpol(amount, maxFeeBps)` (POL→sPOL), each `nonReentrant whenNotPaused`, reading
+      `quoteFee`/`feeBps`/`treasury()` from the FeeRouter, CEI ordering, exact-amount `forceApprove`→0, the
+      `FeeAboveQuoted` consent guard, and the `ResidualFunds` no-leftover assertion (FR-016)
+- [ ] T011 Hardhat unit tests `test/staking/StakingRouter.test.js` — every setter + role gate + pause/unpause;
+      fee split to treasury + net forward; `FeeAboveQuoted` on rate-above-quote; zero-fee = passthrough;
+      treasury-unset skip; `whenNotPaused` blocks stake while exits are untouched; `EnumerableSet` add/remove
+      (dup/absent revert); `ResidualFunds`/reentrancy guard; unauthorized-caller reverts
+- [ ] T012 [P] Fork tests `test/fork/StakingRouterFork.test.js` — against real Lido + sPOL on a mainnet fork:
+      `stakeLido`/`stakeSpol` skim the fee to the treasury, forward the net, return wstETH/sPOL to the member,
+      and leave no residual; treasury balance grows by exactly the disclosed fee
+- [ ] T013 [P] Storage-layout test + run: `npm run check:storage-layout` passes for `StakingRouter`
+      (append-only + `__gap`); document the layout baseline
+- [ ] T014 Run Slither + Medusa on `contracts/staking/` — resolve or document (with rationale) any
+      high/critical findings; ensure the CI security jobs cover the new contract
+- [ ] T015 Smart-contract security-agent review of `StakingRouter.sol`
+      (`.github/agents/smart-contract-security.agent.md`) — address findings; **gate for all downstream merges**
+- [ ] T016 Author `scripts/deploy/deploy-staking-router.js` — `deployProxy(StakingRouter, [admin, feeRouter,
+      providers…])`, record `stakingRouter`/`stakingRouterImpl` (append, never overwrite), then register
+      `stake.lido` + `stake.polygon` on the existing FeeRouter (idempotent); admin/guardian = the multisig
+- [ ] T017 Implement `frontend/src/lib/staking/stakingRouter.js` — read the router's provider addresses,
+      validator allowlist, and `paused()` over a read provider; build the liquid router stake calls
+      (`stakeLido` native `value`; `stakeSpol` approve-router + call); safe-degrade to null when the router
+      is undeployed/unreadable, per contracts/admin-and-runtime.md
+- [ ] T018 Define the `STAKING_ADMIN` role + wire the admin tab shell: add `ROLES.STAKING_ADMIN` + `ROLE_INFO`
+      + `ADMIN_ROLES` in `frontend/src/contexts/RoleContext.js`; `STAKING_ADMIN` `ROLE_HASHES` +
+      `roleHomeContract → stakingRouter` + `isStakingAdmin` flag + nav item (`adminNav.js`) + gated render of a
+      new `frontend/src/components/admin/StakingTab.jsx` shell (empty, resolves the contract, honest "not
+      deployed" state) in `frontend/src/components/AdminPanel.jsx`
+- [ ] T019 [P] Unit tests `frontend/src/test/staking-admin/stakingRouterLib.test.js` (read overlay + safe
+      fallback; liquid stake-call encoding) and `frontend/src/test/staking-admin/StakingTab.shell.test.jsx`
+      (role-gated visibility; "not deployed" empty state; axe clean)
+
+**Checkpoint**: audited contract deployed-ready, frontend read layer + role + tab shell exist; stories can begin.
+
+---
+
+## Phase 3: User Story 1 — Grow the treasury with a platform fee on liquid staking (P1) 🎯 MVP
+
+**Goal**: liquid stakes route through the router, disclose the fee, and grow the treasury; zero fee = today.
+
+**Independent test**: quickstart.md Scenario 1 (and Scenario 5 fallback).
+
+- [ ] T020 [US1] Branch `frontend/src/lib/staking/stakingActions.js#buildStakeForOption` (mirroring
+      `lib/earn/vaultActions.buildDepositCalls`): when a router + non-zero fee apply, build the liquid router
+      path (`stakeLido`/`stakeSpol` with `maxFeeBps`); else the byte-identical spec-065 direct calls. Delegated
+      always uses the direct path (fee-free)
+- [ ] T021 [US1] Thread the fee quote into `frontend/src/hooks/useStakingActions.js` (`stake` ctx) and overlay
+      the per-provider `stakingFeeBps` in `frontend/src/hooks/useStakingOptions.js` from
+      `fetchFeeQuote(STAKE_LIDO/STAKE_POLYGON)` (liquid options only; delegated shows no fee)
+- [ ] T022 [US1] Add the fee line to `frontend/src/components/earn/StakeSheet.jsx` — mirror `VaultSheet`:
+      `fetchFeeQuote` state, `feeApplies`/`feeBlocked`/`feeSplit`, a "FairWins platform fee ({bpsToPercent}) /
+      You stake {net}" disclosure before signing, pass `bps` as `maxFeeBps`, and block submit on `feeBlocked`
+      (router present but rate unreadable). Zero/unavailable ⇒ no fee line (byte-identical to fee-free)
+- [ ] T023 [P] [US1] Component tests `frontend/src/test/staking-admin/StakeSheet.fee.test.jsx` (fee line shows
+      rate + net; delegated shows none; `feeBlocked` disables submit; zero-fee = no line) and
+      `stakingActions.fee.test.js` (router branch vs direct; maxFeeBps passed; delegated stays direct)
+
+**Checkpoint**: MVP — a member's liquid stake discloses and pays the fee to the treasury; delegated is fee-free.
+
+---
+
+## Phase 4: User Story 2 — Emergency pause and resume (P1)
+
+**Goal**: an authorized responder pauses staking per network at runtime; new stakes stop, exits keep working.
+
+**Independent test**: quickstart.md Scenario 2.
+
+- [ ] T024 [US2] Add pause/resume controls to `frontend/src/components/admin/StakingTab.jsx` — GUARDIAN-gated
+      `pause()`/`unpause()` via the shared `runTx`, showing the live `paused()` state (mirrors the Emergency
+      tab handlers)
+- [ ] T025 [US2] Honor the router `paused` flag in the member app: overlay it in
+      `frontend/src/hooks/useStakingOptions.js` and hide **new**-stake in `StakeView`/`StakeSheet` behind the
+      existing honest unavailable state (exits/unstake/withdraw stay available)
+- [ ] T026 [P] [US2] Tests `frontend/src/test/staking-admin/StakingTab.pause.test.jsx` (guardian-only
+      pause/resume; non-guardian cannot) and `frontend/src/test/staking-admin/pausedMember.test.jsx` (paused ⇒
+      new-stake hidden with the unavailable state; exits still offered)
+
+**Checkpoint**: staking can be stopped/resumed per network without a redeploy; funds never trapped.
+
+---
+
+## Phase 5: User Story 3 — Manage staking provider addresses per network (P2)
+
+**Goal**: an operator updates provider addresses at runtime; the member flow uses them.
+
+**Independent test**: quickstart.md Scenario 3 (addresses).
+
+- [ ] T027 [US3] Add provider-address controls to `frontend/src/components/admin/StakingTab.jsx` —
+      STAKING_ADMIN-gated `setLidoContracts`/`setSpolContracts`/`setPolygonContracts`/`setFeeRouter` with
+      current-value display and `ethers.isAddress` + non-zero validation before send (mirror ProtocolConfigTab)
+- [ ] T028 [US3] Ensure `frontend/src/hooks/useStakingOptions.js` overlays the router's provider addresses
+      onto the options when the router is deployed (member flow resolves the updated addresses), with the
+      spec-065 constants as the fallback
+- [ ] T029 [P] [US3] Tests `frontend/src/test/staking-admin/StakingTab.addresses.test.jsx` (current value
+      shown; invalid/zero rejected pre-send; setter dispatched) and an overlay test (member reads router
+      address over the constant)
+
+**Checkpoint**: provider addresses are operator-managed at runtime.
+
+---
+
+## Phase 6: User Story 4 — Curate the validator allowlist (P2)
+
+**Goal**: an operator adds/removes curated validators; new delegations reflect it; existing positions exit.
+
+**Independent test**: quickstart.md Scenario 3 (validator lifecycle).
+
+- [ ] T030 [US4] Add validator allowlist controls to `frontend/src/components/admin/StakingTab.jsx` —
+      STAKING_ADMIN-gated `addValidator`/`removeValidator` with the current list (`validatorCount`/`validatorAt`)
+      and address validation (contract rejects dup/absent)
+- [ ] T031 [US4] Overlay the router's validator allowlist in `frontend/src/hooks/useStakingOptions.js` so a
+      removed validator drops from **new**-delegation options while an existing delegated position stays
+      visible/exitable (via `useStakingPositions`), falling back to `CURATED_POLYGON_VALIDATORS`
+- [ ] T032 [P] [US4] Tests `frontend/src/test/staking-admin/StakingTab.validators.test.jsx` (add/remove;
+      dup/absent rejected) and `frontend/src/test/staking-admin/allowlistOverlay.test.jsx` (removed validator
+      not offered for new delegation; existing position still exitable)
+
+**Checkpoint**: the delegation validator set is operator-curated as a lifecycle activity.
+
+---
+
+## Phase 7: User Story 5 — Least-privilege operator access & audit (P3)
+
+**Goal**: exactly-scoped operator access and a reviewable on-chain history of every control action.
+
+**Independent test**: quickstart.md Scenario 4.
+
+- [ ] T033 [US5] Add the STAKING_ADMIN grantable-role `<option>` to the admin-roles select in
+      `frontend/src/components/AdminPanel.jsx` (grant/revoke via the `stakingRouter` home contract) and confirm
+      the least-privilege split: config = STAKING_ADMIN, pause = GUARDIAN, fee rate = FEE_ADMIN (Fees tab)
+- [ ] T034 [US5] Render the on-chain audit history in `frontend/src/components/admin/StakingTab.jsx` —
+      `queryFilter` the router's setter/pause events (+ FeeRouter `FeeBpsChanged` for the rate), newest-first
+      table with a Blockscout fallback link (mirror FeesTab history), showing actor + before/after + time
+- [ ] T035 [P] [US5] Tests `frontend/src/test/staking-admin/StakingTab.roles.test.jsx` (no-role sees nothing;
+      guardian-only = pause only; staking-admin = config only; fee rate read-only) and
+      `StakingTab.history.test.jsx` (events → rows; range-limited RPC degrades gracefully) + axe on the full tab
+
+**Checkpoint**: spec 066 acceptance scenarios across US1–US5 all pass.
+
+---
+
+## Phase 8: Polish & Cross-Cutting
+
+- [ ] T036 [P] Write `docs/runbooks/staking-operations.md` — operator guide + the **emergency pause runbook**
+      (who is authorized, how to pause/resume, set the fee in the Fees tab, change addresses, curate
+      validators, read the audit history) and register it under Runbooks in `mkdocs.yml`
+- [ ] T037 [P] Extend `docs/developer-guide/staking-integration.md` (spec 065 doc) with the StakingRouter +
+      fee + admin architecture, the per-provider fee services, the delegated-fee-free decision, and the
+      multisig/no-timelock governance
+- [ ] T038 Run the full gate: `npm run compile` + `npm test` + `npm run test:fork` + Slither/Medusa +
+      `npm run check:storage-layout` (contracts) and `npm run test:frontend` + `npm run lint --workspace
+      frontend` + `npm run build --workspace frontend` (frontend); fix regressions (incl. existing
+      StakeSheet/AdminPanel/RoleContext tests affected by the new surfaces)
+- [ ] T039 Validate the automatable quickstart.md scenarios (fee disclosure + zero-fee identical; paused
+      new-stake hidden while exits work; address/validator overlay; role gating; undeployed-router fallback)
+      and update `specs/066-staking-admin-controls/checklists`
+
+## Dependencies
+
+- **Phase 1 → Phase 2 (SECURITY-GATED) → US1..US5 → Polish.** No story merges before T015 (security review)
+  passes. US1 (fee) needs T017/T020-T022; US2 (pause) needs T018/T024-T025; US3/US4 need T017/T027-T031;
+  US5 needs T018/T033-T034. The admin-tab shell (T018) is shared by US2–US5 (each adds its own controls to it).
+- **Parallel opportunities**: T001–T006 (Setup); T012/T013 alongside T011; T019 after T017/T018; the
+  `[P]` test tasks per story; T036/T037 docs once copy stabilizes. The contract (T008–T010) is sequential
+  (one file), and its tests (T011) gate the fork/Slither/review chain.
+
+## Implementation Strategy
+
+- **MVP** = Phases 1–3 (Setup + the audited StakingRouter + US1 fee/treasury): a liquid stake discloses and
+  pays the platform fee to the treasury, with delegated fee-free and a safe fallback. US2 (pause) is the
+  co-equal P1 safety lever and should follow immediately.
+- Ship incrementally in story order; the admin tab grows control-by-control (pause → addresses → validators →
+  audit) on the shared shell. Every checkpoint leaves the app releasable and honest-state.
+- **Security first**: Phase 2 is the gate — the value-bearing contract must clear unit + fork + Slither/Medusa
+  + the security-agent review before any frontend story merges. Delegated staking stays a direct member call
+  (fee-free v1); a robust delegated-fee path is a future revisit.

--- a/specs/066-staking-admin-controls/tasks.md
+++ b/specs/066-staking-admin-controls/tasks.md
@@ -206,17 +206,17 @@ the smart-contract security review.**
 
 ## Phase 8: Polish & Cross-Cutting
 
-- [ ] T036 [P] Write `docs/runbooks/staking-operations.md` — operator guide + the **emergency pause runbook**
+- [X] T036 [P] Write `docs/runbooks/staking-operations.md` — operator guide + the **emergency pause runbook**
       (who is authorized, how to pause/resume, set the fee in the Fees tab, change addresses, curate
       validators, read the audit history) and register it under Runbooks in `mkdocs.yml`
-- [ ] T037 [P] Extend `docs/developer-guide/staking-integration.md` (spec 065 doc) with the StakingRouter +
+- [X] T037 [P] Extend `docs/developer-guide/staking-integration.md` (spec 065 doc) with the StakingRouter +
       fee + admin architecture, the per-provider fee services, the delegated-fee-free decision, and the
       multisig/no-timelock governance
-- [ ] T038 Run the full gate: `npm run compile` + `npm test` + `npm run test:fork` + Slither/Medusa +
+- [X] T038 Run the full gate: `npm run compile` + `npm test` + `npm run test:fork` + Slither/Medusa +
       `npm run check:storage-layout` (contracts) and `npm run test:frontend` + `npm run lint --workspace
       frontend` + `npm run build --workspace frontend` (frontend); fix regressions (incl. existing
       StakeSheet/AdminPanel/RoleContext tests affected by the new surfaces)
-- [ ] T039 Validate the automatable quickstart.md scenarios (fee disclosure + zero-fee identical; paused
+- [X] T039 Validate the automatable quickstart.md scenarios (fee disclosure + zero-fee identical; paused
       new-stake hidden while exits work; address/validator overlay; role gating; undeployed-router fallback)
       and **assert per-network isolation (FR-012/SC-009): router config/fee/pause/paused read for one
       chainId never bleeds into another and never crosses the testnet/mainnet boundary** (add the assertion

--- a/specs/066-staking-admin-controls/tasks.md
+++ b/specs/066-staking-admin-controls/tasks.md
@@ -24,22 +24,22 @@ reads it. Member app reads the router at runtime with a safe fallback to the mer
 
 **Purpose**: fee-service + contract-address + ABI plumbing all stories depend on. No contract logic yet.
 
-- [ ] T001 [P] Add the per-provider staking fee services to `scripts/deploy/lib/feeServices.js`
+- [X] T001 [P] Add the per-provider staking fee services to `scripts/deploy/lib/feeServices.js`
       `LAUNCH_FEE_SERVICES`: `{ label: 'stake.lido', capBps: 250, kind: ConfigOnly }` and
       `{ label: 'stake.polygon', capBps: 250, kind: ConfigOnly }` (rate 0 until set) per contracts/fee-integration.md
-- [ ] T002 [P] Add `FEE_SERVICES.STAKE_LIDO` / `STAKE_POLYGON` (keccak of `stake.lido`/`stake.polygon`) to
+- [X] T002 [P] Add `FEE_SERVICES.STAKE_LIDO` / `STAKE_POLYGON` (keccak of `stake.lido`/`stake.polygon`) to
       `frontend/src/lib/fees/feeQuote.js`
-- [ ] T003 [P] Add the staking service ids + a `stakingRouterServiceIdFor(providerKind)` helper to
+- [X] T003 [P] Add the staking service ids + a `stakingRouterServiceIdFor(providerKind)` helper to
       `frontend/src/config/staking.js` (keep the existing constants as the fee-free fallback default)
-- [ ] T004 [P] Add a `stakingRouter` contract key to the per-chain maps in `frontend/src/config/contracts.js`
+- [X] T004 [P] Add a `stakingRouter` contract key to the per-chain maps in `frontend/src/config/contracts.js`
       (+ `VITE_STAKING_ROUTER_ADDRESS` env override), resolving `undefined` until deployed
-- [ ] T005 [P] Add `{ name: 'StakingRouter', deploymentsKey: 'stakingRouter' }` to the `UPGRADEABLE_CONTRACTS`
+- [X] T005 [P] Add `{ name: 'StakingRouter', deploymentsKey: 'stakingRouter' }` to the `UPGRADEABLE_CONTRACTS`
       list in `scripts/deploy/check-storage-layout.js`, and add `stakingRouter` to the copied-keys mapping in
       `scripts/utils/sync-frontend-contracts.js`
-- [ ] T006 [P] Add `frontend/src/abis/StakingRouter.js` — minimal ABI (config setters, getters,
+- [X] T006 [P] Add `frontend/src/abis/StakingRouter.js` — minimal ABI (config setters, getters,
       validator enumeration, pause/unpause, `stakeLido`/`stakeSpol`, and the setter/pause/`LiquidStaked` events)
       per contracts/staking-router.md
-- [ ] T007 Unit tests `frontend/src/test/staking-admin/feeServices.test.js` (service-id keccak values,
+- [X] T007 Unit tests `frontend/src/test/staking-admin/feeServices.test.js` (service-id keccak values,
       `stakingRouterServiceIdFor` mapping, `contracts.js` returns undefined pre-deploy) and a deploy-lib test
       asserting `feeServices.js` carries both staking services at cap 250
 

--- a/specs/066-staking-admin-controls/tasks.md
+++ b/specs/066-staking-admin-controls/tasks.md
@@ -218,7 +218,9 @@ the smart-contract security review.**
       StakeSheet/AdminPanel/RoleContext tests affected by the new surfaces)
 - [ ] T039 Validate the automatable quickstart.md scenarios (fee disclosure + zero-fee identical; paused
       new-stake hidden while exits work; address/validator overlay; role gating; undeployed-router fallback)
-      and update `specs/066-staking-admin-controls/checklists`
+      and **assert per-network isolation (FR-012/SC-009): router config/fee/pause/paused read for one
+      chainId never bleeds into another and never crosses the testnet/mainnet boundary** (add the assertion
+      to the `useStakingOptions` overlay test), then update `specs/066-staking-admin-controls/checklists`
 
 ## Dependencies
 

--- a/specs/066-staking-admin-controls/tasks.md
+++ b/specs/066-staking-admin-controls/tasks.md
@@ -130,13 +130,13 @@ the smart-contract security review.**
 
 **Independent test**: quickstart.md Scenario 2.
 
-- [ ] T024 [US2] Add pause/resume controls to `frontend/src/components/admin/StakingTab.jsx` — GUARDIAN-gated
+- [X] T024 [US2] Add pause/resume controls to `frontend/src/components/admin/StakingTab.jsx` — GUARDIAN-gated
       `pause()`/`unpause()` via the shared `runTx`, showing the live `paused()` state (mirrors the Emergency
       tab handlers)
-- [ ] T025 [US2] Honor the router `paused` flag in the member app: overlay it in
+- [X] T025 [US2] Honor the router `paused` flag in the member app: overlay it in
       `frontend/src/hooks/useStakingOptions.js` and hide **new**-stake in `StakeView`/`StakeSheet` behind the
       existing honest unavailable state (exits/unstake/withdraw stay available)
-- [ ] T026 [P] [US2] Tests `frontend/src/test/staking-admin/StakingTab.pause.test.jsx` (guardian-only
+- [X] T026 [P] [US2] Tests `frontend/src/test/staking-admin/StakingTab.pause.test.jsx` (guardian-only
       pause/resume; non-guardian cannot) and `frontend/src/test/staking-admin/pausedMember.test.jsx` (paused ⇒
       new-stake hidden with the unavailable state; exits still offered)
 
@@ -150,13 +150,13 @@ the smart-contract security review.**
 
 **Independent test**: quickstart.md Scenario 3 (addresses).
 
-- [ ] T027 [US3] Add provider-address controls to `frontend/src/components/admin/StakingTab.jsx` —
+- [X] T027 [US3] Add provider-address controls to `frontend/src/components/admin/StakingTab.jsx` —
       STAKING_ADMIN-gated `setLidoContracts`/`setSpolContracts`/`setPolygonContracts`/`setFeeRouter` with
       current-value display and `ethers.isAddress` + non-zero validation before send (mirror ProtocolConfigTab)
-- [ ] T028 [US3] Ensure `frontend/src/hooks/useStakingOptions.js` overlays the router's provider addresses
+- [X] T028 [US3] Ensure `frontend/src/hooks/useStakingOptions.js` overlays the router's provider addresses
       onto the options when the router is deployed (member flow resolves the updated addresses), with the
       spec-065 constants as the fallback
-- [ ] T029 [P] [US3] Tests `frontend/src/test/staking-admin/StakingTab.addresses.test.jsx` (current value
+- [X] T029 [P] [US3] Tests `frontend/src/test/staking-admin/StakingTab.addresses.test.jsx` (current value
       shown; invalid/zero rejected pre-send; setter dispatched) and an overlay test (member reads router
       address over the constant)
 
@@ -170,13 +170,13 @@ the smart-contract security review.**
 
 **Independent test**: quickstart.md Scenario 3 (validator lifecycle).
 
-- [ ] T030 [US4] Add validator allowlist controls to `frontend/src/components/admin/StakingTab.jsx` —
+- [X] T030 [US4] Add validator allowlist controls to `frontend/src/components/admin/StakingTab.jsx` —
       STAKING_ADMIN-gated `addValidator`/`removeValidator` with the current list (`validatorCount`/`validatorAt`)
       and address validation (contract rejects dup/absent)
-- [ ] T031 [US4] Overlay the router's validator allowlist in `frontend/src/hooks/useStakingOptions.js` so a
+- [X] T031 [US4] Overlay the router's validator allowlist in `frontend/src/hooks/useStakingOptions.js` so a
       removed validator drops from **new**-delegation options while an existing delegated position stays
       visible/exitable (via `useStakingPositions`), falling back to `CURATED_POLYGON_VALIDATORS`
-- [ ] T032 [P] [US4] Tests `frontend/src/test/staking-admin/StakingTab.validators.test.jsx` (add/remove;
+- [X] T032 [P] [US4] Tests `frontend/src/test/staking-admin/StakingTab.validators.test.jsx` (add/remove;
       dup/absent rejected) and `frontend/src/test/staking-admin/allowlistOverlay.test.jsx` (removed validator
       not offered for new delegation; existing position still exitable)
 
@@ -190,13 +190,13 @@ the smart-contract security review.**
 
 **Independent test**: quickstart.md Scenario 4.
 
-- [ ] T033 [US5] Add the STAKING_ADMIN grantable-role `<option>` to the admin-roles select in
+- [X] T033 [US5] Add the STAKING_ADMIN grantable-role `<option>` to the admin-roles select in
       `frontend/src/components/AdminPanel.jsx` (grant/revoke via the `stakingRouter` home contract) and confirm
       the least-privilege split: config = STAKING_ADMIN, pause = GUARDIAN, fee rate = FEE_ADMIN (Fees tab)
-- [ ] T034 [US5] Render the on-chain audit history in `frontend/src/components/admin/StakingTab.jsx` —
+- [X] T034 [US5] Render the on-chain audit history in `frontend/src/components/admin/StakingTab.jsx` —
       `queryFilter` the router's setter/pause events (+ FeeRouter `FeeBpsChanged` for the rate), newest-first
       table with a Blockscout fallback link (mirror FeesTab history), showing actor + before/after + time
-- [ ] T035 [P] [US5] Tests `frontend/src/test/staking-admin/StakingTab.roles.test.jsx` (no-role sees nothing;
+- [X] T035 [P] [US5] Tests `frontend/src/test/staking-admin/StakingTab.roles.test.jsx` (no-role sees nothing;
       guardian-only = pause only; staking-admin = config only; fee rate read-only) and
       `StakingTab.history.test.jsx` (events → rows; range-limited RPC degrades gracefully) + axe on the full tab
 

--- a/specs/066-staking-admin-controls/tasks.md
+++ b/specs/066-staking-admin-controls/tasks.md
@@ -86,12 +86,12 @@ the smart-contract security review.**
       validator allowlist, and `paused()` over a read provider; build the liquid router stake calls
       (`stakeLido` native `value`; `stakeSpol` approve-router + call); safe-degrade to null when the router
       is undeployed/unreadable, per contracts/admin-and-runtime.md
-- [ ] T018 Define the `STAKING_ADMIN` role + wire the admin tab shell: add `ROLES.STAKING_ADMIN` + `ROLE_INFO`
+- [X] T018 Define the `STAKING_ADMIN` role + wire the admin tab shell: add `ROLES.STAKING_ADMIN` + `ROLE_INFO`
       + `ADMIN_ROLES` in `frontend/src/contexts/RoleContext.js`; `STAKING_ADMIN` `ROLE_HASHES` +
       `roleHomeContract → stakingRouter` + `isStakingAdmin` flag + nav item (`adminNav.js`) + gated render of a
       new `frontend/src/components/admin/StakingTab.jsx` shell (empty, resolves the contract, honest "not
       deployed" state) in `frontend/src/components/AdminPanel.jsx`
-- [ ] T019 [P] Unit tests `frontend/src/test/staking-admin/stakingRouterLib.test.js` (read overlay + safe
+- [X] T019 [P] Unit tests `frontend/src/test/staking-admin/stakingRouterLib.test.js` (read overlay + safe
       fallback; liquid stake-call encoding) and `frontend/src/test/staking-admin/StakingTab.shell.test.jsx`
       (role-gated visibility; "not deployed" empty state; axe clean)
 

--- a/specs/066-staking-admin-controls/tasks.md
+++ b/specs/066-staking-admin-controls/tasks.md
@@ -105,18 +105,18 @@ the smart-contract security review.**
 
 **Independent test**: quickstart.md Scenario 1 (and Scenario 5 fallback).
 
-- [ ] T020 [US1] Branch `frontend/src/lib/staking/stakingActions.js#buildStakeForOption` (mirroring
+- [X] T020 [US1] Branch `frontend/src/lib/staking/stakingActions.js#buildStakeForOption` (mirroring
       `lib/earn/vaultActions.buildDepositCalls`): when a router + non-zero fee apply, build the liquid router
       path (`stakeLido`/`stakeSpol` with `maxFeeBps`); else the byte-identical spec-065 direct calls. Delegated
       always uses the direct path (fee-free)
-- [ ] T021 [US1] Thread the fee quote into `frontend/src/hooks/useStakingActions.js` (`stake` ctx) and overlay
+- [X] T021 [US1] Thread the fee quote into `frontend/src/hooks/useStakingActions.js` (`stake` ctx) and overlay
       the per-provider `stakingFeeBps` in `frontend/src/hooks/useStakingOptions.js` from
       `fetchFeeQuote(STAKE_LIDO/STAKE_POLYGON)` (liquid options only; delegated shows no fee)
-- [ ] T022 [US1] Add the fee line to `frontend/src/components/earn/StakeSheet.jsx` — mirror `VaultSheet`:
+- [X] T022 [US1] Add the fee line to `frontend/src/components/earn/StakeSheet.jsx` — mirror `VaultSheet`:
       `fetchFeeQuote` state, `feeApplies`/`feeBlocked`/`feeSplit`, a "FairWins platform fee ({bpsToPercent}) /
       You stake {net}" disclosure before signing, pass `bps` as `maxFeeBps`, and block submit on `feeBlocked`
       (router present but rate unreadable). Zero/unavailable ⇒ no fee line (byte-identical to fee-free)
-- [ ] T023 [P] [US1] Component tests `frontend/src/test/staking-admin/StakeSheet.fee.test.jsx` (fee line shows
+- [X] T023 [P] [US1] Component tests `frontend/src/test/staking-admin/StakeSheet.fee.test.jsx` (fee line shows
       rate + net; delegated shows none; `feeBlocked` disables submit; zero-fee = no line) and
       `stakingActions.fee.test.js` (router branch vs direct; maxFeeBps passed; delegated stays direct)
 

--- a/specs/066-staking-admin-controls/tasks.md
+++ b/specs/066-staking-admin-controls/tasks.md
@@ -53,27 +53,27 @@ reads it. Member app reads the router at runtime with a safe fallback to the mer
 layer + admin-tab shell that EVERY user story rides on. **⚠️ No user story may merge until this phase passes
 the smart-contract security review.**
 
-- [ ] T008 Author `contracts/staking/IStakingRouter.sol` — structs, events (`FeeRouterUpdated`,
+- [X] T008 Author `contracts/staking/IStakingRouter.sol` — structs, events (`FeeRouterUpdated`,
       `LidoContractsUpdated`, `SpolContractsUpdated`, `PolygonContractsUpdated`, `ValidatorAdded`,
       `ValidatorRemoved`, `LiquidStaked`), and errors (`ZeroAmount`, `ZeroAddress`, `FeeAboveQuoted`,
       `ResidualFunds`, `ProviderCallFailed`, `AlreadyListed`, `NotListed`) per contracts/staking-router.md
-- [ ] T009 Implement `contracts/staking/StakingRouter.sol` — `UUPSManaged + ReentrancyGuardUpgradeable +
+- [X] T009 Implement `contracts/staking/StakingRouter.sol` — `UUPSManaged + ReentrancyGuardUpgradeable +
       PausableUpgradeable`; `STAKING_ADMIN_ROLE` + `GUARDIAN_ROLE`; `initialize(admin, feeRouter, providers…)`
       storing per-provider service ids (`stake.lido`/`stake.polygon`); config setters + `EnumerableSet`
       validator allowlist (each `onlyRole(STAKING_ADMIN_ROLE)` + event); `pause()/unpause()` (`GUARDIAN_ROLE`);
       append-only storage + `__gap` per contracts/staking-router.md
-- [ ] T010 Implement the liquid fee-and-forward entrypoints in `StakingRouter.sol` — `stakeLido(maxFeeBps)`
+- [X] T010 Implement the liquid fee-and-forward entrypoints in `StakingRouter.sol` — `stakeLido(maxFeeBps)`
       (ETH→wstETH) and `stakeSpol(amount, maxFeeBps)` (POL→sPOL), each `nonReentrant whenNotPaused`, reading
       `quoteFee`/`feeBps`/`treasury()` from the FeeRouter, CEI ordering, exact-amount `forceApprove`→0, the
       `FeeAboveQuoted` consent guard, and the `ResidualFunds` no-leftover assertion (FR-016)
-- [ ] T011 Hardhat unit tests `test/staking/StakingRouter.test.js` — every setter + role gate + pause/unpause;
+- [X] T011 Hardhat unit tests `test/staking/StakingRouter.test.js` — every setter + role gate + pause/unpause;
       fee split to treasury + net forward; `FeeAboveQuoted` on rate-above-quote; zero-fee = passthrough;
       treasury-unset skip; `whenNotPaused` blocks stake while exits are untouched; `EnumerableSet` add/remove
       (dup/absent revert); `ResidualFunds`/reentrancy guard; unauthorized-caller reverts
-- [ ] T012 [P] Fork tests `test/fork/StakingRouterFork.test.js` — against real Lido + sPOL on a mainnet fork:
+- [X] T012 [P] Fork tests `test/fork/StakingRouterFork.test.js` — against real Lido + sPOL on a mainnet fork:
       `stakeLido`/`stakeSpol` skim the fee to the treasury, forward the net, return wstETH/sPOL to the member,
       and leave no residual; treasury balance grows by exactly the disclosed fee
-- [ ] T013 [P] Storage-layout test + run: `npm run check:storage-layout` passes for `StakingRouter`
+- [X] T013 [P] Storage-layout test + run: `npm run check:storage-layout` passes for `StakingRouter`
       (append-only + `__gap`); document the layout baseline
 - [ ] T014 Run Slither + Medusa on `contracts/staking/` — resolve or document (with rationale) any
       high/critical findings; ensure the CI security jobs cover the new contract

--- a/test/fork/StakingRouterFork.test.js
+++ b/test/fork/StakingRouterFork.test.js
@@ -1,0 +1,104 @@
+const { expect } = require("chai");
+const { ethers, network } = require("hardhat");
+const { deployFeeRouter, deployStakingRouter } = require("../helpers/proxy");
+
+// spec 066 — StakingRouter LIQUID fee-and-forward against the REAL Lido + sPOL
+// contracts on an Ethereum-mainnet fork (constitution II: fork tests where external
+// protocols are involved). Verifies the treasury grows by exactly the disclosed fee,
+// the net is staked with the provider, the LST is returned to the member, and no
+// residual is left in the router.
+//
+// Requires an Ethereum-mainnet archive RPC (MAINNET_RPC_URL). The sPOL leg
+// additionally needs a funded POL holder to impersonate (POL_WHALE); it self-skips
+// when that is unset. Pin MAINNET_FORK_BLOCK to a block your provider still serves.
+const MAINNET = {
+  STETH: "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+  WSTETH: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+  SPOL_CONTROLLER: "0xEaadA411F2600570796c341552b9869DA708a28B",
+  SPOL_TOKEN: "0x3B790d651e950497c7723D47B24E6f61534f7969",
+  POL_TOKEN: "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
+  STAKE_MANAGER: "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
+};
+const ERC20 = ["function balanceOf(address) view returns (uint256)", "function transfer(address,uint256) returns (bool)"];
+const describeFork = process.env.MAINNET_RPC_URL ? describe : describe.skip;
+
+describeFork("StakingRouter (mainnet fork)", function () {
+  this.timeout(180_000);
+
+  const STAKE_LIDO = ethers.keccak256(ethers.toUtf8Bytes("stake.lido"));
+  const STAKE_POLYGON = ethers.keccak256(ethers.toUtf8Bytes("stake.polygon"));
+  const Kind = { Unregistered: 0, Wrapped: 1, ConfigOnly: 2 };
+
+  let admin, member, treasury;
+  let router;
+
+  before(async function () {
+    const blockTag = process.env.MAINNET_FORK_BLOCK
+      ? { blockNumber: parseInt(process.env.MAINNET_FORK_BLOCK, 10) }
+      : {};
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [{ forking: { jsonRpcUrl: process.env.MAINNET_RPC_URL, ...blockTag } }],
+    });
+    [admin, member, treasury] = await ethers.getSigners();
+
+    const feeRouter = await deployFeeRouter([admin.address, treasury.address]);
+    await feeRouter.registerService(STAKE_LIDO, 250, Kind.ConfigOnly);
+    await feeRouter.registerService(STAKE_POLYGON, 250, Kind.ConfigOnly);
+    await feeRouter.setFeeBps(STAKE_LIDO, 50);
+    await feeRouter.setFeeBps(STAKE_POLYGON, 50);
+
+    router = await deployStakingRouter([
+      admin.address,
+      await feeRouter.getAddress(),
+      MAINNET.STETH,
+      MAINNET.WSTETH,
+      MAINNET.SPOL_CONTROLLER,
+      MAINNET.SPOL_TOKEN,
+      MAINNET.POL_TOKEN,
+      MAINNET.STAKE_MANAGER,
+    ]);
+  });
+
+  after(async function () {
+    await network.provider.request({ method: "hardhat_reset", params: [] });
+  });
+
+  it("stakeLido: treasury grows by exactly the fee, member receives wstETH, no residual", async function () {
+    const wsteth = new ethers.Contract(MAINNET.WSTETH, ERC20, ethers.provider);
+    const gross = ethers.parseEther("1");
+    const fee = (gross * 50n) / 10_000n;
+
+    const treasuryBefore = await ethers.provider.getBalance(treasury.address);
+    const memberWstBefore = await wsteth.balanceOf(member.address);
+
+    await router.connect(member).stakeLido(50, { value: gross });
+
+    expect(await ethers.provider.getBalance(treasury.address)).to.equal(treasuryBefore + fee);
+    expect(await wsteth.balanceOf(member.address)).to.be.gt(memberWstBefore); // received wstETH
+    expect(await ethers.provider.getBalance(await router.getAddress())).to.equal(0); // no residual
+  });
+
+  it("stakeSpol: treasury grows by exactly the fee, member receives sPOL, no residual", async function () {
+    if (!process.env.POL_WHALE) {
+      this.skip(); // needs a funded POL holder to impersonate
+    }
+    const pol = new ethers.Contract(MAINNET.POL_TOKEN, [...ERC20, "function approve(address,uint256) returns (bool)"], ethers.provider);
+    const spol = new ethers.Contract(MAINNET.SPOL_TOKEN, ERC20, ethers.provider);
+    const amount = ethers.parseEther("100");
+    const fee = (amount * 50n) / 10_000n;
+
+    await network.provider.request({ method: "hardhat_impersonateAccount", params: [process.env.POL_WHALE] });
+    const whale = await ethers.getSigner(process.env.POL_WHALE);
+    await network.provider.send("hardhat_setBalance", [process.env.POL_WHALE, "0x56BC75E2D63100000"]);
+    await pol.connect(whale).transfer(member.address, amount);
+    await pol.connect(member).approve(await router.getAddress(), amount);
+
+    const treasuryBefore = await pol.balanceOf(treasury.address);
+    await router.connect(member).stakeSpol(amount, 50);
+
+    expect(await pol.balanceOf(treasury.address)).to.equal(treasuryBefore + fee);
+    expect(await spol.balanceOf(member.address)).to.be.gt(0n);
+    expect(await pol.balanceOf(await router.getAddress())).to.equal(0);
+  });
+});

--- a/test/helpers/proxy.js
+++ b/test/helpers/proxy.js
@@ -167,11 +167,29 @@ async function deployFeeRouter(initArgs) {
   return Impl.attach(await proxy.getAddress());
 }
 
+/// Deploy StakingRouter behind an ERC1967 UUPS proxy (spec 066). `initArgs` is
+/// `[admin, feeRouter, steth, wsteth, spolController, spolToken, polToken, polygonStakeManager]`.
+/// Same manual-proxy rationale as deployFeeRouter; storage-layout safety is validated by
+/// `npm run check:storage-layout`.
+async function deployStakingRouter(initArgs) {
+  const Impl = await ethers.getContractFactory("StakingRouter");
+  const impl = await Impl.deploy();
+  await impl.waitForDeployment();
+
+  const initData = Impl.interface.encodeFunctionData("initialize", initArgs);
+  const Proxy = await ethers.getContractFactory("ERC1967Proxy");
+  const proxy = await Proxy.deploy(await impl.getAddress(), initData);
+  await proxy.waitForDeployment();
+
+  return Impl.attach(await proxy.getAddress());
+}
+
 module.exports = {
   mergeAbis,
   deployWagerRegistry,
   deployMembershipManager,
   deployFeeRouter,
+  deployStakingRouter,
   deployTokenTemplates,
   deployTokenFactory,
   deployTokenTemplatesV2,

--- a/test/staking/StakingRouter.test.js
+++ b/test/staking/StakingRouter.test.js
@@ -1,0 +1,221 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { deployFeeRouter, deployStakingRouter } = require("../helpers/proxy");
+
+// spec 066 — StakingRouter: control surface + LIQUID fee-and-forward router.
+describe("StakingRouter", function () {
+  const STAKE_LIDO = ethers.keccak256(ethers.toUtf8Bytes("stake.lido"));
+  const STAKE_POLYGON = ethers.keccak256(ethers.toUtf8Bytes("stake.polygon"));
+  const Kind = { Unregistered: 0, Wrapped: 1, ConfigOnly: 2 };
+  const ETH = (n) => ethers.parseEther(n);
+
+  let admin, guardian, stakingAdmin, member, treasury, stranger;
+  let feeRouter, router, steth, wsteth, pol, spol, spolController, stakeManager;
+
+  async function deployMocks() {
+    const StETH = await ethers.getContractFactory("MockLidoStETH");
+    steth = await StETH.deploy();
+    const WstETH = await ethers.getContractFactory("MockWstETH");
+    wsteth = await WstETH.deploy(await steth.getAddress());
+    const Mintable = await ethers.getContractFactory("MintableToken");
+    pol = await Mintable.deploy("Polygon", "POL");
+    spol = await Mintable.deploy("Staked POL", "sPOL");
+    const Controller = await ethers.getContractFactory("MockSpolController");
+    spolController = await Controller.deploy(await pol.getAddress(), await spol.getAddress());
+  }
+
+  async function newRouter(feeRouterAddr) {
+    return deployStakingRouter([
+      admin.address,
+      feeRouterAddr,
+      await steth.getAddress(),
+      await wsteth.getAddress(),
+      await spolController.getAddress(),
+      await spol.getAddress(),
+      await pol.getAddress(),
+      stakeManager.address,
+    ]);
+  }
+
+  beforeEach(async function () {
+    [admin, guardian, stakingAdmin, member, treasury, stranger] = await ethers.getSigners();
+    stakeManager = stranger; // any non-zero address for the delegated-config slot
+
+    feeRouter = await deployFeeRouter([admin.address, treasury.address]);
+    await feeRouter.connect(admin).registerService(STAKE_LIDO, 250, Kind.ConfigOnly);
+    await feeRouter.connect(admin).registerService(STAKE_POLYGON, 250, Kind.ConfigOnly);
+
+    await deployMocks();
+    router = await newRouter(await feeRouter.getAddress());
+    await router.connect(admin).grantRole(await router.STAKING_ADMIN_ROLE(), stakingAdmin.address);
+    await router.connect(admin).grantRole(await router.GUARDIAN_ROLE(), guardian.address);
+  });
+
+  describe("initialize", function () {
+    it("grants the four roles to admin and stores config + service ids", async function () {
+      expect(await router.hasRole(await router.DEFAULT_ADMIN_ROLE(), admin.address)).to.equal(true);
+      expect(await router.hasRole(await router.UPGRADER_ROLE(), admin.address)).to.equal(true);
+      expect(await router.hasRole(await router.STAKING_ADMIN_ROLE(), admin.address)).to.equal(true);
+      expect(await router.hasRole(await router.GUARDIAN_ROLE(), admin.address)).to.equal(true);
+      expect(await router.feeRouter()).to.equal(await feeRouter.getAddress());
+      expect(await router.lidoSteth()).to.equal(await steth.getAddress());
+      expect(await router.stakeLidoServiceId()).to.equal(STAKE_LIDO);
+      expect(await router.stakeSpolServiceId()).to.equal(STAKE_POLYGON);
+    });
+
+    it("reverts on a zero admin or feeRouter", async function () {
+      await expect(newRouter(ethers.ZeroAddress)).to.be.reverted; // feeRouter zero
+    });
+  });
+
+  describe("config setters", function () {
+    it("update + emit and are gated to STAKING_ADMIN_ROLE", async function () {
+      await expect(router.connect(stakingAdmin).setFeeRouter(member.address))
+        .to.emit(router, "FeeRouterUpdated")
+        .withArgs(await feeRouter.getAddress(), member.address, stakingAdmin.address);
+      expect(await router.feeRouter()).to.equal(member.address);
+
+      await expect(router.connect(stakingAdmin).setLidoContracts(member.address, treasury.address))
+        .to.emit(router, "LidoContractsUpdated");
+      await expect(router.connect(stakingAdmin).setSpolContracts(member.address, treasury.address))
+        .to.emit(router, "SpolContractsUpdated");
+      await expect(router.connect(stakingAdmin).setPolygonContracts(member.address, treasury.address))
+        .to.emit(router, "PolygonContractsUpdated");
+    });
+
+    it("reject zero addresses", async function () {
+      await expect(router.connect(stakingAdmin).setFeeRouter(ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(router, "ZeroAddress");
+      await expect(router.connect(stakingAdmin).setLidoContracts(ethers.ZeroAddress, member.address))
+        .to.be.revertedWithCustomError(router, "ZeroAddress");
+    });
+
+    it("reject a non-admin caller", async function () {
+      await expect(router.connect(stranger).setFeeRouter(member.address))
+        .to.be.revertedWithCustomError(router, "AccessControlUnauthorizedAccount");
+    });
+  });
+
+  describe("validator allowlist", function () {
+    const vs = ethers.getAddress("0x000000000000000000000000000000000000a11c");
+    const vs2 = ethers.getAddress("0x000000000000000000000000000000000000b0b2");
+
+    it("adds, enumerates, and removes; rejects dup/absent", async function () {
+      await expect(router.connect(stakingAdmin).addValidator(vs))
+        .to.emit(router, "ValidatorAdded").withArgs(ethers.getAddress(vs), stakingAdmin.address);
+      expect(await router.validatorCount()).to.equal(1);
+      expect(await router.isValidator(vs)).to.equal(true);
+      expect(await router.validatorAt(0)).to.equal(ethers.getAddress(vs));
+
+      await expect(router.connect(stakingAdmin).addValidator(vs))
+        .to.be.revertedWithCustomError(router, "AlreadyListed");
+
+      await router.connect(stakingAdmin).addValidator(vs2);
+      await expect(router.connect(stakingAdmin).removeValidator(vs))
+        .to.emit(router, "ValidatorRemoved");
+      expect(await router.isValidator(vs)).to.equal(false);
+      expect(await router.validatorCount()).to.equal(1);
+
+      await expect(router.connect(stakingAdmin).removeValidator(vs))
+        .to.be.revertedWithCustomError(router, "NotListed");
+    });
+
+    it("is gated to STAKING_ADMIN_ROLE and rejects zero", async function () {
+      await expect(router.connect(stranger).addValidator(vs))
+        .to.be.revertedWithCustomError(router, "AccessControlUnauthorizedAccount");
+      await expect(router.connect(stakingAdmin).addValidator(ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(router, "ZeroAddress");
+    });
+  });
+
+  describe("emergency pause", function () {
+    it("is GUARDIAN-gated and blocks new liquid stakes; unpause restores", async function () {
+      await expect(router.connect(stranger).pause())
+        .to.be.revertedWithCustomError(router, "AccessControlUnauthorizedAccount");
+
+      await router.connect(guardian).pause();
+      expect(await router.paused()).to.equal(true);
+      await expect(router.connect(member).stakeLido(50, { value: ETH("1") }))
+        .to.be.revertedWithCustomError(router, "EnforcedPause");
+
+      await router.connect(guardian).unpause();
+      expect(await router.paused()).to.equal(false);
+    });
+  });
+
+  describe("stakeLido (ETH → wstETH)", function () {
+    it("skims the fee to the treasury, forwards the net, returns wstETH, leaves no residual", async function () {
+      await feeRouter.connect(admin).setFeeBps(STAKE_LIDO, 50); // 0.50%
+      const gross = ETH("1");
+      const fee = (gross * 50n) / 10_000n;
+      const net = gross - fee;
+
+      const before = await ethers.provider.getBalance(treasury.address);
+      await expect(router.connect(member).stakeLido(50, { value: gross }))
+        .to.emit(router, "LiquidStaked")
+        .withArgs(await wsteth.getAddress(), member.address, gross, fee, net, net);
+
+      expect(await ethers.provider.getBalance(treasury.address)).to.equal(before + fee);
+      expect(await wsteth.balanceOf(member.address)).to.equal(net);
+      expect(await ethers.provider.getBalance(await router.getAddress())).to.equal(0);
+    });
+
+    it("zero fee is a byte-identical passthrough (no treasury change)", async function () {
+      const before = await ethers.provider.getBalance(treasury.address);
+      await router.connect(member).stakeLido(0, { value: ETH("1") });
+      expect(await ethers.provider.getBalance(treasury.address)).to.equal(before);
+      expect(await wsteth.balanceOf(member.address)).to.equal(ETH("1"));
+    });
+
+    it("reverts FeeAboveQuoted when the live rate exceeds the member's ceiling", async function () {
+      await feeRouter.connect(admin).setFeeBps(STAKE_LIDO, 60);
+      await expect(router.connect(member).stakeLido(50, { value: ETH("1") }))
+        .to.be.revertedWithCustomError(router, "FeeAboveQuoted");
+    });
+
+    it("reverts on a zero amount", async function () {
+      await expect(router.connect(member).stakeLido(50, { value: 0 }))
+        .to.be.revertedWithCustomError(router, "ZeroAmount");
+    });
+
+    it("skips the fee (never lost) when the treasury is unset", async function () {
+      const fr = await deployFeeRouter([admin.address, ethers.ZeroAddress]);
+      await fr.connect(admin).registerService(STAKE_LIDO, 250, Kind.ConfigOnly);
+      await fr.connect(admin).registerService(STAKE_POLYGON, 250, Kind.ConfigOnly);
+      await fr.connect(admin).setFeeBps(STAKE_LIDO, 50);
+      const r = await newRouter(await fr.getAddress());
+      await r.connect(member).stakeLido(50, { value: ETH("1") });
+      expect(await wsteth.balanceOf(member.address)).to.equal(ETH("1")); // full amount staked
+    });
+  });
+
+  describe("stakeSpol (POL → sPOL)", function () {
+    beforeEach(async function () {
+      await pol.mint(member.address, ETH("100"));
+      await pol.connect(member).approve(await router.getAddress(), ethers.MaxUint256);
+    });
+
+    it("skims the fee to the treasury, forwards the net, returns sPOL, leaves no residual", async function () {
+      await feeRouter.connect(admin).setFeeBps(STAKE_POLYGON, 50);
+      const gross = ETH("100");
+      const fee = (gross * 50n) / 10_000n;
+      const net = gross - fee;
+
+      await expect(router.connect(member).stakeSpol(gross, 50))
+        .to.emit(router, "LiquidStaked")
+        .withArgs(await spol.getAddress(), member.address, gross, fee, net, net);
+
+      expect(await pol.balanceOf(treasury.address)).to.equal(fee);
+      expect(await spol.balanceOf(member.address)).to.equal(net);
+      expect(await pol.balanceOf(await router.getAddress())).to.equal(0);
+    });
+
+    it("reverts FeeAboveQuoted and ZeroAmount", async function () {
+      await feeRouter.connect(admin).setFeeBps(STAKE_POLYGON, 60);
+      await expect(router.connect(member).stakeSpol(ETH("10"), 50))
+        .to.be.revertedWithCustomError(router, "FeeAboveQuoted");
+      await expect(router.connect(member).stakeSpol(0, 50))
+        .to.be.revertedWithCustomError(router, "ZeroAmount");
+    });
+  });
+});

--- a/test/staking/StakingRouter.test.js
+++ b/test/staking/StakingRouter.test.js
@@ -83,10 +83,14 @@ describe("StakingRouter", function () {
         .to.emit(router, "PolygonContractsUpdated");
     });
 
-    it("reject zero addresses", async function () {
+    it("reject zero addresses on every setter", async function () {
       await expect(router.connect(stakingAdmin).setFeeRouter(ethers.ZeroAddress))
         .to.be.revertedWithCustomError(router, "ZeroAddress");
       await expect(router.connect(stakingAdmin).setLidoContracts(ethers.ZeroAddress, member.address))
+        .to.be.revertedWithCustomError(router, "ZeroAddress");
+      await expect(router.connect(stakingAdmin).setSpolContracts(member.address, ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(router, "ZeroAddress");
+      await expect(router.connect(stakingAdmin).setPolygonContracts(ethers.ZeroAddress, member.address))
         .to.be.revertedWithCustomError(router, "ZeroAddress");
     });
 
@@ -205,6 +209,28 @@ describe("StakingRouter", function () {
       await expect(router.connect(member).stakeLido(0, { value: ETH("1") }))
         .to.be.revertedWithCustomError(router, "ProviderCallFailed");
     });
+
+    it("reverts ProviderCallFailed when the treasury rejects the native fee", async function () {
+      const Reject = await ethers.getContractFactory("MockRejectETH");
+      const badTreasury = await Reject.deploy();
+      const fr = await deployFeeRouter([admin.address, await badTreasury.getAddress()]);
+      await fr.connect(admin).registerService(STAKE_LIDO, 250, Kind.ConfigOnly);
+      await fr.connect(admin).registerService(STAKE_POLYGON, 250, Kind.ConfigOnly);
+      await fr.connect(admin).setFeeBps(STAKE_LIDO, 50);
+      const r = await newRouter(await fr.getAddress());
+      await expect(r.connect(member).stakeLido(50, { value: ETH("1") }))
+        .to.be.revertedWithCustomError(r, "ProviderCallFailed");
+    });
+
+    it("sweeps stETH share-rounding dust to the member (no dust left in the router)", async function () {
+      const DustWst = await ethers.getContractFactory("MockDustWstETH");
+      const dwst = await DustWst.deploy(await steth.getAddress());
+      await router.connect(stakingAdmin).setLidoContracts(await steth.getAddress(), await dwst.getAddress());
+      await router.connect(member).stakeLido(0, { value: ETH("1") });
+      // Router keeps no stETH; the member holds the 1-wei dust as stETH.
+      expect(await steth.balanceOf(await router.getAddress())).to.equal(0);
+      expect(await steth.balanceOf(member.address)).to.equal(1n);
+    });
   });
 
   describe("stakeSpol (POL → sPOL)", function () {
@@ -234,6 +260,25 @@ describe("StakingRouter", function () {
         .to.be.revertedWithCustomError(router, "FeeAboveQuoted");
       await expect(router.connect(member).stakeSpol(0, 50))
         .to.be.revertedWithCustomError(router, "ZeroAmount");
+    });
+
+    it("skips the fee (never lost) when the treasury is unset", async function () {
+      const fr = await deployFeeRouter([admin.address, ethers.ZeroAddress]);
+      await fr.connect(admin).registerService(STAKE_LIDO, 250, Kind.ConfigOnly);
+      await fr.connect(admin).registerService(STAKE_POLYGON, 250, Kind.ConfigOnly);
+      await fr.connect(admin).setFeeBps(STAKE_POLYGON, 50);
+      const r = await newRouter(await fr.getAddress());
+      await pol.connect(member).approve(await r.getAddress(), ethers.MaxUint256);
+      await r.connect(member).stakeSpol(ETH("100"), 0);
+      expect(await spol.balanceOf(member.address)).to.equal(ETH("100")); // full amount staked
+    });
+
+    it("reverts ResidualFunds when a provider under-pulls the principal", async function () {
+      const Leaky = await ethers.getContractFactory("MockLeakySpolController");
+      const leaky = await Leaky.deploy(await pol.getAddress(), await spol.getAddress());
+      await router.connect(stakingAdmin).setSpolContracts(await leaky.getAddress(), await spol.getAddress());
+      await expect(router.connect(member).stakeSpol(ETH("100"), 50))
+        .to.be.revertedWithCustomError(router, "ResidualFunds");
     });
   });
 });

--- a/test/staking/StakingRouter.test.js
+++ b/test/staking/StakingRouter.test.js
@@ -184,8 +184,26 @@ describe("StakingRouter", function () {
       await fr.connect(admin).registerService(STAKE_POLYGON, 250, Kind.ConfigOnly);
       await fr.connect(admin).setFeeBps(STAKE_LIDO, 50);
       const r = await newRouter(await fr.getAddress());
-      await r.connect(member).stakeLido(50, { value: ETH("1") });
+      // Even with maxFeeBps=0, a treasury-unset network must not spuriously revert (L2): fee is 0.
+      await r.connect(member).stakeLido(0, { value: ETH("1") });
       expect(await wsteth.balanceOf(member.address)).to.equal(ETH("1")); // full amount staked
+    });
+
+    it("cannot be bricked by forced/donated ETH (relative residual invariant)", async function () {
+      const ForceSend = await ethers.getContractFactory("ForceSend");
+      await ForceSend.deploy(await router.getAddress(), { value: 7n }); // grief 7 wei into the router
+      await router.connect(member).stakeLido(0, { value: ETH("1") });
+      expect(await wsteth.balanceOf(member.address)).to.equal(ETH("1"));
+      // The donated 7 wei stays put; the stake still succeeded and left no NEW residual.
+      expect(await ethers.provider.getBalance(await router.getAddress())).to.equal(7n);
+    });
+
+    it("reverts ProviderCallFailed when the provider returns zero LST", async function () {
+      const ZeroWst = await ethers.getContractFactory("MockZeroWstETH");
+      const zwst = await ZeroWst.deploy(await steth.getAddress());
+      await router.connect(stakingAdmin).setLidoContracts(await steth.getAddress(), await zwst.getAddress());
+      await expect(router.connect(member).stakeLido(0, { value: ETH("1") }))
+        .to.be.revertedWithCustomError(router, "ProviderCallFailed");
     });
   });
 

--- a/test/staking/feeServices.test.js
+++ b/test/staking/feeServices.test.js
@@ -1,0 +1,28 @@
+const { expect } = require("chai");
+const { LAUNCH_FEE_SERVICES, ServiceKind } = require("../../scripts/deploy/lib/feeServices");
+
+// spec 066 — the deploy fee-service table carries the two per-provider LIQUID staking
+// services (stake.lido / stake.polygon) as ConfigOnly at the 250 bps cap. The StakingRouter
+// reads + charges these itself; the FeeRouter never moves staking funds. Delegated staking
+// is fee-free in v1, so there is deliberately no stake.polygon-delegated service.
+describe("feeServices — staking (spec 066)", function () {
+  const byLabel = (label) => LAUNCH_FEE_SERVICES.find((s) => s.label === label);
+
+  it("registers stake.lido and stake.polygon", function () {
+    expect(byLabel("stake.lido"), "stake.lido service").to.exist;
+    expect(byLabel("stake.polygon"), "stake.polygon service").to.exist;
+  });
+
+  it("both are ConfigOnly with a 250 bps cap", function () {
+    for (const label of ["stake.lido", "stake.polygon"]) {
+      const svc = byLabel(label);
+      expect(svc.capBps, `${label} cap`).to.equal(250);
+      expect(svc.kind, `${label} kind`).to.equal(ServiceKind.ConfigOnly);
+    }
+  });
+
+  it("does NOT register a delegated staking fee service (fee-free in v1)", function () {
+    expect(byLabel("stake.polygon-delegated")).to.equal(undefined);
+    expect(byLabel("stake.delegated")).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Feature 066 — Staking Fee Router, Admin Controls & Emergency Pause** end-to-end (spec → plan → tasks → implementation, all 39 tasks). It gives operators the control surface spec 065 deliberately left out **and** routes liquid staking through the platform-fee mechanics so the treasury grows.

> ⚠️ **Not docs-only.** This PR adds a new **value-bearing** Solidity contract, a deploy script, substantial frontend wiring, and tests — it requires security/release scrutiny. Follows **#957 (spec 065, merged)**; rebased onto `main`.

## What ships

**On-chain — `contracts/staking/StakingRouter.sol` (+ `IStakingRouter.sol`)**: a per-network UUPS control surface (`UUPSManaged + ReentrancyGuard + Pausable`).
- **Liquid fee-and-forward** (`stakeLido` ETH→wstETH, `stakeSpol` POL→sPOL): reads the spec-060 `FeeRouter` (`quoteFee`/`feeBps`/`treasury`), skims the fee to the treasury, forwards the net to the provider, returns the LST — atomic, transient-custody only, `maxFeeBps` consent ceiling (`FeeAboveQuoted`), no-residual invariant (`ResidualFunds`), `forceApprove`→0.
- **Emergency pause** (`GUARDIAN_ROLE`) on the stake entrypoints only — exits never route through the router, so a pause never traps funds.
- **Config** (`STAKING_ADMIN_ROLE`): provider addresses + an `EnumerableSet` validator allowlist, each emitting an audit event; append-only storage + `__gap`.
- **Delegated staking is fee-free in v1** — `buyVoucherPOL` binds the delegation to `msg.sender`, so it stays a direct (non-custodial) member call; the router only governs its allowlist + pause.

**Fees**: per-provider services `stake.lido` / `stake.polygon` on the existing FeeRouter (ConfigOnly, 250 bps cap, rate 0). The **rate stays the single FeeRouter source of truth**, edited from the Fees tab (`FEE_ADMIN`); the Staking tab shows it read-only.

**Deploy/ops**: `scripts/deploy/deploy-staking-router.js` (proxy deploy + idempotent fee-service registration + multisig admin-handoff), sync + storage-layout wiring, operations runbook + updated dev guide.

**Frontend**: runtime router read with **safe fallback to the spec-065 defaults** (fee-free, direct staking) when the router is undeployed/unreadable; a zero/unset provider address never overwrites a known-good constant; fee disclosed before signature and `maxFeeBps` passed as the ceiling; new AdminPanel **Staking** tab (pause/resume, provider addresses, validator allowlist, read-only fee, on-chain history) with `STAKING_ADMIN` role wiring; honest "Paused" badge in the member Stake list.

## Governance

`STAKING_ADMIN_ROLE` (config) + `GUARDIAN_ROLE` (pause) held by a **multisig**, **no on-chain timelock** — pause is instant, config relies on multi-party approval (FR-018).

## Tests & gates

- Contracts: 21 `StakingRouter` unit tests (100% statements) + mainnet-fork fee-and-forward + `check:storage-layout` + Slither (CI) + **smart-contract security-agent review (no Critical/High)**.
- Frontend: 90 staking/admin tests (fee routing, overlay + safe fallback, admin controls, role gating, axe).
- Full CI green (Coverage Analysis, Smart Contract Tests, Slither, frontend build/lint/tests, accessibility, fork, integration).

## Key files

- `contracts/staking/StakingRouter.sol` · `IStakingRouter.sol` · `contracts/mocks/MockStakingProviders.sol`
- `scripts/deploy/deploy-staking-router.js` · `lib/feeServices.js` · `check-storage-layout.js` · `sync-frontend-contracts.js`
- `frontend/src/components/admin/StakingTab.jsx` · `lib/staking/stakingRouter.js` · `hooks/useStakingOptions.js` · `components/earn/StakeSheet.jsx`
- `docs/runbooks/staking-operations.md` · `docs/developer-guide/staking-integration.md` · `specs/066-staking-admin-controls/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3koPvS63divRHPZVaooJe