### PR TITLE
Spec 067: developer guide, operator runbook, CLAUDE.md guardrail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,35 @@ artifacts live under `specs/<feature>/`.
   recovery is audited via `captureLegacyRecovery` (client-ledger `legacy_account_recovered`, address +
   type only, stable/idempotent entryId, **never** key material). See
   `docs/developer-guide/legacy-account-recovery.md` + `specs/062-legacy-account-recovery/`.
+- **Bridging + supplied liquidity (spec 067) route through TWO UUPS routers that never take custody.**
+  `BridgeRouter` (`bridgeRouter`/`bridgeRouterImpl`, Across Protocol V3) powers the **Bridge** tab inside
+  **Transfer**; `LiquidityRouter` (`liquidityRouter`/`liquidityRouterImpl`, Uniswap V3 + Across HubPool)
+  powers the **Supply** section inside **Earn**. Neither is deployed on any network yet (issue #966).
+  Four rules govern every change here:
+  (1) **THE MEMBER IS THE DEPOSITOR.** `depositV3` is passed `msg.sender`, never `address(this)`, so an
+  unfilled Across deposit refunds to the MEMBER. That is why `IBridgeRouter` has **no rescue or
+  claim-refund function** — the absence is the design, and adding one would create the custody surface
+  the router exists to avoid. (2) **NO CUSTODY.** Uniswap position NFTs mint to the member; Across
+  **bridge-LP deposits never touch a FairWins contract at all** (a direct member call to the HubPool —
+  `addLiquidity` has no recipient parameter, research R3), so the contract *cannot* pause them and only
+  the app-honoured `enabled` flag withholds one. The Supply pause is therefore **"new Uniswap supplies"
+  only** — never label it "pooling". (3) **A PAUSE NEVER TRAPS VALUE**: it stops NEW bridges/supplies;
+  in-flight bridges settle or refund via Across, and positions stay withdrawable because exits never
+  routed through the router. There is no `removePool` — retiring is `setPoolEnabled(false)`, and retired
+  pools stay listed with their position count (FR-024). (4) **FEES**: two spec-060 services
+  (`bridge.transfer`, `liquidity.deposit`), both `ConfigOnly`, both **cap 250 bps / rate 0 at launch** —
+  never hardcode a bps value, never imply a fee ships non-zero. The member's `maxFeeBps` is a consent
+  ceiling, the cap binds the fee **amount** taken (not the rate a FeeRouter reports about itself), and
+  the fee is charged on **capital Uniswap actually consumed**, never on what was offered.
+  **Roles**: `LIQUIDITY_ADMIN_ROLE` curates routes/pools; `GUARDIAN_ROLE` pauses; `DEFAULT_ADMIN_ROLE`
+  owns the fund-path addresses (`spokePool`/`positionManager`/`feeRouter`/`sanctionsGuard`) — curating
+  badly is reversible, repointing a router is not. `GUARDIAN_ROLE` is **per-router** and does NOT inherit
+  the WagerRegistry guardian set; the admin tabs read authority from the router in scope
+  (`readRouterAuthority`), never from the app-wide role flags. **Availability**: Uniswap trading pools on
+  all five EVM mainnets (1/10/137/8453/42161); Across **bridge-LP on ETHEREUM ONLY** (the HubPool is an
+  L1 contract); ETC 61 and Mordor 63 have neither protocol and **cannot host these routers**. See
+  `docs/developer-guide/bridge-and-liquidity.md` + `docs/runbooks/bridge-liquidity-operations.md` +
+  `specs/067-bridge-pool-liquidity/`.
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,

--- a/docs/developer-guide/bridge-and-liquidity.md
+++ b/docs/developer-guide/bridge-and-liquidity.md
@@ -1,0 +1,443 @@
+# Cross-Chain Bridge & Liquidity Supply (spec 067)
+
+Two member surfaces, two per-network UUPS routers, two third-party protocols:
+
+- **Transfer → Bridge** (`frontend/src/components/wallet/BridgeView.jsx`) moves an asset a member
+  already holds to another network, settled by **Across Protocol V3**.
+- **Earn → Supply** (`frontend/src/components/earn/SupplyView.jsx`) supplies liquidity to curated
+  pools — **Uniswap V3** full-range trading pools, and **Across HubPool** bridge pools.
+
+Neither surface takes custody. The member's wallet is the only signer, the member owns every
+position, and the routers exist for exactly two jobs: **charge the spec-060 platform fee atomically
+where that is possible without custody**, and **be the on-chain control surface** (curation, limits,
+killswitch) that decides what is on offer.
+
+- Contracts: `contracts/bridge/BridgeRouter.sol` (`IBridgeRouter.sol`),
+  `contracts/liquidity/LiquidityRouter.sol` (`ILiquidityRouter.sol`)
+- Client libs: `frontend/src/lib/bridge/`, `frontend/src/lib/liquidity/`
+- Spec: [`specs/067-bridge-pool-liquidity/`](../../specs/067-bridge-pool-liquidity/) —
+  `spec.md`, `research.md` (the design-changing findings), `contracts/` (per-contract design notes)
+- Operator runbook: [runbooks/bridge-liquidity-operations.md](../runbooks/bridge-liquidity-operations.md)
+- Related: [platform-fees.md](./platform-fees.md), [staking-integration.md](./staking-integration.md)
+  (spec 066's `StakingRouter` is the shape both routers copy),
+  [upgradeable-contracts.md](./upgradeable-contracts.md)
+
+> **Deployment state:** neither router is deployed on any network yet (issue **#966**). Everything
+> below is the shipped, tested behaviour of code that has no addresses in `deployments/` — which is
+> also why every surface has to degrade honestly rather than assume a router is there.
+
+## Where each half can exist at all (research R8)
+
+The binding constraint was never the protocols; it was which chains carry them.
+
+| Network | Bridge (Across SpokePool) | Trading pools (Uniswap V3) | Bridge pools (Across HubPool) |
+|---|---|---|---|
+| Ethereum (1) | ✅ | ✅ | ✅ **only chain** |
+| Optimism (10) | ✅ | ✅ | ❌ |
+| Polygon (137) | ✅ | ✅ | ❌ |
+| Base (8453) | ✅ | ✅ (**distinct addresses** — R4b) | ❌ |
+| Arbitrum (42161) | ✅ | ✅ | ❌ |
+| Ethereum Classic (61) / Mordor (63) | ❌ | ❌ | ❌ |
+
+**Across's HubPool is an L1 contract by design** — the shared pot lives on Ethereum and the bridge
+lends *from* it to every other network. So bridge-LP listings are **Ethereum-only** while trading
+pools span all five mainnets. This asymmetry is not a rollout gap that will close; do not "fix" it by
+copying `hubPool` onto an L2, and do not let copy imply both kinds of pool exist everywhere
+(`liquidityAvailabilityCopy()` states the two halves separately for this reason).
+
+ETC (61) and Mordor (63) have **neither** protocol and cannot host these routers at all. They do
+carry `dex` config (ETCswap) for the swap surface, which is precisely why availability is not derived
+from the DEX capability alone — see [Availability](#availability-how-a-surface-decides-to-exist).
+
+**Uniswap addresses are not the same on every chain.** Ethereum, Polygon, Arbitrum and Optimism share
+the canonical factory/position manager; **Base does not**. Copying the canonical pair everywhere
+produces a router pointed at a non-contract (deposits revert) or, worse, at a same-address contract
+belonging to something else. Every address is taken from that chain's own deployment record, asserted
+to carry bytecode at deploy time, and re-checked by `scripts/ops/verify-protocol-addresses.js`.
+
+## `BridgeRouter`
+
+**Does:** holds the curated route registry (`inputToken` + `outputToken` + `destinationChainId`, with
+a per-transaction `maxAmount` and an advisory `expectedFillSeconds`), the Across SpokePool address,
+the sanctions guard, and a per-network pause. `bridgeWithFee` pulls the member's gross amount, skims
+the `bridge.transfer` fee to the FeeRouter's treasury, approves the SpokePool for the **net**, and
+calls `depositV3` — one transaction, `nonReentrant`, checks-effects-interactions, approvals reset to
+zero, and a residual-balance assertion (`ResidualFunds`) at the end of both the ERC-20 and native legs.
+
+**Does not:** hold anything between transactions, and has **no rescue or claim-refund function**. That
+absence is deliberate and load-bearing — see below.
+
+### The property this contract exists to get right
+
+Across refunds a deposit that no relayer fills by `fillDeadline` **to the `depositor` address on the
+origin chain**. `depositor` is an ordinary parameter, independent of `msg.sender`. The router therefore
+passes **`msg.sender` — the member** — and never `address(this)`.
+
+Naming the router would send every unfilled bridge into a contract with no per-member accounting and
+no withdrawal path, stranding funds on the one path that is supposed to be the safety net. The failure
+is silent: the happy path is unaffected, so it only surfaces in production, on the unhappy path, with
+real money. `BridgeInitiated` records `depositor` explicitly so the property is auditable without
+decoding the SpokePool's own log, and the merge-blocking fork test asserts an **expiry refund lands on
+the member's address** — a suite that only covers the fill path cannot detect this class of bug.
+
+Because refunds and fills settle directly to the member, adding an operator "rescue" entrypoint would
+imply an operator can reach an in-flight transfer. They cannot, and the admin Operations panel says so
+rather than leaving anyone hunting for a button during an incident.
+
+### Other decisions worth knowing before you touch it
+
+- **`outputToken` is part of the route id.** It was originally omitted, which meant re-running
+  `setRoute` with a different delivered asset overwrote the route **in place** under the same id: a
+  member's quote could name one asset while the deposit delivered another, with no new route appearing
+  anywhere an operator or indexer would notice. `computeRouteId` also mixes in `block.chainid`, so ids
+  are never portable across deployments.
+- **`nativeInput` is explicit, not inferred.** Inferring it from `msg.value > 0` would make a
+  wrapped-token route and a native route indistinguishable. An ERC-20 route that receives native value
+  reverts `UnexpectedNativeValue` rather than accepting funds it could not return.
+- **`removeRoute` exists here and pool removal does not exist on the other router.** A route holds no
+  member position, so removing it only stops new bridges. A pool listing does correspond to member
+  positions, so it can only be retired.
+- **Non-standard tokens fail closed.** A fee-on-transfer token delivers less than `inputAmount`, so the
+  SpokePool's own pull of `net` reverts; a rebasing token trips `ResidualFunds`. Neither can silently
+  under-deliver. Such tokens are simply not curatable as routes.
+
+## `LiquidityRouter`
+
+**Does:** curates the pools members may supply — both `TradingLp` (Uniswap V3) and `BridgeLp` (Across
+HubPool) listings, with per-transaction ceilings per leg — holds the Uniswap position manager address,
+the sanctions guard, and a pause. `mintFullRangeWithFee` charges the `liquidity.deposit` fee and mints
+a **full-range** Uniswap V3 position **to the member** (`recipient: msg.sender`). Full range means
+`±887272` aligned to the pool's tick spacing: no range UI, no out-of-range state, no rebalancing.
+
+`listPool` cross-checks a `TradingLp` listing against the pool it names (`token0`/`token1`/`fee`).
+Without that, listing a 0.3% pool's address with `feeTier: 500` was accepted and the mint then
+succeeded against a **different pool than the one curated** — reproduced on a Polygon fork. The listing
+metadata is what the member is shown, so it has to be true.
+
+**Does not, and this is three separate rulings:**
+
+1. **It is never in an exit path.** Trading-LP members own the position NFT and call Uniswap's
+   `NonfungiblePositionManager` directly; bridge-LP members own the LP tokens and call Across's HubPool
+   directly. A pause, misconfiguration, or upgrade can never block an exit, and no withdrawal can ever
+   carry a platform fee — there is no code path that could charge one.
+2. **It does not touch bridge-LP deposits at all.** `HubPool.addLiquidity(l1Token, amount)` has **no
+   recipient parameter** — LP tokens mint to `msg.sender`. A fee-skimming wrapper would therefore
+   receive the LP tokens itself, making FairWins the custodian of a position the member could never
+   exit. So bridge-LP deposits are a **direct member call** and are **fee-free**, and the router is
+   their registry and killswitch, not their path. This is the same rule spec 066 applied to delegated
+   staking: *a fee is charged only where it can be charged atomically without taking custody.*
+   Consequence: `pause()` here stops **new Uniswap supplies only**, and every operator surface must be
+   labelled that way — an operator reaching for a killswitch during an incident must not believe they
+   have stopped something they have not.
+3. **There is no `removePool`.** Retirement is `setPoolEnabled(false)`. A retired pool stays listed,
+   visible, and withdrawable, because members still hold positions in it. The copy for a closed pool
+   says "no new deposits", never "gone".
+
+`positionManager` may be zero at init (a network can curate bridge pools without Uniswap); the supply
+path then reverts `PositionManagerUnset` rather than failing opaquely. A `BridgeLp` pool id passed to
+`mintFullRangeWithFee` reverts `NotTradingPool` for the same reason.
+
+## UUPS and storage
+
+Both routers inherit `contracts/upgradeable/UUPSManaged.sol` — do not re-roll the proxy or auth
+wiring. Both replace the constructor with a one-time `initialize`, and both carry a trailing
+`uint256[44] private __gap`.
+
+Storage is **append-only**: never insert, reorder, or remove existing state; new state goes at the end
+and comes out of the gap. Both contracts are registered in `scripts/deploy/check-storage-layout.js`
+(`bridgeRouter` / `liquidityRouter`), so `npm run check:storage-layout` validates them and gates CI.
+Ship logic changes as **in-place upgrades** via `scripts/deploy/lib/upgradeable.js`, never a fresh
+redeploy — a redeploy would orphan the curated routes and pools an operator has already seeded, and
+`deployments/` records the proxy (`bridgeRouter`, `liquidityRouter`) separately from its current
+implementation (`bridgeRouterImpl`, `liquidityRouterImpl`).
+
+## The role model
+
+Each router has its **own** AccessControl instance, granted at `initialize` to the deploy admin (a
+multisig in production).
+
+| Role | Controls | Why it sits where it does |
+|---|---|---|
+| `LIQUIDITY_ADMIN_ROLE` | `setRoute` / `setRouteEnabled` / `setRouteLimit` / `removeRoute`; `listPool` / `setPoolEnabled` / `setPoolLimit` | **Curation.** Which routes and pools are offered, at what per-transaction ceiling. |
+| `GUARDIAN_ROLE` | `pause` / `unpause` | **The killswitch**, and nothing else. |
+| `DEFAULT_ADMIN_ROLE` | `setSpokePool`, `setPositionManager`, `setFeeRouter`, `setSanctionsGuard`; role grants | **The fund-path addresses**, deliberately a role above curation. |
+| `UPGRADER_ROLE` | `_authorizeUpgrade` (from `UUPSManaged`) | Upgrades. |
+
+The split exists because the two kinds of mistake are not equally recoverable. **Curating a route or a
+pool badly is reversible by a toggle** — flip `enabled` false and the offer is gone. **Pointing a
+router at a hostile contract is not**: `spokePool` and `positionManager` are approved and handed the
+member's net amount, `feeRouter` names both the rate *and* the `treasury()` the fee is transferred to,
+and `sanctionsGuard` is the compliance gate. Whoever can write those can redirect where member funds
+go, so they are `DEFAULT_ADMIN_ROLE` while `LIQUIDITY_ADMIN_ROLE` stays what its name says. The
+fee-**amount** bound described in the next section is the second half of this: even an admin cannot
+configure a FeeRouter that takes more than `MAX_FEE_BPS` of a member's principal.
+
+### `GUARDIAN_ROLE` here is not the WagerRegistry guardian set
+
+It is a role on **this router's own** AccessControl, granted per router. The app-wide `useRoles()`
+flags cannot answer whether an operator holds it:
+
+- `isGuardian` means "holds `GUARDIAN_ROLE` on the `WagerRegistry`" — a different contract, an
+  unrelated set. An operator with the wager guardianship would be shown an enabled killswitch that
+  reverts, which is exactly the belief the pause requirements exist to prevent.
+- `isLiquidityAdmin` is an **OR** across the two routers, while the role is granted per router on
+  purpose. The OR showed an operator holding it on one router every write control on the other.
+- All of them read the **wallet's** connected chain, while control state is per-network and the admin
+  tabs scope to a network the operator picks. A Polygon guardian whose wallet sat on Ethereum lost the
+  Polygon controls.
+
+So the operator surfaces (`frontend/src/components/admin/BridgeTab.jsx`, `SupplyTab.jsx`) ask the
+contract that will enforce it, via `readRouterAuthority` in
+`frontend/src/components/admin/liquidityAdminCommon.js` — `hasRole` against the **router in scope, on
+the network in scope**. The app-wide flags remain good for one thing only: deciding whether the tab
+appears at all. And `readable: false` from that read means *the question could not be put*, not *the
+answer was no* — the controls stay offered with the authority marked unconfirmed, because withdrawing
+a killswitch because an RPC timed out is itself the failure.
+
+## The two fee services
+
+Both are spec-060 `FeeRouter` services. The rate lives there and **only** there — never hardcode a bps
+value, never cache one in these routers.
+
+| Service id | Charged on | Kind | Cap | Launch rate |
+|---|---|---|---|---|
+| `keccak256("bridge.transfer")` | a bridge submission (value-out) | `ConfigOnly` | 250 bps | **0** |
+| `keccak256("liquidity.deposit")` | a Uniswap full-range supply (value-in) | `ConfigOnly` | 250 bps | **0** |
+
+Client constants: `FEE_SERVICES.BRIDGE_TRANSFER` / `FEE_SERVICES.LIQUIDITY_DEPOSIT` in
+`frontend/src/lib/fees/feeQuote.js`. A zero or unset rate produces **no fee line at all** — not a line
+reading 0.00 — and behaviour byte-identical to fee-free.
+
+There is deliberately **no bridge-LP service**. Registering a rate that cannot be charged (research
+R3) would put a settable control in the admin panel that silently does nothing, which is worse than no
+control.
+
+**Why `ConfigOnly`.** `Wrapped` services are the ones `FeeRouter.depositToVaultWithFee` will charge;
+registering these as `Wrapped` would let a call like
+`depositToVaultWithFee("bridge.transfer", someVault, …)` pass the kind check and treat a bridge fee as
+an ERC-4626 deposit. `quoteFee` / `feeBps` / `setFeeBps` behave identically for either kind, so nothing
+is lost.
+
+**Why each router repeats `MAX_FEE_BPS = 250`.** `FeeRouter` applies its own `MAX_WRAPPED_FEE_BPS`
+only to `Wrapped` services. Declaring the ceiling on the charging contract makes 250 bps a property of
+**the code that moves the money** rather than of a registration argument, and bounds the damage if
+`feeRouter` is ever repointed.
+
+### Three guards, and what each one is actually for
+
+1. **The consent ceiling.** The frontend passes the **quoted** bps back as `maxFeeBps`; a live rate
+   above it reverts `FeeAboveQuoted` instead of overcharging. Never synthesise a `maxFeeBps` you did
+   not display. It only bites when a fee is actually charged (`fee > 0`), so a treasury-unset network
+   quoting zero is never blocked by a stale configured rate.
+2. **The amount bound.** Both routers bound the fee **amount** `quoteFee` returns to `MAX_FEE_BPS` of
+   the principal, and require an exact `fee + net == gross` split (`FeeSplitMismatch`). The cap binds
+   *the fee actually taken, not the rate the FeeRouter reports about itself.* Both ceiling checks read
+   `feeBps()`, which is the FeeRouter's own claim: an implementation reporting `feeBps() = 0` while
+   `quoteFee()` hands back most of the amount satisfies them both, and the transfer would then send
+   the member's principal to its treasury. Exact-split matters for the mirror-image reason — `net` is
+   what reaches Across or the position manager, so a router that under-reports `net` would strand the
+   difference or shrink the member's position.
+3. **The residual assertion.** Every leg compares the closing balance to the opening one and reverts
+   `ResidualFunds` on any difference. Transient custody stays transient.
+
+### The fee is charged on capital actually consumed
+
+For Uniswap supplies, `LiquidityRouter._supply` quotes the fee **after** the mint, against the
+`amount0`/`amount1` the position manager actually took. An earlier version skimmed from the member's
+gross desired amounts **before** the mint. Uniswap almost never consumes both legs exactly — it takes
+whatever the current price ratio needs and refunds the rest — so members were charged a fee on capital
+that was handed straight back to them, unsupplied. Adversarial review reproduced it on a live fork;
+four independent reviewers found it.
+
+Two consequences you cannot design around:
+
+- **The remainder comes back whole, with no fee on it.** The router approves only the *net* to the
+  position manager, so the fee can never be silently deployed as liquidity, and everything the position
+  did not take and the fee did not claim is transferred back to the member.
+- **No function computes "the fee" from a desired amount, because no such number exists before the
+  mint.** `frontend/src/lib/liquidity/liquidityRouter.js` exposes `maxSupplyFee` — an explicit **upper
+  bound** — and the confirm step discloses the **rate**, says it applies to whatever is actually
+  supplied, and says the remainder returns whole. A precise figure computed off the amount the member
+  typed would be too high whenever the pool's ratio takes less than both legs.
+
+The bridge fee has the opposite shape and is simpler: it is skimmed from the gross the member entered
+and only the net goes to Across — which is why `acrossQuotes.js` fetches the Across quote for the
+**net**. Quoting the gross would overstate what arrives.
+
+## Availability: how a surface decides to exist
+
+Three independent conditions compose. Getting this wrong in either direction is a member-facing
+failure: claiming availability we do not have, or hiding a surface that works.
+
+**1. Capability flags** (`frontend/src/config/networks.js`, per network):
+
+| Flag | Derived from | Gates |
+|---|---|---|
+| `capabilities.dex` | `SWAP_CHAIN_IDS.has(chainId) && Boolean(this.dex)` | In-app swapping: the Trade surface, the asset sheet's Swap action, DEX spot pricing |
+| `capabilities.liquidity` | `Boolean(this.dex?.positionManager)` | Earn → Supply (trading pools) |
+| `capabilities.bridge` | `Boolean(this.bridge?.spokePool)` | Transfer → Bridge |
+
+`dex` is an **explicit allow-list**, not `Boolean(this.dex)`, because spec 067 adds `positionManager`
+addresses for liquidity — a different reason — and deriving the swap capability from the presence of
+`dex` config would switch token swapping on as a side effect of a routine config edit. That is exactly
+how Ethereum ended up swap-less: it had no `dex` block, so the capability was false by accident of
+configuration rather than by decision. Keeping swap and liquidity as two flags also keeps the states
+representable: a network may have pools worth supplying before FairWins exposes swapping there, or the
+reverse.
+
+The `bridge` block in `networks.js` is a **build-time display fallback only**. The authoritative
+SpokePool/HubPool addresses, route availability, limits, and pause state are read from the routers at
+runtime.
+
+**2. Router deployment.** `capabilities.liquidity` alone is *not* enough to name a network — it is true
+wherever a Uniswap-shaped position manager is configured, which includes ETC and Mordor via ETCswap,
+where FairWins has shipped nothing. So `tradingLiquidityNetworks()` in
+`frontend/src/lib/liquidity/liquidityCopy.js` requires **both** the capability **and** a deployed
+`liquidityRouter` address. `bridgeLiquidityNetworks()` needs a configured `hubPool` (Ethereum only).
+Both lists are derived, never asserted, so they stay true as deployments land — and an empty list
+produces honest "not set up in this build yet" copy rather than a false roster.
+
+The admin roster is the deliberate exception: `adminNetworks(capability)` lists every capable network
+whether or not a router is deployed there, because the undeployed ones are the ones an operator most
+needs to see.
+
+**3. The quoting gateway.** A bridge price is **not derivable client-side** — it needs Across's
+relayer-fee oracle — so quoting goes through the relay-gateway proxy
+(`services/relay-gateway/src/bridge/`, base URL `VITE_RELAYER_URL`, module env `BRIDGE_ENABLED`,
+`BRIDGE_CHAIN_IDS`, `BRIDGE_KILLSWITCH`, quota and TTL vars). The module is optional infrastructure
+and off unless enabled; when off it answers **503 `bridge_disabled`** rather than 404, so the client
+can tell "an operator turned it off" from "this gateway is too old". Supply needs no gateway at all —
+its reads are direct RPC.
+
+Composed, via `useBridgeAvailability` (`BRIDGE_UNAVAILABLE_REASON`) and the copy tables in
+`bridgeCopy.js` / `liquidityCopy.js`:
+
+| Condition | Bridge shows | Supply shows |
+|---|---|---|
+| Capability false (ETC, Mordor, Bitcoin) | `no_protocol` / `bitcoin` — permanent here, not a fault, and names where it *is* available | Honest per-network empty state naming where pools exist |
+| Capability true, router **undeployed** | `router_undeployed` — a deployment state; Transfer works exactly as before | Network absent from the roster; other networks' pools still listed |
+| Router deployed, **unreachable** | `router_unreachable` — availability withheld, with "as of last read" framing | Same; existing positions still read directly from the protocol |
+| Router says **paused** | New bridges refused; in-flight tracking unaffected | New Uniswap supplies refused; positions still visible and withdrawable |
+| Route / pool **disabled** | Route not offered, with the reason | Pool shown as **closed to new deposits**, still visible and withdrawable |
+| `FeeRouter` present but unreadable | Fee-bearing path **blocked** — never quoted at a rate we are unsure of | Same |
+| Gateway unset / killswitched / unreachable | Surface hides (`gateway`). **In-flight bridges keep resolving** from chain evidence | Unaffected |
+
+That last row is the one that makes hiding an acceptable degradation rather than a trap: a gateway
+outage can stop a member *starting* a bridge, but can never strand one already moving.
+
+**The fallback direction is always toward withholding, never inventing.** Where spec 066 could fall
+back to "fee-free direct staking" because a safe default existed, no safe default exists for a bridge
+route — offering one we cannot price or verify would be inventing data. So the honest fallback is
+absence with a stated reason.
+
+## The R11b predicate inversion
+
+Two-asset surfaces pin the network on the first selection and filter the second list. **One
+mechanism, two predicates that are exact inverses**, both in
+`frontend/src/lib/assets/networkPin.js` so the inversion is visible at the point of use:
+
+```js
+samePair(o, pin)    // o.chainId === pin.pinnedChainId
+bridgeDest(o, pin)  // o.symbol === pin.pinnedSymbol && o.chainId !== pin.pinnedChainId
+```
+
+- **`PIN_MODE.SAME_NETWORK`** — a Uniswap pair and an in-app swap both live within one network, so
+  once the member picks the first asset its `chainId` pins the counterpart list.
+- **`PIN_MODE.OTHER_NETWORK_SAME_ASSET`** — the bridge is the exact inverse. Its whole purpose is that
+  the destination is a *different* network holding the *same* asset.
+
+**Applying `samePair` to the bridge silently reduces it to a same-chain transfer.** Nothing throws:
+the destination would be on the source chain, the gateway would still return a quote, and the member
+would still sign. That plausible copy-paste error is why the two rules live side by side in one module
+instead of being re-derived inline at each call site.
+
+`bridgeDest` matches the symbol **exactly**, so `USDC.e` is not a destination for `USDC` — they are
+genuinely different assets and quoting them as one would be dishonest. Both predicates run over spec
+064's `SelectableAsset` shape from `useSelectableAssets`, unchanged. Bitcoin options carry a **string**
+`chainId` (spec 061) and are excluded from both contexts **with a stated reason**
+(`nonEvmReason`) so the selector disables them visibly rather than dropping them. And pinning can
+legitimately produce an empty second list — `noPairCounterpartCopy` / `noBridgeDestinationCopy` say
+what would change it rather than rendering a dead dropdown.
+
+## Client libraries
+
+Both `lib/` trees follow the same **read/degrade contract**, copied from `lib/staking/stakingRouter.js`
+on purpose: read the router, **return `null` on any core read failure**, and let the caller choose the
+honest fallback. `null` means "we could not establish this", never "no". Nothing invents availability,
+and a failed read is never rendered as a zero — a member shown "0" when the truth is "we could not
+read it" has been told something false about their own money.
+
+### `frontend/src/lib/bridge/`
+
+| Module | Job |
+|---|---|
+| `bridgeRouter.js` | Read the router config (routes, limits, SpokePool, paused) and build the `bridgeWithFee` call as `{target, data, value}` entries for the spec-041 unified send rail. ERC-20 routes get an approve leg; native routes carry `inputAmount` as `value`. |
+| `acrossQuotes.js` | Assemble one quote from exactly two sources — the gateway's Across `suggested-fees` proxy and the live `FeeRouter` rate. Every cost is its own labelled line; a figure the upstream did not give us is marked unavailable, never rendered as 0. Quotes carry a validity window (`isQuoteStale`) and the quoted bps travels back as `maxFeeBps`. |
+| `bridgeStatus.js` | The status machine and cross-session reconciler. `delivered` is reachable **only** from confirmed destination-side evidence (a fill tx hash) — not an upstream string, not an elapsed timer. `needs_attention` is about the clock, not the outcome, and is **not terminal**. |
+| `bridgeActivityBuffer.js` | One notification record per state transition, ever; nothing is re-derived on drain. |
+| `bridgeCopy.js` | All member-facing wording: cost, timing, risk, the honest-unavailable table, and the named settlement protocol. |
+
+Persistence for in-flight bridges is the client ledger store (`data/ledger/sources/bridgeLedgerSource.js`,
+`LEDGER_CLASS.BRIDGE`), which is per-account and rides the spec-032 encrypted backup — so a bridge
+survives the app closing, and the gateway status endpoint is a **convenience, not the authority**.
+
+### `frontend/src/lib/liquidity/`
+
+| Module | Job |
+|---|---|
+| `liquidityRouter.js` | Read the pool registry and build supply calls. **Refuses** a `BridgeLp` pool rather than producing calldata that reverts; `chargesPlatformFee(pool)` is false for one; exposes `maxSupplyFee` (an upper bound) and no "the fee" function. |
+| `uniswapPositions.js` | Local full-range tick derivation (identical to `fullRangeTicks`), position discovery, value/earnings/composition — every figure flagged `isEstimate` — and the **exit** calls (`decreaseLiquidity` + `collect`) straight to the position manager. `positionManager` is always an explicit argument, never hardcoded (R4b). |
+| `acrossLpPositions.js` | Bridge-pool supply, read, and exit. **Nothing here imports, resolves, or targets `LiquidityRouter`**; there is no `maxFeeBps` argument and no fee-quoting function, because there is no fee. Answers for unsupported networks with `available: false` **and a reason naming where it is available**. |
+| `liquidityCopy.js` | All member-facing wording, including the asymmetric availability copy and `liquidityFeeCopy` returning `null` for bridge pools, always. |
+
+Ledger/notification wiring: `LEDGER_CLASS.LIQUIDITY` + `liquidityLedgerSource.js`, and the `bridge` /
+`liquidity` notification domains. Both class names are **new and additive** — nothing is reclassified,
+so historical ledger data and the encrypted backup are unaffected. Note the vocabulary rule from
+research R6: **"Pool" stays with wager pools**; the Earn area is **Supply**, and the wager-pool feed
+label was corrected to "Wager Pool".
+
+## Invariants you must not break
+
+1. **The member is Across's `depositor`.** Never `address(this)`. An unfilled deposit refunds to the
+   member on the origin chain, and there is deliberately no rescue or claim-refund function to make up
+   for getting this wrong.
+2. **No custody, ever.** Uniswap position NFTs mint to the member; Across LP tokens mint to the member
+   because their deposit never touches a FairWins contract at all. Both routers hold value only within
+   a single transaction, and assert it on the way out (`ResidualFunds`).
+3. **A pause stops new activity and can never trap value.** In-flight bridges settle in the SpokePool;
+   positions exit through the protocol with the router nowhere in the path. Both `pause()` functions
+   depend on nothing but their own contract's state, so they stay exercisable while every optional
+   service is degraded. The Supply pause covers **Uniswap supplies only** — label it that way.
+4. **Degrade honestly.** Return `null`, name the reason, and withhold the surface. Never invent a
+   price, an availability, or a zero for a read that failed; never let a fee-bearing action proceed on
+   a rate you could not read.
+5. **Storage is append-only.** New state at the end, out of the `__gap`; `npm run check:storage-layout`
+   green before any upgrade; in-place upgrades only.
+
+## Deploy, sync, and test
+
+```bash
+# 1. deploy both UUPS proxies + register the two fee services (cap 250 / rate 0)
+npx hardhat run scripts/deploy/deploy-bridge-liquidity.js --network <net>
+# 2. seed routes and pools per the R8 matrix (HubPool listings on Ethereum only)
+# 3. addresses + ABIs reach the frontend only through the generated artifacts
+npm run sync:frontend-contracts
+# 4. gating before any subsequent upgrade
+npm run check:storage-layout
+```
+
+The deploy script asserts non-empty bytecode at every configured protocol address before writing a
+record, and writes `bridgeRouter` / `bridgeRouterImpl` / `liquidityRouter` / `liquidityRouterImpl`.
+The fee **rate** is then set from the AdminPanel **Fees** tab (`FEE_ADMIN_ROLE`) — it is read-only on
+the Bridge and Supply tabs, which link to it.
+
+Tests:
+
+- Contracts — `test/bridge/BridgeRouter.test.js`, `test/liquidity/LiquidityRouter.test.js`, including
+  the hostile-FeeRouter case (`contracts/mocks/MockLyingFeeRouter.sol`) that the amount bound exists
+  for.
+- Fork — `test/fork/bridgeRouter.fork.test.js` (**the expiry-refund case is merge-blocking**) and
+  `test/fork/liquidityRouter.fork.test.js`.
+- Frontend — `frontend/src/lib/bridge/__tests__/`, `frontend/src/lib/liquidity/__tests__/`,
+  `frontend/src/lib/assets/__tests__/networkPin.test.js`, and the admin suites under
+  `frontend/src/test/admin/` (least-privilege, network scoping, pause-never-traps).

--- a/docs/runbooks/bridge-liquidity-operations.md
+++ b/docs/runbooks/bridge-liquidity-operations.md
@@ -1,0 +1,425 @@
+# Runbook: Bridge & Supply Liquidity Operations (spec 067)
+
+Operating the two per-network on-chain control surfaces behind Transfer → **Bridge** and
+Earn → **Supply**: the `BridgeRouter` (curated routes, per-transaction limits, protocol addresses,
+emergency pause) and the `LiquidityRouter` (curated pools, caps, protocol addresses, emergency
+pause). Both are UUPS proxies. Design: `specs/067-bridge-pool-liquidity/`.
+
+> **Status: neither router is deployed on any network yet (issue #966).** Everything below is
+> written against the intended deployed state, because a control surface with no written pause
+> procedure is worse than an undeployed one. Where a step names an address or a network, it is the
+> network's own `deployments/<net>-chain<id>-v2.json` record that is authoritative once the deploy
+> lands — not this document.
+
+## Read this first — three facts that change what you do
+
+1. **A pause stops NEW bridges and NEW Uniswap supplies. It cannot trap value, and it cannot
+   release it either.** Both routers are absent from every exit path by construction.
+2. **The Supply pause stops new *Uniswap* supplies only.** Across bridge-LP deposits never touch a
+   FairWins contract, so no FairWins contract can stop them. Only the per-pool `enabled` flag —
+   which the app honours and a direct caller does not — withholds them.
+3. **No operator action can touch a member's in-flight bridge.** Across settles directly to the
+   member. There is deliberately no rescue and no claim-refund function, on either router or in any
+   admin surface. Do not spend an incident looking for one.
+
+## Components, roles, and what each one can actually do
+
+| Thing | Where | Role required |
+|---|---|---|
+| `BridgeRouter` (routes, limits, pause) | on-chain, per network | see below |
+| `LiquidityRouter` (curated pools, caps, pause) | on-chain, per network | see below |
+| Bridge / Supply control views | Operations control plane → **Liquidity** → **Bridge** / **Supply** | entry: ADMIN, LIQUIDITY_ADMIN or GUARDIAN |
+| `FeeRouter` (spec 060) | on-chain, per network | `FEE_ADMIN_ROLE` for rates; `DEFAULT_ADMIN_ROLE` for registration/treasury |
+| Quoting gateway (`/v1/bridge/*`) | relay-gateway, optional | gateway operator — see [relayer-operations.md](relayer-operations.md) |
+
+| Action | Role, on which contract |
+|---|---|
+| `pause()` / `unpause()` | `GUARDIAN_ROLE` **on that router, on that network** (or that router's `DEFAULT_ADMIN_ROLE`) |
+| Routes: add / edit / enable / disable / remove / limit | `LIQUIDITY_ADMIN_ROLE` on the `BridgeRouter` for that network |
+| Pools: list / edit / retire / reopen / caps | `LIQUIDITY_ADMIN_ROLE` on the `LiquidityRouter` for that network |
+| `setSpokePool` / `setPositionManager` / `setFeeRouter` / `setSanctionsGuard` | **`DEFAULT_ADMIN_ROLE`** on that router |
+| Fee rates (`bridge.transfer`, `liquidity.deposit`) | `FEE_ADMIN_ROLE` on the FeeRouter — **not in these tabs** |
+| Upgrade either router | `UPGRADER_ROLE` — see [contract-upgrades.md](contract-upgrades.md) |
+
+The protocol-wiring setters sit a role **above** curation on purpose. `spokePool` is approved and
+handed the member's net amount; `positionManager` is approved and mints the member's position;
+`feeRouter` names both the rate and the `treasury()` the fee is transferred to. Whoever can write
+them can redirect where member funds go. Curating a route or a pool badly is reversible with one
+toggle; pointing a router at a hostile contract is not. Both routers additionally bound the fee
+**amount** they will pay out to `MAX_FEE_BPS` (250) and require `quoteFee` to split exactly
+(`FeeSplitMismatch`) — so even the router's own admin cannot configure a FeeRouter that takes more
+than 250 bps of a member's principal, whatever rate that FeeRouter reports about itself.
+
+### Roles are per-router AND per-network. Both halves bite.
+
+`GUARDIAN_ROLE` on the WagerRegistry carries **no** authority over either router — they are separate
+AccessControl instances that happen to use the same role name. And a grant lands on the router for
+the network your wallet is connected to. So "grant the guardian" is up to ten grants (two routers ×
+five networks), not one.
+
+Grant them from **Operations control plane → Admin Roles** (`DEFAULT_ADMIN_ROLE` only), connected to
+the network you are granting on, choosing the explicit targets:
+
+- `GUARDIAN_BRIDGE` / `GUARDIAN_LIQUIDITY` — the killswitches.
+- `LIQUIDITY_ADMIN_BRIDGE` / `LIQUIDITY_ADMIN_LIQUIDITY` — curation.
+
+Verify a grant by connecting as the grantee, opening the tab, scoping to that network, and
+confirming the write controls are offered. The tabs read `hasRole` from the router in scope, not the
+app-wide role flags, so that check is the real answer.
+
+### Scope is a network, not your wallet's network
+
+Both tabs read every capable network from that network's own RPC, and the network selector at the
+top of each tab is what you are looking at. Only **writes** need the wallet on the selected network;
+the tab says so rather than showing a dead button. An empty route table means that network has no
+routes — it does not mean you are connected somewhere else.
+
+Where the routers can exist at all (research R8):
+
+| Network | Bridge routes | Uniswap trading pools | Across bridge-LP pools |
+|---|---|---|---|
+| Ethereum 1 | ✅ | ✅ | ✅ **only network** — the HubPool is L1-only |
+| Optimism 10, Polygon 137, Base 8453, Arbitrum 42161 | ✅ | ✅ | ❌ |
+| Ethereum Classic 61, Mordor 63 | ❌ neither protocol exists | ❌ | ❌ |
+
+ETC and Mordor cannot host these routers at all. If someone asks you to pause bridging on Mordor,
+the honest answer is that there has never been any.
+
+---
+
+## 1. Pause / resume new bridges (per router, per network)
+
+Use when a route is misbehaving across the board, a protocol address is in doubt, or you want
+everything on one network stopped while you think.
+
+1. Operations control plane → **Liquidity** → **Bridge**.
+2. Set the **network selector** at the top of the *Bridge Controls* card to the affected network.
+3. Connect the wallet to that same network (writes only; reads already work from anywhere).
+4. **Emergency pause** card → **Pause new bridges**. One transaction. No timelock, no redeploy, and
+   no dependency on the gateway or any other optional service — it works while everything else is
+   degraded.
+
+**Verify:**
+- The *Bridge Controls* status row **New bridges** reads `PAUSED — no new bridges start.`
+- Within one member refresh, the member Bridge surface refuses new bridges on that network with the
+  paused reason.
+- **Change history** at the bottom of the tab gains a `Paused` row with your address and the time.
+
+**What it does not do.** It cannot reach a transfer already moving, and it cannot strand one: those
+are held by the Across SpokePool and settle or refund to the member regardless of this contract's
+state. It also covers **every route from that network**. If exactly one destination or asset is
+affected, disabling that single route (procedure 3) is the narrower fix — that needs
+`LIQUIDITY_ADMIN_ROLE`, a different role. Pausing the whole network is the right call when you
+cannot reach someone who holds it; it is the wrong call when you can.
+
+**Resume:** same card → **Resume bridging**. Verify the status row returns to `active` and the
+member surface offers routes again.
+
+---
+
+## 2. Pause / resume new supplies (per network) — read this one twice
+
+1. Operations control plane → **Liquidity** → **Supply**.
+2. Network selector → the affected network; connect the wallet there.
+3. **Emergency pause** card → **Pause new Uniswap supplies**.
+
+**Verify:** the status row shows paused; new Uniswap supplies on that network are refused within one
+member refresh; a `Paused` row appears in the tab's change history.
+
+**What you have stopped:** new full-range Uniswap V3 supplies routed through the `LiquidityRouter`
+on that network.
+
+**What you have NOT stopped, and must not tell anyone you have:**
+
+- **Across bridge-LP deposits.** `HubPool.addLiquidity` has no recipient parameter, so LP tokens
+  mint to `msg.sender`; routing them would leave FairWins owning a position the member could never
+  exit. The deposit is therefore a direct member call with no FairWins contract in the path, and
+  this pause cannot see it, let alone stop it. To withhold a bridge pool, **retire it**
+  (procedure 4) — the `enabled` flag is honoured by every FairWins surface. A member calling the
+  HubPool directly is not bound by it, and never was.
+- **Any exit.** Uniswap members own the position NFT and call the position manager directly;
+  bridge-LP members own the LP tokens and call the HubPool directly. Withdrawal has never gone
+  through this router, so nothing here can block it — and no withdrawal can ever carry a platform
+  fee, because there is no code path that could charge one.
+
+**Resume:** **Resume new Uniswap supplies**, same card.
+
+---
+
+## 3. Curate bridge routes
+
+A route is one asset, from the scoped network, to one destination network. The reverse direction is
+a separate route living on **that** network's router — select it in the network selector to manage
+it. Twenty directed routes per asset across the five mainnets.
+
+Operations control plane → **Liquidity** → **Bridge** → **Routes**
+(`LIQUIDITY_ADMIN_ROLE` on that router; wallet on the scoped network).
+
+**Add or edit.** *Add or edit a route* form: input token, output token, destination network,
+per-transaction maximum, expected delivery window (60 s – 24 h), enabled, native-input flag. Saving
+an existing (input token, output token, destination) triple **updates it in place**; changing the
+delivered asset produces a *different* route rather than silently substituting one.
+Verify: the route appears in the table with the values you entered, and a `RouteSet` row appears in
+the change history.
+
+**Enable / disable.** One button per row. Reversible in one click. Use this to stop new bridges on
+one route without touching the rest of the network. Verify: the row's **Status** flips, the member
+surface stops offering that pair within one refresh and explains the absence rather than hiding it.
+
+**Bulk enable/disable per destination.** The *Destination coverage* table toggles every route to one
+destination. The contract has no batch setter, so this is **one wallet prompt per route** and the
+button says how many. **Rejecting the first prompt cancels the rest** — the run stops on the first
+failure and reports how many of how many actually changed. Verify against the Routes table, not
+against the count you intended.
+
+**Set a per-transaction maximum.** Per-row input. `0` means **uncapped**, not "nothing may pass".
+Type the amount in the unit the input labels itself with; for a token this build does not know the
+decimals of, it says *raw units* and refuses anything but whole digits rather than guessing a scale.
+A mis-scaled limit is a silent member-facing failure (a cap of 1 wei refuses every transfer), so the
+form rejects before the wallet prompt. Verify the table's **Per-transaction max** column.
+
+**Remove.** Deletes the curation entry, not just its availability, and it is not the "safer
+disable". Two consequences:
+
+- Restoring it means re-entering every field.
+- The **Operations** panel loses that route's advisory delivery window, which is how it decides an
+  in-flight transfer is taking too long. Transfers already moving on the route are otherwise
+  unaffected — Across settles those directly to the member — but they will show *"no expected
+  window"* instead of being flagged as late.
+
+The confirm dialog names both, and tells you how many transfers are currently listed on the route.
+**To stop new bridges reversibly, disable. Remove only when the route should not exist.**
+
+---
+
+## 4. Curate supplied pools
+
+Operations control plane → **Liquidity** → **Supply** → **Curated pools**
+(`LIQUIDITY_ADMIN_ROLE`; wallet on the scoped network).
+
+**List a pool.** *Add or edit a pool*: kind, address, tokens, fee tier, caps.
+
+- *Trading pool (Uniswap V3)* — routed and fee-bearing. Use **Check pool** first: the contract
+  cross-checks the listing against the pool it names (`token0`, `token1`, `fee`) and rejects a
+  mismatch, because the listing metadata is what the member is shown.
+- *Bridge pool (Across HubPool)* — curation and killswitch only; the deposit itself is a direct
+  member call and is fee-free by design. Ethereum only.
+
+**Retire / reopen.** One button per row (**Retire** / **Reopen**). Retiring closes the pool to
+**new** deposits and nothing else. There is deliberately **no `removePool` on the contract at all** —
+members still hold positions there and must keep being able to see and exit them, so a retired pool
+stays in the table (with its position count) and stays visible and withdrawable to the members in
+it. A pool must never be hidden while a member's money is inside it.
+Verify: the row reads `RETIRED — closed to new deposits, still withdrawable`; the member Supply list
+shows it as closed to new deposits rather than dropping it; a `PoolEnabledChanged` row appears in
+the change history.
+
+**Set per-transaction caps.** Per-row inputs (one per token for trading pools), then **Set caps**.
+`0` = uncapped. Same unit-honesty rules as route limits.
+
+> **A BRIDGE_LP pool's cap is honoured by the app, not enforced by the contract.** The router's limit
+> check lives inside the Uniswap supply entry point, and a bridge-LP deposit never enters it. Every
+> FairWins surface refuses above the cap, so it does real work — but a member calling the HubPool
+> directly is not bound by it. Exactly the same property as the `enabled` flag.
+
+**Reading the numbers honestly.** *Positions* and *Supplied via FairWins* are counted from the
+router's own deposit events over a bounded recent window — what FairWins routed, not the pool's whole
+size. A bridge pool's *size* is read straight from the HubPool (the whole pool). Its per-member
+*position count* genuinely cannot be produced without an indexer, and the tab says `unknown` rather
+than printing `0` — which would read as "no member has money in this pool", precisely the claim you
+must not act on when retiring one.
+
+---
+
+## 5. Stuck bridge triage
+
+**Start here: the Operations panel on the Bridge tab is observational only.** There is no operator
+action, in the tab or in the contract, that can touch a member's in-flight bridge. The member is
+Across's `depositor`, so an unfilled deposit refunds to **them** on the origin chain — which is
+exactly why `IBridgeRouter` has no rescue or claim function. Everything below is diagnosis and
+communication. None of it is intervention.
+
+### 5.1 Is it late, or has it failed?
+
+Operations control plane → **Liquidity** → **Bridge** → **Operations**, scoped to the **origin**
+network. Rows past their expected window sort **ahead of** newer transfers, so a stuck one is not
+pushed out by healthy traffic.
+
+The **State** column is the answer to "late or failed":
+
+| State | Means | Terminal? |
+|---|---|---|
+| *Sending* / *Sent* / *On the way* | Normal progress; not yet past the window | No |
+| **Taking longer than expected** | Past the route's advisory window. A statement about the **clock**, not the outcome — it can still deliver or be returned | **No** |
+| **Did not send** | The origin transaction itself did not go through. **This is the only "actually failed".** Nothing left the member's wallet beyond that network's cost | Yes |
+| *Delivered* | The destination network delivered it | Yes |
+| *Returned to you* | Refunded to the member on the origin chain | Yes |
+| *Status unavailable* | The state could not be read. Not a verdict — see 5.2/5.3 | n/a |
+| appended: *no expected window* | The route is no longer curated, so lateness **cannot be said** here (procedure 3, Remove) | n/a |
+
+The **Evidence** column says how strong that answer is: `destination fill` (a destination-chain
+transaction), `return transaction`, `bridge knows the deposit` (Across has it, no outcome yet), or
+`origin transaction only` (nothing beyond the member's own send observed).
+
+A bridge is **never** shown as delivered without a destination-chain fill hash, and never shown as
+refunded without a return transaction. If the panel is not claiming one, no one should.
+
+So: *Taking longer than expected* is a clock reading and needs patience plus the checks below.
+*Did not send* is a failure and needs no bridge triage at all — the member still holds their asset.
+Everything in between is in Across's hands.
+
+**Bounded worst case:** an unfilled deposit is refundable after its `fillDeadline`, and the refund
+lands roughly within ~90 minutes of it (next root-bundle proposal plus liveness). Past that with no
+refund is genuinely unusual and is escalation material.
+
+### 5.2 Find the Across deposit id from the origin transaction
+
+Everything downstream is keyed on `(originChainId, depositId)`.
+
+1. Open the member's **origin** transaction on that network's explorer (the Operations row links it
+   as *start tx*, or the member has it from their activity view).
+2. In its logs, find the event emitted by the **Across SpokePool**: `FundsDeposited` (or
+   `V3FundsDeposited` on the pre-rename ABI). `depositId` is an indexed parameter.
+3. Confirm `depositor` is the **member's** address, not the router's. It always should be — that is
+   the property fork test T038 exists to hold — but if it is ever not, stop and escalate as a
+   security incident, because that is the fund-stranding failure the design is built to prevent.
+
+### 5.3 Check the Across side
+
+```bash
+# Through the FairWins gateway (same base URL as the relayer, $VITE_RELAYER_URL):
+curl -s "$GATEWAY/v1/bridge/<originChainId>/status?depositId=<depositId>" | jq .
+```
+
+Read the `state` plus the hashes:
+
+| `state` | Reading |
+|---|---|
+| `in_flight` | Across has it; no fill yet |
+| `delivered` | Filled — `fillTxHash` is the proof |
+| `expired` | Past `fillDeadline`, unfilled — **refundable to the member on the origin chain**, no refund transaction yet |
+| `refunded` | Returned — `refundTxHash` is the proof |
+
+Error codes instead of a body: `bridge_disabled` / `bridge_killed` (the module is switched off —
+this tells you nothing about the transfer), `unsupported_chain`, `invalid_deposit`,
+`upstream_unavailable` (Across, not us).
+
+If the gateway is off or unreachable, go to the chain directly: on the **destination** network's
+SpokePool, look for `FilledRelay` / `FilledV3Relay` with `originChainId` and `depositId` as the two
+indexed topics. That is the same evidence the app uses, and it is available whether or not any
+FairWins service is running. Across's own explorer (<https://across.to>) is a third cross-check.
+
+### 5.4 What to tell the member
+
+- Their transfer is not lost and FairWins does not hold it. FairWins never held it: it went from
+  their wallet to Across and, on delivery, to their address on the other network.
+- If it cannot be delivered, Across **returns the asset automatically to the same wallet on the
+  network it started from**. They are the depositor. There is nothing for them to claim, sign, or
+  ask us to release — and nothing we could release if there were.
+- Network costs already spent are not returned.
+- Give them the origin transaction, and the fill or return transaction once one exists.
+
+Do not promise a delivery time. The advisory window is an estimate from recent transfers, and the
+whole point of *Taking longer than expected* is that it says what is known instead of spinning.
+
+---
+
+## 6. Fee changes
+
+**Not in these tabs.** Both tabs show `bridge.transfer` / `liquidity.deposit` **read-only** with
+their 250 bps cap and a link across to the Fees tab. Rates live on the spec-060 `FeeRouter` and are
+changed by a `FEE_ADMIN_ROLE` holder — see [fee-operations.md](fee-operations.md).
+
+Both services ship at **0 bps against a 250 bps cap**, so launch behaviour is fee-free and
+byte-identical to having no fee configured: no fee line, no fee transfer. Raising either is a
+deliberate act by the fee authorization, and a member can never be charged above the rate they were
+shown (the quoted bps is passed in as `maxFeeBps` and the router reverts `FeeAboveQuoted`).
+
+Fees are charged on value-in only. Pool withdrawals, earnings claims, and bridge refunds carry no
+platform fee — structurally, not by policy: the routers are absent from those paths.
+
+Bridge-LP deposits are fee-free by design, for the reason procedure 2 gives: `addLiquidity` mints to
+`msg.sender`, so there is no atomic, non-custodial place to charge a fee. Do not treat that as a gap
+to close — closing it would make FairWins the owner of a position the member could not exit.
+
+### ⚠️ The ordering hazard — get this wrong and every member action reverts
+
+`bridge.transfer` and `liquidity.deposit` must be **registered on that network's FeeRouter** before
+either router carries traffic. Both routers call `FeeRouter.quoteFee` unconditionally on every member
+action, and an unregistered service **reverts `ServiceUnknown`** — so an unregistered network means
+every bridge and every Uniswap supply on it fails, at zero configured fee, for a reason that looks
+nothing like its cause.
+
+Registration needs `DEFAULT_ADMIN_ROLE` **on the FeeRouter**. `scripts/deploy/deploy-bridge-liquidity.js`
+registers both (ConfigOnly, cap 250 bps, rate 0) as part of the deploy — **but only if the deployer
+still holds that role**. If admin has already been handed to the multisig, the script prints a warning
+and skips, and it is on you to register from the FeeRouter admin before the routers go live.
+
+**Verify before enabling any route or pool on a network** — the Fees tab lists every registered
+service for the connected network, or read it directly:
+
+```bash
+npx hardhat console --network <net>
+> const r = await ethers.getContractAt('FeeRouter', '<feeRouter addr from deployments/>')
+> for (const s of ['bridge.transfer', 'liquidity.deposit'])
+    console.log(s, await r.getService(ethers.id(s)))
+# expect capBps 250, feeBps 0, kind 2 (ConfigOnly) for both.
+# capBps 0 / kind 0 means UNREGISTERED — every member action on this network will revert.
+```
+
+---
+
+## 7. Degraded states — what members see, and what you can still do
+
+| Condition | Bridge surface | Supply surface | Controls |
+|---|---|---|---|
+| Router **not deployed** on the network | Bridge absent; Transfer works exactly as before | Honest per-network empty state | Tab says "not deployed", names the deploy script |
+| Router **paused** | New bridges refused with the paused reason; in-flight tracking unaffected | New Uniswap supplies refused; positions visible + withdrawable | Full |
+| Route / pool **disabled** | Route not offered, absence explained | Pool shown closed to new deposits, still visible + withdrawable | Full |
+| Router deployed but **unreachable** | Surface disabled with "as of last read" framing — never invented availability | Same; positions still read directly from the protocol | Tables read as-of/unreadable; controls stay **offered** with authority *unconfirmed* — the contract is the gate |
+| **FeeRouter** unreachable | Fee-bearing path **blocked** — never assumes a lower rate | Same | Fee cards say so instead of showing a rate |
+| **Gateway** unset / unreachable / killswitched | Quoting is impossible ⇒ Bridge surface **hides**. **In-flight bridges still resolve** from on-chain evidence | Unaffected — Supply reads are direct RPC | **Pause still works** — it depends on nothing but the router's own state |
+
+The last row's asymmetry is the load-bearing one: a gateway outage can prevent a member *starting* a
+bridge but can never strand one already moving. That is what makes hiding the surface an acceptable
+degradation rather than a trap. Fallback is always toward **withholding**, never inventing: there is
+no safe default for a route we cannot price, so the honest fallback is absence with a stated reason.
+
+Your authority read can also degrade. When the tab cannot confirm your role on the router in scope it
+says **unconfirmed** and **still offers the controls** — the contract is the real gate and will refuse
+anything you do not hold. Withdrawing a killswitch because an RPC timed out is the failure that
+behaviour exists to prevent.
+
+---
+
+## 8. Escalation
+
+Work out **which router, on which network**, before paging anyone — the roles do not generalize
+across either axis.
+
+| Need | Wake | Why it has to be them |
+|---|---|---|
+| Stop new bridges / new Uniswap supplies on a network | A `GUARDIAN_ROLE` holder **on that router, on that network** | Wager-registry guardians and guardians of the same router on another network have no authority here |
+| Stop one route or one pool (narrower than a pause) | A `LIQUIDITY_ADMIN_ROLE` holder on that router, that network | Curation is a different role from the killswitch |
+| A protocol address is wrong or suspect (`spokePool`, `positionManager`, `feeRouter`, `sanctionsGuard`) | The router's `DEFAULT_ADMIN_ROLE` — the multisig | Fund-path references, deliberately a role above curation |
+| Change or emergency-zero a fee rate | `FEE_ADMIN_ROLE` on the FeeRouter ([fee-operations.md](fee-operations.md)) | Rates are not editable from these tabs |
+| Register a missing fee service (`ServiceUnknown` reverts) | FeeRouter `DEFAULT_ADMIN_ROLE` | See procedure 6 |
+| Quoting is down / bridge module killswitched | Gateway operator ([relayer-operations.md](relayer-operations.md)) | Optional infrastructure; no member value is at risk |
+| Upgrade or roll back a router | `UPGRADER_ROLE` ([contract-upgrades.md](contract-upgrades.md)) | Run `npm run check:storage-layout` first; in-place upgrade, never a redeploy |
+| `depositor` observed as anything but the member; a member charged above the disclosed rate; funds resident in either router | **Security incident** — pause the affected router first, then escalate per the security process | These are the three invariants the contracts are built around; any of them failing means a bug or an unexpected implementation |
+
+Nobody needs to be woken to release a stuck bridge. There is no such action.
+
+---
+
+## Cross-refs
+
+- Developer guide: [bridge-and-liquidity.md](../developer-guide/bridge-and-liquidity.md)
+- Platform fees: [fee-operations.md](fee-operations.md),
+  [platform-fees.md](../developer-guide/platform-fees.md)
+- Upgrades: [contract-upgrades.md](contract-upgrades.md)
+- Gateway: [relayer-operations.md](relayer-operations.md)
+- Control plane tour: [operations-control-plane.md](operations-control-plane.md)
+- Role grants and operator onboarding: [operator-onboarding.md](operator-onboarding.md)
+- Design and rationale: `specs/067-bridge-pool-liquidity/` (research R2, R3, R8, R10;
+  `contracts/admin-and-runtime.md` for the runtime contract table)


### PR DESCRIPTION
Phase 8 documentation for spec 067 — T144, T145, T146, plus the T149 CI audit.

## What lands

- **`docs/developer-guide/bridge-and-liquidity.md`** — both routers, the two fee services, the role model, the R11b network-pinning predicate, the client libraries and their return-null-on-read-failure contract, and an explicit "invariants you must not break" section.
- **`docs/runbooks/bridge-liquidity-operations.md`** — the repo had **no written pause, curation or stuck-bridge procedure at all**. Numbered procedures, each with a verify step: pause/resume per router per network, route curation (and why *disable* and *remove* are not the same lever — removal also costs the Operations panel that route's advisory window), pool curation, stuck-bridge triage, the fee-registration ordering hazard, degraded states, escalation.
- **`CLAUDE.md`** — spec-067 guardrail block in the established per-spec format.

Both docs are written against **post-#965** behaviour, since that is what will deploy: fund-path setters at `DEFAULT_ADMIN_ROLE`, the fee-amount bound with `FeeSplitMismatch`, and per-router `GUARDIAN_ROLE` that does *not* inherit the WagerRegistry guardian set. Each carries an honest note that neither router is deployed on any network yet (#966), so the procedures describe the intended deployed state.

## T149 — CI audit

**Spec 067 has never touched `.github/workflows/`** (verified against both #961 and #965), so no lint/test/build/security gate was weakened by this work.

Pre-existing `continue-on-error` is confined to coverage-report generation steps, the exploratory `torture-test.yml` (documented as such), and one Cypress fast-E2E step. None introduced here — but the Cypress one is a *test* step carrying `continue-on-error: true`, which is worth its own look independent of this spec.

## Not in this PR

- **T147 / T148** — verification gates, best run against the merged result of #965 + #967 + this.
- **T150** — the smart-contract security review. Both reviewer agents hit a session limit before starting. This still **gates the router deploy** in #966.
- **T158** — the moderated impermanent-loss comprehension check needs human moderation against the article in #967.

Depends on #965 for the behaviour it documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBMvFqhjqsXyUVF2hEFoNc