### PR TITLE
Spec 067 US4: operator control surfaces for Bridge and Supply

### DIFF
--- a/contracts/bridge/BridgeRouter.sol
+++ b/contracts/bridge/BridgeRouter.sol
@@ -180,20 +180,32 @@ contract BridgeRouter is IBridgeRouter, UUPSManaged, ReentrancyGuardUpgradeable,
         emit RouteRemoved(routeId, msg.sender);
     }
 
-    function setSpokePool(address newSpokePool) external onlyRole(LIQUIDITY_ADMIN_ROLE) {
+    // ------------------------------------------- protocol wiring (DEFAULT_ADMIN_ROLE)
+    //
+    // These three are NOT curation, and deliberately sit a role above it.
+    //
+    // `spokePool` is approved and handed the member's net amount; `feeRouter` names both the rate and
+    // the `treasury()` the fee is transferred to; `sanctionsGuard` is the compliance gate. Whoever can
+    // write them can redirect where member funds go, so they are DEFAULT_ADMIN_ROLE while
+    // LIQUIDITY_ADMIN_ROLE stays what its name says — which routes are offered, at what ceiling.
+    // Curating a route badly is recoverable by toggling it; pointing the router at a hostile contract
+    // is not. The amount-bound in `bridgeWithFee` is the second half of this: even an admin cannot
+    // configure a FeeRouter that takes more than MAX_FEE_BPS of a member's principal.
+
+    function setSpokePool(address newSpokePool) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (newSpokePool == address(0)) revert ZeroAddress();
         emit SpokePoolUpdated(spokePool, newSpokePool, msg.sender);
         spokePool = newSpokePool;
     }
 
-    function setFeeRouter(address newFeeRouter) external onlyRole(LIQUIDITY_ADMIN_ROLE) {
+    function setFeeRouter(address newFeeRouter) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (newFeeRouter == address(0)) revert ZeroAddress();
         emit FeeRouterUpdated(feeRouter, newFeeRouter, msg.sender);
         feeRouter = newFeeRouter;
     }
 
     /// @notice Set or clear (zero) the sanctions guard.
