### PR TITLE
Fix off-center chain badge icon; add token icons to Trade selectors

### DIFF
--- a/frontend/src/components/fairwins/TradePanel.jsx
+++ b/frontend/src/components/fairwins/TradePanel.jsx
@@ -18,6 +18,7 @@ import { useLegacyAccounts } from '../../hooks/useLegacyAccounts'
 import LegacyUnlockDialog from '../account/LegacyUnlockDialog'
 import SensitiveValue from '../common/SensitiveValue'
 import InfoTip from '../ui/InfoTip'
+import TradeTokenSelect from './TradeTokenSelect'
 import './TradePanel.css'
 
 // Price impact bands used to color the trade summary, mirroring the thresholds
@@ -558,18 +559,13 @@ function TradePanel() {
               inputMode="decimal"
               className="trade-amount-input"
             />
-            <select
-              aria-label="Token to sell"
+            <TradeTokenSelect
+              ariaLabel="Token to sell"
+              assets={assets}
               value={fromToken}
-              onChange={(e) => handlePairChange('from', e.target.value)}
-              className="trade-token-select"
-            >
-              {assets.map((t) => (
-                <option key={t.address} value={t.address}>
-                  {t.symbol}
-                </option>
-              ))}
-            </select>
+              onChange={(addr) => handlePairChange('from', addr)}
+              chainId={chainId}
+            />
             <button type="button" onClick={handleSetMax} className="trade-max-btn">
               MAX
             </button>
@@ -599,18 +595,13 @@ function TradePanel() {
             <div className="trade-receive-value" aria-live="polite">
               <SensitiveValue>{receiveValue}</SensitiveValue>
             </div>
-            <select
-              aria-label="Token to buy"
+            <TradeTokenSelect
+              ariaLabel="Token to buy"
+              assets={assets}
               value={toToken}
-              onChange={(e) => handlePairChange('to', e.target.value)}
-              className="trade-token-select"
-            >
-              {assets.map((t) => (
-                <option key={t.address} value={t.address}>
-                  {t.symbol}
-                </option>
-              ))}
-            </select>
+              onChange={(addr) => handlePairChange('to', addr)}
+              chainId={chainId}
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/fairwins/TradeTokenSelect.css
+++ b/frontend/src/components/fairwins/TradeTokenSelect.css
@@ -1,0 +1,73 @@
+/* TradeTokenSelect — pill-shaped AssetLogo dropdown for the Trade ticket's
+   pay/receive legs. Colors alias the same --trade-* tokens as TradePanel.css. */
+
+.trade-token-picker {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.trade-token-picker .trade-token-select {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.trade-token-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.trade-token-select-sym {
+  white-space: nowrap;
+}
+
+.trade-token-select-chevron {
+  color: var(--trade-text-2);
+  font-size: 0.7rem;
+}
+
+.trade-token-list {
+  background: var(--trade-surface);
+  border: 1px solid var(--trade-border);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  list-style: none;
+  margin: 6px 0 0;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 6px;
+  position: absolute;
+  right: 0;
+  min-width: 160px;
+  z-index: 30;
+}
+
+.trade-token-li {
+  margin: 0;
+}
+
+.trade-token-option {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 10px;
+  color: var(--trade-text);
+  cursor: pointer;
+  display: flex;
+  font-size: 0.9rem;
+  font-weight: 600;
+  gap: 10px;
+  padding: 8px 10px;
+  text-align: left;
+  width: 100%;
+}
+
+.trade-token-option:hover,
+.trade-token-option:focus-visible {
+  background: var(--trade-surface-2);
+  outline: none;
+}
+
+.trade-token-option.active {
+  background: color-mix(in srgb, var(--trade-accent) 16%, transparent);
+}

--- a/frontend/src/components/fairwins/TradeTokenSelect.jsx
+++ b/frontend/src/components/fairwins/TradeTokenSelect.jsx
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import AssetLogo from '../wallet/AssetLogo'
+import './TradeTokenSelect.css'
+
+/**
+ * TradeTokenSelect — the Trade ticket's pair-leg token picker. A thin,
+ * trade-panel-flavored sibling of UniversalAssetSelect: same AssetLogo
+ * artwork and listbox interaction pattern, sized to sit inline as a pill
+ * next to the amount input (FR: consistent asset iconography app-wide).
+ *
+ * Every option trades on the same active chain as the ticket, so `chainId`
+ * is a single prop rather than per-option.
+ */
+export default function TradeTokenSelect({ assets = [], value, onChange, chainId, ariaLabel }) {
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef(null)
+
+  const selected = assets.find((t) => t.address === value) || null
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onDocClick = (e) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false)
+    }
+    const onKey = (e) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const handleSelect = useCallback(
+    (token) => {
+      onChange?.(token.address)
+      setOpen(false)
+    },
+    [onChange],
+  )
+
+  return (
+    <div className="trade-token-picker" ref={wrapRef}>
+      <button
+        type="button"
+        className="trade-token-select"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        disabled={assets.length === 0}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {selected ? (
+          <>
+            <AssetLogo symbol={selected.symbol} chainId={chainId} showBadge size={20} />
+            <span className="trade-token-select-sym">{selected.symbol}</span>
+          </>
+        ) : (
+          <span className="trade-token-select-sym">Select</span>
+        )}
+        <span className="trade-token-select-chevron" aria-hidden="true">▾</span>
+      </button>
+
+      {open && assets.length > 0 && (
+        <ul className="trade-token-list" role="listbox" aria-label={ariaLabel}>
+          {assets.map((token) => (
+            <li key={token.address} className="trade-token-li">
+              <button
+                type="button"
+                role="option"
+                aria-selected={token.address === value}
+                className={`trade-token-option ${token.address === value ? 'active' : ''}`}
+                onClick={() => handleSelect(token)}
+              >
+                <AssetLogo symbol={token.symbol} chainId={chainId} showBadge size={24} />
+                <span className="trade-token-option-sym">{token.symbol}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/wallet/AssetLogo.css
+++ b/frontend/src/components/wallet/AssetLogo.css
@@ -9,10 +9,21 @@
   border: 2px solid var(--surface-color, var(--bg-secondary, #fff));
   border-radius: 50%;
   bottom: -2px;
-  height: 45%;
+  height: 48%;
+  min-width: 14px;
+  min-height: 14px;
   position: absolute;
   right: -2px;
-  width: 45%;
+  width: 48%;
+}
+/* The badge's <svg> is inline by default, so the browser reserves descender
+   space below its baseline inside the span — pushing the circle down and
+   right within its own box. That shows up as the badge rendering off-center
+   (clipped at the bottom, a crescent of the ring showing at the top) and
+   looking smaller than its true size. display: block removes the inline
+   line-box math so the svg fills the badge box exactly, centered. */
+.asset-logo-badge svg {
+  display: block;
 }
 .asset-logo-badge-testnet {
   border-style: dashed;

--- a/frontend/src/test/TradePanel.test.jsx
+++ b/frontend/src/test/TradePanel.test.jsx
@@ -263,15 +263,23 @@ describe('TradePanel — SDK-driven trade read-out', () => {
     expect(screen.queryByRole('tab', { name: 'Unwrap' })).toBeNull()
   })
 
-  it('lists every tradeable portfolio asset in both selectors', () => {
+  it('lists every tradeable portfolio asset, with its icon, in both selectors', () => {
     mockUseDex.mockReturnValue(polygonDex())
     render(<TradePanel />)
 
-    const sell = screen.getByLabelText('Token to sell')
-    const buy = screen.getByLabelText('Token to buy')
+    fireEvent.click(screen.getByRole('button', { name: 'Token to sell' }))
+    const sellList = screen.getByRole('listbox')
     for (const symbol of ['WPOL', 'USDC', 'WETH', 'WBTC', 'LINK', 'USDT']) {
-      expect(within(sell).getByRole('option', { name: symbol })).toBeInTheDocument()
-      expect(within(buy).getByRole('option', { name: symbol })).toBeInTheDocument()
+      const option = within(sellList).getByRole('option', { name: symbol })
+      expect(option).toBeInTheDocument()
+      expect(option.querySelector('.asset-logo')).toBeInTheDocument()
+    }
+    fireEvent.click(screen.getByRole('button', { name: 'Token to sell' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Token to buy' }))
+    const buyList = screen.getByRole('listbox')
+    for (const symbol of ['WPOL', 'USDC', 'WETH', 'WBTC', 'LINK', 'USDT']) {
+      expect(within(buyList).getByRole('option', { name: symbol })).toBeInTheDocument()
     }
   })
 })
@@ -352,12 +360,14 @@ describe('TradePanel — order & price types', () => {
 
     fireEvent.change(screen.getByLabelText(/Order Type/), { target: { value: 'buy' } })
     // Buy pays the stablecoin to receive the wrapped-native asset.
-    expect(screen.getByLabelText('Token to sell').value).toBe(POLYGON_ADDRESSES.STABLECOIN)
-    expect(screen.getByLabelText('Token to buy').value).toBe(POLYGON_ADDRESSES.WNATIVE)
+    expect(screen.getByRole('button', { name: 'Token to sell' })).toHaveTextContent('USDC')
+    expect(screen.getByRole('button', { name: 'Token to buy' })).toHaveTextContent('WPOL')
 
     // Flipping the pair back flips the order type too.
-    fireEvent.change(screen.getByLabelText('Token to sell'), { target: { value: POLYGON_ADDRESSES.WNATIVE } })
-    fireEvent.change(screen.getByLabelText('Token to buy'), { target: { value: POLYGON_ADDRESSES.STABLECOIN } })
+    fireEvent.click(screen.getByRole('button', { name: 'Token to sell' }))
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'WPOL' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Token to buy' }))
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'USDC' }))
     expect(screen.getByLabelText(/Order Type/).value).toBe('sell')
   })
 


### PR DESCRIPTION
## Summary
- Fixed the network sub-badge (the small "P"/"E"/"C" chain-icon overlay on `AssetLogo`) rendering off-center and clipped — its inline `<svg>` defaulted to `vertical-align: baseline`, which reserves descender space below the badge and pushes it down inside its own box, producing an asymmetric white "ring" (visible crescent at the top, clipped at the bottom). Fix: `display: block` on the badge's `<svg>`, plus a small size bump (45%→48%, 14px floor) so the letter stays legible at every size used across the app.
- Added token icons to the Trade page's asset selectors, which previously rendered as plain native `<select>`/`<option>` lists with no icons (an OS-native picker sheet), inconsistent with the Earn and Pay & Transfer surfaces. New `TradeTokenSelect` component reuses the same `AssetLogo` artwork/interaction pattern already used elsewhere in the app, wired into both legs ("You pay" / "You receive") of `TradePanel`.

## Root cause detail
Confirmed via a headless-browser measurement of the real component: the badge span's outer (border) box and its inner `<svg>` circle were off by several px vertically (not horizontally) — exactly the inline-baseline "phantom descender" bug, not a box-sizing or percentage-rounding issue.

## Test plan
- [x] Updated `TradePanel.test.jsx`'s two tests that asserted on native-`<select>` behavior (`.value`, `fireEvent.change`) to instead drive the new listbox (`getByRole('button'/'listbox'/'option')`), matching the existing pattern used in `PayPanel.test.jsx`/`RequestPanel.test.jsx`.
- [x] `npx vitest run` on `TradePanel`, `PayPanel`, `RequestPanel`, `CreateChallengePanel`, Earn (`EarnPanel`, `EarnRewardsView`, `VaultSheet`), and Portfolio (`PortfolioPanel`, `AssetDetailSheet`) test files — all pass.
- [x] Rendered the real (unmodified) `AssetLogo` component via `@testing-library/react` + a headless Chromium screenshot to visually confirm the badge is now a clean, centered ring for USDC/Polygon, USDT/Ethereum, ETC/Callisto, and LINK/Polygon.
- [x] `npx eslint` on the changed files — no new errors.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXMYTHHjepmcdbzCnXTnuR)_