### PR TITLE
Spec 067 US5: bridge + supply content deliverables

### DIFF
--- a/docs/blog/features/02-bridge-and-supply/blog.md
+++ b/docs/blog/features/02-bridge-and-supply/blog.md
@@ -1,0 +1,100 @@
+# Move It, Then Put It to Work: Bridge and Supply Come to FairWins
+
+*Send an asset you already own to another network from inside Transfer, and supply liquidity to Uniswap and Across pools from inside Earn — from your own wallet, with every cost on the table before you sign.*
+
+---
+
+Holding crypto across several networks used to mean two annoyances at once. Your USDC was on Polygon and you needed it on Ethereum, so you left FairWins for a bridge app you didn't pick and couldn't check. And the assets that *were* in the right place mostly sat there doing nothing, while the Earn section's "Bridges" tile stayed greyed out with a promise on it.
+
+Both are fixed. **Bridge** is now a tab inside **Finance → Transfer**, beside Send and Activity. **Supply** replaced that dead tile in **Finance → Earn**. One moves your asset to another network; the other puts assets into a pool and earns you a share of what people pay to use it. Neither ever holds your assets between transactions, and neither can move a position you own.
+
+## Bridge: the same asset, a different network
+
+Open **Finance → Transfer → Bridge**. Pick the asset you want to move — the selector shows what you hold on *every* supported network, each with its network badge, so you never switch networks just to find it. Pick where you want it: the destination list only ever offers **the same asset on other networks**, and look-alike assets (USDC and USDC.e, say) are genuinely different assets and are never quietly substituted. Then enter an amount, or tap **Max**, which on a native coin deliberately leaves a little behind so you can still pay for the transaction.
+
+### What you see before you sign
+
+A single card titled **"What this transfer costs"**, and nothing hidden inside a rate:
+
+- **Amount received on** *(destination network)* — what is expected to land, after everything below is taken out. Not the amount you send.
+- **Estimated arrival** — Across's own estimate from recent transfers, usually a couple of minutes. It's an estimate, and it's advisory: **nothing counts as delivered until the destination network says so**, however long that takes.
+- **Bridge fee** — Across Protocol's own charge. It pays the people who front the asset on the other side so your transfer lands in minutes.
+- **Delivery on the destination network** — the cost of the transaction that delivers your asset over there, so you don't have to pay it yourself.
+- **Total cost** — the sum of those, and only those.
+- **A countdown.** "This quote is good for another N seconds." When it lapses the card says so and makes you refresh before you can sign. The figure you confirmed is a hard ceiling — you can never be charged above the quote you agreed to.
+
+If your wallet is on a different network, a line above the button says it will switch when you confirm — you don't go and do it yourself. A cost line that can't be read says **"Not available"** rather than showing a made-up `0.00`. And Across is named on the quote itself, with a link, because it is the third party your delivery depends on.
+
+Then you sign once and watch it truthfully: **Sending → Sent → On the way → Delivered.** Only the last one claims completion, and only destination-chain evidence produces it. Close the app mid-transfer and it picks the true status back up when you return. A transfer past its usual window says *"Taking longer than expected"* and tells you what's known — never a silent spinner, never a fake tick.
+
+## Supply: put assets into a pool
+
+Open **Finance → Earn → Supply**. You get one curated list holding two clearly-labelled kinds of pool:
+
+**Trading liquidity (Uniswap).** Supply a pair of assets on one network so other people can swap between them, and earn a share of the fee they pay on every swap. Positions are **full-range only** — your pair earns at every price, with no band to pick and nothing to come back and rebalance. The Uniswap position NFT is minted straight to your address.
+
+**Bridge liquidity (Across).** Supply a single asset to the bridge's shared pot. Across lends it out to pay people out instantly on other networks, and you earn a share of what they're charged. This deposit goes **directly from your wallet to Across** — no FairWins contract is in the path at all.
+
+### What you see before you supply
+
+Amounts first, then a deliberate second step: **Review and confirm**. On it:
+
+- **You supply** — the exact amounts, both legs for a pair.
+- **Into** — the pool kind and the network it lives on.
+- **A fee line, only if there is a fee.** At the moment there isn't one, so you won't see it (more below). A bridge pool goes further and says plainly *why* it can never carry one.
+- **A disclosure you have to acknowledge.** Not a tooltip — a paragraph on the screen with a checkbox beneath it, and **the confirm button stays unusable until you tick it.** For a trading pool it explains in plain words that what you get back is a mix that moves with prices and can be worth less than simply holding. For a bridge pool it explains that your asset is lent out across networks and that withdrawal depends on what's available when you ask.
+- **The network switch**, disclosed before the signature, same as Bridge.
+
+Open positions show current value, earnings so far, and — for a pair — the mix of the two assets you're currently holding, each labelled an **estimate** because each moves with the market. A figure that can't be read shows a dash and a reason, never a filled-in guess.
+
+**Withdrawing is always open and never carries a FairWins fee** — stated on the screen, not merely implied by the absence of a line. If a bridge pool is heavily lent out at that moment, you take what's available now and are told plainly that the rest comes shortly, the same pattern the lending vaults already use.
+
+## What this costs you
+
+**FairWins charges nothing on either surface today.** Both fee services ship at **zero**, and a zero rate renders *no fee line at all* rather than a line reading `0.00` — the flow is identical to a build with no fee configured. There is no revenue to us in bridging or supplying as it stands.
+
+If that ever changes the mechanism is already public: both services sit in the same on-chain fee configuration every other FairWins service reads, each capped at **2.5%** by a limit that can't be raised, each disclosed as its own line before you sign and passed to the contract as a ceiling. Withdrawals, earnings, and bridge refunds are excluded by design and can never be charged.
+
+**The costs that are real are not ours.** The bridge fee and the destination delivery cost go to Across and its relayers, and network gas on the chain you sign from is yours — bridges are never gasless. We itemize all of it rather than folding it into a rate and calling the result "free".
+
+## Nothing here is custodial — and a pause can't trap you
+
+- **When you bridge, you are the depositor.** Our router touches your asset only inside the one transaction, and it hands Across *your* address as the depositor, never its own. That single detail is why an undeliverable transfer refunds to **your wallet on the network it left from**, rather than to a contract you'd have to petition.
+- **Your Uniswap position belongs to you.** The NFT is minted to your address and exits go straight to Uniswap's position manager.
+- **Bridge-pool deposits never touch a FairWins contract.** Across's deposit function has no recipient parameter, so wrapping it would have made FairWins the owner of a position you could never exit. We didn't wrap it.
+- **Emergency pauses stop new value going in, and nothing else.** A paused route accepts no new bridges; transfers already on their way keep settling through Across regardless. A closed pool takes no new deposits, stays listed, keeps earning, and stays withdrawable — because exits never went through our contracts to begin with.
+
+Availability itself is read, not assumed: if the routes or the pool list can't be read right now, the surface says so and offers no controls rather than guessing, and it tells you when it last managed to look.
+
+## Where it works
+
+- **Bridging** runs on the five EVM mainnets where Across is deployed — **Ethereum, Polygon, Arbitrum, Base, and Optimism** — in both directions between every pair. Arbitrum, Base, and Optimism join FairWins as full networks in this release, so what arrives there is visible and spendable.
+- **Trading liquidity (Uniswap)** is offered on those same five networks.
+- **Bridge liquidity (Across)** is **Ethereum only.** The bridge's shared pot is an Ethereum contract by design, so there is nothing to supply on Polygon or on an L2. The app states that asymmetry rather than implying both kinds exist everywhere.
+- **Ethereum Classic and Mordor** run neither protocol and say so instead of going quietly missing. **Bitcoin is not part of either surface** — it's its own network and isn't connected to these; sending and receiving bitcoin work exactly as before.
+
+## The risks, in plain words
+
+- **Impermanent loss** is the big one for trading pools. As people trade, the pool ends up holding more of whichever asset fell and less of whichever rose, so what you withdraw can be worth less than if you had simply held the two assets and done nothing. The fees you earn may cover that, or may not. It isn't a fee, and it isn't something FairWins can prevent.
+- **Bridge pools get rebalanced.** Your asset is lent out across networks, so part of the pot is in transit at any moment and a full exit isn't guaranteed to be fillable the instant you ask.
+- **Estimated returns are estimates** — drawn from what a pool has been earning lately, moving with activity, and capable of falling to almost nothing in a quiet week. No rate anywhere in this feature is a promise.
+- **Third-party protocol risk is real.** Across settles every bridge; Uniswap and Across hold every pool. Smart contracts carry risk. We name the protocol on every quote and every card rather than hiding behind our own logo.
+
+New to any of this? The knowledge-base primer — [Bridges and Liquidity](../../knowledge/21-bridges-and-liquidity/blog.md) — teaches the concepts from scratch, no DeFi background assumed.
+
+## Woven into the app you already use
+
+- **Your activity log** records a bridge as one logical move naming both networks and both transactions — never double-counted as two unrelated movements — plus pool supplies, withdrawals, and claims, each with its own class.
+- **Reporting** includes them with fees attributed, and never treats moving your own assets between networks as income.
+- **Notifications** gained two new categories, **Bridge** and **Liquidity**, each independently controllable and each distinct from Wager Pools — an unrelated feature that keeps the word "Pool".
+- **Passkey and classic wallets both work**, with approve-and-supply batched into one ceremony where your wallet supports it.
+
+## Get started
+
+1. **To move an asset:** open **Finance → Transfer → Bridge**, pick the asset and destination network, enter an amount, read the quote, confirm.
+2. **To put assets to work:** open **Finance → Earn → Supply**, pick a pool, enter amounts, tap **Review and confirm**, read the disclosure and tick it, confirm.
+3. **To get out:** open the pool and hit Withdraw. No fee, no waiting on us, any time.
+
+Your assets should be where you need them, and they shouldn't sit idle when they're not. Both are now one tab away — in your custody, with every number in front of you.
+
+*Bridging depends on a third-party protocol and is not guaranteed to deliver; undelivered transfers are returned to the wallet they came from. Supplying liquidity carries impermanent loss, protocol risk, and variable returns that are not guaranteed. You pay the bridge protocol's fee and network gas on both surfaces. Availability depends on the network and on what operators have enabled. Always read the quote and the disclosure shown before you sign.*