-    function setSanctionsGuard(address newGuard) external onlyRole(LIQUIDITY_ADMIN_ROLE) {
+    function setSanctionsGuard(address newGuard) external onlyRole(DEFAULT_ADMIN_ROLE) {
         emit SanctionsGuardUpdated(sanctionsGuard, newGuard, msg.sender);
         sanctionsGuard = newGuard;
     }
@@ -269,6 +281,16 @@ contract BridgeRouter is IBridgeRouter, UUPSManaged, ReentrancyGuardUpgradeable,
         uint16 liveBps = router.feeBps(bridgeTransferServiceId);
         if (liveBps > MAX_FEE_BPS) revert FeeAboveCap();
         if (fee > 0 && liveBps > maxFeeBps) revert FeeAboveQuoted();
+        // THE CAP BINDS THE FEE ACTUALLY TAKEN, NOT ONLY THE RATE THE ROUTER REPORTS ABOUT ITSELF.
+        // Both checks above read `feeBps()`, which is the FeeRouter's own claim. A FeeRouter reporting
+        // feeBps() = 0 while quoteFee() hands back most of the amount satisfies both — the rate is
+        // under the ceiling and `liveBps > maxFeeBps` is false — and the transfer below would then
+        // send that "fee" to its treasury. Bounding the AMOUNT makes MAX_FEE_BPS true regardless of
+        // what the router says, so pointing this contract at a hostile FeeRouter cannot redirect a
+        // member's principal. Exact-split is required for the same reason: `net` is what reaches
+        // Across, so a router that under-reports `net` would strand the difference here.
+        if (fee + net != inputAmount) revert FeeSplitMismatch();
+        if (fee > (inputAmount * MAX_FEE_BPS) / 10_000) revert FeeAboveCap();
 
         // ---------------- effects ----------------
         // `depositor` is msg.sender — see the contract-level note. Recorded in the event so the

--- a/contracts/bridge/IBridgeRouter.sol
+++ b/contracts/bridge/IBridgeRouter.sol
@@ -73,6 +73,10 @@ interface IBridgeRouter {
     error FeeAboveQuoted();
     /// @dev The live rate exceeds this router's own immutable ceiling, whatever FeeRouter reports.
     error FeeAboveCap();
+    /// @dev `quoteFee` returned a fee/net pair that does not add back to the gross it was quoted on.
+    ///      A conforming FeeRouter always splits exactly; a router that does not is not trusted to
+    ///      report its own rate either, so the bridge refuses rather than moving funds on its word.
+    error FeeSplitMismatch();
     error ResidualFunds();
     error RouteUnknown();
     error RouteDisabled();

--- a/contracts/liquidity/ILiquidityRouter.sol
+++ b/contracts/liquidity/ILiquidityRouter.sol
@@ -102,6 +102,10 @@ interface ILiquidityRouter {
     error ZeroAddress();
     error ZeroAmount();
     error FeeAboveQuoted();
+    /// @dev `quoteFee` returned a fee/net pair that does not add back to the gross it was quoted on.
+    ///      A conforming FeeRouter always splits exactly; a router that does not is not trusted to
+    ///      report its own rate either, so the supply refuses rather than moving funds on its word.
+    error FeeSplitMismatch();
     /// @dev The live rate exceeds this router's own immutable ceiling, whatever FeeRouter reports.
     error FeeAboveCap();
     error ResidualFunds();

--- a/contracts/liquidity/LiquidityRouter.sol
+++ b/contracts/liquidity/LiquidityRouter.sol
@@ -165,18 +165,33 @@ contract LiquidityRouter is ILiquidityRouter, UUPSManaged, ReentrancyGuardUpgrad
         emit PoolLimitChanged(poolId, maxDeposit0PerTx, maxDeposit1PerTx, msg.sender);
     }
 
-    function setPositionManager(address newManager) external onlyRole(LIQUIDITY_ADMIN_ROLE) {
+    // ------------------------------------------- protocol wiring (DEFAULT_ADMIN_ROLE)
+    //
+    // These three are NOT curation, and deliberately sit a role above it.
+    //
+    // `positionManager` is approved and mints the member's position; `feeRouter` names both the rate
+    // and the `treasury()` the fee is transferred to; `sanctionsGuard` is the compliance gate. Whoever
+    // can write them can redirect where member funds go, so they are DEFAULT_ADMIN_ROLE while
+    // LIQUIDITY_ADMIN_ROLE stays what its name says — which pools are curated, at what ceiling.
+    // Curating a pool badly is recoverable by retiring it; pointing the router at a hostile contract
+    // is not. The amount-bound in `_supply` is the second half of this: even an admin cannot configure
+    // a FeeRouter that takes more than MAX_FEE_BPS of a member's capital.
+
+    /// @dev Zero is rejected: an unset manager is reached through `PositionManagerUnset` on the supply
+    ///      path, so there is no reason to allow writing the router into that state deliberately.
+    function setPositionManager(address newManager) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newManager == address(0)) revert ZeroAddress();
         emit PositionManagerUpdated(positionManager, newManager, msg.sender);
         positionManager = newManager;
     }
 
-    function setFeeRouter(address newFeeRouter) external onlyRole(LIQUIDITY_ADMIN_ROLE) {
+    function setFeeRouter(address newFeeRouter) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (newFeeRouter == address(0)) revert ZeroAddress();
         emit FeeRouterUpdated(feeRouter, newFeeRouter, msg.sender);
         feeRouter = newFeeRouter;
     }
 
-    function setSanctionsGuard(address newGuard) external onlyRole(LIQUIDITY_ADMIN_ROLE) {
+    function setSanctionsGuard(address newGuard) external onlyRole(DEFAULT_ADMIN_ROLE) {
         emit SanctionsGuardUpdated(sanctionsGuard, newGuard, msg.sender);
         sanctionsGuard = newGuard;
     }
@@ -266,6 +281,13 @@ contract LiquidityRouter is ILiquidityRouter, UUPSManaged, ReentrancyGuardUpgrad
         uint16 liveBps = router.feeBps(liquidityDepositServiceId);
         if (liveBps > MAX_FEE_BPS) revert FeeAboveCap();
         if ((quoted0 > 0 || quoted1 > 0) && liveBps > maxFeeBps) revert FeeAboveQuoted();
+        // Exact-split, checked before any funds move: `net0`/`net1` are what get approved to the
+        // position manager, so a FeeRouter that under-reports them would shrink the member's position
+        // by the difference. See the amount-bound in `_supply` for the other half of not trusting the
+        // configured FeeRouter's account of itself.
+        if (quoted0 + net0 != amount0Desired || quoted1 + net1 != amount1Desired) {
+            revert FeeSplitMismatch();
+        }
 
         // ---------------- interactions ----------------
         uint256 fee0;
@@ -350,6 +372,15 @@ contract LiquidityRouter is ILiquidityRouter, UUPSManaged, ReentrancyGuardUpgrad
         IFeeRouter router = IFeeRouter(feeRouter);
         (fee0, ) = router.quoteFee(liquidityDepositServiceId, amount0);
         (fee1, ) = router.quoteFee(liquidityDepositServiceId, amount1);
+        // THE CAP BINDS THE FEE ACTUALLY TAKEN, NOT ONLY THE RATE THE ROUTER REPORTS ABOUT ITSELF.
+        // The ceiling checked before the mint reads `feeBps()`, which is the FeeRouter's own claim. A
+        // FeeRouter reporting feeBps() = 0 while quoteFee() hands back most of the amount passes that
+        // check, and these two transfers would then send the member's capital to its treasury. This
+        // re-quote is also the one the member never consented to directly — it happens after the mint,
+        // against amounts nobody knew in advance — so it is bounded here on the amounts themselves.
+        if (
+            fee0 > (amount0 * MAX_FEE_BPS) / 10_000 || fee1 > (amount1 * MAX_FEE_BPS) / 10_000
+        ) revert FeeAboveCap();
         if (fee0 > 0) t0.safeTransfer(treasury, fee0);
         if (fee1 > 0) t1.safeTransfer(treasury, fee1);
 

--- a/contracts/mocks/MockLyingFeeRouter.sol
+++ b/contracts/mocks/MockLyingFeeRouter.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title MockLyingFeeRouter
+/// @notice A FeeRouter that MISREPORTS ITSELF: `feeBps()` returns a low, in-cap rate while
+///         `quoteFee()` hands back an arbitrary fee. Test-only.
+///
+/// @dev Spec 067. This mock exists because both routers' fee ceilings were originally checked against
+///      `feeBps()` — the fee router's own claim about its rate — and never against the fee amount
+///      `quoteFee` actually returned. That made `MAX_FEE_BPS` a statement about a cooperating
+///      contract rather than a guarantee to the member: point a router at this mock and the reported
+///      rate passes every check while the quote drains the principal.
+///
+///      Adversarial review found it; `BridgeRouter.bridgeWithFee` and `LiquidityRouter._supply` now
+///      bound the returned AMOUNT, so this contract can no longer take more than MAX_FEE_BPS. Keep it
+///      in the suite: it is the only thing that fails if that bound is ever removed.
+contract MockLyingFeeRouter {
+    address public treasury;
+
+    /// The rate this contract ADMITS to when asked.
+    uint16 public reportedBps;
+
+    /// The share of every quote it actually takes, in bps. Set far above `reportedBps` to lie.
+    uint16 public actualBps;
+
+    /// When true, `quoteFee` returns a fee/net pair that does not add back to the gross.
+    bool public splitShort;
+
+    constructor(address treasury_, uint16 reportedBps_, uint16 actualBps_) {
+        treasury = treasury_;
+        reportedBps = reportedBps_;
+        actualBps = actualBps_;
+    }
+
+    function setSplitShort(bool on) external {
+        splitShort = on;
+    }
+
+    function feeBps(bytes32) external view returns (uint16) {
+        return reportedBps;
+    }
+
+    function quoteFee(bytes32, uint256 grossAmount)
+        external
+        view
+        returns (uint256 feeAmount, uint256 netAmount)
+    {
+        feeAmount = (grossAmount * actualBps) / 10_000;
+        // A conforming router splits exactly. `splitShort` withholds a unit from `net` instead, which
+        // would strand value in the calling router rather than move it to the treasury.
+        netAmount = splitShort ? grossAmount - feeAmount - 1 : grossAmount - feeAmount;
+    }
+}

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -18,6 +18,8 @@ import MembershipTreasuryOverview from './admin/MembershipTreasuryOverview'
 import ProtocolConfigTab from './admin/ProtocolConfigTab'
 import FeesTab from './admin/FeesTab'
 import StakingTab from './admin/StakingTab'
+import BridgeTab from './admin/BridgeTab'
+import SupplyTab from './admin/SupplyTab'
 import MaintenanceTab from './admin/MaintenanceTab'
 import ServiceHealthCard from './admin/ServiceHealthCard'
 import PaymasterOpsCard from './admin/PaymasterOpsCard'
@@ -37,6 +39,19 @@ const ROLE_HASHES = {
   SANCTIONS_ADMIN: ethers.keccak256(ethers.toUtf8Bytes('SANCTIONS_ADMIN_ROLE')),
   TOKEN_ISSUER: ethers.keccak256(ethers.toUtf8Bytes('TOKEN_ISSUER_ROLE')),
   STAKING_ADMIN: ethers.keccak256(ethers.toUtf8Bytes('STAKING_ADMIN_ROLE')),
+  // LIQUIDITY_ADMIN_ROLE (spec 067) is the same role id on two separate
+  // AccessControl contracts — the BridgeRouter and the LiquidityRouter — so it
+  // is granted/revoked once per router. The picker therefore offers the two
+  // targets explicitly instead of one option that would quietly authorize only
+  // half of what the operator asked for.
+  LIQUIDITY_ADMIN_BRIDGE: ethers.keccak256(ethers.toUtf8Bytes('LIQUIDITY_ADMIN_ROLE')),
+  LIQUIDITY_ADMIN_LIQUIDITY: ethers.keccak256(ethers.toUtf8Bytes('LIQUIDITY_ADMIN_ROLE')),
+  // GUARDIAN_ROLE is per-contract for the same reason, and the spec-067 routers were unreachable:
+  // the bare `GUARDIAN` option above grants on the WagerRegistry, so there was NO in-app way to give
+  // anyone the routers' killswitch. The routers grant it only to their `initialize` admin, which
+  // meant the emergency lever could not be delegated to an on-call operator at all.
+  GUARDIAN_BRIDGE: ethers.keccak256(ethers.toUtf8Bytes('GUARDIAN_ROLE')),
+  GUARDIAN_LIQUIDITY: ethers.keccak256(ethers.toUtf8Bytes('GUARDIAN_ROLE')),
   DEFAULT_ADMIN: ethers.ZeroHash,
 }
 
@@ -94,7 +109,19 @@ function AdminPanel() {
   const isSanctionsAdmin = hasRole(ROLES.SANCTIONS_ADMIN)
   const isFeeAdmin = hasRole(ROLES.FEE_ADMIN)
   const isStakingAdmin = hasRole(ROLES.STAKING_ADMIN)
+  // LIQUIDITY_ADMIN_ROLE lives on BOTH spec-067 routers (BridgeRouter and
+  // LiquidityRouter). It resolves to true when the operator holds it on at
+  // least one router deployed on the connected network — an undeployed router
+  // is skipped, never read as a denial (see hasRoleOnChain). Entry to the tab
+  // is deliberately generous; each tab re-checks authority per router and per
+  // network before offering a write, and the control state the tabs read is
+  // per-network regardless of which network the wallet sits on (FR-050).
+  const isLiquidityAdmin = hasRole(ROLES.LIQUIDITY_ADMIN)
   const hasAdminAccess = hasAnyRole(ADMIN_ROLES)
+  // The Bridge/Supply fee cards link across to where a rate is actually editable — but only for
+  // an operator who can open that tab. Offering the link to someone the Fees tab is closed to
+  // would send them to a blank panel, so they get the same sentence without a dead control.
+  const canOpenFees = isAdmin || isFeeAdmin
 
   const [activeTab, setActiveTab] = useState('overview')
   const [sidebarOpen, setSidebarOpen] = useState(true)
@@ -145,6 +172,8 @@ function AdminPanel() {
   const sanctionsGuardAddr = getContractAddressForChain('sanctionsGuard', chainId)
   const tokenFactoryAddr = getContractAddressForChain('tokenFactory', chainId)
   const stakingRouterAddr = getContractAddressForChain('stakingRouter', chainId)
+  const bridgeRouterAddr = getContractAddressForChain('bridgeRouter', chainId)
+  const liquidityRouterAddr = getContractAddressForChain('liquidityRouter', chainId)
 
   // Each grantable role lives on a specific contract; grants must be sent
   // to the contract that defines the role, not blanket-sent to the registry.
@@ -153,6 +182,8 @@ function AdminPanel() {
     if (role === 'SANCTIONS_ADMIN') return sanctionsGuardAddr
     if (role === 'TOKEN_ISSUER') return tokenFactoryAddr
     if (role === 'STAKING_ADMIN') return stakingRouterAddr
+    if (role === 'LIQUIDITY_ADMIN_BRIDGE' || role === 'GUARDIAN_BRIDGE') return bridgeRouterAddr
+    if (role === 'LIQUIDITY_ADMIN_LIQUIDITY' || role === 'GUARDIAN_LIQUIDITY') return liquidityRouterAddr
     return wagerRegistryAddr
   }
 
@@ -193,17 +224,31 @@ function AdminPanel() {
     return () => clearInterval(interval)
   }, [fetchContractState])
 
+  /**
+   * Send one admin transaction, reporting the outcome to the operator.
+   *
+   * RESOLVES `true` on success and `false` on any failure — including a rejected wallet prompt —
+   * rather than resolving `undefined` either way. Callers that send a SEQUENCE need that: the
+   * spec-067 bulk route toggles promised "a failed or rejected signature stops the rest", and with a
+   * signal-free result the loop could not observe a revert, so rejecting the first prompt still
+   * queued the remaining four. Never rejects, so the existing `.then(refresh)` callers are unchanged.
+   */
   const runTx = useCallback(async (fn, successMsg) => {
-    if (!signer) return showNotification('Connect your wallet first', 'error')
+    if (!signer) {
+      showNotification('Connect your wallet first', 'error')
+      return false
+    }
     setPendingTx(true)
     try {
       const tx = await fn()
       await tx.wait()
       showNotification(successMsg, 'success')
       fetchContractState()
+      return true
     } catch (err) {
       console.error(err)
       showNotification(err.shortMessage || err.message, 'error')
+      return false
     } finally {
       setPendingTx(false)
     }
@@ -323,6 +368,7 @@ function AdminPanel() {
     isSanctionsAdmin,
     isFeeAdmin,
     isStakingAdmin,
+    isLiquidityAdmin,
   })
   const adminTabs = flattenNavGroups(navGroups)
 
@@ -348,12 +394,22 @@ function AdminPanel() {
         <div className="admin-panel-header-content">
           <div className="admin-panel-title-section">
             <h1>Operations</h1>
+            {/*
+              The fallback used to be the literal 'Admin', so an operator whose only authority was
+              LIQUIDITY_ADMIN (or FEE_ADMIN, or STAKING_ADMIN) was badged as an administrator while
+              the permissions card below showed × on every row — the screen asserting both that they
+              were an Admin and that they held nothing. Every role that can open this panel now names
+              itself, and the last resort says what it means: something got you in, not "Admin".
+            */}
             <span className="admin-badge">
               {isAdmin ? 'Administrator' :
                 isGuardian ? 'Guardian' :
                   isAccountModerator ? 'Moderator' :
                     isRoleManager ? 'Role Manager' :
-                      isSanctionsAdmin ? 'Compliance Officer' : 'Admin'}
+                      isSanctionsAdmin ? 'Compliance Officer' :
+                        isFeeAdmin ? 'Fee Administrator' :
+                          isStakingAdmin ? 'Staking Administrator' :
+                            isLiquidityAdmin ? 'Liquidity Administrator' : 'Operator'}
             </span>
           </div>
           <p className="admin-panel-subtitle">
@@ -447,7 +503,36 @@ function AdminPanel() {
                     <span className="permission-icon">{isSanctionsAdmin ? '✓' : '×'}</span>
                     <span className="permission-name">Compliance Officer (deny-list on SanctionsGuard)</span>
                   </div>
+                  {/*
+                    These three were in ROLES, in ADMIN_ROLES and in the nav, but not in this card —
+                    so an operator holding one of them read a list of five × and concluded their grant
+                    had not landed. A permissions card that omits a role it let you in on is worse
+                    than no card.
+                  */}
+                  <div className={`permission-item ${isFeeAdmin ? 'enabled' : 'disabled'}`}>
+                    <span className="permission-icon">{isFeeAdmin ? '✓' : '×'}</span>
+                    <span className="permission-name">Fee Administrator (platform fee rates on the FeeRouter)</span>
+                  </div>
+                  <div className={`permission-item ${isStakingAdmin ? 'enabled' : 'disabled'}`}>
+                    <span className="permission-icon">{isStakingAdmin ? '✓' : '×'}</span>
+                    <span className="permission-name">Staking Administrator (provider addresses + validator allowlist)</span>
+                  </div>
+                  <div className={`permission-item ${isLiquidityAdmin ? 'enabled' : 'disabled'}`}>
+                    <span className="permission-icon">{isLiquidityAdmin ? '✓' : '×'}</span>
+                    <span className="permission-name">Liquidity Administrator (bridge routes + curated pools, per router)</span>
+                  </div>
                 </div>
+                {/*
+                  Every row above is resolved on the CONNECTED network. The spec-067 routers exist on
+                  five, and their roles are per-contract — so this card is a summary, not a verdict:
+                  the Bridge and Supply tabs each ask the router in scope directly before offering a
+                  control. Saying so here stops the summary being read as the authority.
+                */}
+                <p className="card-info">
+                  Read on {NETWORK_CONFIG.name}. Roles are per-contract and per-network, so the
+                  Bridge and Supply tabs re-check the specific router for the network you select —
+                  what they offer there is the authoritative answer.
+                </p>
               </div>
 
               <ServiceHealthCard />
@@ -651,6 +736,21 @@ function AdminPanel() {
                 Only the holder of <code>DEFAULT_ADMIN_ROLE</code> can grant other admin roles.
                 Grant sparingly: each role is a distinct privilege and a foothold.
               </p>
+              <p>
+                <strong>Liquidity Administrator is per-router.</strong> The bridge and
+                liquidity routers each carry their own <code>LIQUIDITY_ADMIN_ROLE</code>;
+                granting one does not grant the other. Grant both if the operator is meant
+                to curate bridge routes <em>and</em> supplied pools.
+              </p>
+              <p>
+                <strong>So is Guardian.</strong> The plain “Guardian” option above grants on the
+                WagerRegistry and does <em>not</em> carry to the bridge or liquidity routers — those
+                check their own role registry, so an on-call operator needs the router-specific
+                Guardian grant to reach the Bridge or Supply killswitch. Note also that the routers
+                keep protocol-wiring changes (SpokePool, position manager, FeeRouter, sanctions guard)
+                at <code>DEFAULT_ADMIN_ROLE</code>: those addresses decide where member funds go, so
+                curating routes and pools does not carry the power to redirect them.
+              </p>
               <div className="admin-form">
                 <label>
                   Account (address or ENS)
@@ -665,12 +765,16 @@ function AdminPanel() {
                   Role
                   <select value={adminRoleForm.role}
                     onChange={(e) => setAdminRoleForm({ ...adminRoleForm, role: e.target.value })}>
-                    <option value="GUARDIAN">Guardian — pause/unpause</option>
+                    <option value="GUARDIAN">Guardian — pause/unpause (WagerRegistry)</option>
                     <option value="ACCOUNT_MODERATOR">Account Moderator — freeze/unfreeze</option>
                     <option value="ROLE_MANAGER">Role Manager — grant/revoke memberships</option>
                     <option value="SANCTIONS_ADMIN">Compliance Officer — deny-list (SanctionsGuard)</option>
                     <option value="TOKEN_ISSUER">Token Issuer — token creation (TokenFactory)</option>
                     <option value="STAKING_ADMIN">Staking Administrator — provider addrs + validator allowlist (StakingRouter)</option>
+                    <option value="LIQUIDITY_ADMIN_BRIDGE">Liquidity Administrator — bridge routes + limits (BridgeRouter only)</option>
+                    <option value="LIQUIDITY_ADMIN_LIQUIDITY">Liquidity Administrator — curated pools + caps (LiquidityRouter only)</option>
+                    <option value="GUARDIAN_BRIDGE">Guardian — pause new bridges (BridgeRouter only)</option>
+                    <option value="GUARDIAN_LIQUIDITY">Guardian — pause new Uniswap supplies (LiquidityRouter only)</option>
                     <option value="DEFAULT_ADMIN">Default Admin — full control (rare)</option>
                   </select>
                 </label>
@@ -780,6 +884,37 @@ function AdminPanel() {
             isAdmin={isAdmin}
             isStakingAdmin={isStakingAdmin}
             isGuardian={isGuardian}
+          />
+        )}
+
+        {/*
+          Bridge + Supply (spec 067). Same gate as the nav group, so a tab id
+          typed by hand renders nothing for an operator who holds none of
+          admin / liquidity-admin / guardian (FR-040 / FR-049). Neither tab is
+          gated on the wallet's active chain: control state is per-network and
+          each tab reads all five networks (FR-050).
+        */}
+        {activeTab === 'bridge' && (isAdmin || isLiquidityAdmin || isGuardian) && (
+          <BridgeTab
+            signer={signer}
+            account={account}
+            chainId={chainId}
+            provider={provider || getProvider(chainId)}
+            runTx={runTx}
+            pendingTx={pendingTx}
+            onOpenFees={canOpenFees ? () => setActiveTab('fees') : null}
+          />
+        )}
+
+        {activeTab === 'supply' && (isAdmin || isLiquidityAdmin || isGuardian) && (
+          <SupplyTab
+            signer={signer}
+            account={account}
+            chainId={chainId}
+            provider={provider || getProvider(chainId)}
+            runTx={runTx}
+            pendingTx={pendingTx}
+            onOpenFees={canOpenFees ? () => setActiveTab('fees') : null}
           />
         )}
 

--- a/frontend/src/components/admin/BridgeTab.jsx
+++ b/frontend/src/components/admin/BridgeTab.jsx
@@ -1,0 +1,1234 @@
+/**
+ * BridgeTab (spec 067, US4) — the operator control surface for cross-chain bridging.
+ *
+ * One screen per network for the on-chain `BridgeRouter`:
+ *   - Status + emergency pause / resume of new bridges — GUARDIAN_ROLE (FR-043/FR-044).
+ *   - Curated routes: add, edit, enable, disable, remove, per-transaction limits, and bulk
+ *     enable/disable per destination — LIQUIDITY_ADMIN_ROLE (FR-041/FR-045, SC-017).
+ *   - Protocol addresses (Across SpokePool, FeeRouter, sanctions guard) with the current value
+ *     beside the input and invalid input refused with a reason BEFORE the wallet prompt (FR-042).
+ *   - The `bridge.transfer` platform fee — READ-ONLY here; rates live on the FeeRouter and are
+ *     edited in the Fees tab by a FEE_ADMIN (spec 060, FR-048).
+ *   - Operations: what is in flight, what is past its expected window, what recently delivered
+ *     or came back, and whether the quoting gateway is up (FR-047).
+ *   - Decoded on-chain change history — the audit trail (FR-046).
+ *
+ * ---------------------------------------------------------------------------------------------
+ * TWO THINGS THIS TAB MUST NOT IMPLY.
+ *
+ * 1. **Scope is a NETWORK, not the connected wallet.** Bridge control state exists on five
+ *    networks at once (FR-050). Reads here span all of them from each network's own RPC; only
+ *    WRITES need the wallet on the selected network, and the tab says so rather than showing a
+ *    dead button. An operator must never conclude "no routes are configured" from being
+ *    connected somewhere else.
+ *
+ * 2. **The Operations panel is OBSERVATIONAL ONLY.** There is no operator action — here or in
+ *    the contract — that can touch a member's in-flight bridge. Across settles directly to the
+ *    member and the router is not in that path, which is exactly why `IBridgeRouter` has no
+ *    rescue or claim-refund function. Pausing stops NEW bridges; it cannot reach one already
+ *    moving, and it cannot strand one either. The panel states this so nobody spends an incident
+ *    hunting for a button that was deliberately never built.
+ * ---------------------------------------------------------------------------------------------
+ */
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { ethers } from 'ethers'
+import { getContractAddressForChain } from '../../config/contracts'
+import { BRIDGE_ROUTER_ABI } from '../../abis/BridgeRouter'
+import { FEE_SERVICES, fetchFeeQuote } from '../../lib/fees/feeQuote'
+import { getBlockscoutUrl, getTransactionUrl } from '../../config/blockExplorer'
+import { useGatewayStatus } from '../../hooks/useGatewayStatus'
+import { BRIDGE_SETTLEMENT, bridgeStateCopy } from '../../lib/bridge/bridgeCopy'
+import { SPOKE_POOL_IFACE, deriveBridgeState, evidenceFromGatewayStatus, fetchBridgeStatus } from '../../lib/bridge/bridgeStatus'
+import { BRIDGE_STATE } from '../../data/ledger/sources/bridgeLedgerSource'
+import { FeeRateCard, HistoryCard, NetworkScopeCard, WriteScopeNotice } from './liquidityAdminCards'
+import {
+  adminNetworks,
+  authorityGates,
+  formatAmount,
+  formatDuration,
+  formatLimit,
+  isValidAddr,
+  limitUnitLabel,
+  loadRouterHistory,
+  networkName,
+  parseLimit,
+  readProviderFor,
+  readRouterAuthority,
+  shortAddr,
+  tokenLabel,
+} from './liquidityAdminCommon'
+
+/** Config events this router emits — the audit trail (FR-046). */
+const HISTORY_EVENTS = [
+  'RouteSet',
+  'RouteEnabledChanged',
+  'RouteLimitChanged',
+  'RouteRemoved',
+  'SpokePoolUpdated',
+  'FeeRouterUpdated',
+  'SanctionsGuardUpdated',
+  'Paused',
+  'Unpaused',
+]
+
+/** Bounds on a route's advisory delivery window — mirrors BridgeRouter's own constants. */
+const MIN_FILL_SECONDS = 60
+const MAX_FILL_SECONDS = 86_400
+
+/**
+ * The Operations scan is deliberately bounded, in two stages.
+ *
+ * `OPS_SCAN_LIMIT` bridges get a block-timestamp read, which is cheap, so lateness can be computed
+ * across a wider slice than the panel shows. `OPS_LIMIT` rows are then displayed — the late ones
+ * first — and only those pay the expensive per-row costs: a receipt read (to recover the Across
+ * deposit id from the SpokePool log in the same transaction) and, when the gateway is up, a status
+ * request. What the panel had to drop is stated in the footnote; the explorer link answers the rest.
+ */
+const OPS_LOOKBACK_BLOCKS = 50_000
+const OPS_SCAN_LIMIT = 40
+const OPS_LIMIT = 10
+
+const safe = (p) => p.then((v) => v).catch(() => undefined)
+
+/** Topic hashes for BOTH Across deposit vocabularies — see SPOKE_POOL_IFACE. */
+const DEPOSIT_TOPICS = new Set(
+  ['V3FundsDeposited', 'FundsDeposited'].map((n) => SPOKE_POOL_IFACE.getEvent(n).topicHash),
+)
+
+export default function BridgeTab({
+  signer,
+  account,
+  chainId,
+  provider,
+  runTx,
+  pendingTx,
+  onOpenFees,
+}) {
+  const networks = useMemo(() => adminNetworks('bridge'), [])
+  const [scopeChainId, setScopeChainId] = useState(
+    () => (networks.some((n) => n.chainId === chainId) ? chainId : networks[0]?.chainId) ?? null,
+  )
+
+  // ── AUTHORITY IS READ FROM THE ROUTER IN SCOPE, NOT FROM THE APP-WIDE ROLE FLAGS ──────────────
+  // The `isAdmin`/`isGuardian`/`isLiquidityAdmin` props are a coarse entry signal: they answer "is
+  // this operator an admin of SOMETHING on the wallet's chain", which is not the question a control
+  // on this tab needs answered. GUARDIAN_ROLE on the WagerRegistry is not GUARDIAN_ROLE on this
+  // BridgeRouter; LIQUIDITY_ADMIN on the LiquidityRouter is not authority over bridge routes; and
+  // the wallet's chain is not the network in scope. So every gate below comes from asking THIS
+  // router on THIS network — see readRouterAuthority for the full account of what went wrong.
+  const [authority, setAuthority] = useState(null) // null = not yet asked
+  const gates = authorityGates(authority)
+  const canConfig = gates.config
+  const canPause = gates.pause
+  // Address writes are DEFAULT_ADMIN_ROLE on the contract, a role ABOVE curation: `spokePool` and
+  // `feeRouter` decide where member funds and fees go, so they are not a route-curation power.
+  // Unconfirmed authority stays permissive here for the same reason it does elsewhere — the contract
+  // is the gate, and a false "you cannot" is as misleading as a false "you can".
+  const canWire = Boolean(authority?.admin || gates.unconfirmed)
+  const onScopeNetwork = Number(scopeChainId) === Number(chainId)
+  const canSubmit = Boolean(signer) && onScopeNetwork && !pendingTx
+
+  const routerAddr = getContractAddressForChain('bridgeRouter', scopeChainId)
+  const readProvider = useMemo(
+    () => readProviderFor(scopeChainId, chainId, provider),
+    [scopeChainId, chainId, provider],
+  )
+
+  const [state, setState] = useState(null) // null = loading
+  const [readError, setReadError] = useState(null)
+  const [lastReadAt, setLastReadAt] = useState(null)
+  const [fee, setFee] = useState(undefined) // undefined = loading
+  const [history, setHistory] = useState({ entries: null, error: null })
+  const [ops, setOps] = useState({ rows: null, error: null })
+  const [formError, setFormError] = useState(null)
+  const [forms, setForms] = useState({
+    inputToken: '',
+    outputToken: '',
+    destinationChainId: '',
+    maxAmount: '0',
+    expectedFillSeconds: '900',
+    nativeInput: false,
+    enabled: true,
+    spokePool: '',
+    feeRouter: '',
+    sanctionsGuard: '',
+  })
+  const [limitDrafts, setLimitDrafts] = useState({})
+
+  const gateway = useGatewayStatus()
+
+  const routerRead = useMemo(
+    () => (routerAddr && readProvider ? new ethers.Contract(routerAddr, BRIDGE_ROUTER_ABI, readProvider) : null),
+    [routerAddr, readProvider],
+  )
+  const write = useCallback(
+    () => new ethers.Contract(routerAddr, BRIDGE_ROUTER_ABI, signer),
+    [routerAddr, signer],
+  )
+
+  /* -------------------------------------------------------------------------------- reads */
+
+  const fetchState = useCallback(async () => {
+    if (!routerRead) {
+      setState(null)
+      return
+    }
+    try {
+      setReadError(null)
+      // CLEARED BEFORE THE NEW NETWORK IS READ, not after. `setState` only fires on success, so
+      // without this the PREVIOUS network's pause banner, table and counts keep rendering under the
+      // newly-selected network's name — with an "as of" timestamp that looks current. On a public RPC
+      // that window is a full round-trip, and it fails in the direction that reads as safe: an
+      // operator pausing network A, switching to B and seeing A's PAUSED banner moves on believing B
+      // is stopped (FR-050 no-mixing, FR-052 as-of).
+      setState(null)
+      setLastReadAt(null)
+      // `paused` is load-bearing: a router we cannot even ask about is reported as unreadable,
+      // never as "not paused" (FR-051 — withhold, never invent).
+      const paused = await routerRead.paused()
+      const [spokePool, feeRouter, sanctionsGuard, maxFeeBps, count] = await Promise.all([
+        safe(routerRead.spokePool()),
+        safe(routerRead.feeRouter()),
+        safe(routerRead.sanctionsGuard()),
+        safe(routerRead.MAX_FEE_BPS()),
+        safe(routerRead.routeCount()),
+      ])
+
+      const routes = []
+      let routesComplete = count !== undefined
+      if (count !== undefined) {
+        const n = Number(count)
+        const ids = await Promise.all(Array.from({ length: n }, (_, i) => safe(routerRead.routeAt(i))))
+        const raws = await Promise.all(ids.map((id) => (id ? safe(routerRead.getRoute(id)) : Promise.resolve(undefined))))
+        for (let i = 0; i < n; i += 1) {
+          const id = ids[i]
+          const raw = raws[i]
+          if (!id || raw === undefined) {
+            routesComplete = false
+            continue
+          }
+          routes.push({
+            routeId: id,
+            inputToken: raw.inputToken,
+            outputToken: raw.outputToken,
+            destinationChainId: Number(raw.destinationChainId),
+            maxAmount: BigInt(raw.maxAmount ?? 0n),
+            expectedFillSeconds: Number(raw.expectedFillSeconds ?? 0),
+            enabled: Boolean(raw.enabled),
+            nativeInput: Boolean(raw.nativeInput),
+          })
+        }
+      }
+
+      setState({
+        spokePool,
+        feeRouter,
+        sanctionsGuard,
+        maxFeeBps: maxFeeBps === undefined ? null : Number(maxFeeBps),
+        paused: Boolean(paused),
+        routes,
+        routesComplete,
+      })
+      setLastReadAt(new Date())
+    } catch (e) {
+      setState(null)
+      setReadError(
+        `Could not read the BridgeRouter on ${networkName(scopeChainId)}: ${e?.message || e}. Nothing below can be trusted as current until this clears.`,
+      )
+    }
+  }, [routerRead, scopeChainId])
+
+  // THE RATE IS QUOTED FROM THE FEE ROUTER THIS ROUTER ACTUALLY HOLDS, NOT FROM THIS BUILD'S CONFIG.
+  //
+  // `fetchFeeQuote` defaults to the configured address, which is right for members but wrong here:
+  // the contract that will charge them is whatever `BridgeRouter.feeRouter()` returns right now, and the
+  // two diverge in exactly the window an operator most needs the truth — after someone repoints the
+  // router and before the config ships, or the reverse. Quoting the config address there reports a
+  // rate (or a confident "no fee") from a contract that is not in the path.
+  //
+  // `liveFeeRouter` is read in fetchState; until it resolves there is nothing to quote FROM, so this
+  // waits rather than falling back to the config address and printing a figure it cannot stand behind.
+  const liveFeeRouter = state?.feeRouter
+  const fetchFee = useCallback(async () => {
+    if (!routerAddr || !readProvider || !liveFeeRouter) return
+    setFee(undefined)
+    try {
+      const quote = await fetchFeeQuote({
+        serviceId: FEE_SERVICES.BRIDGE_TRANSFER,
+        chainId: scopeChainId,
+        provider: readProvider,
+        routerAddress: liveFeeRouter,
+      })
+      // A mismatch is not an error — it is a real, temporary state — but it means the MEMBER surface
+      // is quoting a different contract than the one charging, so the card says so.
+      const configured = getContractAddressForChain('feeRouter', scopeChainId)
+      setFee({
+        ...quote,
+        configuredRouterAddress: configured || null,
+        configMismatch:
+          Boolean(configured) && configured.toLowerCase() !== String(liveFeeRouter).toLowerCase(),
+      })
+    } catch (e) {
+      // A configured-but-unreadable FeeRouter is NOT a zero rate. It blocks the member's
+      // fee-bearing path, and this card has to say which of the two it is (FR-048/FR-051).
+      setFee({ failed: true, reason: e?.message || String(e) })
+    }
+  }, [routerAddr, readProvider, scopeChainId, liveFeeRouter])
+
+  const fetchHistory = useCallback(async () => {
+    if (!routerRead || !readProvider) return
+    setHistory({ entries: null, error: null })
+    setHistory(
+      await loadRouterHistory({
+        contract: routerRead,
+        provider: readProvider,
+        eventNames: HISTORY_EVENTS,
+        describe: describeBridgeEvent(scopeChainId),
+      }),
+    )
+  }, [routerRead, readProvider, scopeChainId])
+
+  /**
+   * Operations (FR-047).
+   *
+   * The router emits `BridgeInitiated` for every member bridge, and the Across SpokePool emits
+   * its deposit event in the SAME transaction — so the deposit id can be recovered from the
+   * receipt and handed to the gateway's status endpoint. That join is the only way an operator
+   * can see delivery at all, because delivery happens on ANOTHER network, straight to the
+   * member, with this contract nowhere in the path.
+   *
+   * Every step degrades on its own: no receipt ⇒ no deposit id ⇒ no status ⇒ the row still
+   * shows what was initiated and how long ago, and the panel says delivery is not observable
+   * from here. Nothing is ever guessed into "delivered".
+   */
+  const fetchOps = useCallback(async () => {
+    if (!routerRead || !readProvider || !state) return
+    setOps({ rows: null, error: null })
+    try {
+      const latest = await readProvider.getBlockNumber()
+      const fromBlock = Math.max(0, Number(latest) - OPS_LOOKBACK_BLOCKS)
+      const evs = (await routerRead.queryFilter(routerRead.filters.BridgeInitiated(), fromBlock, 'latest')) || []
+      const ordered = [...evs].sort((a, b) => b.blockNumber - a.blockNumber || b.index - a.index)
+
+      const byRouteId = new Map((state.routes || []).map((r) => [r.routeId, r]))
+      const now = Date.now()
+
+      // ── WHAT IS LATE OUTRANKS WHAT IS RECENT ─────────────────────────────────────────────────
+      // This used to be a plain "ten most recent". The panel's whole job is to answer "is anything
+      // stuck right now", and on a busy network ten bridges is minutes — so a stuck transfer was
+      // pushed out of the list before its own delivery window had even expired, by the newer
+      // transfers that were fine. Timestamps are read for a wider slice first (cheap), lateness is
+      // computed from each route's advisory window, and the late rows are kept AHEAD of newer ones.
+      // The costly per-row work — a receipt read to recover the Across deposit id, and a gateway
+      // status request — still happens only for the rows actually shown.
+      const scanned = ordered.slice(0, OPS_SCAN_LIMIT)
+      const timed = await Promise.all(
+        scanned.map(async (ev) => {
+          const block = await safe(readProvider.getBlock(ev.blockNumber))
+          const at = block ? Number(block.timestamp) * 1000 : null
+          const route = byRouteId.get(ev.args?.routeId)
+          // A route that is no longer curated (removed, or missing from a partial read) has no
+          // advisory window, so lateness is UNKNOWN for its transfers rather than false. Reporting
+          // `late: false` there silently exonerated exactly the transfers an operator had just
+          // removed a misbehaving route over.
+          const windowUnknown = !route?.expectedFillSeconds
+          const expectedBy = at && !windowUnknown ? at + route.expectedFillSeconds * 1000 : null
+          return { ev, at, route, windowUnknown, expectedBy, late: Boolean(expectedBy && now >= expectedBy) }
+        }),
+      )
+      const attention = timed.filter((r) => r.late || r.windowUnknown)
+      const rest = timed.filter((r) => !r.late && !r.windowUnknown)
+      const picked = [...attention, ...rest].slice(0, OPS_LIMIT)
+      const hidden = timed.length - picked.length + Math.max(0, ordered.length - scanned.length)
+
+      const rows = await Promise.all(
+        picked.map(async ({ ev, at, route, windowUnknown, expectedBy, late }) => {
+          const depositId = await readDepositId(readProvider, ev.transactionHash)
+          let status
+          if (depositId != null && gateway.configured) {
+            status = await safe(fetchBridgeStatus({ originChainId: Number(scopeChainId), depositId }))
+          }
+
+          const evidence = status ? evidenceFromGatewayStatus(status) : {}
+          const derived = deriveBridgeState({
+            // The router event only exists in a mined, successful transaction, so the origin
+            // side is already confirmed. Everything above that needs evidence.
+            current: BRIDGE_STATE.SOURCE_CONFIRMED,
+            evidence,
+            expectedBy,
+            now,
+          })
+
+          return {
+            key: `${ev.transactionHash}-${ev.index}`,
+            txHash: ev.transactionHash,
+            routeId: ev.args?.routeId,
+            member: ev.args?.member,
+            recipient: ev.args?.recipient,
+            destinationChainId: Number(ev.args?.destinationChainId ?? 0),
+            grossAmount: ev.args?.grossAmount,
+            feeAmount: ev.args?.feeAmount,
+            inputToken: route?.inputToken ?? null,
+            at,
+            expectedBy,
+            windowUnknown,
+            late,
+            depositId: depositId == null ? null : String(depositId),
+            observed: Boolean(status),
+            state: derived.state,
+            dstTxHash: derived.dstTxHash,
+            refundTxHash: derived.refundTxHash,
+          }
+        }),
+      )
+      setOps({ rows, error: null, scanned: timed.length, found: ordered.length, hidden })
+    } catch (e) {
+      setOps({ rows: [], error: e?.message || String(e) })
+    }
+  }, [routerRead, readProvider, state, gateway.configured, scopeChainId])
+
+  useEffect(() => {
+    fetchState()
+    fetchFee()
+    fetchHistory()
+  }, [fetchState, fetchFee, fetchHistory])
+
+  useEffect(() => {
+    fetchOps()
+  }, [fetchOps])
+
+  // Re-asked whenever the ROUTER or the NETWORK changes, because the answer is a property of both.
+  useEffect(() => {
+    let live = true
+    setAuthority(null)
+    readRouterAuthority({ provider: readProvider, routerAddress: routerAddr, account }).then((a) => {
+      if (live) setAuthority(a)
+    })
+    return () => {
+      live = false
+    }
+  }, [readProvider, routerAddr, account])
+
+  const refresh = () => {
+    fetchState()
+    fetchFee()
+    fetchHistory()
+    gateway.refresh()
+  }
+
+  /* ------------------------------------------------------------------------------- writes */
+
+  const togglePause = () => {
+    const fn = state?.paused ? 'unpause' : 'pause'
+    runTx(() => write()[fn](), state?.paused ? 'Bridging resumed' : 'New bridges paused').then(refresh)
+  }
+
+  const submitRoute = () => {
+    setFormError(null)
+    const destination = Number(forms.destinationChainId)
+    const fill = Number(forms.expectedFillSeconds)
+    if (!isValidAddr(forms.inputToken) || !isValidAddr(forms.outputToken)) {
+      setFormError('Both the sent asset and the delivered asset must be valid, non-zero token addresses.')
+      return
+    }
+    if (!Number.isInteger(destination) || destination <= 0 || destination === Number(scopeChainId)) {
+      setFormError('Choose a destination network — it cannot be the network this router is on.')
+      return
+    }
+    if (!Number.isInteger(fill) || fill < MIN_FILL_SECONDS || fill > MAX_FILL_SECONDS) {
+      setFormError(`The expected delivery window must be between ${MIN_FILL_SECONDS} and ${MAX_FILL_SECONDS} seconds — the contract refuses anything outside that.`)
+      return
+    }
+    let maxAmount
+    try {
+      maxAmount = parseLimit(scopeChainId, forms.inputToken, forms.maxAmount)
+    } catch (e) {
+      setFormError(e.message)
+      return
+    }
+    runTx(
+      () =>
+        write().setRoute({
+          inputToken: forms.inputToken,
+          enabled: forms.enabled,
+          nativeInput: forms.nativeInput,
+          expectedFillSeconds: fill,
+          outputToken: forms.outputToken,
+          destinationChainId: destination,
+          maxAmount,
+        }),
+      `Route to ${networkName(destination)} saved`,
+    ).then(refresh)
+  }
+
+  const setRouteEnabled = (route, enabled) =>
+    runTx(
+      () => write().setRouteEnabled(route.routeId, enabled),
+      `Route to ${networkName(route.destinationChainId)} ${enabled ? 'enabled' : 'disabled'}`,
+    ).then(refresh)
+
+  /**
+   * Delete a route's curation entirely.
+   *
+   * ── WHY THIS ASKS AND "DISABLE" DOES NOT ───────────────────────────────────────────────────────
+   * Both stop new bridges on the route. Disable is a flag the adjacent button flips straight back;
+   * removal deletes the entry, so restoring it means re-entering every field, and until then the
+   * Operations panel below loses the route's advisory delivery window — which is how it decides that
+   * an in-flight transfer is taking too long. During an incident "Remove" looks like the harder,
+   * safer version of "Disable", and it is the one that degrades the panel you are watching. So the
+   * confirm names that consequence rather than asking "are you sure".
+   */
+  const removeRoute = (route) => {
+    const inFlight = (ops.rows || []).filter((r) => r.routeId === route.routeId).length
+    const dest = networkName(route.destinationChainId)
+    const asset = tokenLabel(scopeChainId, route.inputToken)
+    const ok = window.confirm(
+      `Remove the ${asset} → ${dest} route?\n\n` +
+        'This deletes the curation entry, not just its availability. Disabling stops new bridges too and is one click to undo; ' +
+        'after removal the route has to be re-entered field by field.\n\n' +
+        `Transfers already moving on it are unaffected — Across settles those directly to the member — but the Operations panel loses this route's expected delivery window, so it can no longer flag them as late${inFlight > 0 ? `, and ${inFlight} ${inFlight === 1 ? 'transfer is' : 'transfers are'} currently listed on it` : ''}.\n\n` +
+        'To stop new bridges reversibly, cancel and use Disable instead.',
+    )
+    if (!ok) return
+    return runTx(
+      () => write().removeRoute(route.routeId),
+      `Route to ${dest} removed`,
+    ).then(refresh)
+  }
+
+  const applyLimit = (route) => {
+    setFormError(null)
+    let value
+    try {
+      value = parseLimit(scopeChainId, route.inputToken, limitDrafts[route.routeId])
+    } catch (e) {
+      setFormError(e.message)
+      return
+    }
+    runTx(() => write().setRouteLimit(route.routeId, value), 'Per-transaction maximum updated').then(refresh)
+  }
+
+  /**
+   * Bulk enable/disable every route to one destination.
+   *
+   * One transaction per route, run in order — the contract has no batch setter and inventing a
+   * client-side "batch" that fires several wallet prompts at once would be worse. The button
+   * says how many transactions it will ask for.
+   */
+  const bulkSetEnabled = async (destination, enabled) => {
+    setFormError(null)
+    const targets = (state?.routes || []).filter(
+      (r) => r.destinationChainId === destination && r.enabled !== enabled,
+    )
+    for (const [i, route] of targets.entries()) {
+      // STOPS ON THE FIRST FAILURE, INCLUDING A REJECTED PROMPT.
+      //
+      // This comment used to claim that while `runTx` swallowed every error and resolved with no
+      // signal, so the loop ran to the end regardless: an operator who clicked "Disable all (5 tx)"
+      // on the wrong destination and rejected the first prompt to abort got the other four anyway,
+      // and any they accepted by reflex disabled a live route. `runTx` now resolves false on failure
+      // and this checks it — rejecting the first prompt IS the cancel.
+      const ok = await runTx(
+        () => write().setRouteEnabled(route.routeId, enabled),
+        `Route ${tokenLabel(scopeChainId, route.inputToken)} → ${networkName(destination)} ${enabled ? 'enabled' : 'disabled'}`,
+      )
+      if (!ok) {
+        const done = i
+        const left = targets.length - i
+        setFormError(
+          `Stopped after ${done} of ${targets.length} ${done === 1 ? 'change' : 'changes'} — the last transaction was refused or rejected, so the remaining ${left} ${left === 1 ? 'route was' : 'routes were'} left untouched. The table below shows what actually changed.`,
+        )
+        break
+      }
+    }
+    refresh()
+  }
+
+  const setAddress = (fn, value, label) => {
+    setFormError(null)
+    if (!isValidAddr(value)) {
+      setFormError(`Enter a valid, non-zero address for the ${label} — the contract rejects malformed and zero addresses.`)
+      return
+    }
+    runTx(() => write()[fn](value), `${label} updated`).then(refresh)
+  }
+
+  /* ------------------------------------------------------------------------------- render */
+
+  if (!scopeChainId) {
+    return (
+      <div className="admin-tab-content" role="tabpanel">
+        <div className="admin-card">
+          <h3>Bridge Controls</h3>
+          <p className="card-info">
+            No network in this build carries an Across deployment, so there is nothing to control
+            here. Bridging is hidden for members on every network (FR-006c).
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const destinations = networks.filter((n) => n.chainId !== Number(scopeChainId))
+  const destinationsWithRoutes = destinations
+    .map((net) => {
+      const routes = (state?.routes || []).filter((r) => r.destinationChainId === net.chainId)
+      return { net, total: routes.length, enabled: routes.filter((r) => r.enabled).length }
+    })
+
+  return (
+    <div className="admin-tab-content" role="tabpanel">
+      <NetworkScopeCard
+        title="Bridge Controls"
+        description={`Routes, limits, addresses and the pause for one network's BridgeRouter. Transfers are settled by ${BRIDGE_SETTLEMENT.protocol} — FairWins never holds a member's asset in transit.`}
+        networks={networks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('bridgeRouter', id))}
+        walletChainId={chainId}
+        onRefresh={refresh}
+        lastReadAt={routerAddr ? lastReadAt : null}
+      >
+        {routerAddr && (
+          <div className="status-details">
+            <div className="status-row">
+              <span className="status-label">BridgeRouter</span>
+              <span className="status-value">
+                <code title={routerAddr}>{shortAddr(routerAddr)}</code>
+              </span>
+            </div>
+            <div className="status-row">
+              <span className="status-label">New bridges</span>
+              <span className="status-value">
+                {state == null ? (
+                  '…'
+                ) : state.paused ? (
+                  <span className="status-value paused">
+                    PAUSED — no new bridges start. Transfers already moving are unaffected.
+                  </span>
+                ) : (
+                  'active'
+                )}
+              </span>
+            </div>
+            <div className="status-row">
+              <span className="status-label">Curated routes</span>
+              <span className="status-value">
+                {state == null
+                  ? '…'
+                  : `${state.routes.length} (${state.routes.filter((r) => r.enabled).length} enabled)${state.routesComplete ? '' : ' — partial read, some routes could not be loaded'}`}
+              </span>
+            </div>
+          </div>
+        )}
+        {readError && (
+          <p className="card-info error" role="alert">
+            {readError}
+          </p>
+        )}
+      </NetworkScopeCard>
+
+      {!routerAddr ? (
+        <div className="admin-card">
+          <h3>Not deployed on {networkName(scopeChainId)}</h3>
+          <p className="card-info">
+            No BridgeRouter is deployed on {networkName(scopeChainId)}, so there is nothing to
+            control here and members are shown no bridge on this network — an honest absence, not
+            a broken surface. Deploy it with{' '}
+            <code>scripts/deploy/deploy-bridge-liquidity.js</code>, then pick another network above
+            to manage one that is live.
+          </p>
+        </div>
+      ) : (
+        <>
+          <WriteScopeNotice
+            scopeChainId={scopeChainId}
+            walletChainId={chainId}
+            signer={signer}
+            canWrite={canConfig || canPause}
+          />
+
+          {/*
+            THE CARD IS ALWAYS RENDERED, INCLUDING WHEN THIS OPERATOR CANNOT USE IT.
+
+            It used to be hidden behind the authority check. During an incident that reads as "this
+            network has no killswitch" — the operator stops looking and starts improvising, which is
+            the worst possible outcome of a permission check. So the card states that the killswitch
+            exists, and says separately whether THIS account can pull it and where the role comes
+            from if not (FR-043/FR-044).
+          */}
+          <div className="admin-card">
+            <h3>Emergency pause</h3>
+            <p>
+              Pausing stops <strong>new</strong> bridges on {networkName(scopeChainId)}{' '}
+              immediately, with no redeploy and no dependency on the gateway or any other
+              optional service. It cannot touch a transfer already moving — those are settled by{' '}
+              {BRIDGE_SETTLEMENT.protocol} directly to the member — so a pause never traps
+              member value.
+            </p>
+            {gates.unconfirmed && (
+              <p className="card-info" role="status">
+                Your authority on this router could not be confirmed{authority?.reason ? ` (${authority.reason})` : ''}.
+                The control is still offered, because the contract is the real gate and will refuse
+                anything you do not hold — withholding a killswitch over an unanswered read would be
+                the worse error.
+              </p>
+            )}
+            {gates.pending ? (
+              <p className="card-info">Checking your authority on this router…</p>
+            ) : canPause ? (
+              <button
+                type="button"
+                className={`confirm-btn ${state?.paused ? 'primary' : 'danger'}`}
+                onClick={togglePause}
+                disabled={!canSubmit || state == null}
+              >
+                {state?.paused ? 'Resume bridging' : 'Pause new bridges'}
+              </button>
+            ) : (
+              <p className="card-info" role="status">
+                This account holds neither <code>GUARDIAN_ROLE</code> nor admin on the BridgeRouter on{' '}
+                {networkName(scopeChainId)}, so the pause is not yours to pull —{' '}
+                <strong>the killswitch exists and is exercisable by an account that does hold it.</strong>{' '}
+                Holding the guardian role on another contract (the WagerRegistry, or this router on a
+                different network) does not carry here; a Role Manager grants{' '}
+                <code>GUARDIAN_ROLE</code> on this router from the Roles tab.
+              </p>
+            )}
+            {/*
+              The pause is network-wide, and it is the ONLY lever this role has. Disabling a single
+              route is LIQUIDITY_ADMIN on the contract and renders under the config gate, so a
+              guardian handling a one-destination incident at 03:00 sees one control with a blast
+              radius the incident did not require and no hint the narrow lever exists. Naming it here
+              is the difference between over-pausing and knowing who to wake.
+            */}
+            {canPause && !canConfig && (
+              <p className="card-info">
+                This pause covers <strong>every route from {networkName(scopeChainId)}</strong>. If
+                only one destination or asset is affected, disabling that single route is the narrower
+                fix — it needs <code>LIQUIDITY_ADMIN_ROLE</code>, which this account does not hold, so
+                it is not shown below. Pausing the network is the right call when you cannot reach
+                someone who has it.
+              </p>
+            )}
+          </div>
+
+          <div className="admin-card">
+            <h3>Routes</h3>
+            <p className="card-info">
+              A route is one asset, from {networkName(scopeChainId)}, to one destination network.
+              Routes in the other direction live on that network’s own router — select it above to
+              manage them (FR-050).
+            </p>
+            {state == null ? (
+              <p className="card-info">Loading routes…</p>
+            ) : state.routes.length === 0 ? (
+              <p className="card-info">
+                No routes are curated on {networkName(scopeChainId)} yet, so members are offered no
+                destination from here.
+              </p>
+            ) : (
+              <table className="admin-table" aria-label="Curated bridge routes">
+                <thead>
+                  <tr>
+                    <th scope="col">Asset</th>
+                    <th scope="col">Route</th>
+                    <th scope="col">Delivers</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Per-transaction max</th>
+                    <th scope="col">Expected delivery</th>
+                    {canConfig && <th scope="col">Change</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {state.routes.map((route) => (
+                    <tr key={route.routeId}>
+                      <td>
+                        {tokenLabel(scopeChainId, route.inputToken)}
+                        {route.nativeInput ? ' (native)' : ''}
+                      </td>
+                      <td>
+                        {networkName(scopeChainId)} → {networkName(route.destinationChainId)}
+                      </td>
+                      <td>{tokenLabel(route.destinationChainId, route.outputToken)}</td>
+                      <td>
+                        <span className={route.enabled ? 'status-value' : 'status-value paused'}>
+                          {route.enabled ? 'enabled' : 'disabled'}
+                        </span>
+                      </td>
+                      <td>{formatLimit(scopeChainId, route.inputToken, route.maxAmount)}</td>
+                      <td>{formatDuration(route.expectedFillSeconds)}</td>
+                      {canConfig && (
+                        <td>
+                          <button
+                            type="button"
+                            className={`confirm-btn ${route.enabled ? 'danger' : 'primary'}`}
+                            disabled={!canSubmit}
+                            onClick={() => setRouteEnabled(route, !route.enabled)}
+                          >
+                            {route.enabled ? 'Disable' : 'Enable'}
+                          </button>
+                          <label>
+                            <span className="hint">
+                              New max in {limitUnitLabel(scopeChainId, route.inputToken)} (0 = uncapped)
+                            </span>
+                            <input
+                              type="text"
+                              aria-label={`Per-transaction maximum for ${tokenLabel(scopeChainId, route.inputToken)} to ${networkName(route.destinationChainId)}`}
+                              value={limitDrafts[route.routeId] ?? ''}
+                              onChange={(e) =>
+                                setLimitDrafts((d) => ({ ...d, [route.routeId]: e.target.value }))
+                              }
+                            />
+                          </label>
+                          <button
+                            type="button"
+                            className="confirm-btn primary"
+                            disabled={!canSubmit}
+                            onClick={() => applyLimit(route)}
+                          >
+                            Set limit
+                          </button>
+                          <button
+                            type="button"
+                            className="confirm-btn danger"
+                            disabled={!canSubmit}
+                            onClick={() => removeRoute(route)}
+                          >
+                            Remove
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+
+            <h4>Destination coverage from {networkName(scopeChainId)}</h4>
+            <table className="admin-table" aria-label="Destination coverage">
+              <thead>
+                <tr>
+                  <th scope="col">Destination</th>
+                  <th scope="col">Routes</th>
+                  {canConfig && <th scope="col">All routes to this destination</th>}
+                </tr>
+              </thead>
+              <tbody>
+                {destinationsWithRoutes.map(({ net, total, enabled }) => (
+                  <tr key={net.chainId}>
+                    <td>{net.name}</td>
+                    <td>
+                      {total === 0 ? (
+                        <span className="status-value paused">none — not offered to members</span>
+                      ) : (
+                        `${enabled} of ${total} enabled`
+                      )}
+                    </td>
+                    {canConfig && (
+                      <td>
+                        <button
+                          type="button"
+                          className="confirm-btn primary"
+                          disabled={!canSubmit || enabled === total}
+                          onClick={() => bulkSetEnabled(net.chainId, true)}
+                        >
+                          Enable all ({total - enabled} tx)
+                        </button>
+                        <button
+                          type="button"
+                          className="confirm-btn danger"
+                          disabled={!canSubmit || enabled === 0}
+                          onClick={() => bulkSetEnabled(net.chainId, false)}
+                        >
+                          Disable all ({enabled} tx)
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {canConfig && (
+              <div className="admin-form">
+                <h4>Add or edit a route</h4>
+                <p className="card-info">
+                  A route is identified by the asset sent, the asset delivered, and the destination
+                  network. Saving one that already exists updates it in place; changing the
+                  delivered asset creates a different route rather than overwriting the old one.
+                </p>
+                <label>
+                  Asset sent from {networkName(scopeChainId)}
+                  <input
+                    type="text"
+                    placeholder="input token 0x…"
+                    value={forms.inputToken}
+                    onChange={(e) => setForms((f) => ({ ...f, inputToken: e.target.value }))}
+                  />
+                </label>
+                <label>
+                  Asset delivered on the destination
+                  <input
+                    type="text"
+                    placeholder="output token 0x…"
+                    value={forms.outputToken}
+                    onChange={(e) => setForms((f) => ({ ...f, outputToken: e.target.value }))}
+                  />
+                </label>
+                <label>
+                  Destination network
+                  <select
+                    value={forms.destinationChainId}
+                    onChange={(e) => setForms((f) => ({ ...f, destinationChainId: e.target.value }))}
+                  >
+                    <option value="">Choose…</option>
+                    {destinations.map((net) => (
+                      <option key={net.chainId} value={String(net.chainId)}>
+                        {net.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  Per-transaction maximum ({limitUnitLabel(scopeChainId, forms.inputToken)}) — 0 = uncapped
+                  <input
+                    type="text"
+                    value={forms.maxAmount}
+                    onChange={(e) => setForms((f) => ({ ...f, maxAmount: e.target.value }))}
+                  />
+                </label>
+                <label>
+                  Expected delivery window (seconds, {MIN_FILL_SECONDS}–{MAX_FILL_SECONDS})
+                  <input
+                    type="text"
+                    value={forms.expectedFillSeconds}
+                    onChange={(e) => setForms((f) => ({ ...f, expectedFillSeconds: e.target.value }))}
+                  />
+                  <span className="hint">
+                    Advisory only: it is what tells a member their transfer is running late, not a
+                    promise the contract enforces.
+                  </span>
+                </label>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={forms.nativeInput}
+                    onChange={(e) => setForms((f) => ({ ...f, nativeInput: e.target.checked }))}
+                  />
+                  Member pays in this network’s native coin (the asset above is then its wrapped form)
+                </label>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={forms.enabled}
+                    onChange={(e) => setForms((f) => ({ ...f, enabled: e.target.checked }))}
+                  />
+                  Offer this route to members immediately
+                </label>
+                <button type="button" className="confirm-btn primary" disabled={!canSubmit} onClick={submitRoute}>
+                  Save route
+                </button>
+              </div>
+            )}
+            {formError && (
+              <p className="card-info error" role="alert">
+                {formError}
+              </p>
+            )}
+          </div>
+
+          {canWire && (
+            <div className="admin-card">
+              <h3>Protocol addresses</h3>
+              <p>
+                Current values are shown beside each field. Invalid or zero addresses are rejected
+                here, before the wallet prompt (FR-042).
+              </p>
+              {/*
+                These three are not curation, and the contract does not treat them as such: they are
+                DEFAULT_ADMIN_ROLE, a role above LIQUIDITY_ADMIN. The card says why, because "set an
+                address" reads like configuration and the consequence is not.
+              */}
+              <p className="card-info">
+                <strong>These are fund-path references, not settings.</strong> The SpokePool is
+                approved and handed each member’s net amount; the FeeRouter names both the rate and
+                the treasury the fee is transferred to. Pointing either at the wrong contract
+                redirects member money, which is why they need admin rather than the route-curation
+                role, and why the router caps the fee it will pay out at{' '}
+                {state?.maxFeeBps == null ? 'its own hard ceiling' : `${state.maxFeeBps / 100}%`}{' '}
+                <em>of the amount</em> no matter what a FeeRouter reports about itself. Verify the
+                address on the explorer before saving.
+              </p>
+              <div className="admin-form">
+                <label>
+                  Across SpokePool
+                  <input
+                    type="text"
+                    placeholder="SpokePool 0x…"
+                    value={forms.spokePool}
+                    onChange={(e) => setForms((f) => ({ ...f, spokePool: e.target.value }))}
+                  />
+                  <span className="hint">now: {shortAddr(state?.spokePool) || '—'}</span>
+                </label>
+                <button
+                  type="button"
+                  className="confirm-btn primary"
+                  disabled={!canSubmit}
+                  onClick={() => setAddress('setSpokePool', forms.spokePool, 'SpokePool')}
+                >
+                  Set SpokePool
+                </button>
+
+                <label>
+                  FeeRouter reference
+                  <input
+                    type="text"
+                    placeholder="FeeRouter 0x…"
+                    value={forms.feeRouter}
+                    onChange={(e) => setForms((f) => ({ ...f, feeRouter: e.target.value }))}
+                  />
+                  <span className="hint">now: {shortAddr(state?.feeRouter) || '—'}</span>
+                </label>
+                <button
+                  type="button"
+                  className="confirm-btn primary"
+                  disabled={!canSubmit}
+                  onClick={() => setAddress('setFeeRouter', forms.feeRouter, 'FeeRouter reference')}
+                >
+                  Set FeeRouter
+                </button>
+
+                <label>
+                  Sanctions guard
+                  <input
+                    type="text"
+                    placeholder="SanctionsGuard 0x…"
+                    value={forms.sanctionsGuard}
+                    onChange={(e) => setForms((f) => ({ ...f, sanctionsGuard: e.target.value }))}
+                  />
+                  <span className="hint">now: {shortAddr(state?.sanctionsGuard) || '—'}</span>
+                </label>
+                <button
+                  type="button"
+                  className="confirm-btn primary"
+                  disabled={!canSubmit}
+                  onClick={() => setAddress('setSanctionsGuard', forms.sanctionsGuard, 'Sanctions guard')}
+                >
+                  Set guard
+                </button>
+              </div>
+            </div>
+          )}
+
+          <FeeRateCard
+            serviceLabel="bridge"
+            serviceId="bridge.transfer"
+            quote={fee}
+            routerMaxFeeBps={state?.maxFeeBps ?? null}
+            onOpenFees={onOpenFees}
+          />
+
+          <div className="admin-card">
+            <h3>Operations</h3>
+            <p className="card-info warning-text">
+              <strong>This panel is observational only.</strong> No action here — or anywhere in the
+              contract — can touch a member’s in-flight bridge: {BRIDGE_SETTLEMENT.protocol} settles
+              directly to the member and the router is not in that path, which is why it has no
+              rescue or refund function. A transfer that cannot be delivered is returned
+              automatically to the wallet it left from. There is no button to hunt for.
+            </p>
+            <div className="status-details">
+              <div className="status-row">
+                <span className="status-label">Quoting gateway</span>
+                <span className="status-value">
+                  {!gateway.configured
+                    ? 'not configured — members cannot start a bridge (quoting is impossible), but transfers already moving still resolve'
+                    : gateway.loading
+                      ? 'checking…'
+                      : gateway.reachable
+                        ? `reachable${gateway.status?.killSwitch ? ' — KILL SWITCH ACTIVE' : ''}`
+                        : 'unreachable — new bridges are withheld rather than priced from stale data'}
+                </span>
+              </div>
+              <div className="status-row">
+                <span className="status-label">Delivery evidence</span>
+                <span className="status-value">
+                  {gateway.configured
+                    ? 'gateway status endpoint, joined to each transfer by its Across deposit id'
+                    : 'unavailable — delivery happens on another network, straight to the member, so this router cannot observe it'}
+                </span>
+              </div>
+            </div>
+            {ops.rows == null ? (
+              <p className="card-info">Loading recent bridges…</p>
+            ) : ops.rows.length === 0 ? (
+              <p className="card-info">
+                {ops.error
+                  ? 'Recent bridges could not be read here — this RPC bounds event lookups. Use the block explorer link below.'
+                  : `No bridges have been started from ${networkName(scopeChainId)} in the recent lookback window.`}
+              </p>
+            ) : (
+              <table className="admin-table" aria-label="Recent bridges">
+                <thead>
+                  <tr>
+                    <th scope="col">Started</th>
+                    <th scope="col">Member</th>
+                    <th scope="col">To</th>
+                    <th scope="col">Amount</th>
+                    <th scope="col">State</th>
+                    <th scope="col">Evidence</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {ops.rows.map((row) => (
+                    <tr key={row.key}>
+                      <td>{row.at ? new Date(row.at).toLocaleString() : '—'}</td>
+                      <td>
+                        <code title={row.member}>{shortAddr(row.member)}</code>
+                      </td>
+                      <td>{networkName(row.destinationChainId)}</td>
+                      <td>{formatAmount(scopeChainId, row.inputToken, row.grossAmount ?? 0n)}</td>
+                      <td>
+                        <span className={row.late && row.state !== BRIDGE_STATE.DELIVERED ? 'status-value paused' : 'status-value'}>
+                          {bridgeStateCopy(row.state).label}
+                        </span>
+                        {/*
+                          No curated route ⇒ no advisory window ⇒ lateness is UNKNOWN, not false.
+                          Said in the row, because the alternative is a transfer that silently stops
+                          being flagged the moment an operator removes the route it is on.
+                        */}
+                        {row.windowUnknown && row.state !== BRIDGE_STATE.DELIVERED && (
+                          <span className="hint">
+                            {' '}
+                            — no expected window: this route is no longer curated, so whether this is
+                            overdue cannot be said here
+                          </span>
+                        )}
+                      </td>
+                      <td>
+                        {row.observed
+                          ? row.dstTxHash
+                            ? 'destination fill'
+                            : row.refundTxHash
+                              ? 'return transaction'
+                              : 'bridge knows the deposit'
+                          : 'origin transaction only'}
+                        {row.txHash && getTransactionUrl(scopeChainId, row.txHash) && (
+                          <>
+                            {' '}
+                            <a href={getTransactionUrl(scopeChainId, row.txHash)} target="_blank" rel="noopener noreferrer">
+                              start tx ↗
+                            </a>
+                          </>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+            {/*
+              THE PANEL SAYS WHAT IT COULD NOT SHOW. A bounded list that does not admit its bound
+              reads as "everything is here", which for an incident panel is the one reading that
+              costs something.
+            */}
+            <p className="card-info">
+              Anything past its expected window is listed <strong>ahead of</strong> newer transfers,
+              so a stuck one is not pushed out by traffic that is fine.
+              {ops.found != null && ops.found > (ops.rows?.length ?? 0)
+                ? ` ${ops.found} bridges were found in the lookback window and ${ops.rows.length} are shown${
+                    ops.hidden > 0 ? `; ${ops.hidden} older ${ops.hidden === 1 ? 'one is' : 'ones are'} not listed` : ''
+                  } — use the explorer link for the rest.`
+                : ''}{' '}
+              “Taking longer than expected” means past the route’s advisory window — it is a
+              statement about the clock, not about the outcome: those transfers still deliver or
+              are returned.
+            </p>
+          </div>
+
+          <HistoryCard
+            title="Change history"
+            history={history}
+            explorerUrl={getBlockscoutUrl(scopeChainId, routerAddr, 'address')}
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Recover the Across deposit id from the SpokePool log the router's own transaction emitted.
+ *
+ * Returns null for every ambiguity — no receipt, no matching log, an undecodable one. Null means
+ * "we cannot ask about this transfer", never "this transfer does not exist".
+ */
+async function readDepositId(provider, txHash) {
+  if (!provider || !txHash) return null
+  const receipt = await safe(provider.getTransactionReceipt(txHash))
+  if (!receipt?.logs) return null
+  for (const log of receipt.logs) {
+    if (!DEPOSIT_TOPICS.has(log?.topics?.[0])) continue
+    try {
+      const parsed = SPOKE_POOL_IFACE.parseLog({ topics: [...log.topics], data: log.data })
+      if (parsed?.args?.depositId != null) return parsed.args.depositId
+    } catch {
+      // Not one of the deposit events after all — ignore rather than count it.
+    }
+  }
+  return null
+}
+
+/**
+ * Decode one config event into the audit row: what changed, on what, before → after.
+ *
+ * `RouteLimitChanged` is the only route event carrying an old value, so it is the only one with a
+ * real "before". The others print "—", and the history card explains why rather than letting the
+ * dash read as "it was empty".
+ */
+function describeBridgeEvent(scopeChainId) {
+  const route = (args) => {
+    const dest = Number(args?.destinationChainId ?? 0)
+    return dest ? `route → ${networkName(dest)}` : `route ${shortAddr(args?.routeId) || String(args?.routeId ?? '').slice(0, 10)}`
+  }
+  return (name, args) => {
+    switch (name) {
+      case 'RouteSet':
+        return {
+          action: 'Route saved',
+          target: `${tokenLabel(scopeChainId, args.inputToken)} ${route(args)}`,
+          // `RouteSet` does NOT carry `enabled` (see IBridgeRouter), so `args.enabled` is undefined
+          // and this used to fall through to "offered" — telling an auditor that a route saved with
+          // the box unchecked had gone live. The event says nothing about availability, so neither
+          // does this row: the RouteEnabledChanged rows are where that history actually lives.
+          after: `max ${formatLimit(scopeChainId, args.inputToken, args.maxAmount)}, window ${formatDuration(args.expectedFillSeconds)}`,
+        }
+      case 'RouteEnabledChanged':
+        return { action: 'Route availability', target: route(args), after: args.enabled ? 'enabled' : 'disabled' }
+      case 'RouteLimitChanged':
+        return {
+          action: 'Per-transaction maximum',
+          target: route(args),
+          // The event carries no token, so the figures are shown in raw units and say so
+          // rather than being scaled by a guess about which asset the route moves.
+          before: String(args.oldMax) === '0' ? 'uncapped' : `${args.oldMax} raw units`,
+          after: String(args.newMax) === '0' ? 'uncapped' : `${args.newMax} raw units`,
+        }
+      case 'RouteRemoved':
+        return { action: 'Route removed', target: route(args), after: 'no longer offered' }
+      case 'SpokePoolUpdated':
+        return { action: 'SpokePool address', target: 'Across SpokePool', before: shortAddr(args.oldSpokePool) || '—', after: shortAddr(args.newSpokePool) || '—' }
+      case 'FeeRouterUpdated':
+        return { action: 'FeeRouter reference', target: 'FeeRouter', before: shortAddr(args.oldRouter) || '—', after: shortAddr(args.newRouter) || '—' }
+      case 'SanctionsGuardUpdated':
+        return { action: 'Sanctions guard', target: 'SanctionsGuard', before: shortAddr(args.oldGuard) || '—', after: shortAddr(args.newGuard) || '—' }
+      case 'Paused':
+        return { action: 'Emergency pause', target: 'new bridges', after: 'paused (in-flight transfers unaffected)' }
+      case 'Unpaused':
+        return { action: 'Emergency pause lifted', target: 'new bridges', after: 'active' }
+      default:
+        return { action: name, target: '—' }
+    }
+  }
+}

--- a/frontend/src/components/admin/SupplyTab.jsx
+++ b/frontend/src/components/admin/SupplyTab.jsx
@@ -1,0 +1,1093 @@
+/**
+ * SupplyTab (spec 067, US4) — the operator control surface for supplied liquidity.
+ *
+ * One screen per network for the on-chain `LiquidityRouter`:
+ *   - Status + pause / resume — GUARDIAN_ROLE (FR-043/FR-044).
+ *   - The curated pool list of BOTH kinds, with per-transaction caps, supplied totals and
+ *     position counts — LIQUIDITY_ADMIN_ROLE (FR-041/FR-045/FR-048).
+ *   - Protocol addresses (Uniswap position manager, FeeRouter, sanctions guard), current value
+ *     beside the input, invalid input refused with a reason before the wallet prompt (FR-042).
+ *   - The `liquidity.deposit` platform fee — READ-ONLY (spec 060 single source of truth).
+ *   - Decoded on-chain change history (FR-046).
+ *
+ * ---------------------------------------------------------------------------------------------
+ * THE TWO THINGS THIS TAB EXISTS TO SAY OUT LOUD (research R3, FR-024).
+ *
+ * 1. **The pause is NARROW: it pauses new UNISWAP supplies, and nothing else.** Bridge-pool
+ *    deposits are a DIRECT member call to Across's HubPool — `addLiquidity` has no recipient
+ *    parameter, so routing them would leave FairWins owning a position the member could never
+ *    exit. No FairWins contract is in that path, so no FairWins contract can stop it. What
+ *    withholds a bridge pool is the per-pool `enabled` flag, which the app honours. Every label
+ *    here says "new Uniswap supplies" rather than "pooling", because an operator reaching for a
+ *    killswitch during an incident must not walk away believing they stopped something they did
+ *    not.
+ *
+ * 2. **A retired pool is RETIRED, not GONE.** `setPoolEnabled(false)` closes a pool to NEW
+ *    deposits and nothing else — which is why the contract has no `removePool` at all. Members
+ *    still hold positions there and must keep being able to see and exit them, so retired pools
+ *    stay in this table, with their position count, rather than disappearing from it.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * As on the Bridge tab, scope is a NETWORK and not the connected wallet: reads span every
+ * Uniswap-capable network from its own RPC, and only writes need the wallet there (FR-050).
+ */
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { ethers } from 'ethers'
+import { getContractAddressForChain } from '../../config/contracts'
+import { LIQUIDITY_ROUTER_ABI } from '../../abis/LiquidityRouter'
+import { FEE_SERVICES, fetchFeeQuote } from '../../lib/fees/feeQuote'
+import { getBlockscoutUrl } from '../../config/blockExplorer'
+import { POOL_KIND } from '../../lib/liquidity/liquidityRouter'
+import { readPooledToken } from '../../lib/liquidity/acrossLpPositions'
+import { BRIDGE_LP_FEE_FREE_NOTE } from '../../lib/liquidity/liquidityCopy'
+import { FeeRateCard, HistoryCard, NetworkScopeCard, WriteScopeNotice } from './liquidityAdminCards'
+import {
+  adminNetworks,
+  authorityGates,
+  formatAmount,
+  formatLimit,
+  isValidAddr,
+  limitUnitLabel,
+  loadRouterHistory,
+  networkName,
+  parseLimit,
+  readProviderFor,
+  readRouterAuthority,
+  shortAddr,
+  tokenLabel,
+} from './liquidityAdminCommon'
+
+const HISTORY_EVENTS = [
+  'PoolListed',
+  'PoolEnabledChanged',
+  'PoolLimitChanged',
+  'PositionManagerUpdated',
+  'FeeRouterUpdated',
+  'SanctionsGuardUpdated',
+  'Paused',
+  'Unpaused',
+]
+
+/**
+ * Supplied totals and position counts come from the router's own `LiquiditySupplied` events over
+ * a bounded window — there is no indexer and no backend. That makes them "supplied THROUGH
+ * FairWins in the recent window", which is a narrower claim than "everything in this pool", and
+ * the table says so rather than passing one off as the other.
+ */
+const TOTALS_LOOKBACK_BLOCKS = 200_000
+
+/** Minimal Uniswap V3 pool reads, for verifying a listing before it is signed. */
+const POOL_ABI = [
+  'function token0() view returns (address)',
+  'function token1() view returns (address)',
+  'function fee() view returns (uint24)',
+]
+
+const safe = (p) => p.then((v) => v).catch(() => undefined)
+
+const KIND_LABEL = {
+  [POOL_KIND.BRIDGE_LP]: 'Bridge pool (Across)',
+  [POOL_KIND.TRADING_LP]: 'Trading pool (Uniswap V3)',
+}
+
+export default function SupplyTab({
+  signer,
+  account,
+  chainId,
+  provider,
+  runTx,
+  pendingTx,
+  onOpenFees,
+}) {
+  const networks = useMemo(() => adminNetworks('liquidity'), [])
+  const [scopeChainId, setScopeChainId] = useState(
+    () => (networks.some((n) => n.chainId === chainId) ? chainId : networks[0]?.chainId) ?? null,
+  )
+
+  // ── AUTHORITY IS READ FROM THE ROUTER IN SCOPE, NOT FROM THE APP-WIDE ROLE FLAGS ──────────────
+  // The `isAdmin`/`isGuardian`/`isLiquidityAdmin` props answer "is this operator an admin of
+  // SOMETHING on the wallet's chain", which is not the question a control here needs answered.
+  // GUARDIAN_ROLE on the WagerRegistry is not GUARDIAN_ROLE on this LiquidityRouter, LIQUIDITY_ADMIN
+  // on the BridgeRouter is not authority over pools, and the wallet's chain is not the network in
+  // scope. Every gate below asks THIS router on THIS network — see readRouterAuthority.
+  const [authority, setAuthority] = useState(null) // null = not yet asked
+  const gates = authorityGates(authority)
+  const canConfig = gates.config
+  const canPause = gates.pause
+  // Address writes are DEFAULT_ADMIN_ROLE on the contract, a role ABOVE curation: `positionManager`
+  // is approved and mints the member's position and `feeRouter` names the treasury the fee goes to,
+  // so they are not a pool-curation power.
+  const canWire = Boolean(authority?.admin || gates.unconfirmed)
+  const canSubmit = Boolean(signer) && Number(scopeChainId) === Number(chainId) && !pendingTx
+
+  const routerAddr = getContractAddressForChain('liquidityRouter', scopeChainId)
+  const readProvider = useMemo(
+    () => readProviderFor(scopeChainId, chainId, provider),
+    [scopeChainId, chainId, provider],
+  )
+
+  const [state, setState] = useState(null) // null = loading
+  const [readError, setReadError] = useState(null)
+  const [lastReadAt, setLastReadAt] = useState(null)
+  const [fee, setFee] = useState(undefined)
+  const [history, setHistory] = useState({ entries: null, error: null })
+  const [activity, setActivity] = useState({ byPool: null, error: null })
+  // Per-pool HubPool size for BRIDGE_LP listings: poolId -> readPooledToken result, or null when
+  // that pool's read failed. Absent key = not asked yet.
+  const [bridgeSizes, setBridgeSizes] = useState({})
+  const [formError, setFormError] = useState(null)
+  const [formNote, setFormNote] = useState(null)
+  const [forms, setForms] = useState({
+    kind: String(POOL_KIND.TRADING_LP),
+    poolAddress: '',
+    token0: '',
+    token1: '',
+    feeTier: '',
+    max0: '0',
+    max1: '0',
+    enabled: true,
+    positionManager: '',
+    feeRouter: '',
+    sanctionsGuard: '',
+  })
+  const [capDrafts, setCapDrafts] = useState({})
+
+  const routerRead = useMemo(
+    () => (routerAddr && readProvider ? new ethers.Contract(routerAddr, LIQUIDITY_ROUTER_ABI, readProvider) : null),
+    [routerAddr, readProvider],
+  )
+  const write = useCallback(
+    () => new ethers.Contract(routerAddr, LIQUIDITY_ROUTER_ABI, signer),
+    [routerAddr, signer],
+  )
+
+  /* -------------------------------------------------------------------------------- reads */
+
+  const fetchState = useCallback(async () => {
+    if (!routerRead) {
+      setState(null)
+      return
+    }
+    try {
+      setReadError(null)
+      // CLEARED BEFORE THE NEW NETWORK IS READ, not after. `setState` only fires on success, so
+      // without this the PREVIOUS network's pause banner, table and counts keep rendering under the
+      // newly-selected network's name — with an "as of" timestamp that looks current. On a public RPC
+      // that window is a full round-trip, and it fails in the direction that reads as safe: an
+      // operator pausing network A, switching to B and seeing A's PAUSED banner moves on believing B
+      // is stopped (FR-050 no-mixing, FR-052 as-of).
+      setState(null)
+      setLastReadAt(null)
+      const paused = await routerRead.paused()
+      const [feeRouter, positionManager, sanctionsGuard, maxFeeBps, count] = await Promise.all([
+        safe(routerRead.feeRouter()),
+        safe(routerRead.positionManager()),
+        safe(routerRead.sanctionsGuard()),
+        safe(routerRead.MAX_FEE_BPS()),
+        safe(routerRead.poolCount()),
+      ])
+
+      const pools = []
+      let poolsComplete = count !== undefined
+      if (count !== undefined) {
+        const n = Number(count)
+        const ids = await Promise.all(Array.from({ length: n }, (_, i) => safe(routerRead.poolAt(i))))
+        const raws = await Promise.all(ids.map((id) => (id ? safe(routerRead.getPool(id)) : Promise.resolve(undefined))))
+        for (let i = 0; i < n; i += 1) {
+          const id = ids[i]
+          const raw = raws[i]
+          if (!id || raw === undefined) {
+            poolsComplete = false
+            continue
+          }
+          const kind = Number(raw.kind)
+          // `Unlisted` (0) at an enumerated id is not an incomplete read — the id is simply no
+          // longer a pool — so it does not clear `poolsComplete`.
+          if (kind !== POOL_KIND.BRIDGE_LP && kind !== POOL_KIND.TRADING_LP) continue
+          pools.push({
+            poolId: id,
+            kind,
+            enabled: Boolean(raw.enabled),
+            feeTier: Number(raw.feeTier ?? 0),
+            token0: raw.token0,
+            token1: raw.token1,
+            poolAddress: raw.poolAddress,
+            maxDeposit0PerTx: BigInt(raw.maxDeposit0PerTx ?? 0n),
+            maxDeposit1PerTx: BigInt(raw.maxDeposit1PerTx ?? 0n),
+          })
+        }
+      }
+
+      setState({
+        feeRouter,
+        positionManager,
+        sanctionsGuard,
+        maxFeeBps: maxFeeBps === undefined ? null : Number(maxFeeBps),
+        paused: Boolean(paused),
+        pools,
+        poolsComplete,
+      })
+      setLastReadAt(new Date())
+    } catch (e) {
+      setState(null)
+      setReadError(
+        `Could not read the LiquidityRouter on ${networkName(scopeChainId)}: ${e?.message || e}. Nothing below can be trusted as current until this clears.`,
+      )
+    }
+  }, [routerRead, scopeChainId])
+
+  // THE RATE IS QUOTED FROM THE FEE ROUTER THIS ROUTER ACTUALLY HOLDS, NOT FROM THIS BUILD'S CONFIG.
+  //
+  // `fetchFeeQuote` defaults to the configured address, which is right for members but wrong here:
+  // the contract that will charge them is whatever `LiquidityRouter.feeRouter()` returns right now,
+  // and the two diverge in exactly the window an operator most needs the truth — after someone
+  // repoints the router and before the config ships, or the reverse. Quoting the config address there
+  // reports a rate (or a confident "no fee") from a contract that is not in the path.
+  //
+  // `liveFeeRouter` is read in fetchState; until it resolves there is nothing to quote FROM, so this
+  // waits rather than falling back to the config address and printing a figure it cannot stand behind.
+  const liveFeeRouter = state?.feeRouter
+  const fetchFee = useCallback(async () => {
+    if (!routerAddr || !readProvider || !liveFeeRouter) return
+    setFee(undefined)
+    try {
+      const quote = await fetchFeeQuote({
+        serviceId: FEE_SERVICES.LIQUIDITY_DEPOSIT,
+        chainId: scopeChainId,
+        provider: readProvider,
+        routerAddress: liveFeeRouter,
+      })
+      // A mismatch is not an error — it is a real, temporary state — but it means the MEMBER surface
+      // is quoting a different contract than the one charging, so the card says so.
+      const configured = getContractAddressForChain('feeRouter', scopeChainId)
+      setFee({
+        ...quote,
+        configuredRouterAddress: configured || null,
+        configMismatch:
+          Boolean(configured) && configured.toLowerCase() !== String(liveFeeRouter).toLowerCase(),
+      })
+    } catch (e) {
+      setFee({ failed: true, reason: e?.message || String(e) })
+    }
+  }, [routerAddr, readProvider, scopeChainId, liveFeeRouter])
+
+  const fetchHistory = useCallback(async () => {
+    if (!routerRead || !readProvider) return
+    setHistory({ entries: null, error: null })
+    setHistory(
+      await loadRouterHistory({
+        contract: routerRead,
+        provider: readProvider,
+        eventNames: HISTORY_EVENTS,
+        describe: describeLiquidityEvent(scopeChainId),
+      }),
+    )
+  }, [routerRead, readProvider, scopeChainId])
+
+  /**
+   * Per-pool supplied totals and position counts (FR-048), aggregated from the router's own
+   * `LiquiditySupplied` events.
+   *
+   * What this can and cannot see is the honest part. It counts positions minted THROUGH the
+   * router in the lookback window — which is every trading-pool supply FairWins has made, and
+   * NONE of the bridge-pool deposits, because those never touch this contract. A bridge pool's
+   * count is therefore reported as not observable rather than as zero: zero would read as "no
+   * member has money in here", which is exactly the claim that must not be made about a pool
+   * being retired (FR-024).
+   */
+  const fetchActivity = useCallback(async () => {
+    if (!routerRead || !readProvider) return
+    setActivity({ byPool: null, error: null })
+    try {
+      const latest = await readProvider.getBlockNumber()
+      const fromBlock = Math.max(0, Number(latest) - TOTALS_LOOKBACK_BLOCKS)
+      const evs = (await routerRead.queryFilter(routerRead.filters.LiquiditySupplied(), fromBlock, 'latest')) || []
+      const byPool = {}
+      for (const ev of evs) {
+        const poolId = ev.args?.poolId
+        if (!poolId) continue
+        const entry = byPool[poolId] || { positions: new Set(), amount0: 0n, amount1: 0n }
+        if (ev.args?.tokenId != null) entry.positions.add(String(ev.args.tokenId))
+        entry.amount0 += BigInt(ev.args?.amount0 ?? 0n)
+        entry.amount1 += BigInt(ev.args?.amount1 ?? 0n)
+        byPool[poolId] = entry
+      }
+      setActivity({
+        byPool: Object.fromEntries(
+          Object.entries(byPool).map(([id, e]) => [id, { positions: e.positions.size, amount0: e.amount0, amount1: e.amount1 }]),
+        ),
+        error: null,
+      })
+    } catch (e) {
+      // `byPool: null`, NOT `{}`. An empty map is indistinguishable from "scanned, found nothing",
+      // and the cells below fall back to `?? 0` — so an unreadable scan would print "0 positions"
+      // against a pool members still hold LP in. That is the single claim FR-024 exists to prevent,
+      // made at the moment an operator decides whether to retire it.
+      setActivity({ byPool: null, error: e?.message || String(e) })
+    }
+  }, [routerRead, readProvider])
+
+  /**
+   * How much sits in each curated BRIDGE pool, read from the HubPool itself (FR-048).
+   *
+   * The router's events cannot see these deposits — they never touch it — which is why the position
+   * COUNT stays unobservable here: attributing LP balances to members needs an indexer. But the POOL
+   * SIZE is a plain read that this app already performs on the member-facing Supply view, from the
+   * same address (`readPooledToken` on `pool.poolAddress`, which for a bridge listing IS the
+   * HubPool). Withholding it left an operator deciding whether to retire a bridge pool with no
+   * figure at all for the money inside it, while the member screen showed exactly that. One number
+   * genuinely cannot be produced; this one can, so it is.
+   */
+  const fetchBridgePools = useCallback(async () => {
+    if (!readProvider || !state?.pools) return
+    const bridgePools = state.pools.filter((p) => p.kind === POOL_KIND.BRIDGE_LP)
+    if (bridgePools.length === 0) {
+      setBridgeSizes({})
+      return
+    }
+    const entries = await Promise.all(
+      bridgePools.map(async (pool) => {
+        // Per-pool, so one unreadable HubPool never blanks the others.
+        const info = await readPooledToken({
+          provider: readProvider,
+          hubPool: pool.poolAddress,
+          l1Token: pool.token0,
+        }).catch(() => null)
+        return [pool.poolId, info]
+      }),
+    )
+    setBridgeSizes(Object.fromEntries(entries))
+  }, [readProvider, state?.pools])
+
+  useEffect(() => {
+    fetchState()
+    fetchFee()
+    fetchHistory()
+    fetchActivity()
+  }, [fetchState, fetchFee, fetchHistory, fetchActivity])
+
+  useEffect(() => {
+    fetchBridgePools()
+  }, [fetchBridgePools])
+
+  // Re-asked whenever the ROUTER or the NETWORK changes, because the answer is a property of both.
+  useEffect(() => {
+    let live = true
+    setAuthority(null)
+    readRouterAuthority({ provider: readProvider, routerAddress: routerAddr, account }).then((a) => {
+      if (live) setAuthority(a)
+    })
+    return () => {
+      live = false
+    }
+  }, [readProvider, routerAddr, account])
+
+  const refresh = () => {
+    fetchState()
+    fetchFee()
+    fetchHistory()
+    fetchActivity()
+    fetchBridgePools()
+  }
+
+  /* ------------------------------------------------------------------------------- writes */
+
+  const togglePause = () => {
+    const fn = state?.paused ? 'unpause' : 'pause'
+    runTx(
+      () => write()[fn](),
+      state?.paused ? 'New Uniswap supplies resumed' : 'New Uniswap supplies paused',
+    ).then(refresh)
+  }
+
+  const setPoolEnabled = (pool, enabled) =>
+    runTx(
+      () => write().setPoolEnabled(pool.poolId, enabled),
+      enabled ? 'Pool reopened to new deposits' : 'Pool retired — closed to new deposits, existing positions untouched',
+    ).then(refresh)
+
+  /**
+   * Write new per-transaction ceilings, leaving anything the operator did not type alone.
+   *
+   * ── AN UNTOUCHED LEG KEEPS ITS CURRENT CEILING ─────────────────────────────────────────────────
+   * `setPoolLimit` writes BOTH legs in one call and `0` means UNCAPPED on-chain, so defaulting the
+   * blank leg to '0' silently deleted a member-facing limit the operator never intended to touch:
+   * typing a new WETH ceiling on a pool capped at 25,000 USDC removed the USDC cap and reported
+   * success. Blank now means "keep", read from the pool's live value, and blanking BOTH is refused
+   * outright rather than quietly writing uncapped/uncapped — an operator who wants no ceiling can
+   * type 0, which still means uncapped and now says so only when they asked for it.
+   */
+  const applyCaps = (pool) => {
+    setFormError(null)
+    const draft0 = capDrafts[`${pool.poolId}-0`]
+    const draft1 = capDrafts[`${pool.poolId}-1`]
+    const typed0 = String(draft0 ?? '').trim() !== ''
+    const typed1 = String(draft1 ?? '').trim() !== ''
+    const twoLegs = pool.kind === POOL_KIND.TRADING_LP
+    if (!typed0 && !(twoLegs && typed1)) {
+      setFormError(
+        'Type a new ceiling first. Leaving the boxes blank would write 0 — uncapped — over the current limits; enter 0 explicitly if that is what you intend.',
+      )
+      return
+    }
+    let max0
+    let max1
+    try {
+      max0 = typed0 ? parseLimit(scopeChainId, pool.token0, draft0) : BigInt(pool.maxDeposit0PerTx ?? 0n)
+      if (!twoLegs) {
+        max1 = 0n
+      } else {
+        max1 = typed1 ? parseLimit(scopeChainId, pool.token1, draft1) : BigInt(pool.maxDeposit1PerTx ?? 0n)
+      }
+    } catch (e) {
+      setFormError(e.message)
+      return
+    }
+    runTx(() => write().setPoolLimit(pool.poolId, max0, max1), 'Per-transaction deposit caps updated').then(refresh)
+  }
+
+  /**
+   * Read the named Uniswap pool and check the listing against it BEFORE any signature.
+   *
+   * The contract cross-checks the same three fields and reverts `PoolListingMismatch`, which
+   * costs gas and tells the operator nothing about WHICH field was wrong. Doing it here turns
+   * that into a sentence — and a listing whose metadata disagreed with its pool would have been
+   * shown to members as the pool they were not supplying (FR-042).
+   */
+  const verifyPool = async () => {
+    setFormError(null)
+    setFormNote(null)
+    if (!isValidAddr(forms.poolAddress)) {
+      setFormError('Enter the Uniswap V3 pool address first.')
+      return
+    }
+    if (!readProvider) {
+      setFormError(`No read connection to ${networkName(scopeChainId)}, so the pool cannot be checked from here.`)
+      return
+    }
+    const pool = new ethers.Contract(forms.poolAddress, POOL_ABI, readProvider)
+    const [token0, token1, feeTier] = await Promise.all([safe(pool.token0()), safe(pool.token1()), safe(pool.fee())])
+    if (!token0 || !token1 || feeTier === undefined) {
+      setFormError(
+        'That address did not answer as a Uniswap V3 pool. Check it is the POOL, not the token pair or the position manager.',
+      )
+      return
+    }
+    setForms((f) => ({ ...f, token0, token1, feeTier: String(feeTier) }))
+    setFormNote(
+      `Pool confirmed: ${tokenLabel(scopeChainId, token0)} / ${tokenLabel(scopeChainId, token1)} at ${Number(feeTier) / 10_000}%. The fields above now match the pool the router will check against.`,
+    )
+  }
+
+  const submitPool = () => {
+    setFormError(null)
+    const kind = Number(forms.kind)
+    if (!isValidAddr(forms.poolAddress) || !isValidAddr(forms.token0)) {
+      setFormError('The pool address and the first asset must both be valid, non-zero addresses.')
+      return
+    }
+    if (kind === POOL_KIND.TRADING_LP) {
+      if (!isValidAddr(forms.token1)) {
+        setFormError('A trading pool has two legs — enter the second asset, or use “Check pool” to fill both from the pool itself.')
+        return
+      }
+      if (!/^\d+$/.test(forms.feeTier) || Number(forms.feeTier) === 0) {
+        setFormError('A trading pool needs its Uniswap fee tier (500, 3000 or 10000). The router rejects a listing without one.')
+        return
+      }
+    } else if (forms.token1 && forms.token1 !== ethers.ZeroAddress) {
+      setFormError('A bridge pool has exactly one asset — leave the second asset empty. The router rejects a two-legged bridge listing.')
+      return
+    }
+    let max0
+    let max1
+    try {
+      max0 = parseLimit(scopeChainId, forms.token0, forms.max0)
+      max1 = kind === POOL_KIND.TRADING_LP ? parseLimit(scopeChainId, forms.token1, forms.max1) : 0n
+    } catch (e) {
+      setFormError(e.message)
+      return
+    }
+    runTx(
+      () =>
+        write().listPool({
+          kind,
+          enabled: forms.enabled,
+          feeTier: kind === POOL_KIND.TRADING_LP ? Number(forms.feeTier) : 0,
+          token0: forms.token0,
+          token1: kind === POOL_KIND.TRADING_LP ? forms.token1 : ethers.ZeroAddress,
+          poolAddress: forms.poolAddress,
+          maxDeposit0PerTx: max0,
+          maxDeposit1PerTx: max1,
+        }),
+      'Pool listing saved',
+    ).then(refresh)
+  }
+
+  const setAddress = (fn, value, label) => {
+    setFormError(null)
+    if (!isValidAddr(value)) {
+      setFormError(`Enter a valid, non-zero address for the ${label} — the contract rejects malformed and zero addresses.`)
+      return
+    }
+    runTx(() => write()[fn](value), `${label} updated`).then(refresh)
+  }
+
+  /* ------------------------------------------------------------------------------- render */
+
+  if (!scopeChainId) {
+    return (
+      <div className="admin-tab-content" role="tabpanel">
+        <div className="admin-card">
+          <h3>Supply Controls</h3>
+          <p className="card-info">
+            No network in this build carries a Uniswap position manager, so there is nothing to
+            control here and the Supply area is hidden for members everywhere.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  // A COUNT IS NEVER PRINTED AS A BARE NUMBER UNLESS THE SCAN THAT PRODUCED IT SUCCEEDED.
+  //
+  // Three states, three different sentences, because they mean different things to an operator about
+  // to retire a pool: the scan has not answered yet, the scan FAILED (so nothing is known — the case
+  // that used to render "0"), and the scan succeeded but found nothing in its window (which is not
+  // the same as "no member holds a position", since the window is bounded).
+  const positionsFor = (pool) => {
+    if (pool.kind === POOL_KIND.BRIDGE_LP) return 'not observable here'
+    if (activity.error) return 'unknown — the scan failed'
+    if (activity.byPool == null) return '…'
+    const agg = activity.byPool[pool.poolId]
+    if (!agg) return 'none in window'
+    return String(agg.positions)
+  }
+  const suppliedFor = (pool) => {
+    if (pool.kind === POOL_KIND.BRIDGE_LP) {
+      // Read from the HubPool, not from this router's events — see fetchBridgePools. Three states,
+      // and the failed one says so rather than reading as an empty pool.
+      if (!(pool.poolId in bridgeSizes)) return '…'
+      const info = bridgeSizes[pool.poolId]
+      if (!info) return 'unknown — the HubPool could not be read'
+      const total = info.liquidReserves + (info.utilizedReserves > 0n ? info.utilizedReserves : 0n)
+      return `${formatAmount(scopeChainId, pool.token0, total)} in the pool`
+    }
+    if (activity.error) return 'unknown — the scan failed'
+    if (activity.byPool == null) return '…'
+    const agg = activity.byPool[pool.poolId]
+    if (!agg) return 'none in window'
+    return `${formatAmount(scopeChainId, pool.token0, agg.amount0)} + ${formatAmount(scopeChainId, pool.token1, agg.amount1)}`
+  }
+
+  return (
+    <div className="admin-tab-content" role="tabpanel">
+      <NetworkScopeCard
+        title="Supply Controls"
+        description="The curated pool list, deposit caps, addresses and the Uniswap supply pause for one network's LiquidityRouter."
+        networks={networks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('liquidityRouter', id))}
+        walletChainId={chainId}
+        onRefresh={refresh}
+        lastReadAt={routerAddr ? lastReadAt : null}
+      >
+        {routerAddr && (
+          <div className="status-details">
+            <div className="status-row">
+              <span className="status-label">LiquidityRouter</span>
+              <span className="status-value">
+                <code title={routerAddr}>{shortAddr(routerAddr)}</code>
+              </span>
+            </div>
+            <div className="status-row">
+              <span className="status-label">New Uniswap supplies</span>
+              <span className="status-value">
+                {state == null ? (
+                  '…'
+                ) : state.paused ? (
+                  <span className="status-value paused">
+                    PAUSED — no new Uniswap supplies. Existing positions are untouched and still withdrawable.
+                  </span>
+                ) : (
+                  'active'
+                )}
+              </span>
+            </div>
+            <div className="status-row">
+              <span className="status-label">Curated pools</span>
+              <span className="status-value">
+                {state == null
+                  ? '…'
+                  : `${state.pools.length} (${state.pools.filter((p) => p.enabled).length} open to new deposits)${state.poolsComplete ? '' : ' — partial read, some pools could not be loaded'}`}
+              </span>
+            </div>
+          </div>
+        )}
+        {readError && (
+          <p className="card-info error" role="alert">
+            {readError}
+          </p>
+        )}
+      </NetworkScopeCard>
+
+      {!routerAddr ? (
+        <div className="admin-card">
+          <h3>Not deployed on {networkName(scopeChainId)}</h3>
+          <p className="card-info">
+            No LiquidityRouter is deployed on {networkName(scopeChainId)}, so there is nothing to
+            control here and members are offered no pools on this network. Deploy it with{' '}
+            <code>scripts/deploy/deploy-bridge-liquidity.js</code>, or pick another network above.
+          </p>
+        </div>
+      ) : (
+        <>
+          <WriteScopeNotice
+            scopeChainId={scopeChainId}
+            walletChainId={chainId}
+            signer={signer}
+            canWrite={canConfig || canPause}
+          />
+
+          {/*
+            THE CARD IS ALWAYS RENDERED, INCLUDING WHEN THIS OPERATOR CANNOT USE IT — see the same
+            note in BridgeTab. Hiding it behind the authority check made a network with a working
+            killswitch look like a network without one, mid-incident.
+          */}
+          <div className="admin-card">
+            <h3>Emergency pause</h3>
+            <p>
+              <strong>Pauses new Uniswap supplies</strong> on {networkName(scopeChainId)} —
+              immediately, with no redeploy, and with no dependency on any optional service.
+            </p>
+            <p className="card-info warning-text">
+              It does <strong>not</strong> pause bridge-pool deposits. Those go straight from the
+              member’s wallet to the Across HubPool with no FairWins contract in the path, so this
+              contract cannot stop them: what withholds a bridge pool is its <em>enabled</em> flag
+              in the table below, which the app honours. Nothing here can trap member value —
+              every existing position stays withdrawable, because withdrawing never went through
+              this router in the first place.
+            </p>
+            {gates.unconfirmed && (
+              <p className="card-info" role="status">
+                Your authority on this router could not be confirmed{authority?.reason ? ` (${authority.reason})` : ''}.
+                The control is still offered, because the contract is the real gate and will refuse
+                anything you do not hold — withholding a killswitch over an unanswered read would be
+                the worse error.
+              </p>
+            )}
+            {gates.pending ? (
+              <p className="card-info">Checking your authority on this router…</p>
+            ) : canPause ? (
+              <button
+                type="button"
+                className={`confirm-btn ${state?.paused ? 'primary' : 'danger'}`}
+                onClick={togglePause}
+                disabled={!canSubmit || state == null}
+              >
+                {state?.paused ? 'Resume new Uniswap supplies' : 'Pause new Uniswap supplies'}
+              </button>
+            ) : (
+              <p className="card-info" role="status">
+                This account holds neither <code>GUARDIAN_ROLE</code> nor admin on the LiquidityRouter
+                on {networkName(scopeChainId)}, so the pause is not yours to pull —{' '}
+                <strong>the killswitch exists and is exercisable by an account that does hold it.</strong>{' '}
+                Holding the guardian role on another contract (the WagerRegistry, or this router on a
+                different network) does not carry here; a Role Manager grants{' '}
+                <code>GUARDIAN_ROLE</code> on this router from the Roles tab.
+              </p>
+            )}
+          </div>
+
+          <div className="admin-card">
+            <h3>Curated pools</h3>
+            <p className="card-info">
+              Retiring a pool closes it to <strong>new</strong> deposits only. It stays listed here
+              and for members who hold a position in it, so they can keep seeing and exiting it —
+              which is why the router has no “remove pool” at all (FR-024).
+            </p>
+            {state == null ? (
+              <p className="card-info">Loading pools…</p>
+            ) : state.pools.length === 0 ? (
+              <p className="card-info">
+                No pools are curated on {networkName(scopeChainId)} yet, so members are offered
+                nothing to supply here.
+              </p>
+            ) : (
+              <table className="admin-table" aria-label="Curated pools">
+                <thead>
+                  <tr>
+                    <th scope="col">Kind</th>
+                    <th scope="col">Pool</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Positions</th>
+                    <th scope="col">Supplied via FairWins</th>
+                    <th scope="col">Per-transaction caps</th>
+                    {canConfig && <th scope="col">Change</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {state.pools.map((pool) => (
+                    <tr key={pool.poolId}>
+                      <td>{KIND_LABEL[pool.kind]}</td>
+                      <td>
+                        {pool.kind === POOL_KIND.TRADING_LP
+                          ? `${tokenLabel(scopeChainId, pool.token0)} / ${tokenLabel(scopeChainId, pool.token1)} ${Number(pool.feeTier) / 10_000}%`
+                          : tokenLabel(scopeChainId, pool.token0)}{' '}
+                        <code title={pool.poolAddress}>{shortAddr(pool.poolAddress)}</code>
+                      </td>
+                      <td>
+                        <span className={pool.enabled ? 'status-value' : 'status-value paused'}>
+                          {pool.enabled ? 'open to new deposits' : 'RETIRED — closed to new deposits, still withdrawable'}
+                        </span>
+                      </td>
+                      <td>{positionsFor(pool)}</td>
+                      <td>{suppliedFor(pool)}</td>
+                      <td>
+                        {formatLimit(scopeChainId, pool.token0, pool.maxDeposit0PerTx)}
+                        {pool.kind === POOL_KIND.TRADING_LP && (
+                          <> / {formatLimit(scopeChainId, pool.token1, pool.maxDeposit1PerTx)}</>
+                        )}
+                        {/*
+                          A bridge pool's cap is honoured by the APP, not by the contract: the
+                          router's limit check lives inside the trading-pool entry point, and a
+                          bridge-LP deposit never enters it. Same property the pause card explains
+                          for the enabled flag — so it is said here too, where the number is, rather
+                          than left to imply contract enforcement it does not have.
+                        */}
+                        {pool.kind === POOL_KIND.BRIDGE_LP && (
+                          <span className="hint"> — honoured by this app, not by the contract</span>
+                        )}
+                      </td>
+                      {canConfig && (
+                        <td>
+                          <button
+                            type="button"
+                            className={`confirm-btn ${pool.enabled ? 'danger' : 'primary'}`}
+                            disabled={!canSubmit}
+                            onClick={() => setPoolEnabled(pool, !pool.enabled)}
+                          >
+                            {pool.enabled ? 'Retire' : 'Reopen'}
+                          </button>
+                          <label>
+                            <span className="hint">
+                              New cap, {limitUnitLabel(scopeChainId, pool.token0)} (0 = uncapped)
+                            </span>
+                            <input
+                              type="text"
+                              aria-label={`Per-transaction cap for ${tokenLabel(scopeChainId, pool.token0)} in pool ${shortAddr(pool.poolAddress)}`}
+                              value={capDrafts[`${pool.poolId}-0`] ?? ''}
+                              onChange={(e) =>
+                                setCapDrafts((d) => ({ ...d, [`${pool.poolId}-0`]: e.target.value }))
+                              }
+                            />
+                          </label>
+                          {pool.kind === POOL_KIND.TRADING_LP && (
+                            <label>
+                              <span className="hint">
+                                New cap, {limitUnitLabel(scopeChainId, pool.token1)} (0 = uncapped)
+                              </span>
+                              <input
+                                type="text"
+                                aria-label={`Per-transaction cap for ${tokenLabel(scopeChainId, pool.token1)} in pool ${shortAddr(pool.poolAddress)}`}
+                                value={capDrafts[`${pool.poolId}-1`] ?? ''}
+                                onChange={(e) =>
+                                  setCapDrafts((d) => ({ ...d, [`${pool.poolId}-1`]: e.target.value }))
+                                }
+                              />
+                            </label>
+                          )}
+                          <button
+                            type="button"
+                            className="confirm-btn primary"
+                            disabled={!canSubmit}
+                            onClick={() => applyCaps(pool)}
+                          >
+                            Set caps
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+            <p className="card-info">
+              “Positions” and “Supplied via FairWins” are counted from this router’s own deposit
+              events over the recent window — they are what FairWins routed, not the pool’s whole
+              size. A bridge pool’s <em>size</em> is different: it is read straight from the Across
+              HubPool, so it is the whole pool and not a FairWins subset. Its per-member{' '}
+              <em>position count</em> is the one figure that genuinely cannot be produced without an
+              indexer — those deposits never touch this contract — and it says so rather than
+              printing a zero, which would read as “no member has money in this pool”: precisely the
+              claim that must not be made when retiring one.
+              {activity.error
+                ? ' This RPC bounds event lookups, so the recent window could not be read — the affected cells say “unknown”, never 0.'
+                : ''}
+            </p>
+            <p className="card-info">
+              A <strong>bridge pool’s</strong> per-transaction cap is enforced by this app, not by the
+              router: the contract’s limit check sits inside the Uniswap supply path, and a bridge-LP
+              deposit is a direct member call to Across that never enters it. The cap still does real
+              work — every FairWins surface refuses above it — but a member calling the HubPool
+              directly is not bound by it, exactly as with the <em>enabled</em> flag.
+            </p>
+            {canConfig && (
+              <div className="admin-form">
+                <h4>Add or edit a pool</h4>
+                <label>
+                  Kind
+                  <select value={forms.kind} onChange={(e) => setForms((f) => ({ ...f, kind: e.target.value }))}>
+                    <option value={String(POOL_KIND.TRADING_LP)}>Trading pool (Uniswap V3) — routed, fee-charged</option>
+                    <option value={String(POOL_KIND.BRIDGE_LP)}>Bridge pool (Across HubPool) — direct member call, fee-free</option>
+                  </select>
+                </label>
+                <label>
+                  Pool address
+                  <input
+                    type="text"
+                    placeholder="pool 0x…"
+                    value={forms.poolAddress}
+                    onChange={(e) => setForms((f) => ({ ...f, poolAddress: e.target.value }))}
+                  />
+                </label>
+                {Number(forms.kind) === POOL_KIND.TRADING_LP && (
+                  <button type="button" className="confirm-btn primary" onClick={verifyPool}>
+                    Check pool
+                  </button>
+                )}
+                <label>
+                  First asset
+                  <input
+                    type="text"
+                    placeholder="token0 0x…"
+                    value={forms.token0}
+                    onChange={(e) => setForms((f) => ({ ...f, token0: e.target.value }))}
+                  />
+                </label>
+                {Number(forms.kind) === POOL_KIND.TRADING_LP && (
+                  <>
+                    <label>
+                      Second asset
+                      <input
+                        type="text"
+                        placeholder="token1 0x…"
+                        value={forms.token1}
+                        onChange={(e) => setForms((f) => ({ ...f, token1: e.target.value }))}
+                      />
+                    </label>
+                    <label>
+                      Uniswap fee tier
+                      <input
+                        type="text"
+                        placeholder="500 / 3000 / 10000"
+                        value={forms.feeTier}
+                        onChange={(e) => setForms((f) => ({ ...f, feeTier: e.target.value }))}
+                      />
+                      <span className="hint">
+                        The router checks these three fields against the pool itself and refuses a
+                        listing that disagrees with it — use “Check pool” to fill them from the pool.
+                      </span>
+                    </label>
+                  </>
+                )}
+                <label>
+                  Per-transaction cap, first asset ({limitUnitLabel(scopeChainId, forms.token0)}) — 0 = uncapped
+                  <input
+                    type="text"
+                    value={forms.max0}
+                    onChange={(e) => setForms((f) => ({ ...f, max0: e.target.value }))}
+                  />
+                </label>
+                {Number(forms.kind) === POOL_KIND.TRADING_LP && (
+                  <label>
+                    Per-transaction cap, second asset ({limitUnitLabel(scopeChainId, forms.token1)}) — 0 = uncapped
+                    <input
+                      type="text"
+                      value={forms.max1}
+                      onChange={(e) => setForms((f) => ({ ...f, max1: e.target.value }))}
+                    />
+                    <span className="hint">
+                      Two caps, not one: a pair’s legs routinely differ in decimals, so one number
+                      compared against both would be meaningless.
+                    </span>
+                  </label>
+                )}
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={forms.enabled}
+                    onChange={(e) => setForms((f) => ({ ...f, enabled: e.target.checked }))}
+                  />
+                  Open to new deposits immediately
+                </label>
+                <button type="button" className="confirm-btn primary" disabled={!canSubmit} onClick={submitPool}>
+                  Save pool listing
+                </button>
+                {formNote && <p className="card-info">{formNote}</p>}
+              </div>
+            )}
+            {formError && (
+              <p className="card-info error" role="alert">
+                {formError}
+              </p>
+            )}
+          </div>
+
+          {canWire && (
+            <div className="admin-card">
+              <h3>Protocol addresses</h3>
+              <p>
+                Current values are shown beside each field. Invalid or zero addresses are rejected
+                here, before the wallet prompt (FR-042).
+              </p>
+              {/*
+                Not curation, and the contract does not treat them as such: DEFAULT_ADMIN_ROLE, a role
+                above LIQUIDITY_ADMIN. The card says why, because "set an address" reads like a
+                setting and the consequence is not.
+              */}
+              <p className="card-info">
+                <strong>These are fund-path references, not settings.</strong> The position manager is
+                approved and mints each member’s position; the FeeRouter names both the rate and the
+                treasury the fee is transferred to. Pointing either at the wrong contract redirects
+                member capital, which is why they need admin rather than the pool-curation role, and
+                why the router caps the fee it will pay out at{' '}
+                {state?.maxFeeBps == null ? 'its own hard ceiling' : `${state.maxFeeBps / 100}%`}{' '}
+                <em>of the amount</em> no matter what a FeeRouter reports about itself. Verify the
+                address on the explorer before saving.
+              </p>
+              <div className="admin-form">
+                <label>
+                  Uniswap position manager
+                  <input
+                    type="text"
+                    placeholder="NonfungiblePositionManager 0x…"
+                    value={forms.positionManager}
+                    onChange={(e) => setForms((f) => ({ ...f, positionManager: e.target.value }))}
+                  />
+                  <span className="hint">
+                    now: {shortAddr(state?.positionManager) || 'unset — trading-pool supplies revert until it is set'}
+                  </span>
+                </label>
+                <button
+                  type="button"
+                  className="confirm-btn primary"
+                  disabled={!canSubmit}
+                  onClick={() => setAddress('setPositionManager', forms.positionManager, 'Position manager')}
+                >
+                  Set position manager
+                </button>
+
+                <label>
+                  FeeRouter reference
+                  <input
+                    type="text"
+                    placeholder="FeeRouter 0x…"
+                    value={forms.feeRouter}
+                    onChange={(e) => setForms((f) => ({ ...f, feeRouter: e.target.value }))}
+                  />
+                  <span className="hint">now: {shortAddr(state?.feeRouter) || '—'}</span>
+                </label>
+                <button
+                  type="button"
+                  className="confirm-btn primary"
+                  disabled={!canSubmit}
+                  onClick={() => setAddress('setFeeRouter', forms.feeRouter, 'FeeRouter reference')}
+                >
+                  Set FeeRouter
+                </button>
+
+                <label>
+                  Sanctions guard
+                  <input
+                    type="text"
+                    placeholder="SanctionsGuard 0x…"
+                    value={forms.sanctionsGuard}
+                    onChange={(e) => setForms((f) => ({ ...f, sanctionsGuard: e.target.value }))}
+                  />
+                  <span className="hint">now: {shortAddr(state?.sanctionsGuard) || '—'}</span>
+                </label>
+                <button
+                  type="button"
+                  className="confirm-btn primary"
+                  disabled={!canSubmit}
+                  onClick={() => setAddress('setSanctionsGuard', forms.sanctionsGuard, 'Sanctions guard')}
+                >
+                  Set guard
+                </button>
+              </div>
+            </div>
+          )}
+
+          <FeeRateCard
+            serviceLabel="supply"
+            serviceId="liquidity.deposit"
+            quote={fee}
+            routerMaxFeeBps={state?.maxFeeBps ?? null}
+            onOpenFees={onOpenFees}
+            extraNote={BRIDGE_LP_FEE_FREE_NOTE}
+          />
+
+          <HistoryCard
+            title="Change history"
+            history={history}
+            explorerUrl={getBlockscoutUrl(scopeChainId, routerAddr, 'address')}
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Decode one config event into the audit row (FR-046).
+ *
+ * `PoolLimitChanged` carries only the new caps — the contract emits no old values — so its
+ * "before" is blank and the history card explains why. Inventing one would be worse than a dash.
+ */
+function describeLiquidityEvent(scopeChainId) {
+  const poolTarget = (args) =>
+    args?.poolAddress
+      ? `${KIND_LABEL[Number(args.kind)] || 'pool'} ${shortAddr(args.poolAddress)}`
+      : `pool ${String(args?.poolId ?? '').slice(0, 10)}…`
+  return (name, args) => {
+    switch (name) {
+      case 'PoolListed':
+        return {
+          action: 'Pool listed',
+          target: poolTarget(args),
+          // `PoolListed` does NOT carry `enabled` (see ILiquidityRouter), so `args.enabled` is
+          // undefined and this used to fall through to "open to new deposits" — telling an auditor
+          // that a pool listed with the box unchecked was taking money. The event says nothing about
+          // availability, so neither does this row; PoolEnabledChanged is where that history lives.
+          after: `${tokenLabel(scopeChainId, args.token0)}${args.token1 && args.token1 !== ethers.ZeroAddress ? ` / ${tokenLabel(scopeChainId, args.token1)}` : ''}`,
+        }
+      case 'PoolEnabledChanged':
+        return {
+          action: 'Pool availability',
+          target: poolTarget(args),
+          after: args.enabled ? 'open to new deposits' : 'retired (still visible and withdrawable)',
+        }
+      case 'PoolLimitChanged':
+        return {
+          action: 'Per-transaction caps',
+          target: poolTarget(args),
+          // Raw units: the event carries no token, so the figures are not scaled by a guess.
+          after: `${String(args.newMax0) === '0' ? 'uncapped' : `${args.newMax0} raw units`} / ${String(args.newMax1) === '0' ? 'uncapped' : `${args.newMax1} raw units`}`,
+        }
+      case 'PositionManagerUpdated':
+        return { action: 'Position manager', target: 'Uniswap NonfungiblePositionManager', before: shortAddr(args.oldManager) || '—', after: shortAddr(args.newManager) || '—' }
+      case 'FeeRouterUpdated':
+        return { action: 'FeeRouter reference', target: 'FeeRouter', before: shortAddr(args.oldRouter) || '—', after: shortAddr(args.newRouter) || '—' }
+      case 'SanctionsGuardUpdated':
+        return { action: 'Sanctions guard', target: 'SanctionsGuard', before: shortAddr(args.oldGuard) || '—', after: shortAddr(args.newGuard) || '—' }
+      case 'Paused':
+        return { action: 'Emergency pause', target: 'new Uniswap supplies', after: 'paused (bridge-pool deposits are unaffected — they never route through this contract)' }
+      case 'Unpaused':
+        return { action: 'Emergency pause lifted', target: 'new Uniswap supplies', after: 'active' }
+      default:
+        return { action: name, target: '—' }
+    }
+  }
+}

--- a/frontend/src/components/admin/adminNav.js
+++ b/frontend/src/components/admin/adminNav.js
@@ -19,6 +19,8 @@ export const ADMIN_TAB_ICONS = {
   treasury: 'bank',
   fees: 'coin',
   staking: 'trending',
+  bridge: 'transfer',
+  supply: 'sprout',
   'protocol-config': 'settings',
   'oracle-adapters': 'broadcast',
   maintenance: 'sliders',
@@ -35,6 +37,7 @@ export function buildAdminNavGroups({
   isSanctionsAdmin,
   isFeeAdmin,
   isStakingAdmin,
+  isLiquidityAdmin,
 }) {
   const item = (id, label) => ({ id, label, icon: ADMIN_TAB_ICONS[id] })
 
@@ -64,6 +67,19 @@ export function buildAdminNavGroups({
         isAdmin && item('treasury', 'Treasury'),
         // Unified platform-fee management (spec 060): FEE_ADMIN edits rates; ADMIN also enters.
         (isAdmin || isFeeAdmin) && item('fees', 'Fees'),
+      ].filter(Boolean),
+    },
+    {
+      // Cross-chain bridging + Uniswap supplying (spec 067). These are
+      // member-value surfaces with their own killswitches — routes, curated
+      // pools, limits and pauses that move member money — not protocol
+      // wiring, so they get their own group rather than living under Protocol
+      // Config. LIQUIDITY_ADMIN configures, GUARDIAN pauses, ADMIN enters
+      // (FR-040 / FR-049).
+      label: 'Liquidity',
+      items: [
+        (isAdmin || isLiquidityAdmin || isGuardian) && item('bridge', 'Bridge'),
+        (isAdmin || isLiquidityAdmin || isGuardian) && item('supply', 'Supply'),
       ].filter(Boolean),
     },
     {

--- a/frontend/src/components/admin/liquidityAdminCards.jsx
+++ b/frontend/src/components/admin/liquidityAdminCards.jsx
@@ -1,0 +1,258 @@
+/**
+ * The four cards both spec-067 control tabs render — the Bridge tab and the Supply tab (US4).
+ *
+ * Split from `liquidityAdminCommon.js` (the pure helpers) only because a module that exports
+ * components must export nothing else for React Fast Refresh to work. The reason these live in
+ * ONE place, rather than being written twice, is unchanged and is about honesty rather than
+ * tidiness: each card encodes a rule the two tabs must never state differently.
+ *
+ *   - `NetworkScopeCard` — scope is a NETWORK, not the connected wallet. Control state is
+ *     per-network (FR-050) and there are five of them; reads span every capable network from its
+ *     own RPC, and only writes need the wallet there. An operator must never read "nothing is
+ *     configured" out of being connected somewhere else.
+ *   - `WriteScopeNotice` — when a control is inert, this says which network to switch to. A dead
+ *     button with no explanation is the failure this replaces.
+ *   - `FeeRateCard` — the fee is READ-ONLY on both tabs (spec 060: one source of truth, edited by
+ *     FEE_ADMIN in the Fees tab). It distinguishes "no FeeRouter here" (honestly fee-free, member
+ *     path works) from "could not be read" (the fee-bearing member path is BLOCKED) — opposite
+ *     meanings that must never be collapsed into a 0 (FR-048/FR-051).
+ *   - `HistoryCard` — decoded on-chain events, and an explicit note that some events carry no
+ *     before-value rather than back-filling a number nobody emitted (FR-046).
+ */
+import { bpsToPercent } from '../../lib/fees/feeQuote'
+import { networkName, shortAddr } from './liquidityAdminCommon'
+
+/* ------------------------------------------------------------------------------------------
+ * Presentational pieces
+ * ---------------------------------------------------------------------------------------- */
+
+/**
+ * The network scope selector — the control that makes these tabs per-network rather than
+ * per-wallet-connection.
+ *
+ * It lists every capable network and marks which of them actually carry a deployed router, so
+ * "nothing configured here" and "nothing deployed here" are never confusable.
+ */
+export function NetworkScopeCard({
+  title,
+  description,
+  networks,
+  scopeChainId,
+  onScopeChange,
+  isDeployed,
+  walletChainId,
+  onRefresh,
+  lastReadAt,
+  children,
+}) {
+  const deployedCount = networks.filter((n) => isDeployed(n.chainId)).length
+  return (
+    <div className="admin-card">
+      <div className="admin-card-header">
+        <h3>{title}</h3>
+        <button type="button" className="refresh-btn" onClick={onRefresh} aria-label={`Refresh ${title}`}>
+          ↻
+        </button>
+      </div>
+      <p className="card-info">{description}</p>
+      <div className="admin-form">
+        <label>
+          Network
+          <select
+            value={String(scopeChainId)}
+            onChange={(e) => onScopeChange(Number(e.target.value))}
+          >
+            {networks.map((net) => (
+              <option key={net.chainId} value={String(net.chainId)}>
+                {net.name}
+                {isDeployed(net.chainId) ? '' : ' — no router deployed'}
+                {Number(net.chainId) === Number(walletChainId) ? ' (wallet is here)' : ''}
+              </option>
+            ))}
+          </select>
+          <span className="hint">
+            Control state is per network. Reading any network works from anywhere; changing one
+            needs your wallet on it. Deployed on {deployedCount} of {networks.length} networks.
+          </span>
+        </label>
+      </div>
+      {lastReadAt && (
+        <p className="card-info">
+          Everything below is as of {lastReadAt.toLocaleTimeString()} — the last time this network was read.
+        </p>
+      )}
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Says plainly why the write controls are inert, when they are.
+ *
+ * Reading another network is fine; signing for it is not — the wallet signs on the chain it is
+ * connected to, and a transaction built for a different router would go to the wrong contract
+ * (or nowhere). Naming the required network is the difference between a dead button and an
+ * instruction.
+ */
+export function WriteScopeNotice({ scopeChainId, walletChainId, signer, canWrite }) {
+  if (!canWrite) return null
+  if (!signer) {
+    return (
+      <p className="card-info warning-text">
+        Connect your wallet to make changes here. Everything below is readable without one.
+      </p>
+    )
+  }
+  if (Number(scopeChainId) !== Number(walletChainId)) {
+    return (
+      <p className="card-info warning-text">
+        You are reading {networkName(scopeChainId)} while your wallet is on{' '}
+        {networkName(walletChainId)}. Changes here are signed on {networkName(scopeChainId)}, so
+        switch your wallet to it before making one. Reading is unaffected.
+      </p>
+    )
+  }
+  return null
+}
+
+/**
+ * The read-only platform-fee card (FR-048/FR-051).
+ *
+ * Four states, each said differently because each means something different to members:
+ *   - a live rate            → show it, its service cap, and the router's own hard ceiling
+ *   - no FeeRouter deployed  → honestly fee-free; the member path works exactly as before
+ *   - FeeRouter unreadable   → the fee-bearing member path is BLOCKED (never assume a lower
+ *                              rate), and this tab's other controls still work
+ *   - still loading          → "…", never 0
+ */
+export function FeeRateCard({ serviceLabel, serviceId, quote, routerMaxFeeBps, onOpenFees, extraNote }) {
+  const rateLine = () => {
+    if (quote === undefined) return '…'
+    if (quote?.failed) {
+      return (
+        <span className="status-value paused">
+          could not be read — members cannot start a fee-bearing {serviceLabel} until it can be
+        </span>
+      )
+    }
+    if (!quote?.available) return 'no fee (no FeeRouter service registered on this network)'
+    return `${quote.bps} bps (${bpsToPercent(quote.bps)}) — service cap ${quote.capBps} bps`
+  }
+
+  return (
+    <div className="admin-card">
+      <h3>Platform fee</h3>
+      <div className="status-details">
+        <div className="status-row">
+          <span className="status-label">Live rate ({serviceId})</span>
+          <span className="status-value">{rateLine()}</span>
+        </div>
+        {quote?.routerAddress && (
+          <div className="status-row">
+            <span className="status-label">Quoted from</span>
+            <span className="status-value">
+              {shortAddr(quote.routerAddress)} — the FeeRouter this router holds right now
+            </span>
+          </div>
+        )}
+        <div className="status-row">
+          <span className="status-label">Router hard ceiling</span>
+          <span className="status-value">
+            {routerMaxFeeBps == null ? '…' : `${routerMaxFeeBps} bps — enforced by the router itself, whatever the FeeRouter reports`}
+          </span>
+        </div>
+      </div>
+      <p className="card-info">
+        The rate is <strong>read-only here</strong>. Platform fees have one source of truth — the
+        FeeRouter — and are edited by a Fee Administrator{' '}
+        {onOpenFees ? (
+          <button type="button" className="link-button" onClick={onOpenFees}>
+            in the Fees tab
+          </button>
+        ) : (
+          'in the Fees tab'
+        )}
+        . A rate of 0 means members see no fee line at all.
+      </p>
+      {/*
+        The figure above is read from the FeeRouter the ROUTER holds. Member surfaces quote the one in
+        the app CONFIG. Normally the same address; when they differ, members are being quoted by a
+        contract that is not the one charging them, and the member path will refuse rather than
+        overcharge (the router rejects a live rate above the ceiling the member signed). That is a
+        deployment step left half-done, and it is invisible from every other screen — so it is stated
+        here rather than left for someone to infer from two addresses in different cards.
+      */}
+      {quote?.configMismatch && (
+        <p className="card-info error" role="alert">
+          <strong>Members are being quoted a different FeeRouter than this router uses.</strong> This
+          router charges through {shortAddr(quote.routerAddress)}; the app is built against{' '}
+          {shortAddr(quote.configuredRouterAddress)}, so that is the rate members are shown and
+          consent to. Until the two match, fee-bearing {serviceLabel}s can be refused on-chain even
+          though this card and the member’s screen each look correct. Fix by updating{' '}
+          <code>deployments/</code>, re-running <code>npm run sync:frontend-contracts</code> and
+          redeploying the app — or by pointing this router back at the configured FeeRouter.
+        </p>
+      )}
+      {extraNote && <p className="card-info">{extraNote}</p>}
+    </div>
+  )
+}
+
+/**
+ * Decoded on-chain change history (FR-046).
+ *
+ * `before` is blank for the events whose contract signature does not carry the old value. The
+ * footnote says so rather than letting a "—" read as "it was empty".
+ */
+export function HistoryCard({ title, history, explorerUrl, note }) {
+  return (
+    <div className="admin-card">
+      <h3>{title}</h3>
+      {history.entries == null ? (
+        <p className="card-info">Loading history…</p>
+      ) : history.entries.length === 0 ? (
+        <p className="card-info">
+          {history.error
+            ? 'This RPC bounds event lookups, so the recent history could not be read here — view the full history on the block explorer.'
+            : 'No control actions recorded in the recent lookback window.'}
+        </p>
+      ) : (
+        <table className="admin-table" aria-label={title}>
+          <thead>
+            <tr>
+              <th scope="col">When</th>
+              <th scope="col">Action</th>
+              <th scope="col">Target</th>
+              <th scope="col">Before</th>
+              <th scope="col">After</th>
+              <th scope="col">By</th>
+            </tr>
+          </thead>
+          <tbody>
+            {history.entries.map((h) => (
+              <tr key={h.key}>
+                <td>{h.at ? h.at.toLocaleString() : '—'}</td>
+                <td>{h.action}</td>
+                <td>{h.target}</td>
+                <td>{h.before}</td>
+                <td>{h.after}</td>
+                <td>{h.actor ? <code title={h.actor}>{shortAddr(h.actor)}</code> : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <p className="card-info">
+        Every control action is an on-chain event (what, who, when). Some events record only the
+        new value — those show “—” before rather than a number nobody emitted. Fee-rate changes
+        are in the Fees tab’s own history.{' '}
+        {explorerUrl && (
+          <a href={explorerUrl} target="_blank" rel="noopener noreferrer">
+            Full history on the block explorer ↗
+          </a>
+        )}
+      </p>
+      {note && <p className="card-info">{note}</p>}
+    </div>
+  )
+}

--- a/frontend/src/components/admin/liquidityAdminCommon.js
+++ b/frontend/src/components/admin/liquidityAdminCommon.js
@@ -1,0 +1,315 @@
+/**
+ * Shared helpers behind the two spec-067 operator control surfaces — the Bridge tab and the
+ * Supply tab (US4, FR-040…FR-052). The cards they render live in `liquidityAdminCards.jsx`.
+ *
+ * The two tabs drive two different routers, but several things about them are identical, and
+ * each is an HONESTY rule rather than a convenience. They live here so the two tabs cannot
+ * drift apart on any of them:
+ *
+ *   1. **Scope is a NETWORK, not the wallet's network.** Control state is per-network (FR-050)
+ *      and there are five of them. Gating an admin surface on the connected chain hides four
+ *      fifths of the control state from an operator who is simply connected somewhere else. So
+ *      reads span every capable network via that network's own RPC (`readProviderFor`), and
+ *      only WRITES require the wallet to be there — the same split ClearPath already uses.
+ *
+ *   2. **A number is shown in units we can prove.** `tokenMeta` resolves a symbol and decimals
+ *      only for tokens this build actually configures; everything else renders in RAW UNITS and
+ *      says so. A mis-scaled limit is a silent, member-facing failure (a cap of 1 wei refuses
+ *      every transfer), so `parseLimit` refuses rather than guessing a scale.
+ *
+ *   3. **`0` is not one thing.** A LIMIT of 0 is "uncapped"; an AMOUNT of 0 is zero. They get
+ *      separate formatters precisely so a column of member transfer sizes can never print
+ *      "uncapped".
+ *
+ *   4. **An unreadable read is never a zero.** `loadRouterHistory` distinguishes "no events" from
+ *      "this RPC would not answer", because those are different statements to an operator
+ *      auditing a control surface (FR-046).
+ *
+ *   5. **Authority is read from the router in scope, never inferred.** `readRouterAuthority` asks
+ *      the specific router on the specific network whether THIS account holds the role — see its
+ *      own doc-comment for why the app-wide role flags cannot answer that question.
+ */
+import { ethers } from 'ethers'
+import { NETWORKS, listSupportedChainIds } from '../../config/networks'
+import { makeReadProvider } from '../../utils/rpcProvider'
+
+/** How far back the history/ops event scans look. Bounded — public RPCs refuse open ranges. */
+export const HISTORY_LOOKBACK_BLOCKS = 200_000
+/** Most rows either table renders. The explorer link carries the rest. */
+export const HISTORY_LIMIT = 25
+
+export function shortAddr(a) {
+  return a && a !== ethers.ZeroAddress ? `${a.substring(0, 6)}...${a.substring(a.length - 4)}` : ''
+}
+
+/** A settable address must be a real, non-zero address — the routers reject `ZeroAddress`. */
+export const isValidAddr = (a) => ethers.isAddress(a) && a !== ethers.ZeroAddress
+
+/** Display name for a chain, or an honest placeholder — never a guessed one. */
+export function networkName(chainId) {
+  return NETWORKS[chainId]?.name || `Chain ${chainId}`
+}
+
+/**
+ * Every supported network carrying the capability a tab controls, mainnets first.
+ *
+ * Derived from config, not asserted, so the roster stays true as deployments land: a network
+ * appears here because it has the PROTOCOL (an Across SpokePool / a Uniswap position manager),
+ * and whether FairWins has deployed a router there is a separate question the tab answers
+ * per-network. Listing only deployed networks would hide the ones an operator most needs to
+ * see — the ones still waiting for a deployment.
+ *
+ * @param {'bridge'|'liquidity'} capability
+ */
+export function adminNetworks(capability) {
+  return listSupportedChainIds()
+    .map((id) => NETWORKS[id])
+    .filter((net) => net?.capabilities?.[capability])
+    .sort((a, b) => Number(a.isTestnet) - Number(b.isTestnet))
+}
+
+/**
+ * A read connection for `chainId`.
+ *
+ * Reuses the wallet's own provider when the scope happens to be the connected chain (cheaper,
+ * and it is already authenticated to whatever RPC the member configured), and otherwise builds
+ * a read-only provider from that network's configured RPC. Returns null for a network with no
+ * RPC, which the caller reports as unreadable rather than as empty.
+ */
+export function readProviderFor(chainId, walletChainId, walletProvider) {
+  if (walletProvider && Number(chainId) === Number(walletChainId)) return walletProvider
+  const rpcUrl = NETWORKS[chainId]?.rpcUrl
+  return rpcUrl ? makeReadProvider(rpcUrl, chainId) : null
+}
+
+/** Minimal AccessControl surface — every spec-067 router exposes it via UUPSManaged. */
+const ACCESS_CONTROL_ABI = ['function hasRole(bytes32 role, address account) view returns (bool)']
+
+/** The three roles that gate a control on these two tabs, by their on-chain hashes. */
+export const ROUTER_ROLE_HASHES = {
+  // DEFAULT_ADMIN_ROLE is bytes32(0), not a keccak of a name.
+  admin: ethers.ZeroHash,
+  guardian: ethers.id('GUARDIAN_ROLE'),
+  liquidityAdmin: ethers.id('LIQUIDITY_ADMIN_ROLE'),
+}
+
+/**
+ * Does `account` hold admin / guardian / liquidity-admin on THIS router, on THIS network?
+ *
+ * ── WHY THE APP-WIDE ROLE FLAGS CANNOT ANSWER THIS ──────────────────────────────────────────────
+ * `useRoles()`'s `isAdmin` / `isGuardian` / `isLiquidityAdmin` are a single boolean each, resolved
+ * against a candidate list on the WALLET's connected chain. Three separate things break here:
+ *
+ *   • `isGuardian` means "holds GUARDIAN_ROLE on the WagerRegistry" — a different contract. The
+ *     routers check GUARDIAN_ROLE on their own AccessControl instance, and the two sets are
+ *     unrelated. An operator with the wager guardianship would be shown an enabled killswitch that
+ *     reverts, which is precisely the belief FR-043/FR-044 exist to prevent.
+ *   • `isLiquidityAdmin` is an OR across the BridgeRouter and the LiquidityRouter, while the role is
+ *     granted per router on purpose (the Roles tab offers them as two separate targets). The OR
+ *     showed an operator holding it on one router every write control on the other.
+ *   • all of them read the wallet's chain, while these tabs scope to a NETWORK the operator picks.
+ *     A Polygon guardian whose wallet sits on Ethereum lost the Polygon controls.
+ *
+ * So authority is asked of the contract that will enforce it. The role flags remain what they are
+ * good for — deciding whether the tab appears at all.
+ *
+ * ── AND WHY AN UNREADABLE ANSWER IS NOT A DENIAL ────────────────────────────────────────────────
+ * `readable: false` means the question could not be put, not that the answer was no. Callers must
+ * keep offering the controls in that state and say the authority is unconfirmed: the contract is the
+ * real gate and will refuse anything the operator does not hold, whereas withdrawing the killswitch
+ * because an RPC timed out is the FR-044 failure — an operator who does hold it concludes there
+ * isn't one. `deployed: false` IS a definite answer: there is no router here to hold a role on.
+ *
+ * @returns {Promise<{readable: boolean, deployed: boolean, admin: boolean, guardian: boolean,
+ *                    liquidityAdmin: boolean, reason: string|null}>}
+ */
+export async function readRouterAuthority({ provider, routerAddress, account }) {
+  const none = { admin: false, guardian: false, liquidityAdmin: false, reason: null }
+  if (!routerAddress) return { ...none, readable: true, deployed: false }
+  if (!provider || !account) {
+    return {
+      ...none,
+      readable: false,
+      deployed: true,
+      reason: !account ? 'no account connected' : 'no read connection to this network',
+    }
+  }
+  try {
+    const c = new ethers.Contract(routerAddress, ACCESS_CONTROL_ABI, provider)
+    const [admin, guardian, liquidityAdmin] = await Promise.all([
+      c.hasRole(ROUTER_ROLE_HASHES.admin, account),
+      c.hasRole(ROUTER_ROLE_HASHES.guardian, account),
+      c.hasRole(ROUTER_ROLE_HASHES.liquidityAdmin, account),
+    ])
+    return {
+      readable: true,
+      deployed: true,
+      admin: Boolean(admin),
+      guardian: Boolean(guardian),
+      liquidityAdmin: Boolean(liquidityAdmin),
+      reason: null,
+    }
+  } catch (e) {
+    return { ...none, readable: false, deployed: true, reason: e?.message || String(e) }
+  }
+}
+
+/**
+ * Turn an authority read into the two gates a tab needs, honestly.
+ *
+ * `pause` and `config` are permissive while authority is UNCONFIRMED (see `readRouterAuthority`) and
+ * restrictive only on a definite "no". `unconfirmed` lets the caller say so once, in words, instead
+ * of implying a verdict it does not have.
+ */
+export function authorityGates(authority) {
+  if (!authority) return { pause: false, config: false, unconfirmed: false, pending: true }
+  const unconfirmed = authority.deployed && !authority.readable
+  return {
+    pause: Boolean(authority.admin || authority.guardian || unconfirmed),
+    config: Boolean(authority.admin || authority.liquidityAdmin || unconfirmed),
+    unconfirmed,
+    pending: false,
+  }
+}
+
+/**
+ * Symbol + decimals for a token this build actually knows on this network, or null.
+ *
+ * Deliberately config-only (the network's stablecoin and its wrapped native) rather than an
+ * on-chain `symbol()`/`decimals()` read: an admin table that has to make two RPC calls per
+ * token before it can render a limit is a table that shows nothing when one RPC is slow. An
+ * unknown token is not a failure — it renders in RAW UNITS and SAYS it is raw units, which is
+ * the honest reading of a number whose scale we cannot confirm.
+ */
+export function tokenMeta(chainId, address) {
+  const net = NETWORKS[chainId]
+  if (!net || !address) return null
+  const a = String(address).toLowerCase()
+  const stable = net.stablecoin
+  if (stable?.address && String(stable.address).toLowerCase() === a) {
+    return { symbol: stable.symbol, decimals: Number(stable.decimals) }
+  }
+  const wnative = net.dex?.wnative
+  if (wnative && String(wnative).toLowerCase() === a) {
+    return { symbol: `W${net.nativeCurrency?.symbol || ''}`, decimals: 18 }
+  }
+  return null
+}
+
+/** `"USDC"` for a token this build knows, else its short address — never a made-up ticker. */
+export function tokenLabel(chainId, address) {
+  if (!address || address === ethers.ZeroAddress) return '—'
+  return tokenMeta(chainId, address)?.symbol || shortAddr(address)
+}
+
+/**
+ * A limit rendered for operators. `0` is UNCAPPED on both routers, and saying so in words
+ * matters more here than anywhere else: "0" in a max-amount column reads as "nothing may pass".
+ */
+export function formatLimit(chainId, address, raw) {
+  const value = BigInt(raw ?? 0n)
+  if (value === 0n) return 'uncapped'
+  const meta = tokenMeta(chainId, address)
+  if (!meta) return `${value} (raw units)`
+  return `${ethers.formatUnits(value, meta.decimals)} ${meta.symbol}`
+}
+
+/**
+ * An AMOUNT rendered for operators — deliberately separate from `formatLimit`, because `0`
+ * means opposite things in the two places. A limit of 0 is "uncapped"; an amount of 0 is zero.
+ * Reusing one formatter for both would print "uncapped" in a column of member transfer sizes.
+ */
+export function formatAmount(chainId, address, raw) {
+  const value = BigInt(raw ?? 0n)
+  const meta = tokenMeta(chainId, address)
+  if (!meta) return `${value} (raw units)`
+  return `${ethers.formatUnits(value, meta.decimals)} ${meta.symbol}`
+}
+
+/** The unit an operator is typing a limit in, so the input can label itself honestly. */
+export function limitUnitLabel(chainId, address) {
+  return tokenMeta(chainId, address)?.symbol || 'raw units'
+}
+
+/**
+ * Parse an operator-typed limit into the integer the contract takes.
+ *
+ * Throws with a readable reason rather than returning a wrong number: a mis-scaled limit is a
+ * silent, member-facing failure (a cap of 1 wei refuses every transfer), so it is rejected
+ * BEFORE the wallet prompt. `0` is accepted and means uncapped, matching the contract.
+ */
+export function parseLimit(chainId, address, text) {
+  const raw = String(text ?? '').trim()
+  if (raw === '') throw new Error('Enter a limit — 0 means uncapped.')
+  const meta = tokenMeta(chainId, address)
+  if (!meta) {
+    if (!/^\d+$/.test(raw)) {
+      throw new Error('This token’s decimals are unknown here, so the limit must be typed in whole raw units (digits only).')
+    }
+    return BigInt(raw)
+  }
+  try {
+    return ethers.parseUnits(raw, meta.decimals)
+  } catch {
+    throw new Error(`Enter an amount in ${meta.symbol} (up to ${meta.decimals} decimal places).`)
+  }
+}
+
+/** `1h 30m` / `45s` — the expected-fill window, in the units an operator thinks in. */
+export function formatDuration(seconds) {
+  const s = Number(seconds || 0)
+  if (!Number.isFinite(s) || s <= 0) return '—'
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const rest = s % 60
+  if (m < 60) return rest ? `${m}m ${rest}s` : `${m}m`
+  const h = Math.floor(m / 60)
+  return m % 60 ? `${h}h ${m % 60}m` : `${h}h`
+}
+
+const safe = (p) => p.then((v) => v).catch(() => undefined)
+
+/**
+ * Read a router's decoded change history: what changed, on what, before → after, by whom, when.
+ *
+ * Never throws. A bounded RPC that refuses the range yields `{ entries: [], error }` and the
+ * card says "this RPC bounds event lookups" instead of "no changes" — those are very different
+ * statements to an operator auditing a control surface (FR-046).
+ *
+ * @param {{contract: object, provider: object, eventNames: string[], describe: Function}} args
+ * @returns {Promise<{entries: Array|null, error: string|null}>}
+ */
+export async function loadRouterHistory({ contract, provider, eventNames, describe }) {
+  if (!contract || !provider) return { entries: [], error: 'no read connection' }
+  try {
+    const latest = await provider.getBlockNumber()
+    const fromBlock = Math.max(0, Number(latest) - HISTORY_LOOKBACK_BLOCKS)
+    const all = []
+    for (const name of eventNames) {
+      const evs = await safe(contract.queryFilter(contract.filters[name](), fromBlock, 'latest'))
+      for (const ev of evs || []) all.push({ name, ev })
+    }
+    all.sort((a, b) => b.ev.blockNumber - a.ev.blockNumber || b.ev.index - a.ev.index)
+    const entries = await Promise.all(
+      all.slice(0, HISTORY_LIMIT).map(async ({ name, ev }) => {
+        const block = await safe(provider.getBlock(ev.blockNumber))
+        const described = describe(name, ev.args || {}) || {}
+        return {
+          key: `${ev.transactionHash}-${ev.index}`,
+          name,
+          action: described.action || name,
+          target: described.target || '—',
+          before: described.before ?? '—',
+          after: described.after ?? '—',
+          // `actor` on every config event; OZ's Paused/Unpaused name it `account`.
+          actor: ev.args?.actor || ev.args?.account || null,
+          at: block ? new Date(Number(block.timestamp) * 1000) : null,
+          txHash: ev.transactionHash,
+        }
+      }),
+    )
+    return { entries, error: null }
+  } catch (e) {
+    return { entries: [], error: e?.message || String(e) }
+  }
+}

--- a/frontend/src/contexts/RoleContext.js
+++ b/frontend/src/contexts/RoleContext.js
@@ -23,6 +23,7 @@ export const ROLES = {
   SANCTIONS_ADMIN: 'SANCTIONS_ADMIN',      // SANCTIONS_ADMIN_ROLE — deny-list (on SanctionsGuard)
   FEE_ADMIN: 'FEE_ADMIN',                  // FEE_ADMIN_ROLE — platform-fee rates (on FeeRouter, spec 060)
   STAKING_ADMIN: 'STAKING_ADMIN',          // STAKING_ADMIN_ROLE — staking provider addrs + validator allowlist (on StakingRouter, spec 066)
+  LIQUIDITY_ADMIN: 'LIQUIDITY_ADMIN',      // LIQUIDITY_ADMIN_ROLE — bridge routes + curated pools (on BOTH BridgeRouter and LiquidityRouter, spec 067)
 }
 
 export const ROLE_INFO = {
@@ -74,6 +75,12 @@ export const ROLE_INFO = {
     premium: false,
     isAdminRole: true
   },
+  [ROLES.LIQUIDITY_ADMIN]: {
+    name: 'Liquidity Administrator',
+    description: 'Curate bridge routes and the supplied pool list, and set their limits and addresses, on the BridgeRouter and LiquidityRouter (the fee rate is set by the Fee Administrator)',
+    premium: false,
+    isAdminRole: true
+  },
 }
 
 /**
@@ -88,6 +95,7 @@ export const ADMIN_ROLES = [
   ROLES.SANCTIONS_ADMIN,
   ROLES.FEE_ADMIN,
   ROLES.STAKING_ADMIN,
+  ROLES.LIQUIDITY_ADMIN,
 ]
 
 export function isAdminRole(role) {

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -308,7 +308,7 @@ export function WalletProvider({ children }) {
    */
   const syncRolesWithBlockchain = useCallback(async (walletAddress, localRoles, activeChainId) => {
     const premiumRoles = ['WAGER_PARTICIPANT']
-    const adminRoles = ['ADMIN', 'GUARDIAN', 'ACCOUNT_MODERATOR', 'ROLE_MANAGER', 'SANCTIONS_ADMIN', 'FEE_ADMIN']
+    const adminRoles = ['ADMIN', 'GUARDIAN', 'ACCOUNT_MODERATOR', 'ROLE_MANAGER', 'SANCTIONS_ADMIN', 'FEE_ADMIN', 'LIQUIDITY_ADMIN']
     const allSyncedRoles = [...premiumRoles, ...adminRoles]
     const updatedRoles = []
     let hasChanges = false

--- a/frontend/src/lib/fees/feeQuote.js
+++ b/frontend/src/lib/fees/feeQuote.js
@@ -109,9 +109,16 @@ export function bpsToPercent(bps) {
  * Throws `FeeQuoteUnavailable` when a router IS configured and no rate we can
  * stand behind came back — callers must treat that as "cannot quote" and block
  * the fee-bearing action (FR-015 / FR-051), never fall back to assuming zero.
+ *
+ * `routerAddress` overrides which FeeRouter is asked. It exists for the spec-067 operator surfaces,
+ * which read the `feeRouter` a wrapping router ACTUALLY holds and quote from that rather than from
+ * this build's config. The two can differ — someone repoints a router before the config ships, or
+ * ships config before the transaction lands — and in that window the config address answers for a
+ * contract that is not the one charging. An operator deciding whether members are being charged
+ * correctly needs the live answer, not the built one. Member surfaces keep the default.
  */
-export async function fetchFeeQuote({ serviceId, chainId, provider }) {
-  const routerAddress = getContractAddressForChain('feeRouter', chainId)
+export async function fetchFeeQuote({ serviceId, chainId, provider, routerAddress: routerOverride }) {
+  const routerAddress = routerOverride || getContractAddressForChain('feeRouter', chainId)
   if (!routerAddress) {
     return { available: false, bps: 0, capBps: 0, routerAddress: null }
   }

--- a/frontend/src/test/admin/AdminBridgeTab.test.jsx
+++ b/frontend/src/test/admin/AdminBridgeTab.test.jsx
@@ -1,0 +1,512 @@
+/**
+ * Spec 067 US4 (T123–T126, T130–T132, T135) — the BridgeTab operator control surface (AdminPanel → Liquidity → Bridge).
+ *
+ * What is asserted here is deliberately weighted toward the claims the tab MAKES, not just the
+ * calls it dispatches: the Operations panel saying it cannot touch an in-flight bridge, the fee
+ * card refusing to invent a rate it could not read, and the per-network scope working while the
+ * wallet sits somewhere else. Those are the parts an operator acts on during an incident.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ethers as ethersActual } from 'ethers'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+
+const m = vi.hoisted(() => ({
+  addr: {},
+  reads: {},
+  events: {},
+  receipts: {},
+  gateway: {},
+  feeQuote: null,
+  feeThrows: null,
+  status: null,
+}))
+
+vi.mock('../../config/contracts', () => ({
+  getContractAddressForChain: (name, chainId) => {
+    if (name === 'bridgeRouter') return m.addr[Number(chainId)] || ''
+    // The FeeRouter THIS BUILD is compiled against. The tab compares it with the one the router
+    // actually holds, so the two have to be separately controllable here.
+    if (name === 'feeRouter') return m.configFeeRouter
+    return ''
+  },
+}))
+vi.mock('../../config/blockExplorer', () => ({
+  getBlockscoutUrl: () => 'https://explorer.example/address/0xrouter',
+  getTransactionUrl: () => 'https://explorer.example/tx/0xdead',
+}))
+vi.mock('../../lib/fees/feeQuote', async (orig) => ({
+  ...(await orig()),
+  fetchFeeQuote: vi.fn(() => (m.feeThrows ? Promise.reject(m.feeThrows) : Promise.resolve(m.feeQuote))),
+}))
+vi.mock('../../hooks/useGatewayStatus', () => ({
+  useGatewayStatus: () => ({ refresh: vi.fn(), ...m.gateway }),
+}))
+vi.mock('../../lib/bridge/bridgeStatus', async (orig) => ({
+  ...(await orig()),
+  fetchBridgeStatus: vi.fn(() => (m.status ? Promise.resolve(m.status) : Promise.reject(new Error('no gateway')))),
+}))
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract() {
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          // Name the event on the filter object so a single queryFilter stub can answer per event.
+          if (prop === 'filters') {
+            return new Proxy({}, { get: (_f, name) => () => ({ __event: String(name) }) })
+          }
+          const key = String(prop)
+          return (...args) => (m.reads[key] ? m.reads[key](...args) : Promise.resolve(undefined))
+        },
+      },
+    )
+  }
+  const FakeCtor = vi.fn(FakeContract)
+  return { ...actual, Contract: FakeCtor, ethers: { ...actual.ethers, Contract: FakeCtor } }
+})
+
+import BridgeTab from '../../components/admin/BridgeTab'
+
+const ROUTER = '0x1111111111111111111111111111111111111111'
+const VALID = '0x00000000000000000000000000000000000000a1' // lowercase ⇒ checksum-safe
+const USDC_ETH = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+const USDC_POLYGON = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+
+const ROUTE_TO_POLYGON = {
+  routeId: '0xroute1',
+  inputToken: USDC_ETH,
+  outputToken: USDC_POLYGON,
+  destinationChainId: 137n,
+  maxAmount: 5_000_000_000n, // 5,000 USDC
+  expectedFillSeconds: 900n,
+  enabled: true,
+  nativeInput: false,
+}
+const ROUTE_TO_BASE = {
+  routeId: '0xroute2',
+  inputToken: USDC_ETH,
+  outputToken: USDC_ETH,
+  destinationChainId: 8453n,
+  maxAmount: 0n,
+  expectedFillSeconds: 600n,
+  enabled: false,
+  nativeInput: false,
+}
+
+const providerStub = {
+  getBlockNumber: () => Promise.resolve(1_000_000),
+  getBlock: () => Promise.resolve({ timestamp: Math.floor(Date.now() / 1000) - 60 }),
+  getTransactionReceipt: (hash) => Promise.resolve(m.receipts[hash] || null),
+}
+
+
+/** `runTx` resolves true on success — callers that send a sequence rely on the signal. */
+const TX_OK = true
+const ACCOUNT = '0x9999999999999999999999999999999999999999'
+const ROLE_HASH = {
+  admin: ethersActual.ZeroHash,
+  guardian: ethersActual.id('GUARDIAN_ROLE'),
+  liquidityAdmin: ethersActual.id('LIQUIDITY_ADMIN_ROLE'),
+}
+
+function props(overrides = {}) {
+  const runTx = vi.fn(() => Promise.resolve(TX_OK))
+  // ── ROLE FLAGS ARE TRANSLATED INTO ON-CHAIN ANSWERS, NOT PASSED AS PROPS ──────────────────────
+  // The tab asks the router in scope `hasRole(...)` rather than trusting an app-wide flag, because
+  // the flags were resolved against the wrong contract and the wrong network (see
+  // readRouterAuthority). Call sites keep the readable `{ isGuardian: true }` shape; what it now
+  // means is "the router says so", which is the thing that actually gates the control.
+  const { isAdmin = false, isLiquidityAdmin = false, isGuardian = false, ...node } = overrides
+  const held = []
+  if (isAdmin) held.push(ROLE_HASH.admin)
+  if (isGuardian) held.push(ROLE_HASH.guardian)
+  if (isLiquidityAdmin) held.push(ROLE_HASH.liquidityAdmin)
+  m.reads.hasRole = (role) => Promise.resolve(held.includes(role))
+  return {
+    runTx,
+    node: {
+      signer: {},
+      account: ACCOUNT,
+      chainId: 1,
+      provider: providerStub,
+      runTx,
+      pendingTx: false,
+      ...node,
+    },
+  }
+}
+
+beforeEach(() => {
+  m.addr = { 1: ROUTER }
+  m.events = {}
+  m.receipts = {}
+  m.feeQuote = { available: true, bps: 10, capBps: 250 }
+  m.feeThrows = null
+  m.status = null
+  m.configFeeRouter = VALID // matches the router's own feeRouter by default
+  m.gateway = { configured: false, loading: false, reachable: false, status: null }
+  const routes = { [ROUTE_TO_POLYGON.routeId]: ROUTE_TO_POLYGON, [ROUTE_TO_BASE.routeId]: ROUTE_TO_BASE }
+  const ids = [ROUTE_TO_POLYGON.routeId, ROUTE_TO_BASE.routeId]
+  m.reads = {
+    paused: () => Promise.resolve(false),
+    spokePool: () => Promise.resolve('0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5'),
+    feeRouter: () => Promise.resolve(VALID),
+    sanctionsGuard: () => Promise.resolve(VALID),
+    MAX_FEE_BPS: () => Promise.resolve(250n),
+    routeCount: () => Promise.resolve(BigInt(ids.length)),
+    routeAt: (i) => Promise.resolve(ids[Number(i)]),
+    getRoute: (id) => Promise.resolve(routes[id]),
+    queryFilter: (filter) => Promise.resolve(m.events[filter?.__event] || []),
+  }
+})
+
+describe('BridgeTab — honest empty states', () => {
+  it('says the router is not deployed rather than showing empty controls', async () => {
+    m.addr = {}
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    expect(await screen.findByText(/No BridgeRouter is deployed on Ethereum/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Pause new bridges/i })).not.toBeInTheDocument()
+  })
+
+  it('is axe-clean in the not-deployed state', async () => {
+    m.addr = {}
+    const { container } = render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    await screen.findByText(/No BridgeRouter is deployed/i)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('reports an unreadable router as unreadable, never as “no routes”', async () => {
+    m.reads.paused = () => Promise.reject(new Error('rpc down'))
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/Could not read the BridgeRouter on Ethereum/i)
+    expect(alert).toHaveTextContent(/Nothing below can be trusted as current/i)
+  })
+})
+
+describe('BridgeTab — least privilege (FR-049)', () => {
+  it('a guardian gets the pause and no configuration controls', async () => {
+    render(<BridgeTab {...props({ isGuardian: true }).node} />)
+    expect(await screen.findByRole('button', { name: 'Pause new bridges' })).toBeInTheDocument()
+    expect(screen.queryByText('Protocol addresses')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save route' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Disable' })).not.toBeInTheDocument()
+  })
+
+  it('a liquidity admin gets route curation, and neither the pause nor the fund-path addresses', async () => {
+    render(<BridgeTab {...props({ isLiquidityAdmin: true }).node} />)
+    expect(await screen.findByRole('button', { name: 'Save route' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Pause new bridges/i })).not.toBeInTheDocument()
+    // `setSpokePool` / `setFeeRouter` decide where a member's money goes and are DEFAULT_ADMIN_ROLE
+    // on the contract. Curating which routes are offered is not authority to redirect the funds
+    // moving through them, and the tab must not offer what the contract will refuse.
+    expect(screen.queryByText('Protocol addresses')).not.toBeInTheDocument()
+  })
+
+  it('an admin gets the fund-path addresses, with the consequence stated', async () => {
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    expect(await screen.findByText('Protocol addresses')).toBeInTheDocument()
+    expect(screen.getByText(/fund-path references, not settings/i)).toBeInTheDocument()
+  })
+
+  it('an operator with none of the three sees the state and can act on none of it', async () => {
+    render(<BridgeTab {...props().node} />)
+    await screen.findByRole('heading', { name: 'Routes' })
+    expect(screen.queryByRole('button', { name: /Pause/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Disable/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Remove/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Set limit/i })).not.toBeInTheDocument()
+    expect(screen.queryByText('Protocol addresses')).not.toBeInTheDocument()
+  })
+})
+
+describe('BridgeTab — routes (T124, FR-041/FR-045)', () => {
+  it('renders each curated route with its limit, window and state', async () => {
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    const table = await screen.findByRole('table', { name: 'Curated bridge routes' })
+    expect(within(table).getByText('Ethereum → Polygon')).toBeInTheDocument()
+    expect(within(table).getByText('5000.0 USDC')).toBeInTheDocument()
+    expect(within(table).getByText('15m')).toBeInTheDocument()
+    // A 0 maximum is UNCAPPED, not "nothing may pass".
+    expect(within(table).getByText('uncapped')).toBeInTheDocument()
+    expect(within(table).getByText('disabled')).toBeInTheDocument()
+  })
+
+  it('dispatches enable, limit and remove for a liquidity admin', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<BridgeTab {...node} />)
+    await screen.findByRole('table', { name: 'Curated bridge routes' })
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Disable' })[0])
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /disabled/.test(c[1]))).toBe(true))
+
+    fireEvent.change(screen.getByLabelText(/Per-transaction maximum for USDC to Polygon/i), {
+      target: { value: '1000' },
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Set limit' })[0])
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /Per-transaction maximum updated/.test(c[1]))).toBe(true))
+
+    // Removal ASKS FIRST, and the question names what it costs — removal is not the harder version
+    // of Disable, it is the one that deletes the entry and blinds the Operations panel's lateness
+    // detection for transfers still moving on the route.
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[0])
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /removed/.test(c[1]))).toBe(true))
+    expect(confirm).toHaveBeenCalledTimes(1)
+    expect(confirm.mock.calls[0][0]).toMatch(/Disable/)
+    expect(confirm.mock.calls[0][0]).toMatch(/expected delivery window/i)
+    confirm.mockRestore()
+  })
+
+  it('does not remove a route when the operator declines the confirm', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<BridgeTab {...node} />)
+    await screen.findByRole('table', { name: 'Curated bridge routes' })
+
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[0])
+    expect(confirm).toHaveBeenCalled()
+    expect(runTx).not.toHaveBeenCalled()
+    confirm.mockRestore()
+  })
+
+  it('refuses an invalid route before the wallet prompt and dispatches a valid one', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<BridgeTab {...node} />)
+    await screen.findByRole('button', { name: 'Save route' })
+
+    // No addresses at all.
+    fireEvent.click(screen.getByRole('button', { name: 'Save route' }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/valid, non-zero token addresses/i)
+    expect(runTx).not.toHaveBeenCalled()
+
+    fireEvent.change(screen.getByPlaceholderText('input token 0x…'), { target: { value: USDC_ETH } })
+    fireEvent.change(screen.getByPlaceholderText('output token 0x…'), { target: { value: USDC_POLYGON } })
+
+    // No destination chosen.
+    fireEvent.click(screen.getByRole('button', { name: 'Save route' }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/cannot be the network this router is on/i)
+    expect(runTx).not.toHaveBeenCalled()
+
+    fireEvent.change(screen.getByLabelText(/Destination network/i), { target: { value: '137' } })
+
+    // A delivery window the contract would refuse.
+    fireEvent.change(screen.getByLabelText(/Expected delivery window/i), { target: { value: '5' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save route' }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/between 60 and 86400 seconds/i)
+    expect(runTx).not.toHaveBeenCalled()
+
+    fireEvent.change(screen.getByLabelText(/Expected delivery window/i), { target: { value: '900' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save route' }))
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /Route to Polygon saved/.test(c[1]))).toBe(true))
+  })
+
+  it('offers bulk enable/disable per destination and says how many transactions it costs', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<BridgeTab {...node} />)
+    const coverage = await screen.findByRole('table', { name: 'Destination coverage' })
+    // One route to Polygon (enabled), one to Base (disabled), none elsewhere.
+    expect(within(coverage).getByText('1 of 1 enabled')).toBeInTheDocument()
+    expect(within(coverage).getByText('0 of 1 enabled')).toBeInTheDocument()
+    expect(within(coverage).getAllByText('none — not offered to members').length).toBeGreaterThan(0)
+
+    fireEvent.click(within(coverage).getAllByRole('button', { name: 'Enable all (1 tx)' })[0])
+    await waitFor(() => expect(runTx).toHaveBeenCalled())
+  })
+})
+
+describe('BridgeTab — addresses (T125, FR-042)', () => {
+  it('shows the current value and refuses invalid input with a reason', async () => {
+    // Admin, not liquidity-admin: these three addresses are DEFAULT_ADMIN_ROLE on the contract.
+    const { node, runTx } = props({ isAdmin: true })
+    render(<BridgeTab {...node} />)
+    await screen.findByText('Protocol addresses')
+    expect(screen.getByText(/now: 0x5c7B\.\.\.35C5/)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('SpokePool 0x…'), { target: { value: 'not-an-address' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Set SpokePool' }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/valid, non-zero address for the SpokePool/i)
+    expect(runTx).not.toHaveBeenCalled()
+
+    fireEvent.change(screen.getByPlaceholderText('SpokePool 0x…'), { target: { value: VALID } })
+    fireEvent.click(screen.getByRole('button', { name: 'Set SpokePool' }))
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /SpokePool updated/.test(c[1]))).toBe(true))
+  })
+})
+
+describe('BridgeTab — the pause is always visible, and honest about who can pull it', () => {
+  // Hiding the card behind the authority check made a network WITH a working killswitch look like a
+  // network without one, mid-incident: the operator stops looking and starts improvising. The card
+  // now always renders and says separately whether this account can use it.
+  it('renders the card with a reason, not nothing, when the account holds neither role', async () => {
+    render(<BridgeTab {...props().node} />)
+    expect(await screen.findByText('Emergency pause')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Pause new bridges/i })).not.toBeInTheDocument()
+    const notice = screen.getByText(/the killswitch exists and is exercisable/i)
+    expect(notice).toBeInTheDocument()
+    expect(notice.parentElement.textContent).toMatch(/does not carry here/i)
+    expect(notice.parentElement.textContent).toMatch(/Role Manager grants/i)
+  })
+
+  it('offers the killswitch when authority cannot be read, and says it is unconfirmed (FR-044)', async () => {
+    // Built first: `props()` installs its own hasRole stub, so the rejection has to land after it.
+    const { node } = props()
+    m.reads.hasRole = () => Promise.reject(new Error('missing revert data'))
+    render(<BridgeTab {...node} />)
+    await screen.findByRole('button', { name: /^Pause new bridges/i })
+    expect(screen.getByText(/could not be confirmed/i)).toBeInTheDocument()
+  })
+
+  it('tells a guardian that the narrower per-route lever exists behind another role', async () => {
+    render(<BridgeTab {...props({ isGuardian: true }).node} />)
+    await screen.findByRole('button', { name: /^Pause new bridges/i })
+    // Otherwise a one-destination incident gets a network-wide pause, because the guardian cannot
+    // see that disabling a single route is even possible.
+    expect(screen.getByText(/covers/i).parentElement.textContent).toMatch(/LIQUIDITY_ADMIN_ROLE/)
+  })
+})
+
+describe('BridgeTab — bulk toggles stop on the first refusal (FR-041)', () => {
+  it('does not queue the remaining prompts after a rejected signature', async () => {
+    // The loop's comment claimed this; `runTx` swallowed every error and resolved with no signal, so
+    // rejecting the first prompt to abort still fired the rest — and any accepted by reflex disabled
+    // a live route. `runTx` now reports failure and the loop honours it.
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    runTx.mockImplementation(() => Promise.resolve(false)) // wallet rejected
+    render(<BridgeTab {...node} />)
+    // One row per destination network; take the one that actually has an enabled route to disable.
+    const bulk = (await screen.findAllByRole('button', { name: /Disable all \(1 tx\)/i }))[0]
+    fireEvent.click(bulk)
+    await waitFor(() => expect(runTx).toHaveBeenCalledTimes(1))
+    expect(screen.getByRole('alert')).toHaveTextContent(/Stopped after 0 of/i)
+    expect(screen.getByRole('alert')).toHaveTextContent(/left untouched/i)
+  })
+})
+
+describe('BridgeTab — fee is read-only (T132, FR-048/FR-051)', () => {
+  it('shows the live rate, its cap and the router ceiling, and says where it is edited', async () => {
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    expect(await screen.findByText(/10 bps \(0\.10%\) — service cap 250 bps/)).toBeInTheDocument()
+    expect(screen.getByText(/250 bps — enforced by the router itself/)).toBeInTheDocument()
+    expect(screen.getByText(/read-only here/i)).toBeInTheDocument()
+    expect(screen.getByText(/Fee Administrator/i)).toBeInTheDocument()
+  })
+
+  it('says the rate could not be read — and leaves every other control usable', async () => {
+    m.feeThrows = new Error('FeeRouter unreachable')
+    render(<BridgeTab {...props({ isAdmin: true, isLiquidityAdmin: true }).node} />)
+    expect(await screen.findByText(/could not be read — members cannot start a fee-bearing bridge/i)).toBeInTheDocument()
+    // The pause and the route controls are untouched by an unreadable fee.
+    expect(screen.getByRole('button', { name: 'Pause new bridges' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Save route' })).toBeEnabled()
+  })
+})
+
+describe('BridgeTab — the fee is quoted from the router in the path (T132, FR-048)', () => {
+  it('quotes the FeeRouter the ROUTER holds, not the one in the app config', async () => {
+    // `fetchFeeQuote` defaults to the configured address, which is right for members and wrong here:
+    // the contract that will charge them is whatever `BridgeRouter.feeRouter()` returns right now.
+    const { fetchFeeQuote } = await import('../../lib/fees/feeQuote')
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    await screen.findByText(/10 bps/)
+    expect(fetchFeeQuote).toHaveBeenCalledWith(expect.objectContaining({ routerAddress: VALID }))
+  })
+
+  it('says so when the router and the app disagree about which FeeRouter charges', async () => {
+    // A real, temporary state — someone repoints the router before the config ships, or the reverse.
+    // In that window members are quoted by a contract that is not the one charging them, and the
+    // member path refuses rather than overcharging. Invisible from every other screen.
+    m.reads.feeRouter = () => Promise.resolve('0x00000000000000000000000000000000000000b2')
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    const alert = await screen.findByText(/Members are being quoted a different FeeRouter/i)
+    expect(alert).toBeInTheDocument()
+    expect(alert.parentElement.textContent).toMatch(/sync:frontend-contracts/)
+  })
+})
+
+describe('BridgeTab — operations are observational only (T126, FR-047)', () => {
+  it('states plainly that no action can touch an in-flight bridge', async () => {
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    await screen.findByText('Operations')
+    expect(screen.getByText(/This panel is observational only\./)).toBeInTheDocument()
+    expect(screen.getByText(/no rescue or refund function/i)).toBeInTheDocument()
+    expect(screen.getByText(/There is no button to hunt for/i)).toBeInTheDocument()
+  })
+
+  it('reports an unset gateway without claiming transfers are lost', async () => {
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    await screen.findByText('Operations')
+    expect(
+      screen.getByText(/not configured — members cannot start a bridge .* transfers already moving still resolve/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/this router cannot observe it/i)).toBeInTheDocument()
+  })
+
+  it('lists recent bridges and marks a late one without calling it lost', async () => {
+    const longAgo = Math.floor(Date.now() / 1000) - 7200
+    m.events.BridgeInitiated = [
+      {
+        blockNumber: 999_000,
+        index: 0,
+        transactionHash: '0xdead',
+        args: {
+          routeId: ROUTE_TO_POLYGON.routeId,
+          member: VALID,
+          recipient: VALID,
+          destinationChainId: 137n,
+          grossAmount: 1_000_000n,
+          feeAmount: 0n,
+        },
+      },
+    ]
+    // Two hours ago against a 15-minute window ⇒ past its expected delivery.
+    const stub = { ...providerStub, getBlock: () => Promise.resolve({ timestamp: longAgo }) }
+    render(<BridgeTab {...props({ isAdmin: true }).node} provider={stub} />)
+    const table = await screen.findByRole('table', { name: 'Recent bridges' })
+    expect(within(table).getByText('Taking longer than expected')).toBeInTheDocument()
+    expect(within(table).getByText('1.0 USDC')).toBeInTheDocument()
+    expect(within(table).getByText(/origin transaction only/)).toBeInTheDocument()
+  })
+})
+
+describe('BridgeTab — history (T131, FR-046)', () => {
+  it('decodes each control action with before → after', async () => {
+    m.events.RouteLimitChanged = [
+      {
+        blockNumber: 999_900,
+        index: 1,
+        transactionHash: '0xhist',
+        args: { routeId: ROUTE_TO_POLYGON.routeId, destinationChainId: 137n, oldMax: 0n, newMax: 5_000_000n, actor: VALID },
+      },
+    ]
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    const table = await screen.findByRole('table', { name: 'Change history' })
+    expect(within(table).getByText('Per-transaction maximum')).toBeInTheDocument()
+    expect(within(table).getByText('uncapped')).toBeInTheDocument()
+    expect(within(table).getByText('5000000 raw units')).toBeInTheDocument()
+  })
+})
+
+describe('BridgeTab — scope is a network, not the wallet (FR-050)', () => {
+  it('reads another network and says why changes need the wallet there', async () => {
+    m.addr = { 1: ROUTER, 137: ROUTER }
+    render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    await screen.findByRole('table', { name: 'Curated bridge routes' })
+
+    fireEvent.change(screen.getByLabelText(/^Network/), { target: { value: '137' } })
+    await waitFor(() =>
+      expect(screen.getByText(/You are reading Polygon while your wallet is on Ethereum/i)).toBeInTheDocument(),
+    )
+    // The controls are still rendered — they are simply not signable from here.
+    expect(screen.getByRole('button', { name: 'Pause new bridges' })).toBeDisabled()
+  })
+
+  it('is axe-clean fully loaded', async () => {
+    const { container } = render(<BridgeTab {...props({ isAdmin: true }).node} />)
+    await screen.findByRole('table', { name: 'Curated bridge routes' })
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/admin/AdminSupplyTab.test.jsx
+++ b/frontend/src/test/admin/AdminSupplyTab.test.jsx
@@ -1,0 +1,502 @@
+/**
+ * Spec 067 US4 (T127–T132, T135) — the SupplyTab operator control surface (AdminPanel → Liquidity → Supply).
+ *
+ * Two assertions here matter more than the rest, and both are about what the tab REFUSES to
+ * imply (research R3, FR-024):
+ *
+ *   - the pause is labelled "Pauses new Uniswap supplies" and says out loud that it cannot stop
+ *     bridge-pool deposits, because no FairWins contract is in that path;
+ *   - a retired pool stays in the table, with its position count, because members still hold
+ *     positions in it and must keep being able to exit.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ethers as ethersActual } from 'ethers'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+
+const m = vi.hoisted(() => ({ addr: {}, reads: {}, events: {}, feeQuote: null, feeThrows: null }))
+
+vi.mock('../../config/contracts', () => ({
+  getContractAddressForChain: (name, chainId) =>
+    name === 'liquidityRouter' ? m.addr[Number(chainId)] || '' : '',
+}))
+vi.mock('../../config/blockExplorer', () => ({
+  getBlockscoutUrl: () => 'https://explorer.example/address/0xrouter',
+  getTransactionUrl: () => 'https://explorer.example/tx/0xdead',
+}))
+vi.mock('../../lib/fees/feeQuote', async (orig) => ({
+  ...(await orig()),
+  fetchFeeQuote: vi.fn(() => (m.feeThrows ? Promise.reject(m.feeThrows) : Promise.resolve(m.feeQuote))),
+}))
+vi.mock('../../lib/liquidity/acrossLpPositions', () => ({
+  // The bridge-pool SIZE comes from the Across HubPool, not from the router's events. `null` is the
+  // unreadable case, which the tab must report as unknown rather than as an empty pool.
+  readPooledToken: vi.fn(() => Promise.resolve(m.pooledToken)),
+}))
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract() {
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          if (prop === 'filters') {
+            return new Proxy({}, { get: (_f, name) => () => ({ __event: String(name) }) })
+          }
+          const key = String(prop)
+          return (...args) => (m.reads[key] ? m.reads[key](...args) : Promise.resolve(undefined))
+        },
+      },
+    )
+  }
+  const FakeCtor = vi.fn(FakeContract)
+  return { ...actual, Contract: FakeCtor, ethers: { ...actual.ethers, Contract: FakeCtor } }
+})
+
+import SupplyTab from '../../components/admin/SupplyTab'
+import { POOL_KIND } from '../../lib/liquidity/liquidityRouter'
+
+const ROUTER = '0x2222222222222222222222222222222222222222'
+const VALID = '0x00000000000000000000000000000000000000a1'
+const USDC_ETH = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+const POOL_ADDR = '0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640'
+const HUB_POOL = '0xc186fA914353c44b2E33eBE05f21846F1048bEda'
+
+const TRADING_POOL = {
+  poolId: '0xpool1',
+  kind: BigInt(POOL_KIND.TRADING_LP),
+  enabled: true,
+  feeTier: 500n,
+  token0: USDC_ETH,
+  token1: WETH,
+  poolAddress: POOL_ADDR,
+  maxDeposit0PerTx: 10_000_000_000n, // 10,000 USDC
+  maxDeposit1PerTx: 0n,
+}
+const RETIRED_POOL = {
+  poolId: '0xpool2',
+  kind: BigInt(POOL_KIND.TRADING_LP),
+  enabled: false,
+  feeTier: 3000n,
+  token0: USDC_ETH,
+  token1: WETH,
+  poolAddress: '0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8',
+  maxDeposit0PerTx: 0n,
+  maxDeposit1PerTx: 0n,
+}
+const BRIDGE_POOL = {
+  poolId: '0xpool3',
+  kind: BigInt(POOL_KIND.BRIDGE_LP),
+  enabled: true,
+  feeTier: 0n,
+  token0: USDC_ETH,
+  token1: '0x0000000000000000000000000000000000000000',
+  poolAddress: HUB_POOL,
+  maxDeposit0PerTx: 0n,
+  maxDeposit1PerTx: 0n,
+}
+
+const providerStub = {
+  getBlockNumber: () => Promise.resolve(1_000_000),
+  getBlock: () => Promise.resolve({ timestamp: Math.floor(Date.now() / 1000) }),
+}
+
+
+/** `runTx` resolves true on success — callers that send a sequence rely on the signal. */
+const TX_OK = true
+const ACCOUNT = '0x9999999999999999999999999999999999999999'
+const ROLE_HASH = {
+  admin: ethersActual.ZeroHash,
+  guardian: ethersActual.id('GUARDIAN_ROLE'),
+  liquidityAdmin: ethersActual.id('LIQUIDITY_ADMIN_ROLE'),
+}
+
+function props(overrides = {}) {
+  const runTx = vi.fn(() => Promise.resolve(TX_OK))
+  // ── ROLE FLAGS ARE TRANSLATED INTO ON-CHAIN ANSWERS, NOT PASSED AS PROPS ──────────────────────
+  // The tab asks the router in scope `hasRole(...)` rather than trusting an app-wide flag, because
+  // the flags were resolved against the wrong contract and the wrong network (see
+  // readRouterAuthority). Call sites keep the readable `{ isGuardian: true }` shape; what it now
+  // means is "the router says so", which is the thing that actually gates the control.
+  const { isAdmin = false, isLiquidityAdmin = false, isGuardian = false, ...node } = overrides
+  const held = []
+  if (isAdmin) held.push(ROLE_HASH.admin)
+  if (isGuardian) held.push(ROLE_HASH.guardian)
+  if (isLiquidityAdmin) held.push(ROLE_HASH.liquidityAdmin)
+  m.reads.hasRole = (role) => Promise.resolve(held.includes(role))
+  return {
+    runTx,
+    node: {
+      signer: {},
+      account: ACCOUNT,
+      chainId: 1,
+      provider: providerStub,
+      runTx,
+      pendingTx: false,
+      ...node,
+    },
+  }
+}
+
+beforeEach(() => {
+  m.addr = { 1: ROUTER }
+  m.events = {}
+  m.feeQuote = { available: true, bps: 25, capBps: 250 }
+  m.feeThrows = null
+  m.pooledToken = null
+  const pools = {
+    [TRADING_POOL.poolId]: TRADING_POOL,
+    [RETIRED_POOL.poolId]: RETIRED_POOL,
+    [BRIDGE_POOL.poolId]: BRIDGE_POOL,
+  }
+  const ids = Object.keys(pools)
+  m.reads = {
+    paused: () => Promise.resolve(false),
+    feeRouter: () => Promise.resolve(VALID),
+    positionManager: () => Promise.resolve('0xC36442b4a4522E871399CD717aBDD847Ab11FE88'),
+    sanctionsGuard: () => Promise.resolve(VALID),
+    MAX_FEE_BPS: () => Promise.resolve(250n),
+    poolCount: () => Promise.resolve(BigInt(ids.length)),
+    poolAt: (i) => Promise.resolve(ids[Number(i)]),
+    getPool: (id) => Promise.resolve(pools[id]),
+    queryFilter: (filter) => Promise.resolve(m.events[filter?.__event] || []),
+  }
+})
+
+describe('SupplyTab — honest empty states', () => {
+  it('says the router is not deployed rather than showing empty controls', async () => {
+    m.addr = {}
+    render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    expect(await screen.findByText(/No LiquidityRouter is deployed on Ethereum/i)).toBeInTheDocument()
+  })
+
+  it('is axe-clean in the not-deployed state', async () => {
+    m.addr = {}
+    const { container } = render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    await screen.findByText(/No LiquidityRouter is deployed/i)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('SupplyTab — the pause is narrow and says so (T128, research R3)', () => {
+  it('is labelled "new Uniswap supplies", never "pooling"', async () => {
+    render(<SupplyTab {...props({ isGuardian: true }).node} />)
+    expect(await screen.findByRole('button', { name: 'Pause new Uniswap supplies' })).toBeInTheDocument()
+    expect(screen.getByText('Pauses new Uniswap supplies')).toBeInTheDocument()
+    expect(screen.queryByText(/Pauses pooling/i)).not.toBeInTheDocument()
+  })
+
+  it('states that it cannot stop bridge-pool deposits, and why', async () => {
+    render(<SupplyTab {...props({ isGuardian: true }).node} />)
+    await screen.findByRole('button', { name: 'Pause new Uniswap supplies' })
+    // The emphasis tags split the sentence across nodes, so the paragraph is read whole.
+    const note = screen.getByText(/pause bridge-pool deposits/i).closest('p')
+    expect(note.textContent).toMatch(/It does not pause bridge-pool deposits/i)
+    expect(note.textContent).toMatch(/no FairWins contract in the path/i)
+    expect(note.textContent).toMatch(/what withholds a bridge pool is its enabled flag/i)
+    expect(note.textContent).toMatch(/every existing position stays withdrawable/i)
+  })
+
+  it('names the paused state as Uniswap-only and keeps positions withdrawable', async () => {
+    m.reads.paused = () => Promise.resolve(true)
+    render(<SupplyTab {...props({ isGuardian: true }).node} />)
+    expect(
+      await screen.findByText(/PAUSED — no new Uniswap supplies\. Existing positions are untouched and still withdrawable\./),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Resume new Uniswap supplies' })).toBeInTheDocument()
+  })
+
+  it('dispatches the pause with Uniswap-only wording', async () => {
+    const { node, runTx } = props({ isGuardian: true })
+    render(<SupplyTab {...node} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Pause new Uniswap supplies' }))
+    await waitFor(() => expect(runTx.mock.calls.some((c) => c[1] === 'New Uniswap supplies paused')).toBe(true))
+  })
+})
+
+describe('SupplyTab — a retired pool is retired, not gone (T129, FR-024)', () => {
+  it('keeps the retired pool listed, marked retired and still withdrawable', async () => {
+    render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    const table = await screen.findByRole('table', { name: 'Curated pools' })
+    expect(within(table).getByText(/RETIRED — closed to new deposits, still withdrawable/)).toBeInTheDocument()
+    // Both trading pools are present: retiring one does not remove it from the list.
+    expect(within(table).getAllByText(/Trading pool \(Uniswap V3\)/).length).toBe(2)
+    expect(screen.getByRole('button', { name: 'Reopen' })).toBeInTheDocument()
+  })
+
+  it('shows a position count for it, sourced from the router’s own deposits', async () => {
+    m.events.LiquiditySupplied = [
+      { blockNumber: 900_000, index: 0, transactionHash: '0xa', args: { poolId: RETIRED_POOL.poolId, tokenId: 1n, amount0: 1_000_000n, amount1: 0n } },
+      { blockNumber: 900_001, index: 0, transactionHash: '0xb', args: { poolId: RETIRED_POOL.poolId, tokenId: 2n, amount0: 2_000_000n, amount1: 0n } },
+    ]
+    render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    const table = await screen.findByRole('table', { name: 'Curated pools' })
+    const retiredRow = within(table).getByText(/RETIRED/).closest('tr')
+    expect(within(retiredRow).getByText('2')).toBeInTheDocument()
+    expect(within(retiredRow).getByText(/3\.0 USDC/)).toBeInTheDocument()
+  })
+
+  it('reports a bridge pool’s position COUNT as not observable, never as zero', async () => {
+    render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    const table = await screen.findByRole('table', { name: 'Curated pools' })
+    const bridgeRow = within(table).getByText(/Bridge pool \(Across\)/).closest('tr')
+    // Exactly ONE cell, not two. Attributing LP balances to individual members needs an indexer, so
+    // the COUNT genuinely cannot be produced — but the pool's SIZE is a plain HubPool read that the
+    // member-facing Supply view already performs, so withholding it too left an operator deciding
+    // whether to retire a bridge pool with no figure at all for the money inside it.
+    expect(within(bridgeRow).getAllByText('not observable here').length).toBe(1)
+    expect(screen.getByText(/would read as “no member has money in this pool”/)).toBeInTheDocument()
+  })
+
+  // ── AN UNREADABLE SCAN IS NOT A ZERO ─────────────────────────────────────────────────────────
+  // The error path stored an EMPTY map rather than a null one, so the cell fell through to `?? 0` and
+  // printed "0 positions" against a pool members still hold LP in — at the exact moment an operator
+  // is deciding whether to retire it. That is the one claim FR-024 exists to prevent.
+  it('says the position count is unknown when the deposit scan fails, never 0', async () => {
+    m.reads.queryFilter = () => Promise.reject(new Error('query returned more than 10000 results'))
+    render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    const table = await screen.findByRole('table', { name: 'Curated pools' })
+    const retiredRow = within(table).getByText(/RETIRED/).closest('tr')
+    await waitFor(() =>
+      expect(within(retiredRow).getAllByText(/unknown — the scan failed/).length).toBe(2),
+    )
+    expect(within(retiredRow).queryByText('0')).not.toBeInTheDocument()
+  })
+
+  it('distinguishes "none in window" from a failed scan', async () => {
+    // The lookback is bounded, so a pool whose deposits predate it has nothing to show — which is a
+    // different statement from "the scan would not run", and a different one again from zero.
+    m.reads.queryFilter = () => Promise.resolve([])
+    render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    const table = await screen.findByRole('table', { name: 'Curated pools' })
+    const retiredRow = within(table).getByText(/RETIRED/).closest('tr')
+    await waitFor(() => expect(within(retiredRow).getAllByText('none in window').length).toBe(2))
+  })
+
+  it('reads a bridge pool’s size from the HubPool, and says so when that read fails', async () => {
+    m.pooledToken = { liquidReserves: 4_000_000n, utilizedReserves: 1_000_000n }
+    const { unmount } = render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    let table = await screen.findByRole('table', { name: 'Curated pools' })
+    let bridgeRow = within(table).getByText(/Bridge pool \(Across\)/).closest('tr')
+    await waitFor(() => expect(within(bridgeRow).getByText(/5\.0 USDC in the pool/)).toBeInTheDocument())
+    unmount()
+
+    // An unreadable HubPool is not an empty pool.
+    m.pooledToken = null
+    render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    table = await screen.findByRole('table', { name: 'Curated pools' })
+    bridgeRow = within(table).getByText(/Bridge pool \(Across\)/).closest('tr')
+    await waitFor(() =>
+      expect(within(bridgeRow).getByText(/unknown — the HubPool could not be read/)).toBeInTheDocument(),
+    )
+  })
+
+  it('dispatches retire and reopen', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<SupplyTab {...node} />)
+    await screen.findByRole('table', { name: 'Curated pools' })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Retire' })[0])
+    await waitFor(() =>
+      expect(runTx.mock.calls.some((c) => /existing positions untouched/.test(c[1]))).toBe(true),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen' }))
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /reopened/.test(c[1]))).toBe(true))
+  })
+})
+
+describe('SupplyTab — per-leg caps (T130, FR-045)', () => {
+  it('renders two ceilings for a trading pool and dispatches both', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<SupplyTab {...node} />)
+    const table = await screen.findByRole('table', { name: 'Curated pools' })
+    // 10,000 USDC on leg 0, uncapped on leg 1 — not one scalar for both.
+    expect(within(table).getByText(/10000\.0 USDC/)).toBeInTheDocument()
+
+    fireEvent.change(screen.getAllByLabelText(/Per-transaction cap for USDC in pool/i)[0], {
+      target: { value: '500' },
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Set caps' })[0])
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /caps updated/.test(c[1]))).toBe(true))
+  })
+
+  // ── SETTING ONE CEILING MUST NOT DELETE THE OTHER ────────────────────────────────────────────
+  // `setPoolLimit` writes BOTH legs in one call, and 0 means UNCAPPED on-chain. The blank leg used to
+  // default to '0', so typing a new WETH ceiling on a pool capped at 10,000 USDC silently removed the
+  // USDC cap and reported success — a member-facing limit deleted by an operator who never touched
+  // it. The old test filled only leg 0 and asserted nothing about the values sent, so it was blind
+  // to this; these three assert the ARGUMENTS.
+  it('keeps the untouched leg’s current ceiling instead of writing 0 over it', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<SupplyTab {...node} />)
+    await screen.findByRole('table', { name: 'Curated pools' })
+
+    // Type ONLY the WETH leg. The pool is capped at 10,000 USDC on leg 0 and uncapped on leg 1.
+    fireEvent.change(screen.getAllByLabelText(/Per-transaction cap for WETH in pool/i)[0], {
+      target: { value: '2' },
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Set caps' })[0])
+    await waitFor(() => expect(runTx).toHaveBeenCalled())
+
+    // Inspect what the transaction thunk actually asks the contract for.
+    const args = []
+    m.reads.setPoolLimit = (...a) => {
+      args.push(a)
+      return Promise.resolve({ wait: () => Promise.resolve() })
+    }
+    await runTx.mock.calls[runTx.mock.calls.length - 1][0]()
+    expect(args.length).toBe(1)
+    const [, max0, max1] = args[0]
+    expect(max0).toBe(TRADING_POOL.maxDeposit0PerTx) // 10,000 USDC preserved, not zeroed
+    expect(max1).toBe(ethersActual.parseUnits('2', 18))
+  })
+
+  it('refuses to write anything when both cap boxes are blank', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<SupplyTab {...node} />)
+    await screen.findByRole('table', { name: 'Curated pools' })
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Set caps' })[0])
+    expect(screen.getByRole('alert')).toHaveTextContent(/Type a new ceiling first/i)
+    expect(screen.getByRole('alert')).toHaveTextContent(/enter 0 explicitly/i)
+    expect(runTx).not.toHaveBeenCalled()
+  })
+
+  it('still accepts an explicit 0 as uncapped', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<SupplyTab {...node} />)
+    await screen.findByRole('table', { name: 'Curated pools' })
+
+    fireEvent.change(screen.getAllByLabelText(/Per-transaction cap for USDC in pool/i)[0], {
+      target: { value: '0' },
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Set caps' })[0])
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /caps updated/.test(c[1]))).toBe(true))
+  })
+
+  it('marks a bridge pool’s cap as app-honoured, not contract-enforced', async () => {
+    render(<SupplyTab {...props({ isLiquidityAdmin: true }).node} />)
+    const table = await screen.findByRole('table', { name: 'Curated pools' })
+    const bridgeRow = within(table).getByText(/Bridge pool \(Across\)/).closest('tr')
+    // The router's limit check lives inside the Uniswap supply path; a bridge-LP deposit is a direct
+    // member call to Across that never enters it. Same property the pause card explains for the
+    // enabled flag, so the number does not get to imply enforcement it does not have.
+    expect(within(bridgeRow).getByText(/honoured by this app, not by the contract/i)).toBeInTheDocument()
+  })
+
+  it('refuses a mis-scaled cap before the wallet prompt', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<SupplyTab {...node} />)
+    await screen.findByRole('table', { name: 'Curated pools' })
+    fireEvent.change(screen.getAllByLabelText(/Per-transaction cap for USDC in pool/i)[0], {
+      target: { value: 'lots' },
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Set caps' })[0])
+    expect(screen.getByRole('alert')).toHaveTextContent(/Enter an amount in USDC/i)
+    expect(runTx).not.toHaveBeenCalled()
+  })
+})
+
+describe('SupplyTab — listing a pool (FR-041/FR-042)', () => {
+  it('refuses the listing shapes the contract refuses, with the reason', async () => {
+    const { node, runTx } = props({ isLiquidityAdmin: true })
+    render(<SupplyTab {...node} />)
+    await screen.findByRole('button', { name: 'Save pool listing' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save pool listing' }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/pool address and the first asset must both be valid/i)
+
+    fireEvent.change(screen.getByPlaceholderText('pool 0x…'), { target: { value: POOL_ADDR } })
+    fireEvent.change(screen.getByPlaceholderText('token0 0x…'), { target: { value: USDC_ETH } })
+    fireEvent.change(screen.getByPlaceholderText('token1 0x…'), { target: { value: WETH } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save pool listing' }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/needs its Uniswap fee tier/i)
+    expect(runTx).not.toHaveBeenCalled()
+
+    fireEvent.change(screen.getByPlaceholderText('500 / 3000 / 10000'), { target: { value: '500' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save pool listing' }))
+    await waitFor(() => expect(runTx.mock.calls.some((c) => /Pool listing saved/.test(c[1]))).toBe(true))
+  })
+
+  it('checks the named pool before signing and explains a non-pool address', async () => {
+    const { node } = props({ isLiquidityAdmin: true })
+    m.reads.token0 = () => Promise.reject(new Error('not a pool'))
+    render(<SupplyTab {...node} />)
+    await screen.findByRole('button', { name: 'Check pool' })
+    fireEvent.change(screen.getByPlaceholderText('pool 0x…'), { target: { value: POOL_ADDR } })
+    fireEvent.click(screen.getByRole('button', { name: 'Check pool' }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/did not answer as a Uniswap V3 pool/i),
+    )
+  })
+
+  it('fills the legs from the pool itself when it does answer', async () => {
+    const { node } = props({ isLiquidityAdmin: true })
+    m.reads.token0 = () => Promise.resolve(USDC_ETH)
+    m.reads.token1 = () => Promise.resolve(WETH)
+    m.reads.fee = () => Promise.resolve(500n)
+    render(<SupplyTab {...node} />)
+    await screen.findByRole('button', { name: 'Check pool' })
+    fireEvent.change(screen.getByPlaceholderText('pool 0x…'), { target: { value: POOL_ADDR } })
+    fireEvent.click(screen.getByRole('button', { name: 'Check pool' }))
+    await waitFor(() => expect(screen.getByText(/Pool confirmed: USDC \/ WETH at 0\.05%/)).toBeInTheDocument())
+  })
+})
+
+describe('SupplyTab — fee is read-only (T132, FR-048)', () => {
+  it('shows the live rate with its cap and the bridge-pool fee-free rule', async () => {
+    render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    expect(await screen.findByText(/25 bps \(0\.25%\) — service cap 250 bps/)).toBeInTheDocument()
+    expect(screen.getByText(/read-only here/i)).toBeInTheDocument()
+    expect(screen.getByText(/carries no FairWins fee/i)).toBeInTheDocument()
+  })
+
+  it('says the rate could not be read and keeps the other controls usable', async () => {
+    m.feeThrows = new Error('FeeRouter unreachable')
+    render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    expect(await screen.findByText(/could not be read — members cannot start a fee-bearing supply/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Pause new Uniswap supplies' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Save pool listing' })).toBeEnabled()
+  })
+})
+
+describe('SupplyTab — least privilege and history', () => {
+  it('a guardian gets the pause and no configuration controls', async () => {
+    render(<SupplyTab {...props({ isGuardian: true }).node} />)
+    await screen.findByRole('button', { name: 'Pause new Uniswap supplies' })
+    expect(screen.queryByText('Protocol addresses')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save pool listing' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Retire' })).not.toBeInTheDocument()
+  })
+
+  it('an operator with none of the three can act on nothing', async () => {
+    render(<SupplyTab {...props().node} />)
+    await screen.findByRole('table', { name: 'Curated pools' })
+    expect(screen.queryByRole('button', { name: /Pause/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Retire/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Set caps/i })).not.toBeInTheDocument()
+    expect(screen.queryByText('Protocol addresses')).not.toBeInTheDocument()
+  })
+
+  it('decodes retirement in the history and says it stays withdrawable', async () => {
+    m.events.PoolEnabledChanged = [
+      {
+        blockNumber: 999_000,
+        index: 0,
+        transactionHash: '0xhist',
+        args: { poolId: RETIRED_POOL.poolId, enabled: false, actor: VALID },
+      },
+    ]
+    render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    const table = await screen.findByRole('table', { name: 'Change history' })
+    expect(within(table).getByText('Pool availability')).toBeInTheDocument()
+    expect(within(table).getByText('retired (still visible and withdrawable)')).toBeInTheDocument()
+  })
+
+  it('is axe-clean fully loaded', async () => {
+    const { container } = render(<SupplyTab {...props({ isAdmin: true }).node} />)
+    await screen.findByRole('table', { name: 'Curated pools' })
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/admin/adminLeastPrivilege.test.jsx
+++ b/frontend/src/test/admin/adminLeastPrivilege.test.jsx
@@ -1,0 +1,287 @@
+/**
+ * Spec 067 T133 (SC-011) — least privilege on the two new control surfaces.
+ *
+ * The success criterion is not "the tab is hidden": it is that an operator holding none of
+ * admin / liquidity-admin / guardian can perform **no control action by any route**. There are
+ * three routes to try, and this file closes all three:
+ *
+ *   1. the navigation — the group is not built for them;
+ *   2. a hand-typed tab id — the AdminPanel gates the tab RENDER with the same predicate as the
+ *      nav, so guessing the id renders nothing;
+ *   3. the component itself — asked directly, the ROUTER says this account holds nothing, and
+ *      neither tab exposes a single control. That is the belt-and-braces layer: a future refactor
+ *      that loosens the panel gate still cannot hand out a write.
+ *
+ * ── WHY AUTHORITY IS DRIVEN THROUGH `hasRole` HERE AND NOT THROUGH PROPS ───────────────────────
+ * These tests used to hand the tabs `isAdmin` / `isGuardian` / `isLiquidityAdmin` props and assert
+ * on those. They passed while the real surface was wrong in three ways an adversarial review found:
+ * `isGuardian` was read from the WagerRegistry (a different contract from the one being paused),
+ * `isLiquidityAdmin` was a single OR across BOTH routers (so holding it on one unlocked the other),
+ * and all of them were resolved on the WALLET's chain rather than the network in scope. A test that
+ * asserts a prop cannot see any of that. So the tabs now ask the router in scope, and these tests
+ * answer as that router — which means they fail if the question is ever asked of the wrong contract.
+ *
+ * It also pins the SEPARATION between the roles: configuring routes and pools is not a licence to
+ * pause, pausing is not a licence to configure, changing a fund-path ADDRESS needs admin rather than
+ * either, and none of them is a licence to change a fee — that lives on the FeeRouter, behind
+ * FEE_ADMIN, in the Fees tab (FR-049).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ethers } from 'ethers'
+import { buildAdminNavGroups, flattenNavGroups } from '../../components/admin/adminNav'
+import adminPanelSource from '../../components/AdminPanel.jsx?raw'
+import bridgeTabSource from '../../components/admin/BridgeTab.jsx?raw'
+import supplyTabSource from '../../components/admin/SupplyTab.jsx?raw'
+
+const m = vi.hoisted(() => ({ reads: {} }))
+
+const BRIDGE_ROUTER = '0x1111111111111111111111111111111111111111'
+const LIQUIDITY_ROUTER = '0x2222222222222222222222222222222222222222'
+
+vi.mock('../../config/contracts', () => ({
+  getContractAddressForChain: (name) => {
+    if (name === 'bridgeRouter') return '0x1111111111111111111111111111111111111111'
+    if (name === 'liquidityRouter') return '0x2222222222222222222222222222222222222222'
+    return ''
+  },
+}))
+vi.mock('../../config/blockExplorer', () => ({
+  getBlockscoutUrl: () => '',
+  getTransactionUrl: () => '',
+}))
+vi.mock('../../lib/fees/feeQuote', async (orig) => ({
+  ...(await orig()),
+  fetchFeeQuote: vi.fn(() => Promise.resolve({ available: false, bps: 0, capBps: 0 })),
+}))
+vi.mock('../../lib/liquidity/acrossLpPositions', () => ({ readPooledToken: vi.fn(() => Promise.resolve(null)) }))
+vi.mock('../../hooks/useGatewayStatus', () => ({
+  useGatewayStatus: () => ({ configured: false, loading: false, reachable: false, status: null, refresh: vi.fn() }),
+}))
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  // Records which ADDRESS each contract was constructed against, so a test can prove the authority
+  // question was put to the router the tab manages and not to some other contract.
+  function FakeContract(address) {
+    m.constructedAt = [...(m.constructedAt || []), String(address)]
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          if (prop === 'filters') return new Proxy({}, { get: (_f, name) => () => ({ __event: String(name) }) })
+          const key = String(prop)
+          return (...args) => (m.reads[key] ? m.reads[key](address, ...args) : Promise.resolve(undefined))
+        },
+      },
+    )
+  }
+  const FakeCtor = vi.fn(FakeContract)
+  return { ...actual, Contract: FakeCtor, ethers: { ...actual.ethers, Contract: FakeCtor } }
+})
+
+import BridgeTab from '../../components/admin/BridgeTab'
+import SupplyTab from '../../components/admin/SupplyTab'
+
+const NO_ROLES = {
+  isAdmin: false,
+  isGuardian: false,
+  isAccountModerator: false,
+  isRoleManager: false,
+  isSanctionsAdmin: false,
+  isFeeAdmin: false,
+  isStakingAdmin: false,
+  isLiquidityAdmin: false,
+}
+
+const ACCOUNT = '0x9999999999999999999999999999999999999999'
+const ROLE = {
+  admin: ethers.ZeroHash,
+  guardian: ethers.id('GUARDIAN_ROLE'),
+  liquidityAdmin: ethers.id('LIQUIDITY_ADMIN_ROLE'),
+}
+
+const providerStub = {
+  getBlockNumber: () => Promise.resolve(1000),
+  getBlock: () => Promise.resolve({ timestamp: 0 }),
+  getTransactionReceipt: () => Promise.resolve(null),
+}
+
+function tabProps(overrides = {}) {
+  return {
+    signer: {},
+    account: ACCOUNT,
+    chainId: 1,
+    provider: providerStub,
+    runTx: vi.fn(() => Promise.resolve(true)),
+    pendingTx: false,
+    ...overrides,
+  }
+}
+
+/**
+ * Answer `hasRole` as the routers would.
+ *
+ * `grants` is keyed by ROUTER ADDRESS, so a test can grant a role on one router and prove it does
+ * not carry to the other — the asymmetric grant the Roles tab deliberately provisions.
+ */
+function grantOnChain(grants) {
+  m.reads.hasRole = (address, role) => {
+    const held = grants[String(address).toLowerCase()] || []
+    return Promise.resolve(held.some((r) => r === role))
+  }
+}
+
+beforeEach(() => {
+  m.constructedAt = []
+  m.reads = {
+    paused: () => Promise.resolve(false),
+    routeCount: () => Promise.resolve(0n),
+    poolCount: () => Promise.resolve(0n),
+    MAX_FEE_BPS: () => Promise.resolve(250n),
+    feeRouter: () => Promise.resolve('0x3333333333333333333333333333333333333333'),
+    queryFilter: () => Promise.resolve([]),
+  }
+  grantOnChain({})
+})
+
+describe('SC-011 route 1 — the navigation never offers the tabs', () => {
+  it('an operator holding every OTHER admin role reaches neither', () => {
+    const flat = flattenNavGroups(
+      buildAdminNavGroups({
+        ...NO_ROLES,
+        isAccountModerator: true,
+        isRoleManager: true,
+        isSanctionsAdmin: true,
+        isFeeAdmin: true,
+        isStakingAdmin: true,
+      }),
+    ).map((i) => i.id)
+    expect(flat).not.toContain('bridge')
+    expect(flat).not.toContain('supply')
+  })
+})
+
+describe('SC-011 route 2 — a hand-typed tab id renders nothing', () => {
+  it('the AdminPanel gates both tab renders on the same predicate as the nav', () => {
+    // Guessing `?tab=bridge` must not be a way in: the render is gated, not just the menu.
+    expect(adminPanelSource).toMatch(
+      /activeTab === 'bridge' && \(isAdmin \|\| isLiquidityAdmin \|\| isGuardian\)/,
+    )
+    expect(adminPanelSource).toMatch(
+      /activeTab === 'supply' && \(isAdmin \|\| isLiquidityAdmin \|\| isGuardian\)/,
+    )
+  })
+})
+
+describe('SC-011 route 3 — the components themselves hand out nothing', () => {
+  it('BridgeTab renders no control when the router says this account holds nothing', async () => {
+    render(<BridgeTab {...tabProps()} />)
+    await screen.findByRole('heading', { name: 'Routes' })
+    for (const name of [/^Pause/i, /^Resume/i, /Save route/i, /Disable/i, /Enable/i, /Remove/i, /Set limit/i, /Set SpokePool/i, /Set FeeRouter/i, /Set guard/i]) {
+      expect(screen.queryByRole('button', { name })).not.toBeInTheDocument()
+    }
+    // Read-only surfaces stay: seeing the control state is not a privilege to change it.
+    expect(screen.getByText('Platform fee')).toBeInTheDocument()
+    expect(screen.getByText('Operations')).toBeInTheDocument()
+  })
+
+  it('SupplyTab renders no control when the router says this account holds nothing', async () => {
+    render(<SupplyTab {...tabProps()} />)
+    await screen.findByRole('heading', { name: 'Curated pools' })
+    for (const name of [/^Pause/i, /^Resume/i, /Save pool listing/i, /Retire/i, /Reopen/i, /Set caps/i, /Check pool/i, /Set position manager/i, /Set FeeRouter/i, /Set guard/i]) {
+      expect(screen.queryByRole('button', { name })).not.toBeInTheDocument()
+    }
+    expect(screen.getByText('Platform fee')).toBeInTheDocument()
+  })
+
+  it('asks the ROUTER IT MANAGES, not some other contract', async () => {
+    render(<BridgeTab {...tabProps()} />)
+    await screen.findByRole('heading', { name: 'Routes' })
+    // The authority read is constructed against the bridge router for this network. If it were ever
+    // resolved from the WagerRegistry (the bug this replaced) or from the liquidity router, the
+    // address recorded here would not be the bridge router's.
+    expect(m.constructedAt).toContain(BRIDGE_ROUTER)
+    expect(m.constructedAt).not.toContain(LIQUIDITY_ROUTER)
+  })
+})
+
+describe('a role on ONE router is not a role on the other', () => {
+  it('LIQUIDITY_ADMIN on the liquidity router unlocks no bridge control', async () => {
+    grantOnChain({ [LIQUIDITY_ROUTER.toLowerCase()]: [ROLE.liquidityAdmin] })
+    render(<BridgeTab {...tabProps()} />)
+    await screen.findByRole('heading', { name: 'Routes' })
+    // The grant is real, just not here. Offering bridge controls on the strength of it produced
+    // AccessControlUnauthorizedAccount reverts after the operator believed a route was closed.
+    expect(screen.queryByRole('button', { name: /Save route/i })).not.toBeInTheDocument()
+    expect(screen.queryByText('Protocol addresses')).not.toBeInTheDocument()
+  })
+
+  it('LIQUIDITY_ADMIN on the bridge router unlocks no pool control', async () => {
+    grantOnChain({ [BRIDGE_ROUTER.toLowerCase()]: [ROLE.liquidityAdmin] })
+    render(<SupplyTab {...tabProps()} />)
+    await screen.findByRole('heading', { name: 'Curated pools' })
+    expect(screen.queryByRole('button', { name: /Save pool listing/i })).not.toBeInTheDocument()
+    expect(screen.queryByText('Protocol addresses')).not.toBeInTheDocument()
+  })
+})
+
+describe('the roles stay separate (FR-049)', () => {
+  it('configuring is not pausing, and pausing is not configuring', async () => {
+    grantOnChain({ [BRIDGE_ROUTER.toLowerCase()]: [ROLE.liquidityAdmin] })
+    const { unmount } = render(<BridgeTab {...tabProps()} />)
+    await screen.findByRole('button', { name: /Save route/i })
+    expect(screen.queryByRole('button', { name: /^Pause new bridges/i })).not.toBeInTheDocument()
+    unmount()
+
+    grantOnChain({ [BRIDGE_ROUTER.toLowerCase()]: [ROLE.guardian] })
+    render(<BridgeTab {...tabProps()} />)
+    await screen.findByRole('button', { name: /^Pause new bridges/i })
+    expect(screen.queryByRole('button', { name: /Save route/i })).not.toBeInTheDocument()
+  })
+
+  it('curating routes does not carry the power to redirect member funds', async () => {
+    // `setSpokePool` / `setFeeRouter` decide where a member's money goes; the contract puts them at
+    // DEFAULT_ADMIN_ROLE for that reason, and the tab must not offer what the contract refuses.
+    grantOnChain({ [BRIDGE_ROUTER.toLowerCase()]: [ROLE.liquidityAdmin] })
+    const { unmount } = render(<BridgeTab {...tabProps()} />)
+    await screen.findByRole('button', { name: /Save route/i })
+    expect(screen.queryByText('Protocol addresses')).not.toBeInTheDocument()
+    unmount()
+
+    grantOnChain({ [BRIDGE_ROUTER.toLowerCase()]: [ROLE.admin] })
+    render(<BridgeTab {...tabProps()} />)
+    await screen.findByText('Protocol addresses')
+  })
+
+  it('curating pools does not carry the power to repoint the position manager', async () => {
+    grantOnChain({ [LIQUIDITY_ROUTER.toLowerCase()]: [ROLE.liquidityAdmin] })
+    const { unmount } = render(<SupplyTab {...tabProps()} />)
+    await screen.findByRole('button', { name: /Save pool listing/i })
+    expect(screen.queryByText('Protocol addresses')).not.toBeInTheDocument()
+    unmount()
+
+    grantOnChain({ [LIQUIDITY_ROUTER.toLowerCase()]: [ROLE.admin] })
+    render(<SupplyTab {...tabProps()} />)
+    await screen.findByText('Protocol addresses')
+  })
+
+  it('neither tab can change a fee rate — there is no rate setter in either', () => {
+    // The fee is quoted and displayed; the only mutation path is the Fees tab (spec 060).
+    for (const source of [bridgeTabSource, supplyTabSource]) {
+      expect(source).not.toMatch(/setFeeBps|setServiceFee|setRate\(/)
+      expect(source).toMatch(/fetchFeeQuote/)
+    }
+  })
+})
+
+describe('an unreadable authority is not a denial (FR-044)', () => {
+  it('offers the killswitch, and says the authority is unconfirmed, when hasRole cannot be read', async () => {
+    m.reads.hasRole = () => Promise.reject(new Error('missing revert data'))
+    render(<BridgeTab {...tabProps()} />)
+    // The contract is the real gate. Withdrawing the pause because an RPC would not answer tells an
+    // operator who DOES hold it that the network has no killswitch — the worse of the two errors.
+    await screen.findByRole('button', { name: /^Pause new bridges/i })
+    expect(screen.getByText(/could not be confirmed/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/admin/networkScoping.test.jsx
+++ b/frontend/src/test/admin/networkScoping.test.jsx
@@ -1,0 +1,264 @@
+/**
+ * Spec 067 T157 (FR-050) — control state and history are scoped PER NETWORK, and nothing leaks
+ * across the boundary.
+ *
+ * The two failures this guards against are opposite and both silent:
+ *
+ *   1. **Under-reading** — gating the tab on the connected chain, so an operator on Polygon is
+ *      told there are no Ethereum routes. Earlier phases of this spec did exactly that; the tabs
+ *      read every capable network from its own RPC instead, and each is a separate scope.
+ *
+ *   2. **Over-reading** — carrying one network's routes, pools, addresses, limits or history into
+ *      another's view. There is no shared cache and no merged list: switching scope re-reads from
+ *      the router address configured for THAT chain, and only that one is ever contacted.
+ *
+ * The second is what makes the testnet/mainnet half of FR-050 true: a testnet router is never
+ * queried while a mainnet is in scope, so no testnet control state can reach a mainnet surface.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+
+const m = vi.hoisted(() => ({ addr: {}, byAddr: {}, constructed: [] }))
+
+vi.mock('../../config/contracts', () => ({
+  getContractAddressForChain: (name, chainId) =>
+    name === 'bridgeRouter' || name === 'liquidityRouter' ? m.addr[Number(chainId)] || '' : '',
+}))
+vi.mock('../../config/blockExplorer', () => ({
+  getBlockscoutUrl: () => '',
+  getTransactionUrl: () => '',
+}))
+vi.mock('../../lib/fees/feeQuote', async (orig) => ({
+  ...(await orig()),
+  fetchFeeQuote: vi.fn(() => Promise.resolve({ available: false, bps: 0, capBps: 0 })),
+}))
+vi.mock('../../hooks/useGatewayStatus', () => ({
+  useGatewayStatus: () => ({ configured: false, loading: false, reachable: false, status: null, refresh: vi.fn() }),
+}))
+vi.mock('../../lib/bridge/bridgeStatus', async (orig) => ({
+  ...(await orig()),
+  fetchBridgeStatus: vi.fn(() => Promise.reject(new Error('no gateway'))),
+}))
+// Every read is keyed by the CONTRACT ADDRESS the tab constructed, so a value from one network's
+// router can only appear on screen if the tab actually asked that router for it.
+vi.mock('../../utils/rpcProvider', () => ({
+  makeReadProvider: () => ({
+    getBlockNumber: () => Promise.resolve(1_000_000),
+    getBlock: () => Promise.resolve({ timestamp: 0 }),
+    getTransactionReceipt: () => Promise.resolve(null),
+  }),
+}))
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract(address) {
+    m.constructed.push(address)
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          if (prop === 'filters') return new Proxy({}, { get: (_f, name) => () => ({ __event: String(name) }) })
+          const key = String(prop)
+          const reads = m.byAddr[address] || {}
+          return (...args) => (reads[key] ? reads[key](...args) : Promise.resolve(undefined))
+        },
+      },
+    )
+  }
+  const FakeCtor = vi.fn(FakeContract)
+  return { ...actual, Contract: FakeCtor, ethers: { ...actual.ethers, Contract: FakeCtor } }
+})
+
+import BridgeTab from '../../components/admin/BridgeTab'
+import SupplyTab from '../../components/admin/SupplyTab'
+import { POOL_KIND } from '../../lib/liquidity/liquidityRouter'
+
+const ETH_ROUTER = '0x1111111111111111111111111111111111111111'
+const POLY_ROUTER = '0x2222222222222222222222222222222222222222'
+const USDC_ETH = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+const USDC_POLY = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+const WMATIC = '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270'
+
+const providerStub = {
+  getBlockNumber: () => Promise.resolve(1_000_000),
+  getBlock: () => Promise.resolve({ timestamp: 0 }),
+  getTransactionReceipt: () => Promise.resolve(null),
+}
+
+const tabProps = (overrides = {}) => ({
+  signer: {},
+  chainId: 1,
+  provider: providerStub,
+  runTx: vi.fn(() => Promise.resolve()),
+  pendingTx: false,
+  isAdmin: true,
+  isLiquidityAdmin: true,
+  isGuardian: true,
+  ...overrides,
+})
+
+const routerReads = (extra) => ({
+  paused: () => Promise.resolve(false),
+  MAX_FEE_BPS: () => Promise.resolve(250n),
+  queryFilter: () => Promise.resolve([]),
+  ...extra,
+})
+
+beforeEach(() => {
+  m.addr = { 1: ETH_ROUTER, 137: POLY_ROUTER }
+  m.constructed = []
+})
+
+describe('Bridge control state is per network', () => {
+  beforeEach(() => {
+    m.byAddr = {
+      [ETH_ROUTER]: routerReads({
+        spokePool: () => Promise.resolve('0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5'),
+        routeCount: () => Promise.resolve(1n),
+        routeAt: () => Promise.resolve('0xeth-route'),
+        getRoute: () =>
+          Promise.resolve({
+            inputToken: USDC_ETH,
+            outputToken: USDC_POLY,
+            destinationChainId: 137n,
+            maxAmount: 1_000_000n,
+            expectedFillSeconds: 900n,
+            enabled: true,
+            nativeInput: false,
+          }),
+      }),
+      [POLY_ROUTER]: routerReads({
+        spokePool: () => Promise.resolve('0x9295ee1d8C5b022Be115A2AD3c30C72E34e7F096'),
+        routeCount: () => Promise.resolve(1n),
+        routeAt: () => Promise.resolve('0xpoly-route'),
+        getRoute: () =>
+          Promise.resolve({
+            inputToken: WMATIC,
+            outputToken: WETH,
+            destinationChainId: 1n,
+            maxAmount: 0n,
+            expectedFillSeconds: 1800n,
+            enabled: false,
+            nativeInput: true,
+          }),
+      }),
+    }
+  })
+
+  it('shows only the scoped network’s routes, and swaps them wholesale on switch', async () => {
+    render(<BridgeTab {...tabProps()} />)
+    const table = await screen.findByRole('table', { name: 'Curated bridge routes' })
+    expect(within(table).getByText('Ethereum → Polygon')).toBeInTheDocument()
+    expect(within(table).queryByText('Polygon → Ethereum')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText(/^Network/), { target: { value: '137' } })
+    await waitFor(() =>
+      expect(
+        within(screen.getByRole('table', { name: 'Curated bridge routes' })).getByText('Polygon → Ethereum'),
+      ).toBeInTheDocument(),
+    )
+    // The first network's route is GONE, not merged in beneath the second's.
+    expect(
+      within(screen.getByRole('table', { name: 'Curated bridge routes' })).queryByText('Ethereum → Polygon'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('contacts only the router deployed on the network in scope', async () => {
+    render(<BridgeTab {...tabProps()} />)
+    await screen.findByRole('table', { name: 'Curated bridge routes' })
+    expect(m.constructed).toContain(ETH_ROUTER)
+    expect(m.constructed).not.toContain(POLY_ROUTER)
+
+    fireEvent.change(screen.getByLabelText(/^Network/), { target: { value: '137' } })
+    await waitFor(() => expect(m.constructed).toContain(POLY_ROUTER))
+  })
+
+  it('reads a network the wallet is not on, and says changes need the wallet there', async () => {
+    // The wallet is on Polygon; the scope opens there, and Ethereum is still fully readable.
+    render(<BridgeTab {...tabProps({ chainId: 137 })} />)
+    await screen.findByRole('table', { name: 'Curated bridge routes' })
+    fireEvent.change(screen.getByLabelText(/^Network/), { target: { value: '1' } })
+    await waitFor(() =>
+      expect(screen.getByText(/You are reading Ethereum while your wallet is on Polygon/i)).toBeInTheDocument(),
+    )
+    expect(
+      within(screen.getByRole('table', { name: 'Curated bridge routes' })).getByText('Ethereum → Polygon'),
+    ).toBeInTheDocument()
+  })
+
+  it('treats a network with no deployment as its own honest state, not the other’s', async () => {
+    m.addr = { 1: ETH_ROUTER }
+    render(<BridgeTab {...tabProps()} />)
+    await screen.findByRole('table', { name: 'Curated bridge routes' })
+    fireEvent.change(screen.getByLabelText(/^Network/), { target: { value: '137' } })
+    await waitFor(() =>
+      expect(screen.getByText(/No BridgeRouter is deployed on Polygon/i)).toBeInTheDocument(),
+    )
+    expect(screen.queryByRole('table', { name: 'Curated bridge routes' })).not.toBeInTheDocument()
+  })
+})
+
+describe('Supply control state is per network', () => {
+  beforeEach(() => {
+    m.byAddr = {
+      [ETH_ROUTER]: routerReads({
+        positionManager: () => Promise.resolve('0xC36442b4a4522E871399CD717aBDD847Ab11FE88'),
+        poolCount: () => Promise.resolve(1n),
+        poolAt: () => Promise.resolve('0xeth-pool'),
+        getPool: () =>
+          Promise.resolve({
+            kind: BigInt(POOL_KIND.BRIDGE_LP),
+            enabled: true,
+            feeTier: 0n,
+            token0: USDC_ETH,
+            token1: '0x0000000000000000000000000000000000000000',
+            poolAddress: '0xc186fA914353c44b2E33eBE05f21846F1048bEda',
+            maxDeposit0PerTx: 0n,
+            maxDeposit1PerTx: 0n,
+          }),
+      }),
+      [POLY_ROUTER]: routerReads({
+        positionManager: () => Promise.resolve('0xC36442b4a4522E871399CD717aBDD847Ab11FE88'),
+        poolCount: () => Promise.resolve(1n),
+        poolAt: () => Promise.resolve('0xpoly-pool'),
+        getPool: () =>
+          Promise.resolve({
+            kind: BigInt(POOL_KIND.TRADING_LP),
+            enabled: true,
+            feeTier: 500n,
+            token0: USDC_POLY,
+            token1: WMATIC,
+            poolAddress: '0xa374094527e1673a86de625aa59517c5de346d32',
+            maxDeposit0PerTx: 0n,
+            maxDeposit1PerTx: 0n,
+          }),
+      }),
+    }
+  })
+
+  it('does not carry one network’s pools into another’s list', async () => {
+    render(<SupplyTab {...tabProps()} />)
+    const table = await screen.findByRole('table', { name: 'Curated pools' })
+    // Ethereum is the only network with an Across HubPool (research R8) — its bridge pool must
+    // not follow the operator to Polygon.
+    expect(within(table).getByText(/Bridge pool \(Across\)/)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText(/^Network/), { target: { value: '137' } })
+    await waitFor(() =>
+      expect(
+        within(screen.getByRole('table', { name: 'Curated pools' })).getByText(/Trading pool \(Uniswap V3\)/),
+      ).toBeInTheDocument(),
+    )
+    expect(
+      within(screen.getByRole('table', { name: 'Curated pools' })).queryByText(/Bridge pool \(Across\)/),
+    ).not.toBeInTheDocument()
+  })
+
+  it('contacts only the router deployed on the network in scope', async () => {
+    render(<SupplyTab {...tabProps()} />)
+    await screen.findByRole('table', { name: 'Curated pools' })
+    expect(m.constructed).toContain(ETH_ROUTER)
+    expect(m.constructed).not.toContain(POLY_ROUTER)
+  })
+})

--- a/frontend/src/test/admin/pauseNeverTraps.test.jsx
+++ b/frontend/src/test/admin/pauseNeverTraps.test.jsx
@@ -1,0 +1,201 @@
+/**
+ * Spec 067 T134 (FR-043) — a pause stops new value going in, and traps none that is already in.
+ *
+ * The two surfaces fail in different ways if this is got wrong, so they are asserted separately:
+ *
+ *   BRIDGE — a paused router must not imply anything about transfers already moving. Across
+ *   settles them directly to the member with the router nowhere in the path, so the pause cannot
+ *   reach them, and the Operations panel keeps reporting them while the pause is on.
+ *
+ *   SUPPLY — a paused router must not imply that positions are stuck. Withdrawing never routed
+ *   through this contract in the first place; the member owns the position NFT and exits through
+ *   Uniswap directly. And a RETIRED pool must still be listed while paused, because that is the
+ *   state in which a member most needs to find their position (FR-024).
+ *
+ * The last test pins the structural half of the same promise: the frontend ABI carries no
+ * `removePool` fragment, because the contract deliberately has no such function — retirement is
+ * `setPoolEnabled(false)` precisely so a pool holding member money can never be erased.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { LIQUIDITY_ROUTER_ABI } from '../../abis/LiquidityRouter'
+import { BRIDGE_ROUTER_ABI } from '../../abis/BridgeRouter'
+import { POOL_KIND } from '../../lib/liquidity/liquidityRouter'
+
+const m = vi.hoisted(() => ({ reads: {}, events: {}, paused: true }))
+
+vi.mock('../../config/contracts', () => ({
+  getContractAddressForChain: (name) =>
+    name === 'bridgeRouter' || name === 'liquidityRouter'
+      ? '0x1111111111111111111111111111111111111111'
+      : '',
+}))
+vi.mock('../../config/blockExplorer', () => ({
+  getBlockscoutUrl: () => '',
+  getTransactionUrl: () => 'https://explorer.example/tx/0xdead',
+}))
+vi.mock('../../lib/fees/feeQuote', async (orig) => ({
+  ...(await orig()),
+  fetchFeeQuote: vi.fn(() => Promise.resolve({ available: false, bps: 0, capBps: 0 })),
+}))
+vi.mock('../../hooks/useGatewayStatus', () => ({
+  useGatewayStatus: () => ({ configured: false, loading: false, reachable: false, status: null, refresh: vi.fn() }),
+}))
+vi.mock('../../lib/bridge/bridgeStatus', async (orig) => ({
+  ...(await orig()),
+  fetchBridgeStatus: vi.fn(() => Promise.reject(new Error('no gateway'))),
+}))
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract() {
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          if (prop === 'filters') return new Proxy({}, { get: (_f, name) => () => ({ __event: String(name) }) })
+          const key = String(prop)
+          return (...args) => (m.reads[key] ? m.reads[key](...args) : Promise.resolve(undefined))
+        },
+      },
+    )
+  }
+  const FakeCtor = vi.fn(FakeContract)
+  return { ...actual, Contract: FakeCtor, ethers: { ...actual.ethers, Contract: FakeCtor } }
+})
+
+import BridgeTab from '../../components/admin/BridgeTab'
+import SupplyTab from '../../components/admin/SupplyTab'
+
+const USDC_ETH = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+const VALID = '0x00000000000000000000000000000000000000a1'
+
+const ROUTE = {
+  inputToken: USDC_ETH,
+  outputToken: USDC_ETH,
+  destinationChainId: 137n,
+  maxAmount: 0n,
+  expectedFillSeconds: 900n,
+  enabled: true,
+  nativeInput: false,
+}
+const RETIRED_POOL = {
+  kind: BigInt(POOL_KIND.TRADING_LP),
+  enabled: false,
+  feeTier: 500n,
+  token0: USDC_ETH,
+  token1: WETH,
+  poolAddress: '0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640',
+  maxDeposit0PerTx: 0n,
+  maxDeposit1PerTx: 0n,
+}
+
+const providerStub = {
+  getBlockNumber: () => Promise.resolve(1_000_000),
+  getBlock: () => Promise.resolve({ timestamp: Math.floor(Date.now() / 1000) - 30 }),
+  getTransactionReceipt: () => Promise.resolve(null),
+}
+
+const tabProps = (overrides = {}) => ({
+  signer: {},
+  chainId: 1,
+  provider: providerStub,
+  runTx: vi.fn(() => Promise.resolve()),
+  pendingTx: false,
+  isAdmin: true,
+  isLiquidityAdmin: true,
+  isGuardian: true,
+  ...overrides,
+})
+
+beforeEach(() => {
+  m.events = {}
+  m.reads = {
+    // Both routers are PAUSED for every test in this file.
+    paused: () => Promise.resolve(true),
+    MAX_FEE_BPS: () => Promise.resolve(250n),
+    spokePool: () => Promise.resolve(VALID),
+    feeRouter: () => Promise.resolve(VALID),
+    positionManager: () => Promise.resolve(VALID),
+    sanctionsGuard: () => Promise.resolve(VALID),
+    routeCount: () => Promise.resolve(1n),
+    routeAt: () => Promise.resolve('0xroute1'),
+    getRoute: () => Promise.resolve(ROUTE),
+    poolCount: () => Promise.resolve(1n),
+    poolAt: () => Promise.resolve('0xpool1'),
+    getPool: () => Promise.resolve(RETIRED_POOL),
+    queryFilter: (filter) => Promise.resolve(m.events[filter?.__event] || []),
+  }
+})
+
+describe('a paused BridgeRouter stops new bridges and reaches no moving one', () => {
+  it('says exactly that in the status line and on the control', async () => {
+    render(<BridgeTab {...tabProps()} />)
+    expect(
+      await screen.findByText(/PAUSED — no new bridges start\. Transfers already moving are unaffected\./),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Resume bridging' })).toBeInTheDocument()
+
+    const pauseCard = screen.getByText('Emergency pause').closest('.admin-card')
+    expect(pauseCard.textContent).toMatch(/cannot touch a transfer already moving/i)
+    expect(pauseCard.textContent).toMatch(/a pause never traps member value/i)
+    // FR-044: the pause does not depend on optional infrastructure being healthy.
+    expect(pauseCard.textContent).toMatch(/no dependency on the gateway or any other optional service/i)
+  })
+
+  it('keeps reporting an in-flight transfer while paused', async () => {
+    m.events.BridgeInitiated = [
+      {
+        blockNumber: 999_000,
+        index: 0,
+        transactionHash: '0xdead',
+        args: {
+          routeId: '0xroute1',
+          member: VALID,
+          recipient: VALID,
+          destinationChainId: 137n,
+          grossAmount: 1_000_000n,
+          feeAmount: 0n,
+        },
+      },
+    ]
+    render(<BridgeTab {...tabProps()} />)
+    const table = await screen.findByRole('table', { name: 'Recent bridges' })
+    // Started 30s ago against a 15-minute window: still on its way, pause or no pause.
+    expect(within(table).getByText('Sent')).toBeInTheDocument()
+    expect(screen.getByText(/This panel is observational only\./)).toBeInTheDocument()
+  })
+
+  it('offers no control that claims to recall or refund one', () => {
+    // The contract has no such function, so no button may suggest it exists.
+    expect(BRIDGE_ROUTER_ABI.some((f) => /rescue|recall|refund|cancelDeposit/i.test(f))).toBe(false)
+  })
+})
+
+describe('a paused LiquidityRouter leaves every position withdrawable', () => {
+  it('says positions are untouched and still withdrawable', async () => {
+    render(<SupplyTab {...tabProps()} />)
+    expect(
+      await screen.findByText(/PAUSED — no new Uniswap supplies\. Existing positions are untouched and still withdrawable\./),
+    ).toBeInTheDocument()
+    const pauseCard = screen.getByText('Emergency pause').closest('.admin-card')
+    expect(pauseCard.textContent).toMatch(/Nothing here can trap member value/i)
+    expect(pauseCard.textContent).toMatch(/withdrawing never went through this router in the first place/i)
+  })
+
+  it('still lists a retired pool while paused — that is when it is most needed', async () => {
+    render(<SupplyTab {...tabProps()} />)
+    const table = await screen.findByRole('table', { name: 'Curated pools' })
+    expect(within(table).getByText(/RETIRED — closed to new deposits, still withdrawable/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reopen' })).toBeInTheDocument()
+  })
+
+  it('has no way to remove a pool at all — retirement is the only exit from the list', () => {
+    expect(LIQUIDITY_ROUTER_ABI.some((f) => /removePool/.test(f))).toBe(false)
+    expect(LIQUIDITY_ROUTER_ABI.some((f) => /setPoolEnabled/.test(f))).toBe(true)
+    // Nor is there any withdrawal entrypoint: exits never route through the router, so no
+    // router state — paused, retired, or misconfigured — can stand between a member and theirs.
+    expect(LIQUIDITY_ROUTER_ABI.some((f) => /function (withdraw|burn|collect|decreaseLiquidity)/i.test(f))).toBe(false)
+  })
+})

--- a/frontend/src/test/adminNav.test.js
+++ b/frontend/src/test/adminNav.test.js
@@ -1,9 +1,15 @@
 import { describe, it, expect } from 'vitest'
+import { ethers } from 'ethers'
 import {
   buildAdminNavGroups,
   flattenNavGroups,
   ADMIN_TAB_ICONS,
 } from '../components/admin/adminNav'
+import { ROLES, ROLE_INFO, ADMIN_ROLES } from '../contexts/RoleContext'
+import { getRoleHash } from '../utils/blockchainService'
+import adminPanelSource from '../components/AdminPanel.jsx?raw'
+import blockchainServiceSource from '../utils/blockchainService.js?raw'
+import walletContextSource from '../contexts/WalletContext.jsx?raw'
 
 const NO_ROLES = {
   isAdmin: false,
@@ -12,6 +18,8 @@ const NO_ROLES = {
   isRoleManager: false,
   isSanctionsAdmin: false,
   isFeeAdmin: false,
+  isStakingAdmin: false,
+  isLiquidityAdmin: false,
 }
 
 const ids = (groups) => flattenNavGroups(groups).map((i) => i.id)
@@ -31,6 +39,7 @@ describe('buildAdminNavGroups', () => {
       'Incident Response',
       'Compliance',
       'Membership & Revenue',
+      'Liquidity',
       'Protocol Config',
       'Identity',
       'Access Control',
@@ -89,6 +98,67 @@ describe('buildAdminNavGroups', () => {
     expect(flat).not.toContain('treasury')
   })
 
+  // Spec 067 (FR-040 / FR-049): the Bridge + Supply control surfaces.
+  describe('Liquidity group (spec 067)', () => {
+    it('a liquidity admin reaches Bridge and Supply and nothing else privileged', () => {
+      const groups = buildAdminNavGroups({ ...NO_ROLES, isLiquidityAdmin: true })
+      const flat = ids(groups)
+      expect(flat).toContain('bridge')
+      expect(flat).toContain('supply')
+      expect(labels(groups)).toContain('Liquidity')
+      // Configuring routes and pools is not a licence to touch anything else.
+      expect(flat).not.toContain('protocol-config')
+      expect(flat).not.toContain('oracle-adapters')
+      expect(flat).not.toContain('staking')
+      expect(flat).not.toContain('fees')
+      expect(flat).not.toContain('tiers')
+      expect(flat).not.toContain('treasury')
+      expect(flat).not.toContain('admin-roles')
+      expect(flat).not.toContain('emergency')
+    })
+
+    it('a guardian reaches both tabs (the pause lives there)', () => {
+      const flat = ids(buildAdminNavGroups({ ...NO_ROLES, isGuardian: true }))
+      expect(flat).toContain('bridge')
+      expect(flat).toContain('supply')
+    })
+
+    it('a full admin reaches both tabs without the dedicated role', () => {
+      const flat = ids(buildAdminNavGroups({ ...NO_ROLES, isAdmin: true }))
+      expect(flat).toContain('bridge')
+      expect(flat).toContain('supply')
+    })
+
+    it('an operator with none of admin/liquidity-admin/guardian sees neither tab', () => {
+      const withOtherRoles = buildAdminNavGroups({
+        ...NO_ROLES,
+        isAccountModerator: true,
+        isRoleManager: true,
+        isSanctionsAdmin: true,
+        isFeeAdmin: true,
+        isStakingAdmin: true,
+      })
+      const flat = ids(withOtherRoles)
+      expect(flat).not.toContain('bridge')
+      expect(flat).not.toContain('supply')
+      expect(labels(withOtherRoles)).not.toContain('Liquidity')
+    })
+
+    it('sits outside Protocol Config — member-value surfaces, not protocol wiring', () => {
+      const groups = buildAdminNavGroups({ ...NO_ROLES, isAdmin: true, isGuardian: true })
+      const protocolConfig = groups.find((g) => g.label === 'Protocol Config')
+      const liquidity = groups.find((g) => g.label === 'Liquidity')
+      expect(protocolConfig.items.map((i) => i.id)).not.toContain('bridge')
+      expect(protocolConfig.items.map((i) => i.id)).not.toContain('supply')
+      expect(liquidity.items.map((i) => i.label)).toEqual(['Bridge', 'Supply'])
+    })
+
+    it('uses the transfer and sprout glyphs', () => {
+      expect(ADMIN_TAB_ICONS.bridge).toBe('transfer')
+      expect(ADMIN_TAB_ICONS.supply).toBe('sprout')
+    })
+  })
+
   it('every view carries a known NavIcon glyph for the mobile quick-nav', () => {
     const groups = buildAdminNavGroups({
       isAdmin: true,
@@ -100,6 +170,85 @@ describe('buildAdminNavGroups', () => {
     for (const item of flattenNavGroups(groups)) {
       expect(item.icon, `icon for ${item.id}`).toBe(ADMIN_TAB_ICONS[item.id])
       expect(item.icon).toBeTruthy()
+    }
+  })
+})
+
+/**
+ * Spec 067 T122 — the LIQUIDITY_ADMIN_ROLE plumbing behind the nav flag.
+ *
+ * The flag is only meaningful if the role is declared as an admin role (so a
+ * liquidity-admin-only operator can enter the panel at all), hashes to the
+ * on-chain role id, and is resolved against BOTH routers — the role is defined
+ * independently on the BridgeRouter and the LiquidityRouter.
+ */
+describe('LIQUIDITY_ADMIN_ROLE resolution (spec 067)', () => {
+  it('is a first-class admin role with a described purpose', () => {
+    expect(ROLES.LIQUIDITY_ADMIN).toBe('LIQUIDITY_ADMIN')
+    expect(ADMIN_ROLES).toContain(ROLES.LIQUIDITY_ADMIN)
+    expect(ROLE_INFO[ROLES.LIQUIDITY_ADMIN].isAdminRole).toBe(true)
+    expect(ROLE_INFO[ROLES.LIQUIDITY_ADMIN].premium).toBe(false)
+  })
+
+  it('hashes to keccak256("LIQUIDITY_ADMIN_ROLE")', () => {
+    expect(getRoleHash('LIQUIDITY_ADMIN')).toBe(
+      ethers.keccak256(ethers.toUtf8Bytes('LIQUIDITY_ADMIN_ROLE'))
+    )
+  })
+
+  it('is read from both routers, either of which may be undeployed', () => {
+    // VITE_SKIP_BLOCKCHAIN_CALLS short-circuits hasRoleOnChain under vitest, so
+    // the resolution branch is asserted at the source level: both routers are
+    // candidates, and an address that resolves empty is simply not pushed.
+    const branch = blockchainServiceSource.split("roleName === 'LIQUIDITY_ADMIN'")[1] || ''
+    expect(branch).toContain("resolveAddress('bridgeRouter')")
+    expect(branch).toContain("resolveAddress('liquidityRouter')")
+    expect(branch).toMatch(/if \(bridge\) candidates\.push\(bridge\)/)
+    expect(branch).toMatch(/if \(liquidity\) candidates\.push\(liquidity\)/)
+  })
+
+  it('is synced from chain on connect like the other admin roles', () => {
+    expect(walletContextSource).toMatch(/const adminRoles = \[[^\]]*'LIQUIDITY_ADMIN'/)
+  })
+
+  it('the AdminPanel reads the flag and passes it to the nav builder', () => {
+    expect(adminPanelSource).toContain('hasRole(ROLES.LIQUIDITY_ADMIN)')
+    expect(adminPanelSource).toMatch(/isLiquidityAdmin,\s*\}\)/)
+  })
+
+  it('grants target one router at a time — the role lives on both', () => {
+    // A single "LIQUIDITY_ADMIN" option would authorize half of what the
+    // operator asked for, silently. The picker names the router instead.
+    expect(adminPanelSource).toContain('LIQUIDITY_ADMIN_BRIDGE')
+    expect(adminPanelSource).toContain('LIQUIDITY_ADMIN_LIQUIDITY')
+    expect(adminPanelSource).toMatch(/role === 'LIQUIDITY_ADMIN_BRIDGE'[\s\S]{0,60}return bridgeRouterAddr/)
+    expect(adminPanelSource).toMatch(/role === 'LIQUIDITY_ADMIN_LIQUIDITY'[\s\S]{0,60}return liquidityRouterAddr/)
+  })
+
+  it('GUARDIAN is grantable per router too — the killswitch has to be delegable', () => {
+    // The plain GUARDIAN option grants on the WagerRegistry, so before these existed there was NO
+    // in-app way to give an on-call operator the routers' pause: they grant it only to their
+    // `initialize` admin. An emergency lever that cannot be delegated is a single point of failure.
+    expect(adminPanelSource).toContain('GUARDIAN_BRIDGE')
+    expect(adminPanelSource).toContain('GUARDIAN_LIQUIDITY')
+    expect(adminPanelSource).toMatch(/role === 'GUARDIAN_BRIDGE'[\s\S]{0,60}return bridgeRouterAddr/)
+    expect(adminPanelSource).toMatch(/role === 'GUARDIAN_LIQUIDITY'[\s\S]{0,60}return liquidityRouterAddr/)
+  })
+
+  it('every role that can open the panel appears in the permissions card', () => {
+    // FEE_ADMIN, STAKING_ADMIN and LIQUIDITY_ADMIN were in ROLES, in ADMIN_ROLES and in the nav but
+    // not in this card, so an operator holding one read a list of × and concluded their grant had not
+    // landed. A permissions card that omits a role it let you in on is worse than no card.
+    for (const flag of ['isFeeAdmin', 'isStakingAdmin', 'isLiquidityAdmin']) {
+      expect(adminPanelSource).toMatch(new RegExp(`permission-item \\$\\{${flag} \\?`))
+    }
+  })
+
+  it('both tab bodies are gated exactly like the nav items (no direct-id bypass)', () => {
+    for (const tab of ['bridge', 'supply']) {
+      expect(adminPanelSource).toContain(
+        `activeTab === '${tab}' && (isAdmin || isLiquidityAdmin || isGuardian)`
+      )
     }
   })
 })

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -657,6 +657,7 @@ const ROLE_NAME_TO_HASH = {
   'ROLE_MANAGER': ethers.keccak256(ethers.toUtf8Bytes('ROLE_MANAGER_ROLE')),
   'SANCTIONS_ADMIN': ethers.keccak256(ethers.toUtf8Bytes('SANCTIONS_ADMIN_ROLE')),
   'FEE_ADMIN': ethers.keccak256(ethers.toUtf8Bytes('FEE_ADMIN_ROLE')),
+  'LIQUIDITY_ADMIN': ethers.keccak256(ethers.toUtf8Bytes('LIQUIDITY_ADMIN_ROLE')),
 }
 
 // Minimal ABI for role manager contract
@@ -1027,12 +1028,43 @@ export async function hasRoleOnChain(userAddress, roleName, chainId) {
     // FEE_ADMIN lives on the FeeRouter (spec 060); no router deployed => nobody holds it here.
     const addr = resolveAddress('feeRouter')
     if (addr) candidates.push(addr)
+  } else if (roleName === 'LIQUIDITY_ADMIN') {
+    // LIQUIDITY_ADMIN_ROLE (spec 067) is defined independently on BOTH the
+    // BridgeRouter and the LiquidityRouter, so it is resolved as "holds it on
+    // at least one deployed router": undeployed routers are skipped rather
+    // than treated as a denial (the loop below is an OR), and if neither is
+    // deployed on this network nobody holds it here. The admin tabs then
+    // re-check per-router before offering a write, so an operator who holds
+    // the role on one router cannot be shown a control the other would revert.
+    const bridge = resolveAddress('bridgeRouter')
+    if (bridge) candidates.push(bridge)
+    const liquidity = resolveAddress('liquidityRouter')
+    if (liquidity) candidates.push(liquidity)
   } else {
     const wager = resolveAddress('wagerRegistry')
     if (wager) candidates.push(wager)
     if (roleName === 'ADMIN') {
       const mm = resolveAddress('membershipManager')
       if (mm) candidates.push(mm)
+    }
+    if (roleName === 'ADMIN' || roleName === 'GUARDIAN') {
+      // The spec-067 routers define DEFAULT_ADMIN_ROLE and GUARDIAN_ROLE on THEMSELVES, and they
+      // are deployed on networks that have no WagerRegistry at all — Ethereum, Optimism, Base and
+      // Arbitrum carry the two routers and nothing else. Resolving these two roles only against the
+      // WagerRegistry therefore returned false for EVERY account on four of the five spec-067
+      // networks, including the account that actually holds the routers' killswitch, which hid the
+      // Bridge/Supply tabs and their emergency pause from the one operator who could use them.
+      //
+      // As with LIQUIDITY_ADMIN above, this is an OR across deployed contracts and is a COARSE
+      // entry signal only — "you are an admin/guardian of something here". It is not authority to
+      // act on a particular router: the Bridge and Supply tabs read `hasRole` on the specific
+      // router for the specific network in scope before offering any control (see
+      // `readRouterAuthority`), because holding GUARDIAN on the WagerRegistry is not holding it on
+      // the BridgeRouter.
+      const bridge = resolveAddress('bridgeRouter')
+      if (bridge) candidates.push(bridge)
+      const liquidity = resolveAddress('liquidityRouter')
+      if (liquidity) candidates.push(liquidity)
     }
   }
   for (const addr of candidates) {

--- a/specs/067-bridge-pool-liquidity/contracts/admin-and-runtime.md
+++ b/specs/067-bridge-pool-liquidity/contracts/admin-and-runtime.md
@@ -22,7 +22,8 @@ are member-value surfaces with their own killswitches, not protocol wiring, so t
 ```
 
 `ADMIN_TAB_ICONS`: `bridge: 'transfer'`, `supply: 'sprout'`. `buildAdminNavGroups` takes a new
-`isLiquidityAdmin` flag, resolved from `LIQUIDITY_ADMIN_ROLE` on either router.
+`isLiquidityAdmin` flag, resolved from `LIQUIDITY_ADMIN_ROLE` on either router. That flag gates ENTRY
+only; each control is gated by a `hasRole` read against the router in scope (see corrections below).
 
 An operator holding none of admin / liquidity-admin / guardian sees neither tab and cannot reach either
 by direct URL (FR-040, FR-049).
@@ -37,7 +38,7 @@ Modeled on `StakingTab.jsx` (366 lines) and `ProtocolConfigTab.jsx`.
 |---|---|---|
 | **Status** | Paused banner; `pause` / `unpause` | `GUARDIAN_ROLE` |
 | **Routes** | Table (asset, origin → destination, enabled, max amount, expected fill) across the 20 directed mainnet routes. Add / edit / enable / disable / remove; bulk enable/disable per network pair | `LIQUIDITY_ADMIN_ROLE` |
-| **Addresses** | `spokePool`, `feeRouter` — current value shown beside the input; invalid input rejected with a reason before submit (FR-042) | `LIQUIDITY_ADMIN_ROLE` |
+| **Addresses** | `spokePool`, `feeRouter` — current value shown beside the input; invalid input rejected with a reason before submit (FR-042) | `DEFAULT_ADMIN_ROLE` — fund-path, see corrections below |
 | **Fee** | `bridge.transfer` live rate + 250 bps cap, **read-only**, with a link to the Fees tab | read-only |
 | **Operations** (FR-047) | In-flight bridges; transfers past `expectedBy` needing attention; recent deliveries and refunds; gateway health | read-only |
 | **History** (FR-046) | Decoded router events — action, route, before → after, operator, time | read-only |
@@ -55,7 +56,7 @@ not in that path. The tab should say so, so nobody goes looking for a rescue but
 |---|---|---|
 | **Status** | Paused banner; `pause` / `unpause` — **labelled as affecting Uniswap supplies only**. Shown per network across all five deployments | `GUARDIAN_ROLE` |
 | **Pools** | Table (kind, pair/asset, protocol, network, enabled, cap, supplied total, position count) spanning all five networks. List / edit / retire / set cap | `LIQUIDITY_ADMIN_ROLE` |
-| **Addresses** | `positionManager`, `feeRouter` | `LIQUIDITY_ADMIN_ROLE` |
+| **Addresses** | `positionManager`, `feeRouter` | `DEFAULT_ADMIN_ROLE` — fund-path, see corrections below |
 | **Fee** | `liquidity.deposit` live rate + cap, read-only; an explicit note that bridge-LP pools are fee-free by design with a link to the rationale | read-only |
 | **History** | Decoded router events | read-only |
 
@@ -122,6 +123,33 @@ absence with a stated reason.
 ## Role provisioning
 
 `LIQUIDITY_ADMIN_ROLE = keccak256("LIQUIDITY_ADMIN_ROLE")`, granted on both routers at initialize to the
-admin and thereafter managed from the existing **Admin Roles** tab, which enumerates roles generically —
-no new role-management UI is needed. `GUARDIAN_ROLE` reuses the existing guardian set so the emergency
-pause is exercisable by the operators who already hold incident authority (FR-044).
+admin and thereafter managed from the existing **Admin Roles** tab.
+
+### Corrections found in the US4 security audit
+
+Three assumptions above were wrong in ways that mattered, and the implementation differs from them:
+
+1. **Protocol-wiring addresses are `DEFAULT_ADMIN_ROLE`, not `LIQUIDITY_ADMIN_ROLE`** (the Addresses rows
+   in both tables). `spokePool` is approved and handed the member's net amount; `positionManager` is
+   approved and mints the member's position; `feeRouter` names both the rate and the `treasury()` the fee
+   is transferred to. Whoever can write them can redirect where member funds go, which is not the same
+   authority as deciding which routes and pools are offered. Curating badly is reversible by a toggle;
+   pointing a router at a hostile contract is not.
+
+2. **`GUARDIAN_ROLE` does NOT reuse the existing guardian set.** It cannot: each router checks
+   `GUARDIAN_ROLE` on its own AccessControl instance, and holding it on the WagerRegistry carries no
+   authority over a router. As written, the emergency pause was grantable to nobody but each router's
+   `initialize` admin — an undelegable killswitch. The Admin Roles tab now offers `GUARDIAN_BRIDGE` and
+   `GUARDIAN_LIQUIDITY` alongside the two per-router liquidity-admin targets, and FR-044 is satisfied by
+   granting those, not by inheriting the wager guardians.
+
+3. **The role flags in `useRoles()` are an entry signal only, never a control gate.** They are resolved
+   on the WALLET's chain against a candidate contract list; four of the five spec-067 networks (Ethereum,
+   Optimism, Base, Arbitrum) carry no WagerRegistry at all, so `isAdmin`/`isGuardian` were false there for
+   every account including each router's real admin. Both tabs read `hasRole` on the specific router for
+   the specific network in scope (`readRouterAuthority`). An unreadable answer is reported as unconfirmed
+   and the controls stay offered — the contract is the gate, and withdrawing a killswitch because an RPC
+   timed out is the FR-044 failure it exists to prevent.
+
+Both routers additionally bound the fee they will pay out to `MAX_FEE_BPS` **of the amount**, and require
+`quoteFee` to split exactly, rather than trusting the configured FeeRouter's `feeBps()` report of itself.

--- a/specs/067-bridge-pool-liquidity/tasks.md
+++ b/specs/067-bridge-pool-liquidity/tasks.md
@@ -260,23 +260,78 @@ admin control panel without a redeploy.
 availability, and pause/resume — each visible to members within one refresh and recorded in history with
 actor and timestamp. As an unauthorized operator, confirm the controls are neither visible nor actionable.
 
-- [ ] T121 [US4] Add the **Liquidity** group with `bridge` and `supply` items, the `isLiquidityAdmin` flag, and both tab icons to `frontend/src/components/admin/adminNav.js`
-- [ ] T122 [P] [US4] Resolve `LIQUIDITY_ADMIN_ROLE` membership and pass `isLiquidityAdmin` into `buildAdminNavGroups`, in `frontend/src/hooks/useAdminRoles.js`
-- [ ] T123 [US4] Create `frontend/src/components/admin/BridgeTab.jsx` with Status, Routes, Addresses, Fee (read-only), Operations, and History sections per [contracts/admin-and-runtime.md](./contracts/admin-and-runtime.md)
-- [ ] T124 [US4] (SC-017) Implement route add/edit/enable/disable/remove plus bulk per-network-pair toggles across the 20 directed routes in `frontend/src/components/admin/BridgeTab.jsx` (FR-041)
-- [ ] T125 [US4] Implement address editing with the current value shown and invalid input rejected with a reason before submit, in `frontend/src/components/admin/BridgeTab.jsx` (FR-042)
-- [ ] T126 [US4] Implement the Operations panel (in-flight, past-`expectedBy`, recent completions/refunds, gateway health) in `frontend/src/components/admin/BridgeTab.jsx`, stating plainly that it is observational — no operator action can touch an in-flight bridge (FR-047)
-- [ ] T127 [US4] Create `frontend/src/components/admin/SupplyTab.jsx` with Status, Pools, Addresses, Fee (read-only), and History sections spanning all five networks
-- [ ] T128 [US4] Label the Supply pause control **"Pauses new Uniswap supplies"** in `frontend/src/components/admin/SupplyTab.jsx` — bridge-LP deposits bypass the router, so the contract cannot stop them and the tab must not imply otherwise (research R3)
-- [ ] T129 [US4] Show retired pools as **retired, not gone**, with their position count, in `frontend/src/components/admin/SupplyTab.jsx` (FR-024)
-- [ ] T130 [P] [US4] Implement per-transaction bridge maximum editing in `frontend/src/components/admin/BridgeTab.jsx` and per-pool deposit cap editing in `frontend/src/components/admin/SupplyTab.jsx`, each honoured and explained in the member flows (FR-045)
-- [ ] T131 [P] [US4] Implement decoded event history (action, target, before → after, operator, time) in `frontend/src/components/admin/BridgeTab.jsx` and `frontend/src/components/admin/SupplyTab.jsx` (FR-046)
-- [ ] T132 [P] [US4] Show the live fee rate and cap read-only with a link to the Fees tab, and state plainly when `FeeRouter` is undeployed or unreachable while keeping other controls usable, in both admin tabs (FR-048/FR-051)
-- [ ] T133 [P] [US4] (SC-011) Tests asserting least-privilege — an operator with none of admin/liquidity-admin/guardian sees neither tab and can perform no control action by any route — in `frontend/src/test/admin/`
-- [ ] T134 [P] [US4] Tests asserting pause stops new value in while in-flight bridges settle and existing positions stay withdrawable, in `frontend/src/test/admin/`
-- [ ] T135 [P] [US4] vitest-axe coverage for both admin tabs in `frontend/src/test/admin/` (SC-014)
-- [ ] T156 [P] [US4] Test that **pause and resume still work with every optional service unavailable** — gateway unset and unreachable — for both routers, in `test/bridge/BridgeRouter.test.js` and `test/liquidity/LiquidityRouter.test.js` (FR-044). A killswitch that depends on optional infrastructure is not a killswitch
-- [ ] T157 [P] [US4] Test that control state and history are **scoped per network** and that no testnet control state reaches a mainnet surface, in `frontend/src/test/admin/` (FR-050)
+- [X] T121 [US4] Add the **Liquidity** group with `bridge` and `supply` items, the `isLiquidityAdmin` flag, and both tab icons to `frontend/src/components/admin/adminNav.js`
+- [X] T122 [P] [US4] Resolve `LIQUIDITY_ADMIN_ROLE` membership and pass `isLiquidityAdmin` into `buildAdminNavGroups` — **path corrected**: there is no `frontend/src/hooks/useAdminRoles.js` in this codebase and none was invented. Role flags are resolved in `frontend/src/components/AdminPanel.jsx` (the `isStakingAdmin` precedent), with the role declared in `contexts/RoleContext.js`, synced in `contexts/WalletContext.jsx`, and read from BOTH routers in `utils/blockchainService.js#hasRoleOnChain`
+- [X] T123 [US4] Create `frontend/src/components/admin/BridgeTab.jsx` with Status, Routes, Addresses, Fee (read-only), Operations, and History sections per [contracts/admin-and-runtime.md](./contracts/admin-and-runtime.md)
+- [X] T124 [US4] (SC-017) Implement route add/edit/enable/disable/remove plus bulk per-network-pair toggles across the 20 directed routes in `frontend/src/components/admin/BridgeTab.jsx` (FR-041)
+- [X] T125 [US4] Implement address editing with the current value shown and invalid input rejected with a reason before submit, in `frontend/src/components/admin/BridgeTab.jsx` (FR-042)
+- [X] T126 [US4] Implement the Operations panel (in-flight, past-`expectedBy`, recent completions/refunds, gateway health) in `frontend/src/components/admin/BridgeTab.jsx`, stating plainly that it is observational — no operator action can touch an in-flight bridge (FR-047)
+- [X] T127 [US4] Create `frontend/src/components/admin/SupplyTab.jsx` with Status, Pools, Addresses, Fee (read-only), and History sections spanning all five networks
+- [X] T128 [US4] Label the Supply pause control **"Pauses new Uniswap supplies"** in `frontend/src/components/admin/SupplyTab.jsx` — bridge-LP deposits bypass the router, so the contract cannot stop them and the tab must not imply otherwise (research R3)
+- [X] T129 [US4] Show retired pools as **retired, not gone**, with their position count, in `frontend/src/components/admin/SupplyTab.jsx` (FR-024)
+- [X] T130 [P] [US4] Implement per-transaction bridge maximum editing in `frontend/src/components/admin/BridgeTab.jsx` and per-pool deposit cap editing in `frontend/src/components/admin/SupplyTab.jsx`, each honoured and explained in the member flows (FR-045)
+- [X] T131 [P] [US4] Implement decoded event history (action, target, before → after, operator, time) in `frontend/src/components/admin/BridgeTab.jsx` and `frontend/src/components/admin/SupplyTab.jsx` (FR-046)
+- [X] T132 [P] [US4] Show the live fee rate and cap read-only with a link to the Fees tab, and state plainly when `FeeRouter` is undeployed or unreachable while keeping other controls usable, in both admin tabs (FR-048/FR-051)
+- [X] T133 [P] [US4] (SC-011) Tests asserting least-privilege — an operator with none of admin/liquidity-admin/guardian sees neither tab and can perform no control action by any route — in `frontend/src/test/admin/`
+- [X] T134 [P] [US4] Tests asserting pause stops new value in while in-flight bridges settle and existing positions stay withdrawable, in `frontend/src/test/admin/`
+- [X] T135 [P] [US4] vitest-axe coverage for both admin tabs in `frontend/src/test/admin/` (SC-014)
+- [X] T156 [P] [US4] Test that **pause and resume still work with every optional service unavailable** — gateway unset and unreachable — for both routers, in `test/bridge/BridgeRouter.test.js` and `test/liquidity/LiquidityRouter.test.js` (FR-044). A killswitch that depends on optional infrastructure is not a killswitch
+- [X] T157 [P] [US4] Test that control state and history are **scoped per network** and that no testnet control state reaches a mainnet surface, in `frontend/src/test/admin/` (FR-050)
+
+### US4 audit remediation (post-build, three adversarial lenses)
+
+An operator-honesty / least-privilege / regression audit of the finished US4 surfaces returned 23
+findings; 1 critical, 6 high. These were fixed in the same phase — the critical one made the emergency
+pause structurally unreachable on 4 of the 5 networks, which is the opposite of what US4 exists for.
+
+- [X] T157a [US4] **Contracts — the fee ceiling now binds the fee TAKEN, not the rate the FeeRouter
+      reports about itself.** Both routers checked `MAX_FEE_BPS` against `feeBps()` and then transferred
+      whatever `quoteFee()` returned, unbounded: a FeeRouter reporting 0 bps while quoting 99% passed
+      every check and drained the member. Both now bound the returned amount and require an exact
+      fee/net split (`FeeSplitMismatch`). `contracts/mocks/MockLyingFeeRouter.sol` is the regression.
+- [X] T157b [US4] **Contracts — protocol-wiring setters moved to `DEFAULT_ADMIN_ROLE`.**
+      `setSpokePool` / `setPositionManager` / `setFeeRouter` / `setSanctionsGuard` were
+      `LIQUIDITY_ADMIN_ROLE`, the same role as "enable a route" — so a route curator could redirect
+      member funds. `setPositionManager` also now rejects the zero address.
+- [X] T157c [US4] **(CRITICAL) Authority is read from the router in scope, not from the app-wide role
+      flags.** `hasRole(ADMIN|GUARDIAN)` resolved only against `wagerRegistry`/`membershipManager`,
+      which do not exist on Ethereum / Optimism / Base / Arbitrum — so `canPause` was false for EVERY
+      account on four of five networks, including each router's real guardian, and the pause card
+      rendered nothing at all. Added `readRouterAuthority` + `authorityGates`; both tabs now ask the
+      specific router for the specific network. An unreadable answer keeps the controls offered and
+      says it is unconfirmed (FR-044); a definite "no" renders the card with the reason and where the
+      role comes from, never an empty space.
+- [X] T157d [US4] **`GUARDIAN_ROLE` is grantable per router.** The Roles tab could only grant it on the
+      WagerRegistry, so the routers' killswitch was undelegable — held by the `initialize` admin alone.
+- [X] T157e [US4] **The fee card quotes the FeeRouter the router actually holds**, and says plainly when
+      that disagrees with the app config (members are then quoted by a contract that is not charging
+      them, and the member path refuses rather than overcharging).
+- [X] T157f [US4] **`applyCaps` no longer deletes the untouched leg's ceiling.** `setPoolLimit` writes
+      both legs and 0 means uncapped, so typing one cap silently removed the other and reported success.
+- [X] T157g [US4] **No false zeros.** A failed deposit scan stored `byPool: {}` and the cells fell through
+      to `?? 0`, printing "0 positions" for a pool members still hold LP in — the one claim FR-024 exists
+      to prevent. Bridge-pool SIZE is now read from the HubPool (it was withheld as "not observable"
+      while the member view read exactly that); only the per-member COUNT genuinely needs an indexer.
+- [X] T157h [US4] **Bulk route toggles actually stop on the first refusal.** `runTx` swallowed every
+      error and resolved with no signal, so rejecting the first prompt to abort still fired the rest;
+      `runTx` now resolves a boolean and the loop honours it.
+- [X] T157i [US4] **Operations panel: late outranks recent**, so a stuck transfer is not evicted by ten
+      newer ones that are fine; a route whose curation was removed reports its window as UNKNOWN rather
+      than not-late; `removeRoute` confirms first and names that consequence; and the panel states what
+      it could not show.
+- [X] T157j [US4] **Scope switches clear state first**, so the previous network's pause banner cannot
+      render under the newly-selected network's name (FR-050/FR-052).
+- [X] T157k [US4] **History no longer claims a route/pool went live when it did not.** `RouteSet` and
+      `PoolListed` carry no `enabled` field, so `args.enabled === false` was always false.
+- [X] T157l [US4] **The permissions card and header badge name every role that can open the panel** —
+      `FEE_ADMIN`, `STAKING_ADMIN` and `LIQUIDITY_ADMIN` were missing, so holders read a list of × and
+      concluded their grant had not landed while being badged "Admin".
+
+**Still open, reported not fixed:** `test/WagerRegistry.coverage.test.js` and
+`test/intent/WagerRegistryIntents.coverage.test.js` (1,043 lines of spec-035/046 coverage) were untracked
+scratch work swept into PR #961 by a `git add -A`. They pass (56 tests) and are legitimate coverage, but
+they shipped under a bridge/liquidity PR and were reviewed as such. Left in place; re-attribution is a
+call for the maintainer.
 
 **Checkpoint**: every member-facing surface has a working operator control.
 

--- a/test/bridge/BridgeRouter.test.js
+++ b/test/bridge/BridgeRouter.test.js
@@ -173,22 +173,38 @@ describe("BridgeRouter", function () {
       expect(await router.routeCount()).to.equal(2);
     });
 
-    it("rejects setSpokePool from a caller without LIQUIDITY_ADMIN_ROLE", async function () {
-      await expect(router.connect(stranger).setSpokePool(stranger.address))
-        .to.be.revertedWithCustomError(router, "AccessControlUnauthorizedAccount");
+    // The protocol-wiring setters are DEFAULT_ADMIN_ROLE, a role ABOVE curation. `spokePool` is
+    // approved and handed the member's net amount and `feeRouter` names the treasury the fee is
+    // transferred to, so whoever can write them can redirect where member funds go — that is not the
+    // same authority as deciding which routes are offered. A LIQUIDITY_ADMIN holder is rejected here
+    // on purpose; the assertions below are the privilege boundary, not incidental coverage.
+    it("rejects the protocol-wiring setters from LIQUIDITY_ADMIN and from a stranger", async function () {
+      for (const caller of [stranger, liquidityAdmin]) {
+        await expect(router.connect(caller).setSpokePool(caller.address))
+          .to.be.revertedWithCustomError(router, "AccessControlUnauthorizedAccount");
+        await expect(router.connect(caller).setFeeRouter(caller.address))
+          .to.be.revertedWithCustomError(router, "AccessControlUnauthorizedAccount");
+        await expect(router.connect(caller).setSanctionsGuard(caller.address))
+          .to.be.revertedWithCustomError(router, "AccessControlUnauthorizedAccount");
+      }
       expect(await router.spokePool()).to.equal(spokeAddr);
-    });
-
-    it("rejects setFeeRouter from a caller without LIQUIDITY_ADMIN_ROLE", async function () {
-      await expect(router.connect(stranger).setFeeRouter(stranger.address))
-        .to.be.revertedWithCustomError(router, "AccessControlUnauthorizedAccount");
       expect(await router.feeRouter()).to.equal(await feeRouter.getAddress());
+      expect(await router.sanctionsGuard()).to.equal(ethers.ZeroAddress);
     });
 
-    it("rejects setSanctionsGuard from a caller without LIQUIDITY_ADMIN_ROLE", async function () {
-      await expect(router.connect(stranger).setSanctionsGuard(stranger.address))
-        .to.be.revertedWithCustomError(router, "AccessControlUnauthorizedAccount");
-      expect(await router.sanctionsGuard()).to.equal(ethers.ZeroAddress);
+    it("lets DEFAULT_ADMIN_ROLE write the protocol wiring, each emitting its audit event", async function () {
+      await expect(router.connect(admin).setSpokePool(stranger.address))
+        .to.emit(router, "SpokePoolUpdated")
+        .withArgs(spokeAddr, stranger.address, admin.address);
+      expect(await router.spokePool()).to.equal(stranger.address);
+
+      await expect(router.connect(admin).setFeeRouter(stranger.address))
+        .to.emit(router, "FeeRouterUpdated")
+        .withArgs(await feeRouter.getAddress(), stranger.address, admin.address);
+
+      await expect(router.connect(admin).setSanctionsGuard(stranger.address))
+        .to.emit(router, "SanctionsGuardUpdated")
+        .withArgs(ethers.ZeroAddress, stranger.address, admin.address);
     });
 
     it("rejects pause and unpause from a caller without GUARDIAN_ROLE", async function () {
@@ -205,7 +221,7 @@ describe("BridgeRouter", function () {
       expect(await router.paused()).to.equal(true);
     });
 
-    it("lets a LIQUIDITY_ADMIN holder call every setter, each emitting its audit event", async function () {
+    it("lets a LIQUIDITY_ADMIN holder curate routes, each emitting its audit event", async function () {
       const newRoute = route({ destinationChainId: 10n, maxAmount: AMT("5") });
       const newId = await router.computeRouteId(usdcAddr, usdcDest, 10n);
       await expect(router.connect(liquidityAdmin).setRoute(newRoute))
@@ -219,19 +235,6 @@ describe("BridgeRouter", function () {
       await expect(router.connect(liquidityAdmin).setRouteLimit(newId, AMT("9")))
         .to.emit(router, "RouteLimitChanged")
         .withArgs(newId, AMT("5"), AMT("9"), liquidityAdmin.address);
-
-      await expect(router.connect(liquidityAdmin).setSpokePool(stranger.address))
-        .to.emit(router, "SpokePoolUpdated")
-        .withArgs(spokeAddr, stranger.address, liquidityAdmin.address);
-      expect(await router.spokePool()).to.equal(stranger.address);
-
-      await expect(router.connect(liquidityAdmin).setFeeRouter(stranger.address))
-        .to.emit(router, "FeeRouterUpdated")
-        .withArgs(await feeRouter.getAddress(), stranger.address, liquidityAdmin.address);
-
-      await expect(router.connect(liquidityAdmin).setSanctionsGuard(stranger.address))
-        .to.emit(router, "SanctionsGuardUpdated")
-        .withArgs(ethers.ZeroAddress, stranger.address, liquidityAdmin.address);
 
       await expect(router.connect(liquidityAdmin).removeRoute(newId))
         .to.emit(router, "RouteRemoved")
@@ -252,9 +255,9 @@ describe("BridgeRouter", function () {
         .to.be.revertedWithCustomError(router, "RouteUnknown");
       await expect(router.connect(liquidityAdmin).removeRoute(unknown))
         .to.be.revertedWithCustomError(router, "RouteUnknown");
-      await expect(router.connect(liquidityAdmin).setSpokePool(ethers.ZeroAddress))
+      await expect(router.connect(admin).setSpokePool(ethers.ZeroAddress))
         .to.be.revertedWithCustomError(router, "ZeroAddress");
-      await expect(router.connect(liquidityAdmin).setFeeRouter(ethers.ZeroAddress))
+      await expect(router.connect(admin).setFeeRouter(ethers.ZeroAddress))
         .to.be.revertedWithCustomError(router, "ZeroAddress");
     });
   });
@@ -356,10 +359,49 @@ describe("BridgeRouter", function () {
       const fr = await deployFeeRouter([admin.address, ethers.ZeroAddress]);
       await fr.connect(admin).registerService(BRIDGE_TRANSFER, 250, Kind.ConfigOnly);
       await fr.connect(admin).setFeeBps(BRIDGE_TRANSFER, 250);
-      await router.connect(liquidityAdmin).setFeeRouter(await fr.getAddress());
+      await router.connect(admin).setFeeRouter(await fr.getAddress());
 
       await bridge(member, await args({ maxFeeBps: 0 }));
       expect(await spoke.lastInputAmount()).to.equal(AMT("1000")); // whole amount bridged, fee skipped
+    });
+
+    // ---- the ceiling binds the fee TAKEN, not the rate the fee router claims ----
+    //
+    // Adversarial review found that both ceiling checks read `feeBps()` — the FeeRouter's own account
+    // of its rate — while the amount transferred to the treasury came from `quoteFee()`, unbounded. A
+    // FeeRouter reporting 0 bps and quoting 99% therefore passed `liveBps > MAX_FEE_BPS` (0 > 250 is
+    // false) AND `fee > 0 && liveBps > maxFeeBps` (0 > anything is false), and sent the member's
+    // principal to its own treasury. These two tests are that scenario.
+    it("refuses a FeeRouter that under-reports its rate and over-quotes the fee", async function () {
+      const Lying = await ethers.getContractFactory("MockLyingFeeRouter");
+      // Admits to 0 bps; actually takes 99%.
+      const lying = await Lying.deploy(stranger.address, 0, 9_900);
+      await router.connect(admin).setFeeRouter(await lying.getAddress());
+
+      const before = await usdc.balanceOf(member.address);
+      // maxFeeBps 0 — the member consented to no fee at all, and the router reports none.
+      await expect(bridge(member, await args({ maxFeeBps: 0 })))
+        .to.be.revertedWithCustomError(router, "FeeAboveCap");
+      expect(await usdc.balanceOf(member.address)).to.equal(before);
+      expect(await usdc.balanceOf(stranger.address)).to.equal(0n);
+
+      // Exactly at the cap it is allowed through — the bound is on MAX_FEE_BPS, not on honesty.
+      const atCap = await Lying.deploy(treasury.address, 0, 250);
+      await router.connect(admin).setFeeRouter(await atCap.getAddress());
+      await bridge(member, await args({ maxFeeBps: 0 }));
+      expect(await usdc.balanceOf(treasury.address)).to.equal((AMT("1000") * 250n) / BPS);
+    });
+
+    it("refuses a FeeRouter whose fee and net do not add back to the gross", async function () {
+      const Lying = await ethers.getContractFactory("MockLyingFeeRouter");
+      const lying = await Lying.deploy(treasury.address, 100, 100);
+      await lying.setSplitShort(true); // withholds a unit from `net`
+      await router.connect(admin).setFeeRouter(await lying.getAddress());
+
+      // `net` is what reaches Across, so an under-reported net would strand the difference in this
+      // contract — caught before any funds move rather than by the residual-funds guard afterwards.
+      await expect(bridge(member, await args())).to.be.revertedWithCustomError(router, "FeeSplitMismatch");
+      expect(await usdc.balanceOf(routerAddr)).to.equal(0n);
     });
 
     it("charges the fee to the treasury and forwards only the net", async function () {
@@ -474,9 +516,9 @@ describe("BridgeRouter", function () {
       await router.connect(liquidityAdmin).setRoute(route({ destinationChainId: 8453n }));
       await router.connect(liquidityAdmin).setRouteEnabled(otherId, false);
       await router.connect(liquidityAdmin).setRouteLimit(otherId, AMT("2"));
-      await router.connect(liquidityAdmin).setSpokePool(stranger.address);
-      await router.connect(liquidityAdmin).setFeeRouter(stranger.address);
-      await router.connect(liquidityAdmin).setSanctionsGuard(stranger.address);
+      await router.connect(admin).setSpokePool(stranger.address);
+      await router.connect(admin).setFeeRouter(stranger.address);
+      await router.connect(admin).setSanctionsGuard(stranger.address);
       await router.connect(liquidityAdmin).removeRoute(otherId);
 
       expect(await router.spokePool()).to.equal(stranger.address);
@@ -492,8 +534,8 @@ describe("BridgeRouter", function () {
     it("remains pausable with every optional service unreachable (FR-044)", async function () {
       // A killswitch that needs the SpokePool, the FeeRouter, or the gateway to be healthy is not a
       // killswitch: point both references at code-less addresses and pause anyway.
-      await router.connect(liquidityAdmin).setSpokePool(stranger.address);
-      await router.connect(liquidityAdmin).setFeeRouter(stranger.address);
+      await router.connect(admin).setSpokePool(stranger.address);
+      await router.connect(admin).setFeeRouter(stranger.address);
 
       await router.connect(guardian).pause();
       expect(await router.paused()).to.equal(true);
@@ -506,7 +548,7 @@ describe("BridgeRouter", function () {
     it("rejects a SpokePool that re-enters bridgeWithFee mid-deposit", async function () {
       const Evil = await ethers.getContractFactory("MockReentrantSpokePool");
       const evil = await Evil.deploy();
-      await router.connect(liquidityAdmin).setSpokePool(await evil.getAddress());
+      await router.connect(admin).setSpokePool(await evil.getAddress());
 
       const a = await args({ inputAmount: AMT("10") });
       const callback = router.interface.encodeFunctionData("bridgeWithFee", [
@@ -576,7 +618,7 @@ describe("BridgeRouter", function () {
     it("reverts ResidualFunds when the SpokePool under-pulls the approved net", async function () {
       const Leaky = await ethers.getContractFactory("MockLeakySpokePool");
       const leaky = await Leaky.deploy();
-      await router.connect(liquidityAdmin).setSpokePool(await leaky.getAddress());
+      await router.connect(admin).setSpokePool(await leaky.getAddress());
 
       await expect(bridge(member, await args()))
         .to.be.revertedWithCustomError(router, "ResidualFunds");
@@ -646,7 +688,7 @@ describe("BridgeRouter", function () {
       const oracle = await Oracle.deploy();
       const Guard = await ethers.getContractFactory("SanctionsGuard");
       guard = await Guard.deploy(admin.address, await oracle.getAddress());
-      await router.connect(liquidityAdmin).setSanctionsGuard(await guard.getAddress());
+      await router.connect(admin).setSanctionsGuard(await guard.getAddress());
     });
 
     it("refuses a deny-listed wallet BEFORE any transfer is attempted", async function () {
@@ -679,7 +721,7 @@ describe("BridgeRouter", function () {
     });
 
     it("skips screening entirely when the guard is unset", async function () {
-      await router.connect(liquidityAdmin).setSanctionsGuard(ethers.ZeroAddress);
+      await router.connect(admin).setSanctionsGuard(ethers.ZeroAddress);
       await guard.connect(admin).setDenied(member.address, true, "ignored once the guard is cleared");
       await bridge(member, await args());
       expect(await spoke.depositCount()).to.equal(1);

--- a/test/liquidity/LiquidityRouter.test.js
+++ b/test/liquidity/LiquidityRouter.test.js
@@ -196,30 +196,52 @@ describe("LiquidityRouter", function () {
         .to.be.revertedWithCustomError(router, unauthorized);
       await expect(router.connect(stranger).setPoolLimit(tradingPoolId, ETH("1"), ETH("1")))
         .to.be.revertedWithCustomError(router, unauthorized);
-      await expect(router.connect(stranger).setPositionManager(stranger.address))
-        .to.be.revertedWithCustomError(router, unauthorized);
-      await expect(router.connect(stranger).setFeeRouter(stranger.address))
-        .to.be.revertedWithCustomError(router, unauthorized);
-      await expect(router.connect(stranger).setSanctionsGuard(stranger.address))
-        .to.be.revertedWithCustomError(router, unauthorized);
 
-      // The role holder passes on every one of them, and each emits its audit event (FR-046).
+      // The role holder passes on every CURATION setter, and each emits its audit event (FR-046).
       await expect(router.connect(liquidityAdmin).setPoolEnabled(tradingPoolId, false))
         .to.emit(router, "PoolEnabledChanged")
         .withArgs(tradingPoolId, false, liquidityAdmin.address);
       await expect(router.connect(liquidityAdmin).setPoolLimit(tradingPoolId, ETH("1"), ETH("1")))
         .to.emit(router, "PoolLimitChanged")
         .withArgs(tradingPoolId, ETH("1"), ETH("1"), liquidityAdmin.address);
-      await expect(router.connect(liquidityAdmin).setSanctionsGuard(stranger.address))
+    });
+
+    // The protocol-wiring setters are DEFAULT_ADMIN_ROLE, a role ABOVE curation. `positionManager` is
+    // approved and mints the member's position and `feeRouter` names the treasury the fee is
+    // transferred to, so whoever can write them can redirect where member capital goes — that is not
+    // the same authority as deciding which pools are curated. A LIQUIDITY_ADMIN holder is rejected
+    // here on purpose; these assertions are the privilege boundary, not incidental coverage.
+    it("gates the protocol-wiring setters to DEFAULT_ADMIN_ROLE, above LIQUIDITY_ADMIN", async function () {
+      const unauthorized = "AccessControlUnauthorizedAccount";
+      for (const caller of [stranger, liquidityAdmin, guardian]) {
+        await expect(router.connect(caller).setPositionManager(caller.address))
+          .to.be.revertedWithCustomError(router, unauthorized);
+        await expect(router.connect(caller).setFeeRouter(caller.address))
+          .to.be.revertedWithCustomError(router, unauthorized);
+        await expect(router.connect(caller).setSanctionsGuard(caller.address))
+          .to.be.revertedWithCustomError(router, unauthorized);
+      }
+      expect(await router.positionManager()).to.equal(nfpmAddr);
+      expect(await router.feeRouter()).to.equal(await feeRouter.getAddress());
+      expect(await router.sanctionsGuard()).to.equal(ethers.ZeroAddress);
+
+      await expect(router.connect(admin).setSanctionsGuard(stranger.address))
         .to.emit(router, "SanctionsGuardUpdated")
-        .withArgs(ethers.ZeroAddress, stranger.address, liquidityAdmin.address);
-      await expect(router.connect(liquidityAdmin).setPositionManager(stranger.address))
+        .withArgs(ethers.ZeroAddress, stranger.address, admin.address);
+      await expect(router.connect(admin).setPositionManager(stranger.address))
         .to.emit(router, "PositionManagerUpdated")
-        .withArgs(nfpmAddr, stranger.address, liquidityAdmin.address);
-      await expect(router.connect(liquidityAdmin).setFeeRouter(stranger.address))
+        .withArgs(nfpmAddr, stranger.address, admin.address);
+      await expect(router.connect(admin).setFeeRouter(stranger.address))
         .to.emit(router, "FeeRouterUpdated")
-        .withArgs(await feeRouter.getAddress(), stranger.address, liquidityAdmin.address);
+        .withArgs(await feeRouter.getAddress(), stranger.address, admin.address);
       expect(await router.feeRouter()).to.equal(stranger.address);
+
+      // Zero is refused on both fund-path references — the supply path reaches an unset manager
+      // through `PositionManagerUnset`, so there is no reason to allow writing that state on purpose.
+      await expect(router.connect(admin).setPositionManager(ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(router, "ZeroAddress");
+      await expect(router.connect(admin).setFeeRouter(ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(router, "ZeroAddress");
     });
 
     it("gates pause/unpause to GUARDIAN_ROLE and pause blocks new supplies", async function () {
@@ -240,6 +262,28 @@ describe("LiquidityRouter", function () {
       expect(await router.paused()).to.equal(false);
       await supply(); // supplies resume
       expect(await nfpm.ownerOf(1)).to.equal(member.address);
+    });
+
+    it("remains pausable with every optional service unreachable (FR-044)", async function () {
+      // A killswitch that needs the FeeRouter, the position manager or the sanctions guard to be
+      // healthy is not a killswitch. Point all three at code-less addresses and pause anyway —
+      // the emergency authority must not depend on optional infrastructure being up.
+      await router.connect(admin).setFeeRouter(stranger.address);
+      await router.connect(admin).setPositionManager(stranger.address);
+      await router.connect(admin).setSanctionsGuard(stranger.address);
+
+      await router.connect(guardian).pause();
+      expect(await router.paused()).to.equal(true);
+      await expect(supply()).to.be.revertedWithCustomError(router, "EnforcedPause");
+
+      // Retirement stays exercisable in the same degraded state — and it has to, because it is the
+      // ONLY thing that withholds a BRIDGE pool: those deposits never touch this contract, so the
+      // pause cannot reach them (research R3).
+      await router.connect(liquidityAdmin).setPoolEnabled(bridgePoolId, false);
+      expect((await router.getPool(bridgePoolId)).enabled).to.equal(false);
+
+      await router.connect(guardian).unpause();
+      expect(await router.paused()).to.equal(false);
     });
 
     it("rejects a BridgeLp poolId with NotTradingPool — curated, but not routable", async function () {
@@ -433,9 +477,24 @@ describe("LiquidityRouter", function () {
 
     it("reverts PositionManagerUnset on a network with no Uniswap deployment", async function () {
       // Bridge pools can still be curated on such a network, so this must fail explicitly rather
-      // than opaquely against address(0).
-      await router.connect(liquidityAdmin).setPositionManager(ethers.ZeroAddress);
-      await expect(supply()).to.be.revertedWithCustomError(router, "PositionManagerUnset");
+      // than opaquely against address(0). Reached by DEPLOYING into that state rather than by
+      // writing it: `setPositionManager` refuses zero, so `initialize` is the only way in — which is
+      // also the only way it happens in production (a chain with no Uniswap deployment to point at).
+      const bare = await deployLiquidityRouter([
+        admin.address,
+        await feeRouter.getAddress(),
+        ethers.ZeroAddress, // no Uniswap on this network
+        ethers.ZeroAddress,
+      ]);
+      await bare.connect(admin).listPool(tradingListing());
+      for (const t of [token0, token1]) {
+        await t.connect(member).approve(await bare.getAddress(), ethers.MaxUint256);
+      }
+      await expect(
+        bare
+          .connect(member)
+          .mintFullRangeWithFee(tradingPoolId, ETH("100"), ETH("200"), 0, 0, DEADLINE, 250)
+      ).to.be.revertedWithCustomError(bare, "PositionManagerUnset");
     });
 
     it("reverts ZeroAmount when both legs are zero", async function () {
@@ -460,10 +519,53 @@ describe("LiquidityRouter", function () {
       expect(await nfpm.ownerOf(1)).to.equal(member.address);
     });
 
+    // ---- the ceiling binds the fee TAKEN, not the rate the fee router claims ----
+    //
+    // The consent ceiling is checked before the mint against `feeBps()` — the FeeRouter's own account
+    // of its rate. But the fee is finally quoted AFTER the mint, against amounts nobody knew in
+    // advance, and that second quote was unbounded. So a FeeRouter reporting 0 bps and quoting 99%
+    // passed every pre-mint check and then took the member's deployed capital. The bound is on the
+    // amounts themselves, which is the only thing a lying router cannot restate.
+    it("refuses a FeeRouter that under-reports its rate and over-quotes the post-mint fee", async function () {
+      const Lying = await ethers.getContractFactory("MockLyingFeeRouter");
+      const lying = await Lying.deploy(stranger.address, 0, 9_900); // admits 0 bps, takes 99%
+      await router.connect(admin).setFeeRouter(await lying.getAddress());
+
+      const before0 = await token0.balanceOf(member.address);
+      await expect(supply({ maxFeeBps: 0 })).to.be.revertedWithCustomError(router, "FeeAboveCap");
+      // Nothing moved: the whole supply reverted, so the mint is undone with it.
+      expect(await token0.balanceOf(member.address)).to.equal(before0);
+      expect(await token0.balanceOf(stranger.address)).to.equal(0n);
+
+      // At the cap it goes through — the bound is MAX_FEE_BPS, not honesty.
+      const atCap = await Lying.deploy(treasury.address, 0, 250);
+      await router.connect(admin).setFeeRouter(await atCap.getAddress());
+      await supply({ maxFeeBps: 0 });
+      // 250 bps of what Uniswap CONSUMED, not of the 100 offered — the bound is checked against the
+      // same post-mint amounts the fee is quoted on, so it does not reintroduce the gross-basis
+      // overcharge this router was fixed for.
+      const consumed0 = await token0.balanceOf(nfpmAddr);
+      expect(await token0.balanceOf(treasury.address)).to.equal((consumed0 * 250n) / 10_000n);
+      expect(await token0.balanceOf(treasury.address)).to.be.lessThan((ETH("100") * 250n) / 10_000n);
+      expect(await nfpm.ownerOf(1)).to.equal(member.address);
+    });
+
+    it("refuses a FeeRouter whose fee and net do not add back to the gross", async function () {
+      const Lying = await ethers.getContractFactory("MockLyingFeeRouter");
+      const lying = await Lying.deploy(treasury.address, 100, 100);
+      await lying.setSplitShort(true); // withholds a unit from `net`
+      await router.connect(admin).setFeeRouter(await lying.getAddress());
+
+      // `net0`/`net1` are what get approved to the position manager, so an under-reported net would
+      // silently shrink the member's position. Caught before any funds move.
+      await expect(supply()).to.be.revertedWithCustomError(router, "FeeSplitMismatch");
+      expect(await token0.balanceOf(routerAddr)).to.equal(0n);
+    });
+
     it("screens the member and rejects a denied address (FR-031)", async function () {
       const Guard = await ethers.getContractFactory("SanctionsGuard");
       const guard = await Guard.deploy(admin.address, ethers.ZeroAddress); // deny-list only
-      await router.connect(liquidityAdmin).setSanctionsGuard(await guard.getAddress());
+      await router.connect(admin).setSanctionsGuard(await guard.getAddress());
 
       await guard.connect(admin).setDenied(member.address, true, "test");
       await expect(supply())


### PR DESCRIPTION
Phase 6 of spec 067 — the Bridge and Supply operator control surfaces (T121–T135, T156, T157) — plus the remediation of a three-lens security audit run against them.

## What this adds

Two admin tabs under a new **Liquidity** nav group, driving the `BridgeRouter` and `LiquidityRouter` per network: status + emergency pause, route/pool curation with per-transaction ceilings, protocol addresses, a read-only fee card, an observational Operations panel, and decoded change history.

## What the audit found

23 findings across operator-honesty, least-privilege and regression lenses; 1 critical, 6 high. The interesting ones:

### The pause was unreachable on 4 of 5 networks (critical)

`hasRole(ADMIN|GUARDIAN)` resolved only against `wagerRegistry`/`membershipManager`, neither of which is deployed on Ethereum, Optimism, Base or Arbitrum. So `canPause` was false for **every** account on those chains — including each router's actual guardian — and the pause card rendered nothing. Mid-incident that reads as "this network has no killswitch."

Fixed by asking the router in scope for the network in scope (`readRouterAuthority`): GUARDIAN_ROLE on the WagerRegistry is not GUARDIAN_ROLE on a BridgeRouter, and LIQUIDITY_ADMIN on one router is not authority over the other. An unreadable answer keeps controls offered and says it is unconfirmed — the contract is the real gate, and withholding a killswitch over a timed-out RPC read is the FR-044 failure it exists to prevent. `GUARDIAN_ROLE` is now grantable per router, so the killswitch is delegable at all (previously only the `initialize` admin could ever hold it).

### The fee cap did not bind the fee (contracts)

Both routers checked `MAX_FEE_BPS` against `feeBps()` — the FeeRouter's own claim about its rate — then transferred whatever `quoteFee()` returned, unbounded. A FeeRouter reporting **0 bps** while quoting **99%** passed the cap check *and* the member's consent ceiling, and sent the principal to its own treasury. Both routers now bound the returned amount and require an exact fee/net split; `MockLyingFeeRouter` is that exact scenario as a test.

Reaching it needed `setFeeRouter`, which was `LIQUIDITY_ADMIN_ROLE` — the same role as "enable a route". `setSpokePool` / `setPositionManager` / `setFeeRouter` / `setSanctionsGuard` are now `DEFAULT_ADMIN_ROLE`: curating a route badly is reversible by a toggle, pointing a router at a hostile contract is not.

### Honesty fixes

- Fee card quotes the FeeRouter the router *actually holds*, and says so when that disagrees with the app config (members would be quoted by a contract that is not charging them).
- `applyCaps` no longer writes `0` (= uncapped) over the leg the operator did not type — that silently deleted a member-facing limit and reported success.
- No false zeros: a failed deposit scan printed "0 positions" against a pool members still hold LP in. Bridge-pool *size* now comes from the HubPool rather than being withheld, since the member view already reads it from the same address; only the per-member *count* genuinely needs an indexer.
- Bulk route toggles actually stop on the first refusal (`runTx` swallowed every error and resolved with no signal, so rejecting the first prompt still fired the rest).
- Operations: late outranks recent so a stuck transfer is not evicted by newer healthy ones; a de-curated route's window is UNKNOWN, not not-late; `removeRoute` confirms and names the consequence; the panel states what it could not show.
- Scope switches clear state first; history no longer claims a route went live from an event carrying no `enabled` field; the permissions card and header badge name every role that can open the panel.

## Verification

| Check | Result |
|---|---|
| Frontend suite | 4484 passing — 4 known pre-existing failures unchanged (ProposalBuilder ×3, UnifiedLookupModal ×1) |
| Contract suite | 979 passing — 2 pre-existing fork/RPC failures, verified identical on a clean tree |
| `check:storage-layout` | both routers upgrade-safe |
| eslint | 0 errors |

## Not fixed, reported

`test/WagerRegistry.coverage.test.js` and `test/intent/WagerRegistryIntents.coverage.test.js` (1,043 lines of spec-035/046 coverage) were untracked scratch work swept into #961 by a `git add -A`. They pass and are legitimate coverage, but shipped under a bridge/liquidity PR and were reviewed as such. Left in place — re-attribution is your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBMvFqhjqsXyUVF2hEFoNc