### PR TITLE
fix(earn): scope Morpho branding to Lend and Rewards views only

### DIFF
--- a/frontend/src/components/earn/EarnPanel.jsx
+++ b/frontend/src/components/earn/EarnPanel.jsx
@@ -4,8 +4,11 @@
  * A member-friendly gateway to passive earning. Every area is now live: Lend
  * (Morpho vaults), Rewards (Merkl), Stake (spec 065), and Supply (spec 067 —
  * liquidity pools, which replaced the disabled "Bridges" tile per FR-003).
- * Plus protocol attribution + risk disclosure and a link to the user guide.
- * Every DeFi term carries an InfoTip (FR-011).
+ * Plus a link to the user guide. Every DeFi term carries an InfoTip (FR-011).
+ *
+ * Protocol attribution + risk disclosure (FR-012) render only on the Lend and
+ * Rewards views — the two that actually show Morpho markets. Stake and Supply
+ * don't touch Morpho, so they stay unbranded; the hub itself is unbranded too.
  *
  * NAMING (spec 067 FR-003/FR-039): the liquidity area is **Supply**. It is not
  * "Bridges" — bridging itself lives in Transfer → Bridge and is a payment, not
@@ -122,7 +125,11 @@ export default function EarnPanel() {
       {view === 'supply' && <SupplyView tokenFilter={tokenFilter} />}
 
       <footer className="earn-footer">
-        {earnConfig?.provider && (
+        {/* Protocol attribution + risk disclosure (FR-012) only apply where the
+            protocol's own markets are on screen — Lend and Rewards. Stake,
+            Supply, and the hub itself don't touch Morpho, so they don't carry
+            its branding. */}
+        {(view === 'lend' || view === 'rewards') && earnConfig?.provider && (
           <a
             className="earn-attribution"
             href={earnConfig.provider.url}
@@ -132,7 +139,9 @@ export default function EarnPanel() {
             {EARN_DISCLOSURE.attribution}
           </a>
         )}
-        <p className="earn-risk">{EARN_DISCLOSURE.risk}</p>
+        {(view === 'lend' || view === 'rewards') && (
+          <p className="earn-risk">{EARN_DISCLOSURE.risk}</p>
+        )}
         <a className="earn-docs-link" href={EARN_DOCS_URL} target="_blank" rel="noopener noreferrer">
           Learn more in the Earn guide ↗
         </a>

--- a/frontend/src/test/earn/EarnPanel.test.jsx
+++ b/frontend/src/test/earn/EarnPanel.test.jsx
@@ -134,15 +134,38 @@ describe('EarnPanel hub (US1)', () => {
     expect(screen.getByText(LIQUIDITY_AREA_DESC)).toBeInTheDocument()
   })
 
-  it('displays protocol attribution, risk disclosure, and the docs link (FR-012/FR-014)', () => {
+  it('shows the docs link on the hub, with no Morpho attribution or risk disclosure yet', () => {
     renderPanel()
-    const attribution = screen.getByRole('link', { name: /powered by morpho/i })
-    expect(attribution).toHaveAttribute('href', 'https://app.morpho.org')
-    expect(screen.getByText(/not guaranteed/i)).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /powered by morpho/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/not guaranteed/i)).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: /earn guide/i })).toHaveAttribute(
       'href',
       expect.stringContaining('docs.FairWins.app'),
     )
+  })
+
+  it('displays protocol attribution and risk disclosure on the Lend view (FR-012)', () => {
+    renderPanel('/wallet?tab=earn&view=lend')
+    const attribution = screen.getByRole('link', { name: /powered by morpho/i })
+    expect(attribution).toHaveAttribute('href', 'https://app.morpho.org')
+    expect(screen.getByText(/not guaranteed/i)).toBeInTheDocument()
+  })
+
+  it('displays protocol attribution and risk disclosure on the Rewards view (FR-012)', () => {
+    renderPanel('/wallet?tab=earn&view=rewards')
+    const attribution = screen.getByRole('link', { name: /powered by morpho/i })
+    expect(attribution).toHaveAttribute('href', 'https://app.morpho.org')
+    expect(screen.getByText(/not guaranteed/i)).toBeInTheDocument()
+  })
+
+  it('does not brand the Stake or Supply views with Morpho attribution', () => {
+    renderPanel('/wallet?tab=earn&view=stake')
+    expect(screen.queryByRole('link', { name: /powered by morpho/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(earnCopy.EARN_DISCLOSURE.risk)).not.toBeInTheDocument()
+
+    renderPanel('/wallet?tab=earn&view=supply')
+    expect(screen.queryByRole('link', { name: /powered by morpho/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(earnCopy.EARN_DISCLOSURE.risk)).not.toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Summary
- The Earn section's footer ("Powered by Morpho" attribution link + risk disclosure, FR-012) was rendering on **every** Earn view — the hub, Lend, Rewards, Stake, and Supply — even though only Lend and Rewards actually surface Morpho markets.
- Scope the Morpho attribution and risk disclosure to render only on the `lend` and `rewards` views. The hub, Stake, and Supply (neither of which touch Morpho) no longer carry the branding. The generic "Learn more in the Earn guide" docs link still shows everywhere.

## Test plan
- [x] `npx vitest run src/test/earn/` — all 191 tests pass, including updated/new `EarnPanel.test.jsx` cases asserting attribution shows on Lend/Rewards and is absent from the hub/Stake/Supply.
- [x] `npx eslint src/components/earn/EarnPanel.jsx src/test/earn/EarnPanel.test.jsx` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MB1v3TnNsqABfq8VXiN8yu)_