### PR TITLE
Cut the steps between opening the app and a connected wallet

### DIFF
--- a/docs/developer-guide/frontend.md
+++ b/docs/developer-guide/frontend.md
@@ -40,13 +40,41 @@ frontend/src/
 
 | Route | Page | Notes |
 |-------|------|-------|
-| `/` | LandingPage | public marketing page |
+| `/` | LandingRoute | public marketing page — forwards returning visitors to `/app` (see below) |
 | `/terms`, `/risk`, `/privacy` | LegalDocPage | versioned, hash-linked legal documents |
 | `/app` (aliases `/main`, `/fairwins`) | Dashboard | main workspace, inside `AppLayout` (Header + EntryGate + Footer) |
 | `/wallet` | WalletPage | Account Center: Account / Membership / Security / Preferences / Swap tabs |
 | `/friend-market/accept` | MarketAcceptancePage | QR / deep-link wager acceptance (`?marketId=N`) |
 | `/admin` | AdminPanel | the operations control plane, grouped by operator area; role-gated (Admin / Guardian / Account Moderator / Role Manager / Compliance Officer) — see `docs/runbooks/operations-control-plane.md` |
 | `*` | redirect to `/` | |
+
+### Getting to a connected account
+
+Nothing in the app works without a connected account, so the path to one is
+kept as short as it can honestly be:
+
+1. **`/` forwards returning visitors** (`components/LandingRoute.jsx`). Any
+   browser that has attached an account before — a recorded passkey, or a wagmi
+   `recentConnectorId` — and has acknowledged the entry gate goes straight to
+   `/app`. First-time visitors still get the marketing page. Escape hatches,
+   both remembered for the tab session: **Leave** on the entry gate, and
+   `/?stay=1`.
+2. **Entering the app prompts to unlock** (`components/wallet/AutoConnectPrompt.jsx`,
+   mounted in `AppLayout`). It opens the shared ConnectModal once, after the
+   eligibility gate is acknowledged and after wagmi's eager reconnect has
+   **settled** (`connectionStatus` on the wallet context) — a restored session
+   is never interrupted, and a deliberate sign-out is never undone by a
+   re-prompt. Dismissing it leaves the member disconnected with the header and
+   in-panel Connect buttons intact.
+3. **The dialog opens where the member can act** (`components/wallet/ConnectModal.jsx`).
+   When this browser already knows a usable passkey it opens on the account
+   chooser — unlock in one tap instead of methods → Passkey → chooser. The
+   choice itself is unchanged (issue #849: the app never guesses which account),
+   and *More sign-in options* reaches every connector. A browser with no
+   recorded passkey still opens on the methods list.
+
+Spec 045 FR-001 still holds throughout: these surfaces *open* the one shared
+ConnectModal, they never render connector choices of their own.
 
 ## Getting started
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,7 @@ import ModalSystem from './components/ui/ModalSystem'
 import AnnouncementRegion from './components/ui/AnnouncementRegion'
 
 // Main flow
-import LandingPage from './components/LandingPage'
+import LandingRoute from './components/LandingRoute'
 import HomeScreen from './components/fairwins/HomeScreen'
 import WagersPage from './components/fairwins/WagersPage'
 import Header from './components/Header'
@@ -24,6 +24,7 @@ import MarketAcceptancePage from './pages/MarketAcceptancePage'
 import PoolPage from './pages/PoolPage'
 import { TermsPage, RiskPage, PrivacyPage } from './pages/legal/LegalDocPage'
 import EntryGate from './components/compliance/EntryGate'
+import AutoConnectPrompt from './components/wallet/AutoConnectPrompt'
 import { ActivityProvider } from './contexts/ActivityProvider.jsx'
 import { NavDrawerProvider } from './contexts/NavDrawerContext.jsx'
 import ActivityNotificationBridge from './components/notifications/ActivityNotificationBridge'
@@ -65,6 +66,9 @@ function AppLayout() {
         <ActivityNotificationBridge />
         {/* Spec 007 (US4): client-side eligibility notice gate before any app content. */}
         <EntryGate />
+        {/* Entering the app with no account opens the unlock dialog by itself —
+            every surface below is inert until one is connected. */}
+        <AutoConnectPrompt />
         <Outlet />
         {/* Spec 010 (US2): condensed legal/policy footer inside the app. The menu
             drawer carries its own copy; /wallet relies on that to avoid duplication. */}
@@ -128,7 +132,7 @@ function AppContent() {
       <Routes>
         <Route
           path="/"
-          element={<LandingPage />}
+          element={<LandingRoute />}
         />
         <Route path="/ui-components" element={<ComponentExamples />} />
         <Route path="/state-demo" element={<StateManagementDemo />} />

--- a/frontend/src/components/LandingRoute.jsx
+++ b/frontend/src/components/LandingRoute.jsx
@@ -1,0 +1,40 @@
+/**
+ * The "/" route.
+ *
+ * First-time visitors get the marketing page. Anyone this browser has already
+ * attached an account for goes straight to the app, where the unlock prompt
+ * meets them — "Launch App" is a step with no decision in it for a returning
+ * member, and nothing in FairWins works until an account is connected.
+ *
+ * Escape hatches, both honoured for the rest of the tab session: "Leave" on the
+ * entry gate, and /?stay=1.
+ */
+
+import { useEffect } from 'react'
+import { Navigate, useLocation } from 'react-router-dom'
+import { useWallet } from '../hooks/useWalletManagement'
+import LandingPage from './LandingPage'
+import { hasAcknowledged } from '../utils/entryGateAck'
+import { hasWalletHistory, keepOnLanding, shouldStayOnLanding } from '../utils/appEntry'
+
+export default function LandingRoute() {
+  const { isConnected, connectionStatus } = useWallet()
+  const { search } = useLocation()
+  const askedToStay = new URLSearchParams(search).get('stay') === '1'
+
+  useEffect(() => {
+    if (askedToStay) keepOnLanding()
+  }, [askedToStay])
+
+  const stay = askedToStay || shouldStayOnLanding()
+  // 'connecting'/'reconnecting' means a stored session is being restored — that
+  // is a returning member even before isConnected flips.
+  const restoring = connectionStatus === 'connecting' || connectionStatus === 'reconnecting'
+  const returning = isConnected || restoring || hasWalletHistory()
+
+  // Never forward past the eligibility gate: a visitor who has not entered yet
+  // has to see it, and "Leave" must land somewhere that stays put.
+  if (!stay && returning && hasAcknowledged()) return <Navigate to="/app" replace />
+
+  return <LandingPage />
+}

--- a/frontend/src/components/compliance/EntryGate.jsx
+++ b/frontend/src/components/compliance/EntryGate.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getCurrentDocument } from '../../utils/legalDocs'
+import { readAck, writeAck } from '../../utils/entryGateAck'
+import { keepOnLanding } from '../../utils/appEntry'
 import './EntryGate.css'
 
 /**
@@ -15,16 +17,6 @@ import './EntryGate.css'
  *
  * WCAG 2.1 AA: role="dialog" + aria-modal, focus moved in and trapped, labelled controls.
  */
-
-const ACK_KEY = 'fairwins.entryGate.ack.v1'
-
-function readAck() {
-  try {
-    return JSON.parse(localStorage.getItem(ACK_KEY) || 'null')
-  } catch {
-    return null
-  }
-}
 
 export default function EntryGate() {
   const navigate = useNavigate()
@@ -59,11 +51,22 @@ export default function EntryGate() {
   const risk = getCurrentDocument('risk')
 
   const onEnter = () => {
-    const record = { terms: terms?.hash || null, risk: risk?.hash || null, at: new Date().toISOString() }
-    try { localStorage.setItem(ACK_KEY, JSON.stringify(record)) } catch { /* storage disabled */ }
+    // writeAck broadcasts, so the auto-connect prompt can open the unlock
+    // dialog the moment the gate clears — same visit, no reload.
+    const record = writeAck({
+      terms: terms?.hash || null,
+      risk: risk?.hash || null,
+      at: new Date().toISOString(),
+    })
     setAck(record)
   }
-  const onLeave = () => navigate('/')
+  // Leaving is a deliberate request for the marketing page: pin it for this tab
+  // session so the landing route does not forward a returning visitor straight
+  // back into the app they just stepped out of.
+  const onLeave = () => {
+    keepOnLanding()
+    navigate('/')
+  }
 
   return (
     <div className="entry-gate-overlay" role="presentation">

--- a/frontend/src/components/wallet/AutoConnectPrompt.jsx
+++ b/frontend/src/components/wallet/AutoConnectPrompt.jsx
@@ -1,0 +1,52 @@
+/**
+ * AutoConnectPrompt — opens the ONE connect surface as soon as the app is
+ * entered without an account.
+ *
+ * Nothing in FairWins is usable disconnected: every panel behind this is a
+ * "Connect wallet to …" placeholder. Making the member find and press a Connect
+ * button first was a step with no decision in it, so entering the app now
+ * prompts to unlock straight away (spec 045 FR-001 still holds — this opens the
+ * shared ConnectModal, it never renders connector choices of its own).
+ *
+ * Three rules keep the prompt honest:
+ *  - It waits for wagmi's eager reconnect to SETTLE. A returning passkey or
+ *    WalletConnect session restores itself; prompting mid-restore would ask the
+ *    member to unlock an account they already have (spec 045 FR-004).
+ *  - It waits for the eligibility gate. The connect dialog never stacks on top
+ *    of the spec-007 entry gate.
+ *  - It prompts at most ONCE per entry into the app. Dismissing it, or signing
+ *    out on purpose, leaves the member disconnected — the header and the
+ *    in-panel Connect buttons are still there when they want back in.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { useWallet } from '../../hooks/useWalletManagement'
+import { hasAcknowledged, subscribeAck } from '../../utils/entryGateAck'
+
+export default function AutoConnectPrompt() {
+  const { isConnected, connectionStatus, isConnectModalOpen, openConnectModal } = useWallet()
+  const [gateAcknowledged, setGateAcknowledged] = useState(() => hasAcknowledged())
+  const promptedRef = useRef(false)
+
+  useEffect(() => {
+    if (gateAcknowledged) return undefined
+    return subscribeAck((ack) => setGateAcknowledged(Boolean(ack)))
+  }, [gateAcknowledged])
+
+  useEffect(() => {
+    if (promptedRef.current) return
+    if (!gateAcknowledged) return
+    // Undefined status (older test doubles) counts as settled.
+    if (connectionStatus === 'connecting' || connectionStatus === 'reconnecting') return
+    // A restored session needs no prompt — and marking it spent here means a
+    // later, deliberate sign-out is not immediately undone by a re-prompt.
+    if (isConnected) {
+      promptedRef.current = true
+      return
+    }
+    promptedRef.current = true
+    if (!isConnectModalOpen) openConnectModal()
+  }, [gateAcknowledged, connectionStatus, isConnected, isConnectModalOpen, openConnectModal])
+
+  return null
+}

--- a/frontend/src/components/wallet/ConnectModal.jsx
+++ b/frontend/src/components/wallet/ConnectModal.jsx
@@ -10,9 +10,15 @@
  * won't reliably offer the choice, and even a lone recorded passkey must not
  * silently pin the member to index 0) → ceremony pinned to the chosen
  * credential, or a discoverable request for a passkey not yet in the book.
+ *
+ * Returning members open STRAIGHT on that chooser: when this browser already
+ * knows a usable passkey there is nothing to decide on the methods list, so the
+ * dialog opens as an unlock prompt (one tap to sign in) instead of methods →
+ * Passkey → chooser. The choice itself is untouched — #849's "never guess which
+ * account" still holds — and "More sign-in options" reaches every connector.
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useWallet } from '../../hooks/useWalletManagement'
 import { useConnectorAvailability } from '../../hooks/useConnectorAvailability'
 import { getWalletLabel, getWalletIcon } from '../../utils/walletLabel'
@@ -38,17 +44,24 @@ function ConnectModal() {
 function ConnectModalDialog() {
   const { isConnectModalOpen, closeConnectModal, connectWallet, connectors, isConnected } = useWallet()
   const availability = useConnectorAvailability()
-  const [step, setStep] = useState('methods') // methods | explainer | picker
+  // Computed once per opening (the dialog only mounts while open): the passkeys
+  // this browser can sign in with right now.
+  const knownAccounts = useMemo(() => knownCredentials().filter(isTransactComplete), [])
+  const unlockFirst = knownAccounts.length > 0
+  const [step, setStep] = useState(unlockFirst ? 'picker' : 'methods') // methods | explainer | picker
   const [pendingId, setPendingId] = useState(null)
   const [error, setError] = useState(null)
-  const [pickerAccounts, setPickerAccounts] = useState([])
+  const [pickerAccounts, setPickerAccounts] = useState(knownAccounts)
   const dialogRef = useRef(null)
 
+  // "Back to where this opened" — the methods list normally, the unlock chooser
+  // for a returning member (who would otherwise be dropped a step BACKWARDS
+  // after a cancelled ceremony).
   const reset = useCallback(() => {
-    setStep('methods')
+    setStep(unlockFirst ? 'picker' : 'methods')
     setPendingId(null)
     setError(null)
-  }, [])
+  }, [unlockFirst])
 
   const close = useCallback(() => {
     reset()
@@ -101,8 +114,9 @@ function ConnectModalDialog() {
         await connectWallet(connectorId, opts)
       } catch (err) {
         if (err?.name === 'CeremonyCancelled') {
-          // Clean abort — back to an immediately re-attemptable idle state.
-          setStep('methods')
+          // Clean abort — back to an immediately re-attemptable idle state:
+          // the unlock chooser for a returning member, the methods list otherwise.
+          setStep(unlockFirst ? 'picker' : 'methods')
         } else {
           setError(err?.message || 'Connection failed. Please try again.')
         }
@@ -110,7 +124,7 @@ function ConnectModalDialog() {
         setPendingId(null)
       }
     },
-    [connectWallet]
+    [connectWallet, unlockFirst]
   )
 
   const startPasskey = useCallback(() => {
@@ -205,7 +219,13 @@ function ConnectModalDialog() {
         onClick={(e) => e.stopPropagation()}
       >
         <div className="connect-modal__header">
-          <h3>{step === 'picker' ? 'Choose an account' : 'Connect to FairWins'}</h3>
+          <h3>
+            {step !== 'picker'
+              ? 'Connect to FairWins'
+              : unlockFirst
+                ? 'Unlock your account'
+                : 'Choose an account'}
+          </h3>
           <button type="button" className="connect-modal__close" onClick={close} aria-label="Close">
             ×
           </button>
@@ -302,8 +322,11 @@ function ConnectModalDialog() {
             >
               Create a new account
             </button>
-            <button type="button" className="connect-modal__back" onClick={reset}>
-              Back
+            {/* Always reaches the full connector list — a returning member who
+                opened straight on the chooser can still pick WalletConnect or a
+                browser wallet from here. */}
+            <button type="button" className="connect-modal__back" onClick={() => setStep('methods')}>
+              {unlockFirst ? 'More sign-in options' : 'Back'}
             </button>
           </div>
         )}

--- a/frontend/src/components/wallet/__tests__/AutoConnectPrompt.test.jsx
+++ b/frontend/src/components/wallet/__tests__/AutoConnectPrompt.test.jsx
@@ -1,0 +1,84 @@
+/**
+ * AutoConnectPrompt — entering the app with no account opens the unlock dialog
+ * by itself, without racing the eager reconnect or the eligibility gate.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, waitFor } from '@testing-library/react'
+
+const mockWallet = {
+  isConnected: false,
+  connectionStatus: 'disconnected',
+  isConnectModalOpen: false,
+  openConnectModal: vi.fn(),
+}
+vi.mock('../../../hooks/useWalletManagement', () => ({
+  useWallet: () => mockWallet,
+}))
+
+import AutoConnectPrompt from '../AutoConnectPrompt'
+import { writeAck, ENTRY_GATE_ACK_KEY } from '../../../utils/entryGateAck'
+
+const acknowledge = () => localStorage.setItem(ENTRY_GATE_ACK_KEY, JSON.stringify({ at: 'earlier' }))
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+  mockWallet.isConnected = false
+  mockWallet.connectionStatus = 'disconnected'
+  mockWallet.isConnectModalOpen = false
+  mockWallet.openConnectModal = vi.fn()
+})
+
+describe('AutoConnectPrompt', () => {
+  it('prompts to unlock when the app is entered with no account', () => {
+    acknowledge()
+    render(<AutoConnectPrompt />)
+    expect(mockWallet.openConnectModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for the eager reconnect to settle — a restoring session is never interrupted', () => {
+    acknowledge()
+    mockWallet.connectionStatus = 'reconnecting'
+    const { rerender } = render(<AutoConnectPrompt />)
+    expect(mockWallet.openConnectModal).not.toHaveBeenCalled()
+
+    // The stored session restores: still no prompt, the member is already in.
+    mockWallet.connectionStatus = 'connected'
+    mockWallet.isConnected = true
+    rerender(<AutoConnectPrompt />)
+    expect(mockWallet.openConnectModal).not.toHaveBeenCalled()
+  })
+
+  it('never re-prompts after a deliberate sign-out', () => {
+    acknowledge()
+    mockWallet.isConnected = true
+    mockWallet.connectionStatus = 'connected'
+    const { rerender } = render(<AutoConnectPrompt />)
+
+    mockWallet.isConnected = false
+    mockWallet.connectionStatus = 'disconnected'
+    rerender(<AutoConnectPrompt />)
+    expect(mockWallet.openConnectModal).not.toHaveBeenCalled()
+  })
+
+  it('prompts only once, so dismissing the dialog is respected', () => {
+    acknowledge()
+    const { rerender } = render(<AutoConnectPrompt />)
+    expect(mockWallet.openConnectModal).toHaveBeenCalledTimes(1)
+
+    mockWallet.isConnectModalOpen = true
+    rerender(<AutoConnectPrompt />)
+    mockWallet.isConnectModalOpen = false // dismissed
+    rerender(<AutoConnectPrompt />)
+    expect(mockWallet.openConnectModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('never stacks on the eligibility gate — it waits for the acknowledgement', async () => {
+    render(<AutoConnectPrompt />)
+    expect(mockWallet.openConnectModal).not.toHaveBeenCalled()
+
+    // Entering the gate prompts in the same visit, without a reload.
+    act(() => writeAck({ terms: 'x', risk: 'y', at: 'now' }))
+    await waitFor(() => expect(mockWallet.openConnectModal).toHaveBeenCalledTimes(1))
+  })
+})

--- a/frontend/src/components/wallet/__tests__/ConnectModal.test.jsx
+++ b/frontend/src/components/wallet/__tests__/ConnectModal.test.jsx
@@ -6,6 +6,10 @@
  *  - in-app account picker when several passkeys are known (FR-007), with the
  *    chosen credential pinned into the connect call;
  *  - errors surface in the dialog; ceremony cancellation resets silently.
+ *
+ * Onboarding step-reduction: when this browser already knows a usable passkey
+ * the dialog OPENS on that chooser (unlock in one tap) instead of methods →
+ * Passkey → chooser, with every connector still one tap away.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
@@ -165,7 +169,6 @@ describe('ConnectModal — multi-passkey account picker (US3)', () => {
     rememberCredential({ credentialId: 'c-only', publicKey: PK(1), address: '0x' + 'a'.repeat(40), label: 'Phone' })
     const user = userEvent.setup()
     render(<ConnectModal />)
-    await user.click(screen.getByText('Passkey').closest('button'))
 
     // A member with one recorded passkey is still presented with a choice
     // (acceptance #1) rather than being locked to the first credential.
@@ -186,7 +189,6 @@ describe('ConnectModal — multi-passkey account picker (US3)', () => {
     rememberCredential({ credentialId: 'c2', publicKey: PK(2), address: '0x' + 'b'.repeat(40), label: 'Laptop' })
     const user = userEvent.setup()
     render(<ConnectModal />)
-    await user.click(screen.getByText('Passkey').closest('button'))
 
     expect(screen.getByTestId('passkey-picker')).toBeInTheDocument()
     expect(mockWallet.connectWallet).not.toHaveBeenCalled()
@@ -203,7 +205,6 @@ describe('ConnectModal — multi-passkey account picker (US3)', () => {
     rememberCredential({ credentialId: 'c-broken', address: '0x' + 'b'.repeat(40), label: 'Broken' }) // no key
     const user = userEvent.setup()
     render(<ConnectModal />)
-    await user.click(screen.getByText('Passkey').closest('button'))
     // The picker lists only the usable record; the broken one never appears.
     expect(screen.getByTestId('passkey-picker')).toBeInTheDocument()
     expect(screen.getByText('Phone')).toBeInTheDocument()
@@ -221,7 +222,6 @@ describe('ConnectModal — multi-passkey account picker (US3)', () => {
     rememberCredential({ credentialId: 'c2', publicKey: PK(2), address: '0x' + 'b'.repeat(40), label: 'Laptop' })
     const user = userEvent.setup()
     render(<ConnectModal />)
-    await user.click(screen.getByText('Passkey').closest('button'))
 
     await user.click(screen.getByText('Use a different passkey…'))
     // Discoverable request (no allowCredentials) so passkeys this browser has
@@ -240,10 +240,54 @@ describe('ConnectModal — multi-passkey account picker (US3)', () => {
     rememberCredential({ credentialId: 'c2', publicKey: PK(2), address: '0x' + 'b'.repeat(40), label: 'Stale' })
     const user = userEvent.setup()
     render(<ConnectModal />)
-    await user.click(screen.getByText('Passkey').closest('button'))
     await user.click(screen.getByLabelText(/Remove Stale/))
     expect(screen.queryByText('Stale')).not.toBeInTheDocument()
     const stored = JSON.parse(localStorage.getItem('fairwins.passkey.credentials.v1'))
     expect(stored.map((c) => c.credentialId)).toEqual(['c1'])
+  })
+})
+
+describe('ConnectModal — returning members unlock in one tap', () => {
+  beforeEach(() => {
+    markExplainerSeen()
+  })
+
+  it('opens straight on the unlock chooser when this browser knows a passkey', () => {
+    rememberCredential({ credentialId: 'c1', publicKey: PK(1), address: '0x' + 'a'.repeat(40), label: 'Phone' })
+    render(<ConnectModal />)
+
+    // No methods list to walk through first — the account is one tap away.
+    expect(screen.getByTestId('passkey-picker')).toBeInTheDocument()
+    expect(screen.queryByTestId('connect-options')).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Unlock your account' })).toBeInTheDocument()
+  })
+
+  it('still reaches every other connector from the chooser', async () => {
+    rememberCredential({ credentialId: 'c1', publicKey: PK(1), address: '0x' + 'a'.repeat(40), label: 'Phone' })
+    const user = userEvent.setup()
+    render(<ConnectModal />)
+
+    await user.click(screen.getByText('More sign-in options'))
+    expect(screen.getByTestId('connect-options')).toBeInTheDocument()
+    await user.click(screen.getByText('WalletConnect').closest('button'))
+    expect(mockWallet.connectWallet).toHaveBeenCalledWith('walletConnect', undefined)
+  })
+
+  it('returns to the chooser — not backwards to the methods list — when a ceremony is cancelled', async () => {
+    rememberCredential({ credentialId: 'c1', publicKey: PK(1), address: '0x' + 'a'.repeat(40), label: 'Phone' })
+    const cancelled = Object.assign(new Error('Passkey prompt was cancelled'), { name: 'CeremonyCancelled' })
+    mockWallet.connectWallet = vi.fn().mockRejectedValue(cancelled)
+    const user = userEvent.setup()
+    render(<ConnectModal />)
+
+    await user.click(screen.getByText('Phone').closest('button'))
+    await waitFor(() => expect(screen.getByTestId('passkey-picker')).toBeInTheDocument())
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('a browser with no recorded passkey still opens on the methods list', () => {
+    render(<ConnectModal />)
+    expect(screen.getByTestId('connect-options')).toBeInTheDocument()
+    expect(screen.queryByTestId('passkey-picker')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -668,8 +668,13 @@ export function WalletProvider({ children }) {
     address,
     account: address, // Alias for backwards compatibility
     isConnected,
+    // wagmi's raw account status ('connecting' | 'reconnecting' | 'connected' |
+    // 'disconnected'). Surfaces that act on "definitely signed out" — the
+    // auto-connect prompt, the landing forward — must wait for it to SETTLE so
+    // they never race the eager reconnect of a stored session (spec 045 FR-004).
+    connectionStatus: accountStatus,
     chainId,
-    
+
     // Available connectors
     connectors,
     

--- a/frontend/src/pages/VouchersPage.jsx
+++ b/frontend/src/pages/VouchersPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Navigate, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import { ethers } from 'ethers'
 import { useWallet } from '../hooks/useWalletManagement'
 import { useVouchers } from '../hooks/useVouchers'
@@ -24,7 +24,7 @@ const MAX_QUANTITY = 50
  * ABIs come from synced config (Principle V); privacy is disclosed honestly.
  */
 export default function VouchersPage() {
-  const { account, isConnected } = useWallet()
+  const { account, isConnected, openConnectModal } = useWallet()
   const { getPrice, ROLE_HASHES, TIER_IDS, usingFallbackPrices } = useTierPrices()
   const {
     status, error, lastTxHash, voucherAvailable, batchMintAvailable,
@@ -93,7 +93,20 @@ export default function VouchersPage() {
     refreshVouchers()
   }, [refreshVouchers])
 
-  if (!isConnected) return <Navigate to="/" replace />
+  // Disconnected members stay HERE rather than being bounced to the landing
+  // page: the app's unlock dialog is already opening over this route, and
+  // connecting drops them straight into the vouchers they came for.
+  if (!isConnected) {
+    return (
+      <div className="vch-page">
+        <header className="vch-header">
+          <h1>Membership Vouchers</h1>
+          <p className="vch-sub">Connect an account to buy, gift, or redeem a membership voucher.</p>
+        </header>
+        <Button onClick={openConnectModal}>Connect</Button>
+      </div>
+    )
+  }
 
   // Resolve the gift recipient: prefer the ENS-resolved address, else accept a
   // directly-typed hex address. Empty when neither is valid yet.

--- a/frontend/src/test/LandingRoute.test.jsx
+++ b/frontend/src/test/LandingRoute.test.jsx
@@ -1,0 +1,95 @@
+/**
+ * LandingRoute — a returning visitor is not made to walk the marketing page
+ * before they can sign in, and a visitor who asked for it still gets it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+const mockWallet = { isConnected: false, connectionStatus: 'disconnected' }
+vi.mock('../hooks/useWalletManagement', () => ({ useWallet: () => mockWallet }))
+vi.mock('../components/LandingPage', () => ({ default: () => <div>Marketing page</div> }))
+
+import LandingRoute from '../components/LandingRoute'
+import { ENTRY_GATE_ACK_KEY } from '../utils/entryGateAck'
+import { keepOnLanding } from '../utils/appEntry'
+
+const PK = { x: `0x${'1'.repeat(64)}`, y: `0x${'1'.repeat(64)}` }
+
+const acknowledge = () => localStorage.setItem(ENTRY_GATE_ACK_KEY, JSON.stringify({ at: 'earlier' }))
+const rememberPasskey = () =>
+  localStorage.setItem(
+    'fairwins.passkey.credentials.v1',
+    JSON.stringify([{ credentialId: 'c1', publicKey: PK, address: '0x' + 'a'.repeat(40) }]),
+  )
+
+function renderAt(path = '/') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/" element={<LandingRoute />} />
+        <Route path="/app" element={<div>App home</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+  mockWallet.isConnected = false
+  mockWallet.connectionStatus = 'disconnected'
+})
+
+describe('LandingRoute', () => {
+  it('shows the marketing page to a first-time visitor', () => {
+    renderAt()
+    expect(screen.getByText('Marketing page')).toBeInTheDocument()
+  })
+
+  it('forwards a returning member with a recorded passkey straight into the app', () => {
+    acknowledge()
+    rememberPasskey()
+    renderAt()
+    expect(screen.getByText('App home')).toBeInTheDocument()
+  })
+
+  it('forwards on a previously used wallet connector too', () => {
+    acknowledge()
+    localStorage.setItem('wagmi.recentConnectorId', '"injected"')
+    renderAt()
+    expect(screen.getByText('App home')).toBeInTheDocument()
+  })
+
+  it('forwards while a stored session is still restoring', () => {
+    acknowledge()
+    mockWallet.connectionStatus = 'reconnecting'
+    renderAt()
+    expect(screen.getByText('App home')).toBeInTheDocument()
+  })
+
+  it('never forwards past the eligibility gate (not acknowledged yet)', () => {
+    rememberPasskey()
+    renderAt()
+    expect(screen.getByText('Marketing page')).toBeInTheDocument()
+  })
+
+  it('respects a visitor who stepped out of the app ("Leave")', () => {
+    acknowledge()
+    rememberPasskey()
+    keepOnLanding()
+    renderAt()
+    expect(screen.getByText('Marketing page')).toBeInTheDocument()
+  })
+
+  it('respects /?stay=1 and remembers it for the tab session', () => {
+    acknowledge()
+    rememberPasskey()
+    renderAt('/?stay=1')
+    expect(screen.getByText('Marketing page')).toBeInTheDocument()
+
+    // A later plain "/" in the same tab still shows the marketing page.
+    renderAt()
+    expect(screen.getAllByText('Marketing page').length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/test/VouchersPage.test.jsx
+++ b/frontend/src/test/VouchersPage.test.jsx
@@ -145,11 +145,17 @@ describe('VouchersPage (spec 026)', () => {
     expect(screen.getByText(/aren’t available on this network yet/i)).toBeInTheDocument()
   })
 
-  it('redirects to landing when the wallet is not connected', () => {
-    useWallet.mockReturnValue({ account: null, isConnected: false })
+  it('keeps a disconnected visitor here with a connect prompt instead of bouncing them to landing', () => {
+    const openConnectModal = vi.fn()
+    useWallet.mockReturnValue({ account: null, isConnected: false, openConnectModal })
     useVouchers.mockReturnValue(baseVouchers)
-    const { container } = renderPage()
-    // Navigate renders nothing; the page heading must be absent.
-    expect(container.querySelector('.vch-page')).toBeNull()
+    renderPage()
+
+    // The deep link is not thrown away: connecting drops the member straight
+    // into the vouchers they came for.
+    expect(screen.getByRole('heading', { name: /Membership Vouchers/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Redeem/i })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+    expect(openConnectModal).toHaveBeenCalled()
   })
 })

--- a/frontend/src/utils/appEntry.js
+++ b/frontend/src/utils/appEntry.js
@@ -1,0 +1,55 @@
+/**
+ * App-entry routing helpers — "how many steps until this visitor can sign?"
+ *
+ * Nothing in FairWins works without a connected account, so a visitor who has
+ * used this browser before should land on the app (and its unlock prompt), not
+ * on the marketing page with a "Launch App" button in the way. These helpers
+ * answer two questions for the landing route:
+ *
+ *   hasWalletHistory()   — has this browser ever had an account attached?
+ *                          (a recorded passkey, or a wagmi connector it used)
+ *   shouldStayOnLanding() — did the visitor deliberately ask for the marketing
+ *                          page this tab session? ("Leave" on the entry gate,
+ *                          or /?stay=1)
+ *
+ * The stay flag is sessionStorage, not localStorage: wanting to read the
+ * marketing page once is not a durable preference.
+ */
+
+import { knownCredentials, isTransactComplete } from '../lib/passkey/credentials'
+
+// wagmi persists the last connector it connected with; `disconnectWallet`
+// clears it, so an explicit sign-out correctly reads as "no history".
+const RECENT_CONNECTOR_KEY = 'wagmi.recentConnectorId'
+const STAY_KEY = 'fairwins.landing.stay.v1'
+
+/** True when this browser has previously attached an account of any kind. */
+export function hasWalletHistory() {
+  try {
+    if (knownCredentials().some(isTransactComplete)) return true
+  } catch {
+    /* credential book unreadable — fall through to the connector check */
+  }
+  try {
+    return Boolean(localStorage.getItem(RECENT_CONNECTOR_KEY))
+  } catch {
+    return false
+  }
+}
+
+/** Remember, for this tab session, that the visitor wants the landing page. */
+export function keepOnLanding() {
+  try {
+    sessionStorage.setItem(STAY_KEY, '1')
+  } catch {
+    /* storage disabled — the visitor can still use /?stay=1 */
+  }
+}
+
+export function shouldStayOnLanding() {
+  try {
+    return sessionStorage.getItem(STAY_KEY) === '1'
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/utils/entryGateAck.js
+++ b/frontend/src/utils/entryGateAck.js
@@ -1,0 +1,48 @@
+/**
+ * Entry-gate acknowledgement record (spec 007 US4) as a shared, observable store.
+ *
+ * The gate component still owns the dialog; this module owns the record so other
+ * surfaces can read it and react to it. The auto-connect prompt depends on that:
+ * the connect dialog must never stack on top of the eligibility gate, and it has
+ * to open the moment the visitor presses "Enter" — in the same visit, without a
+ * reload — so the acknowledgement is broadcast rather than merely written.
+ */
+
+export const ENTRY_GATE_ACK_KEY = 'fairwins.entryGate.ack.v1'
+const ACK_EVENT = 'fairwins:entry-gate-ack'
+
+/** The stored acknowledgement, or null when this browser has never entered. */
+export function readAck() {
+  try {
+    return JSON.parse(localStorage.getItem(ENTRY_GATE_ACK_KEY) || 'null')
+  } catch {
+    return null
+  }
+}
+
+export function hasAcknowledged() {
+  return Boolean(readAck())
+}
+
+/** Persist the acknowledgement and notify subscribers in this tab. */
+export function writeAck(record) {
+  try {
+    localStorage.setItem(ENTRY_GATE_ACK_KEY, JSON.stringify(record))
+  } catch {
+    /* storage disabled — the gate still un-blocks for this session */
+  }
+  try {
+    window.dispatchEvent(new CustomEvent(ACK_EVENT, { detail: record }))
+  } catch {
+    /* no window (SSR/tests) — subscribers simply never fire */
+  }
+  return record
+}
+
+/** Subscribe to acknowledgement changes. Returns an unsubscribe function. */
+export function subscribeAck(listener) {
+  if (typeof window === 'undefined') return () => {}
+  const handler = () => listener(readAck())
+  window.addEventListener(ACK_EVENT, handler)
+  return () => window.removeEventListener(ACK_EVENT, handler)
+}


### PR DESCRIPTION
## What

Nothing in FairWins works without a connected account, so every tap before the connect ceremony was a step with no decision in it. This shortens the path in three places, without changing what the member actually chooses.

**1. `/` forwards returning visitors into the app** — new `components/LandingRoute.jsx`. A browser that has attached an account before (a recorded passkey, or a wagmi `recentConnectorId`) *and* has acknowledged the entry gate goes straight to `/app`, where the unlock prompt meets it. First-time visitors still get the marketing page. Escape hatches, both remembered for the tab session: **Leave** on the entry gate, and `/?stay=1`.

**2. Entering the app opens the unlock dialog by itself** — new `components/wallet/AutoConnectPrompt.jsx`, mounted in `AppLayout`. It opens the shared ConnectModal once, and only after:
- the spec-007 eligibility gate is acknowledged (the dialog never stacks on the gate), and
- wagmi's eager reconnect has **settled** — a restoring passkey/WalletConnect session is never interrupted (spec 045 FR-004).

It prompts at most once per entry, so dismissing it, or signing out on purpose, is respected; the header and in-panel Connect buttons are still there.

**3. The dialog opens where the member can act** — `ConnectModal` now opens on the passkey chooser when this browser already knows a usable passkey: unlock in one tap instead of methods → Passkey → chooser. The choice itself is untouched (issue #849 — the app never guesses which account), *More sign-in options* reaches every connector, and a cancelled ceremony returns to the chooser rather than dropping a step backwards. A browser with no recorded passkey still opens on the methods list.

Spec 045 FR-001 holds throughout: these surfaces *open* the one shared ConnectModal; none of them render connector choices of their own.

### Supporting changes

- `utils/entryGateAck.js` — the entry-gate acknowledgement becomes a shared, observable store, so pressing **Enter** opens the unlock dialog in the same visit rather than on the next load. `EntryGate` now reads/writes through it.
- `utils/appEntry.js` — returning-visitor detection and the "stay on the landing page" session flag.
- `WalletContext` exposes wagmi's raw `connectionStatus`, which is what lets the prompt and the landing forward wait for the reconnect to settle.
- `/vouchers` while disconnected now shows a connect prompt in place instead of bouncing to the landing page — the deep link survives the sign-in.

## Testing

- `ConnectModal.test.jsx` — updated for chooser-first (the picker tests no longer walk the methods list) plus new cases: opens on the chooser with the "Unlock your account" heading, still reaches every connector via *More sign-in options*, a cancelled ceremony returns to the chooser, and a browser with no passkey still opens on the methods list.
- `AutoConnectPrompt.test.jsx` (new) — prompts on entry, waits for reconnect to settle, never re-prompts after a deliberate sign-out, prompts once so dismissal sticks, waits for the eligibility gate and fires the moment it clears.
- `LandingRoute.test.jsx` (new) — marketing page for first-timers; forwards on a recorded passkey, on a prior connector, and while a session is restoring; never forwards past the eligibility gate; respects **Leave** and `/?stay=1`.
- `VouchersPage.test.jsx` — the redirect case becomes the in-place connect prompt.

Ran locally: the wallet/connect/entry-gate/vouchers/home tests plus a 50-file batch of `src/test` (all green) and eslint on every changed file. The full frontend suite is left to CI.

## Docs

`docs/developer-guide/frontend.md` gains a "Getting to a connected account" section describing the three steps above, and the routes table now lists `LandingRoute` for `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mgPXYEue93yXzzucZyEE6

---
_Generated by [Claude Code](https://claude.ai/code/session_016mgPXYEue93yXzzucZyEE6)_