--- a/docs/blog/features/02-bridge-and-supply/social.md
+++ b/docs/blog/features/02-bridge-and-supply/social.md
@@ -1,0 +1,36 @@
+# Social & Image — Move It, Then Put It to Work: Bridge and Supply Come to FairWins
+
+## X (Twitter)
+
+Bridge and Supply are live on FairWins. 🌉 Move an asset across Ethereum, Polygon, Arbitrum, Base and Optimism from Transfer → Bridge, or supply Uniswap and Across pools from Earn → Supply. Every cost itemized before you sign, FairWins fee is 0, exits always free. 🔗 <link> #bridge #DeFi #Uniswap #web3
+
+## LinkedIn
+
+Two gaps closed in one release: **cross-chain Bridge and liquidity Supply are now live on FairWins.**
+
+**Finance → Transfer → Bridge** moves an asset you already hold to another network. **Finance → Earn → Supply** puts assets into a Uniswap trading pool or an Across bridge pool and earns you a share of the fees people pay to use it.
+
+What you see before you sign, on both:
+
+- **Every cost as its own line** — the bridge protocol's fee, the destination delivery cost, the total, and a countdown on the quote. The figure you confirm is a hard ceiling.
+- **No FairWins fee at all today.** Both services ship at **zero**, which renders no fee line rather than a line reading 0.00. The costs that are real — Across's fee and network gas — are named as not ours.
+- **A disclosure you have to acknowledge**, not a tooltip: on a trading pool the confirm button stays unusable until you've ticked that you understand impermanent loss.
+- **An arrival estimate that stays an estimate.** Nothing is shown as delivered until the destination chain confirms it.
+
+And it's non-custodial in the way that actually matters:
+
+- Your wallet is the **depositor** on every bridge, which is why an undeliverable transfer refunds to **you**, not to a contract.
+- Your Uniswap position NFT is minted to your address; Across bridge-pool deposits never touch a FairWins contract at all.
+- **An emergency pause stops new deposits only.** In-flight transfers still settle and existing positions stay withdrawable — because exits never routed through us.
+
+Availability, stated honestly: bridging in both directions across **five EVM mainnets** (Ethereum, Polygon, Arbitrum, Base, Optimism); Uniswap pools on all five; **Across bridge pools on Ethereum only**, because that pot is an Ethereum contract by design.
+
+Read the announcement: <link>
+
+If bridging has ever put you off, was it the opaque pricing, the wait, or not knowing who was holding your asset in the middle?
+
+#DeFi #bridge #liquidity #Uniswap #Across #selfcustody #web3 #fintech
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration in an isometric style: two translucent network platforms floating at different heights, each a slim hexagonal plate with faint circuit etching, connected by a single luminous arc of light along which one glowing coin travels — caught mid-journey, with a soft motion trail behind it and its destination plate already lit in welcome. A stylized human hand supports the departing plate from below to signal self-custody, and the coin is clearly the same coin at both ends. Below the arc, a second visual idea: a small shared basin of softly glowing liquid light on a third plate, with two paired tokens settling into it and gentle upward sparks rising off the surface, visualizing supplied liquidity earning a share of activity. Deep navy and teal base palette with a single warm amber accent on the traveling coin and the rising sparks, soft volumetric lighting from the upper left, generous negative space, precise geometric shapes with slight depth and soft shadows, trustworthy fintech brand mood, no text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/features/README.md
+++ b/docs/blog/features/README.md
@@ -25,6 +25,7 @@ Swap the `<link>` placeholders in each `social.md` for the live post URL at publ
 | # | Announcement | Area | Spec(s) | Status |
 |---|--------------|------|---------|--------|
 | 01 | [Put Your Idle Crypto to Work: Staking Comes to FairWins](01-staking/blog.md) · [social](01-staking/social.md) | Finance → Earn | 065, 066 | Draft |
+| 02 | [Move It, Then Put It to Work: Bridge and Supply Come to FairWins](02-bridge-and-supply/blog.md) · [social](02-bridge-and-supply/social.md) | Finance → Transfer, Finance → Earn | 067 | Draft |
 
 ## Adding an announcement
 

--- a/docs/blog/knowledge/21-bridges-and-liquidity/blog.md
+++ b/docs/blog/knowledge/21-bridges-and-liquidity/blog.md
@@ -1,0 +1,115 @@
+# Bridges and Liquidity Pools, Explained Simply
+
+*How money gets from one blockchain network to another, what it means to "provide liquidity", and the one risk almost everybody underestimates*
+
+| | |
+|---|---|
+| **Series** | Knowledge Base |
+| **Track** | Earning & Yield |
+| **Level** | Beginner |
+| **Audience** | Anyone who has seen a "Bridge" or "Supply liquidity" button and hesitated |
+| **Tags** | `bridge`, `cross-chain`, `liquidity`, `impermanent-loss`, `defi` |
+| **Reading time** | ~8 minutes |
+
+---
+
+## Two buttons that sound simpler than they are
+
+Most crypto apps have a button called **Bridge** and another called **Supply** or **Add liquidity**. One appears to move your money; the other appears to earn you some. Both work in ways that will surprise you if you assume they behave like a bank.
+
+Three things, in order: what a bridge actually does, what you're really doing when you provide liquidity, and **impermanent loss** — the risk that costs people money precisely because it doesn't sound like one.
+
+## What a bridge actually is
+
+Start with something that sounds obvious but isn't: **a blockchain network is a self-contained record book.** Ethereum has one. Polygon has another. Different crowds of computers keep them, and neither can see or edit the other's pages. (New to that? Read [Blockchain networks and layer-2s](../19-blockchain-networks-and-l2s/blog.md) first.)
+
+So moving a token from Polygon to Ethereum is **nothing like a bank transfer**. Two banks sit inside a shared settlement system with agreed rules for debiting one and crediting the other. Blockchain networks have no such system: there is no wire between them, and your dollars on Polygon genuinely cannot travel to Ethereum.
+
+A **bridge** is what people built instead — and the fast ones are closer to a favour between friends than to a transfer. Say you want $500 of USDC moved from Polygon to Ethereum:
+
+1. You hand $500 to the bridge's contract **on Polygon**, saying where you want it delivered.
+2. A **relayer** — an independent participant whose own money already sits on Ethereum — takes the job and immediately pays you $500 out of *their* funds. That's what lands in your wallet.
+3. Later, in the background, the bridge reimburses that relayer from your Polygon deposit, plus a fee.
+
+Nothing crossed anything. Two separate payments happened on two separate networks, and a stranger's inventory covered the gap in time between them. That explains everything people find confusing about bridges:
+
+- **Why it's fast.** You're not waiting for two chains to agree — only for one relayer to decide your job is worth taking. Often a couple of minutes.
+- **Why there's a fee.** Somebody put their own capital at risk on your behalf, and had to keep it stocked on the right network. That's what the fee buys.
+- **Why the estimate is only an estimate.** An "expected delivery window" is a forecast from how fast recent transfers got picked up. Nothing counts as delivered until the destination network itself confirms it — and an honest app won't tick the box a moment earlier.
+
+If no relayer ever takes the job, a well-designed bridge has a deadline, after which your deposit is **returned to you on the network it left from**. Which is why one unglamorous detail matters enormously: the address recorded as the depositor must be **yours**, not an app's contract. Then a failed transfer simply comes home.
+
+## What "providing liquidity" means
+
+**Liquidity** is just a word for *inventory that's ready to be traded with*. An airport exchange booth has liquidity: it can hand you euros because it keeps euros in the drawer. Empty drawer, no deal, however good the rate on the sign.
+
+**Providing liquidity means being the person who stocks the drawer**, and taking a cut of what people pay to use it. You're not lending to a named borrower and not buying a share of a company — you're supplying working inventory to a machine other people use.
+
+Two kinds show up here. **Trading pools** take a *pair* of assets — say ETH and USDC — into a shared pot anyone can swap against; each swap pays a small fee, split among everyone who stocked the pot. Supply 1% of the pool, collect 1% of the fees. **Bridge pools** take a *single* asset into the pot relayers ultimately draw on, so other people's transfers can be paid out instantly. You are, indirectly, the one fronting the money.
+
+Either way the return is **a share of activity, not a rate**. A busy week pays well; a quiet week pays close to nothing. Any percentage shown is an estimate from what the pool earned recently — a fact about the past, not a commitment about the future.
+
+## Impermanent loss — read this part twice
+
+This one applies to **trading pools**, and it is the single most important thing to understand before supplying one.
+
+**Impermanent loss is not a fee, not a hack, and nobody takes it from you.** It is a comparison: the gap between what your position is worth when you withdraw and what those same assets would have been worth if you had simply held them and done nothing.
+
+The gap opens because a trading pool has no opinion about prices. When an asset gets more valuable elsewhere, traders buy it cheaply out of the pool until the pool catches up; when it gets less valuable, they dump it in. The net effect is that **the pool automatically sells whatever is rising and buys whatever is falling**, using your inventory, all day.
+
+### A worked example, with real numbers
+
+ETH is at $2,000, and you supply an ETH/USDC pool with **0.5 ETH** (worth $1,000) and **1,000 USDC** — $2,000 total, half in each. ETH then doubles to $4,000, and you withdraw.
+
+- **Had you just held:** 0.5 ETH × $4,000 = $2,000, plus 1,000 USDC = **$3,000**.
+- **What the pool hands back:** roughly **0.354 ETH and 1,414 USDC** — about **$2,828**.
+
+You're about **$172 short**, roughly **5.7%** behind. Traders bought your ETH out of the pool the whole way up, paying you dollars at each step, so you finish holding less of the asset that doubled and more of the one that didn't.
+
+Two things worth noticing. **You're still up in absolute terms** — $2,000 in, $2,828 out. Impermanent loss is usually an *underperformance* against doing nothing rather than a shrinking balance, which is exactly why it's easy to miss. And **it works both ways**: had ETH halved instead, you'd have finished holding more ETH and fewer dollars, again worth less than holding. What matters is how far the two prices move *apart*, not which direction.
+
+### Why "impermanent" is a misleading word
+
+It's called impermanent because if prices drift back to the ratio they had when you supplied, the gap closes on its own. True — and that's where the reassuring version of this explanation usually stops.
+
+Here's the part that matters: **the moment you withdraw while the prices have diverged, the loss is permanent.** It stops being a paper comparison and becomes the final difference between what you have and what you'd have had. Prices are under no obligation to come back, and you're under no obligation to wait — but you can't have both.
+
+### Do the earned fees make up for it?
+
+**Sometimes. Nobody can tell you in advance.** The honest arithmetic is *fees earned − impermanent loss = whether supplying beat just holding.* In a busy pool over a period where prices moved little, fees can comfortably win; in a quiet pool over a period where one asset ran away, they may not come close. Anyone who says the fees "always cover it" is guessing, and anyone calling this passive income is skipping the second half of that subtraction. A useful instinct: the more likely two assets are to move apart, the bigger the effect — two dollar-pegged stablecoins barely diverge, and their fees are usually small to match.
+
+Single-asset **bridge pools** have no pair, so there's no divergence and no impermanent loss. They carry a different risk: your asset is lent out across networks, so much of the pot is in transit at any moment and a large withdrawal may only be fillable in part until inventory returns.
+
+## What this costs you
+
+- **FairWins charges no platform fee on bridging or on supplying today.** Both are configured at zero, and a zero rate shows **no fee line at all** — not a line reading 0.00. There is nothing in these two features for us as they stand.
+- **The bridge fee is real, and it isn't ours.** It goes to the bridge protocol and the relayer who fronted your money, alongside the cost of the transaction that delivers it. Both are itemized before you sign.
+- **Network fees ("gas") are real, and they're yours.** These are blockchain transactions; bridging is never free of that.
+
+"FairWins takes nothing" is not the same sentence as "this is free", and we'd rather you read the first one.
+
+## How it shows up in FairWins
+
+**Bridge** sits in **Transfer**, beside Send. Transfers settle through Across Protocol, which is named on the quote itself because it is the third party your delivery depends on. Pick an asset and a destination network, read one quote with every cost on its own line and a countdown on its validity, then confirm from your own wallet. Progress reads *Sending → Sent → On the way → Delivered*, and only destination-chain evidence produces that last one. **You** are recorded as the depositor, so an undeliverable transfer refunds to your wallet on the network it left from.
+
+**Supply** sits in **Earn**. Trading pools are full-range only — no price band to pick, nothing to rebalance — and the position created belongs to your address, not ours; bridge-pool deposits never touch a FairWins contract at all. Before a trading-pool deposit you must read and tick an impermanent-loss disclosure on the screen itself. Bridging and trading pools cover five networks — Ethereum, Polygon, Arbitrum, Base and Optimism — while **bridge liquidity is Ethereum only**, because the bridge's shared pot is an Ethereum contract by design. Withdrawing is always open, never carries a FairWins fee, and doesn't route through us — which is why an emergency pause stops new deposits without ever trapping a position that exists.
+
+## What to watch out for
+
+- **Nothing is delivered until the destination network says so.** Be suspicious of any app that ticks the box before the far side confirms.
+- **Supplying liquidity is not a savings account.** You can withdraw less than you supplied, and you can end up ahead of your deposit while still doing worse than holding. Both are normal outcomes, not malfunctions.
+- **Estimated returns are estimates.** Drawn from recent activity, moving constantly, capable of falling to almost nothing.
+- **You're trusting other people's code.** Bridges and pools are third-party software holding real value; no audit removes that risk. Only supply what you could afford to have at risk.
+
+Both ideas are old ones in new clothes: somebody fronting money so a transfer feels instant, and somebody stocking a shelf for a cut of the till. Neither is magic, and neither is free of consequences — which is why they're worth understanding before you tap the button.
+
+## Related deep-dive
+
+Want the engineering details? Read [One Argument Decides Who Gets the Money Back](../../posts/35-cross-chain-intents-and-lp/blog.md) — how FairWins built cross-chain transfers and pooled liquidity so the failure path needs no rescue button.
+
+## Learn more
+
+- [Ethereum.org — Blockchain bridges](https://ethereum.org/en/developers/docs/bridges/) — why separate networks need bridges, and the trade-offs between designs
+- [Across Protocol — Documentation](https://docs.across.to/) — the bridge behind FairWins' Bridge tab, including the deposit, fill and refund lifecycle
+- [Uniswap — Documentation](https://docs.uniswap.org/) — how trading pools price swaps and pay the people who supply them
+- [Ethereum.org — Decentralized finance (DeFi)](https://ethereum.org/en/defi/) — the wider landscape both of these sit inside

--- a/docs/blog/knowledge/21-bridges-and-liquidity/social.md
+++ b/docs/blog/knowledge/21-bridges-and-liquidity/social.md
@@ -1,0 +1,23 @@
+# Social & Image — Bridges and Liquidity Pools, Explained Simply
+
+## X (Twitter)
+
+A "bridge" doesn't move your money between chains — nothing crosses. A stranger pays you on the far side out of their own funds and gets reimbursed later. That's why it's fast, and why there's a fee. Our new beginner primer explains that, plus the risk nobody reads properly: impermanent loss. 🔗 <link>
+
+#DeFi #bridges #liquidity
+
+## LinkedIn
+
+Two buttons in every crypto app sound simpler than they are: **Bridge** and **Supply liquidity**. Our new beginner primer takes both apart in plain language, no DeFi background assumed:
+
+- **What a bridge actually does.** Blockchain networks are separate record books with no wire between them, so nothing "crosses". A relayer fronts you the money on the destination side out of their own inventory and is reimbursed afterwards — which is why delivery takes minutes, why there's a fee, and why an arrival time is a forecast rather than a promise.
+- **What providing liquidity means.** You're stocking the drawer other people trade out of, and collecting a share of what they pay. A share of activity, not a rate.
+- **Impermanent loss, with real numbers.** Supply 0.5 ETH + 1,000 USDC at $2,000/ETH, watch ETH double, withdraw: the pool returns about $2,828 where simply holding would have left you $3,000. Up in absolute terms, ~5.7% behind having done nothing. It's called impermanent because the gap closes if prices come back — but it becomes permanent the moment you withdraw while they haven't. Whether the fees you earned cover it is genuinely unknowable in advance.
+
+FairWins charges no platform fee on either surface today — a zero rate shows no fee line at all — while the bridge protocol's fee and network gas are real costs that are not ours, itemized before you sign. 🔗 <link>
+
+#DeFi #bridges #liquidity #impermanentloss #financialliteracy
+
+## Image prompt (Gemini / Nano Banana)
+
+A clean modern editorial illustration of two separate island-like ledger platforms with no road between them, connected instead by a single figure carrying a parcel across on behalf of someone else — and in the foreground a set of balance scales holding two unequal stacks of tokens, one visibly taller than the other, quietly suggesting a pair drifting apart. Deep navy and teal base with one warm amber accent on the scales. Soft calm lighting, generous negative space, educational and trustworthy rather than corporate or alarmist. No text, no numbers, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/knowledge/README.md
+++ b/docs/blog/knowledge/README.md
@@ -35,6 +35,7 @@ interleaves these primers with the deep-dives, is in the
 - [Morpho & vaults explained](08-morpho-and-vaults/blog.md)
 - [Reading APY & understanding risk](09-apy-and-risk/blog.md)
 - [Fees & basis points: reading what you pay](10-fees-and-basis-points/blog.md)
+- [Bridges & liquidity pools: moving assets between networks, and impermanent loss](21-bridges-and-liquidity/blog.md)
 
 ### Security & Custody
 - [Multisig wallets: why several signatures beat one](11-multisig-wallets/blog.md)

--- a/docs/blog/posts/35-cross-chain-intents-and-lp/blog.md
+++ b/docs/blog/posts/35-cross-chain-intents-and-lp/blog.md
@@ -1,0 +1,79 @@
+# One Argument Decides Who Gets the Money Back
+
+*How FairWins built cross-chain transfers and pooled liquidity where the failure path needs no rescue button — and why a platform fee, if one is ever set, is charged after the deposit rather than before*
+
+| | |
+|---|---|
+| **Series** | FairWins Engineering |
+| **Audience** | Product and engineering readers curious about cross-chain design |
+| **Tags** | `bridge`, `liquidity`, `cross-chain`, `non-custodial`, `fees` |
+| **Reading time** | ~7 minutes |
+
+---
+
+## Two surfaces, one constraint
+
+FairWins members hold assets on several networks at once, but until now the app could only move value *within* a network: if your USDC sat on Polygon and you needed it on Ethereum, you left the app to fix that. Meanwhile the Earn section carried a fourth tile — "Bridges" — greyed out as a placeholder since the day it was drawn.
+
+Both gaps are now closed. Transfer gained a **Bridge** tab, and Earn's dead tile became **Supply**: a curated list of pools to put assets into, Uniswap V3 trading pools on five networks and Across bridge pools on Ethereum. Behind them sit two small upgradeable contracts, one of each per network — a bridge router and a liquidity router. Both hold funds only for the duration of a single transaction, and neither is ever in an exit path. The interesting engineering is almost entirely in what they decline to do.
+
+## One argument decides who gets refunded
+
+Cross-chain transfers settle through Across, an intent-based bridge. The model matters because the safety property falls straight out of it: you deposit on the origin chain, and a relayer competing for the job immediately pays your recipient on the destination chain out of their own inventory, to be reimbursed later from the protocol's pooled liquidity. The speed comes from somebody else fronting the money.
+
+That model needs an answer for the case where nobody takes the job. Across's answer is a refund: a deposit no relayer fills by its fill deadline is returned on the *origin* chain — to the address recorded on the deposit as the **depositor**.
+
+The depositor is an ordinary parameter, not "whoever sent the transaction". That flexibility is deliberate — it's what lets wrapper contracts exist at all, including Across's own periphery contract that deposits on a user's behalf. It is also the trap. The obvious fee-taking wrapper names *itself*: the router pulls the member's tokens, so surely the router is the depositor. Every successful bridge behaves identically either way. Only the *unfilled* deposit diverges, and then the refund lands inside a contract with no per-member accounting and no withdrawal path — a silent failure, surfacing first in production, on the unhappy path, with real money, at exactly the moment a member's transfer has already gone wrong once.
+
+So the router passes the **member's own address** as depositor, never its own. One argument, and the worst case resolves itself — an unfilled deposit comes back to the person who made it, on the chain they started from, with no privileged action by anyone.
+
+What that buys downstream is the point. Had the router named itself, it would have needed a rescue function: something an operator could call to pull stranded deposits out and return them, plus a record of whose money was whose. That function is a custody surface — an address FairWins controls that can reach into a member's in-flight transfer. Because the refund never arrives here, the contract has no rescue path, no claim-refund path, and no way for an operator to touch a submitted transfer. **The absence is the design**, and the contract says so in a comment, so a later reader doesn't mistake it for an oversight and helpfully add one.
+
+## Testing a property you cannot stage
+
+The plan asked for the direct test: let a deposit expire on a forked chain and assert the refund lands on the member. It isn't reproducible. An Across refund is not a timer — it needs an off-chain dataworker to propose a root bundle on Ethereum, a dispute window to elapse, and a merkle-proved refund leaf to execute back on the origin chain. Staging that would mostly be testing Across's machinery, then asserting against our own simulation of it.
+
+What FairWins owns is one field: the depositor recorded on the deposit, because that is what Across's bundle logic reads when deciding who a refund belongs to. So the fork test runs against the **real** SpokePool, decodes the deposit event Across itself emits, and asserts the depositor is the member's address and is *not* the router's. It is merge-blocking, and the file says why in its header: the happy-path test passes whichever address is supplied, so this is the only assertion that catches the bug.
+
+## A fee charged on capital that was actually used
+
+The Supply side produced its own version of the same lesson — an implementation that looks entirely correct from outside. (The rate in question is currently **zero**, on both surfaces. The mechanism still has to be right before anyone ever sets one.)
+
+A Uniswap V3 mint takes two tokens and the maximum of each you're willing to supply, then consumes only what the pool's current price ratio requires and hands the rest back. It almost never takes both legs exactly. The first version of the liquidity router skimmed the platform fee from the amounts the member *offered*, before minting. Concretely: a member offers 1,000 USDC and 0.3 ETH; the ratio needs all the USDC but only 0.21 ETH; 0.09 ETH comes back untouched — and they have nonetheless paid a fee on the full 0.3, charged on capital handed straight back to them, unsupplied.
+
+Nothing about that looks wrong on the surface: a disclosed fee, the right percentage of a number on the confirm screen, a position that exists, a refund that arrives. The overcharge hides in the least-examined leg. It was found in adversarial review and reproduced on a live fork; four reviewers arrived at it independently.
+
+The fix inverts the order. The mint happens first, and the fee is quoted afterwards against the amounts Uniswap actually consumed — at the same rate the member's consent ceiling was already checked against, earlier in the same transaction. Whatever the position didn't take and the fee didn't claim is returned whole, and the transaction reverts outright if the router's balance afterwards differs from what it started with.
+
+That has an upstream consequence: **before the mint, there is no such number as "the fee".** So the confirm screen discloses the *rate*, says it applies to whatever is actually supplied, says the remainder comes back whole, and shows an upper bound rather than a precise figure — and the client library exposes no function computing a fee from a desired amount, because no honest one exists. A contract detail became a copy constraint; a fee line showing an exact figure would have been a small, confident lie.
+
+Ownership follows the same rule as the depositor: the position NFT is minted with the **member** as recipient, never the router. Once the mint returns, the member holds a position the router has no power over — they add to it, collect from it, or close it by calling Uniswap directly. A fork test exercises exactly that with the router paused *and* the pool retired, to prove the exit doesn't depend on us.
+
+## The deposit that is deliberately not ours
+
+Bridge pools work differently, because of one missing parameter. Across's `addLiquidity` takes an asset and an amount — and no recipient. LP tokens mint to whoever called it. A fee-skimming wrapper would hold those LP tokens itself, making FairWins the custodian of a position the member could never withdraw.
+
+So bridge-pool deposits are **not routed at all**: they are a direct call from the member's wallet to Across's HubPool, and they are fee-free. It is the same rule the codebase applied earlier to delegated staking — a fee is charged only where it can be charged atomically *without* taking custody. Where it can't, the fee doesn't ship; the guarantee does.
+
+That costs real control, and the honest thing is to name it. The liquidity router still curates and lists bridge pools, but it is not in their path, so its pause switch cannot stop them; only the listing's enabled flag, which the app honours, withholds one from members. That is a weaker lever than the Uniswap path has, and the admin surfaces say so rather than implying the button does more than it does.
+
+One asymmetry the copy has to carry: the HubPool is an L1 contract by design — the pot lives on Ethereum and the bridge lends *from* it to every other network. **Bridge liquidity is therefore available on Ethereum and nowhere else** — not on Polygon, not on any of the L2s — while trading liquidity is available on all five networks this feature covers (Ethereum, Polygon, Arbitrum, Base, Optimism). Every client entry point answers for an unsupported network with an explicit "not available here" naming where it is, rather than an empty list that would read as "nothing to show".
+
+## Why build it this way
+
+**The platform fee is zero today, and a zero fee shows nothing.** Both services — one for bridging, one for pool deposits — are registered at 0 bps against a permanent 250 bps ceiling, so neither surface shows a fee line at all right now; a line reading 0.00 implies a lever that isn't being pulled. What members do pay is real and is not FairWins': the relayer's fee for fronting money on the far side, and network gas. Those are itemised, named for what they are, and never called free.
+
+**Two ceilings, in two places.** The rate the member was shown travels back into the transaction as a maximum, and a live rate above it reverts rather than overcharging. Each router also carries its own hard 250 bps constant, making the cap a property of the charging contract rather than of a registration argument.
+
+**A pause stops new value going in, never value already in.** In-flight bridges live in the SpokePool and settle or refund regardless of this contract's state; existing positions were never held by us to begin with. Both pause switches depend on nothing but their own contract's storage, so they work while every optional service is degraded. On the same principle, a pool listing has no removal function at all — retirement is a flag, because a listing may have members' money behind it and must stay visible and withdrawable.
+
+**Honest limits.** Positions are full-range only: no ranges, no rebalancing, no out-of-range state. Fee-on-transfer and rebasing tokens aren't curatable — residual-balance assertions make both routers fail closed rather than under-deliver. And a bridge price isn't derivable client-side, so when the quoting service is unreachable the Bridge surface says it's unavailable rather than showing a remembered number, while an already-submitted transfer still resolves without it, straight from the chain.
+
+The property this feature most wants to be boring is the one nobody should ever need: when a cross-chain transfer fails, there is nothing to rescue, because nothing FairWins holds was ever standing in the way.
+
+## Further reading
+
+- [Across Protocol documentation](https://docs.across.to/) — the intent-based bridge behind Transfer → Bridge, including the deposit / fill / refund lifecycle and the origin-chain refund rule
+- [Uniswap V3 position manager](https://docs.uniswap.org/contracts/v3/reference/periphery/NonfungiblePositionManager) — how a mint consumes only what the current price ratio requires and returns the rest
+- [ERC-1822 / UUPS proxies](https://eips.ethereum.org/EIPS/eip-1822) and [OpenZeppelin's upgradeable-contract docs](https://docs.openzeppelin.com/contracts/5.x/api/proxy) — the upgrade pattern both routers use
+- For deeper implementation details, see the FairWins developer documentation.

--- a/docs/blog/posts/35-cross-chain-intents-and-lp/social.md
+++ b/docs/blog/posts/35-cross-chain-intents-and-lp/social.md
@@ -1,0 +1,30 @@
+# Social & Image — One Argument Decides Who Gets the Money Back
+
+## X (Twitter)
+
+When a cross-chain deposit goes unfilled, the bridge refunds it to whatever address the deposit named as its depositor. Name your own router and every failed transfer strands inside it. FairWins names the member — so the failure path fixes itself, and the contract needs no rescue button. 🔗 <link>
+
+#Ethereum #DeFi #SmartContracts
+
+## LinkedIn
+
+The most consequential line in FairWins' new cross-chain bridge is a single argument.
+
+Across, the protocol that settles these transfers, refunds an unfilled deposit on the origin chain — to whatever address the deposit recorded as its "depositor". That's an ordinary parameter, not "whoever sent the transaction". The obvious wrapper implementation names itself, and every successful bridge then behaves identically. Only the *unfilled* deposit diverges, refunding into a contract with no per-member accounting and no way out. A silent failure, surfacing first in production, on the unhappy path, with real money.
+
+So the router passes the member's own address, and gets something better than a fix: the failure path needs no privileged action at all. No rescue function, no claim-refund function, no operator who can reach into an in-flight transfer. The new engineering post walks through that decision and its counterpart on the liquidity side:
+
+- A fork test asserts the depositor field against the real bridge contract, because the refund itself can't be staged — and it's merge-blocking, since the happy-path test passes either way.
+- The liquidity fee is charged on what Uniswap actually consumed, not what the member offered. An earlier version skimmed it up front, charging members on capital that was handed straight back to them unsupplied. Adversarial review reproduced it on a live fork.
+- Bridge-pool deposits aren't routed at all: that protocol's deposit call has no recipient parameter, so a fee-taking wrapper would own a position the member could never exit. Direct member call, no fee.
+- Both platform fee services ship at 0 bps against a permanent 250 bps ceiling, so there's no fee line on either surface today. The relayer fee and network gas are real costs, disclosed as their own lines and never described as free.
+
+Full write-up: 🔗 <link>
+
+Where else does "we don't need that capability, so we didn't build it" beat adding a safety net?
+
+#Ethereum #DeFi #SmartContracts #Fintech #Security
+
+## Image prompt (Gemini / Nano Banana)
+
+Clean modern isometric editorial illustration: two elevated hexagonal platforms separated by open space, connected by a taut arc of small geometric tokens travelling left to right. Midway along the arc sits a small, fully transparent glass module that the stream passes straight through without collecting inside it — visibly empty, nothing resting in its interior. From that midpoint a single fine return filament curves back and terminates precisely at a small figure-marker standing on the origin platform, deliberately *not* at the glass module. On the right platform, a shallow circular basin of layered tokens suggests a shared pool. Deep navy background with teal gradients and a fine engineering grid; one warm amber accent lights only the return filament, making the path home the brightest element in the frame. Soft precise studio lighting, crisp edges, minimalist fintech-engineering aesthetic, generous negative space. No text, no logos, no watermarks. Aspect ratio 16:9.

--- a/docs/blog/posts/README.md
+++ b/docs/blog/posts/README.md
@@ -56,6 +56,7 @@ notable correction.
 | 32 | [Spec-driven development with Spec Kit](32-spec-driven-development/blog.md) | Security & DevOps |
 | 33 | [CallsignRegistry: an in-house ENS-style naming system](33-callsign-registry/blog.md) | Standalone |
 | 34 | [TokenFactory: templated token minting](34-token-factory/blog.md) | Standalone |
+| 35 | [Cross-chain intents & pooled liquidity: the refund address and the no-custody fee rule](35-cross-chain-intents-and-lp/blog.md) | Standalone |
 
 ## Suggested publishing order
 


### PR DESCRIPTION
Phase 7 of spec 067 — the User Story 5 content deliverables (T136–T143).

Three pieces for one feature at three registers:

| Piece | Audience | Path |
|---|---|---|
| Feature announcement | Members | `docs/blog/features/02-bridge-and-supply/` |
| Engineering post | Semi-technical | `docs/blog/posts/35-cross-chain-intents-and-lp/` |
| Knowledge primer | Complete beginner | `docs/blog/knowledge/21-bridges-and-liquidity/` |

Each has a `social.md` promotion kit (X, LinkedIn, 16:9 image prompt) and an index row in its series README.

## What each does

**The announcement** shows the *actual* confirm step for both surfaces, read out of `BridgeView` / `SupplySheet` rather than paraphrased — what's quoted, the expiry countdown and refresh, the acknowledgement checkbox that keeps confirm unusable until ticked, and the always-open withdraw path.

**The engineering post** is built on the two properties that shaped the design: the `depositor` refund invariant (and why there is deliberately no rescue function — that function *would be* the custody surface the router exists to avoid), and the no-custody fee rule, told with its real history including the overcharge on capital Uniswap refunded unsupplied that adversarial review reproduced on a fork.

**The primer** teaches impermanent loss properly, because SC-005 requires it to be genuinely comprehensible — T158 runs a moderated comprehension check against this article before mainnet launch.

## T143 fact-check

Both failure modes T143 names are clear:

- **Bridge liquidity is Ethereum-only**, stated explicitly in all three pieces with the L1-HubPool reason. Uniswap trading pools on all five EVM mainnets.
- **Both fee services ship at zero.** The pieces say a zero rate renders *no fee line at all*, and that there's no revenue to FairWins here today; 250 bps appears only as the cap that would apply if a rate were ever raised. Across relayer fees and network gas are disclosed as real and explicitly not ours.

The impermanent-loss worked example was verified against the constant-product formula rather than taken on trust:

```
0.5 ETH + 1,000 USDC at ETH $2,000; ETH doubles
→ pool returns 0.3536 ETH + 1,414.21 USDC = $2,828.43
   vs $3,000 held = $171.57 short = 5.72%
```

The article rounds to 0.354 / 1,414 / $2,828 / $172 / 5.7%.

## Note

The two fact-check agents hit a session limit mid-run, so I did T143 directly rather than re-spawning them. The checks above are mine and are reproducible from the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBMvFqhjqsXyUVF2hEFoNc