### PR TITLE
Deploy tooling: reach the four missing mainnets, and stop reporting false success

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -207,6 +207,44 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD).setAction(async (args, hre, runSup
   };
 });
 
+// --- Which network is this invocation acting on? ---
+// Used by BOTH the explorer config below (Etherscan V2 vs Blockscout is a per-network
+// choice that has to be made at config time) and requiredRpcUrl() further down, which
+// only fails on a missing endpoint for the network actually being targeted.
+function targetNetworkName() {
+  const i = process.argv.indexOf("--network");
+  if (i !== -1) return process.argv[i + 1];
+  // Hardhat also accepts the network via the HARDHAT_NETWORK env var (no --network flag).
+  return process.env.HARDHAT_NETWORK;
+}
+
+// --- RPC endpoint resolution ---
+// Every network entry below pins an explicit `chainId`, so hardhat rejects an endpoint
+// that answers with a different chain instead of trusting it. That guard is only worth
+// anything if we never QUIETLY substitute an endpoint of our own: a baked-in public
+// default is exactly how a deploy ends up on the wrong chain, or half-finished against a
+// rate-limited node with deployments/ already partly written.
+//
+// So an unset RPC variable is a hard failure — but ONLY for the network being targeted.
+// `npx hardhat compile`, `npm test` and the frontend tooling all load this config on
+// machines that have no mainnet endpoints configured at all, and they must keep working.
+// Networks nobody asked for therefore resolve to an unroutable `.invalid` sentinel that
+// names the missing variable if anything ever does reach it (RFC 2606 reserves .invalid,
+// so it cannot resolve to a real host).
+function requiredRpcUrl(networkName, envVar) {
+  const url = process.env[envVar];
+  if (url) return url;
+  if (targetNetworkName() === networkName) {
+    throw new Error(
+      `${envVar} is not set, so network '${networkName}' has no RPC endpoint. ` +
+        `Set ${envVar} in .env to an endpoint for that chain (archive-capable if you are ` +
+        `forking). Refusing to fall back to a public default: a wrong or throttled endpoint ` +
+        `here means deploying to the wrong chain or stranding a partial deployments/ record.`
+    );
+  }
+  return `http://${envVar.toLowerCase().replace(/_/g, "-")}-is-unset.invalid`;
+}
+
 // --- Block explorer verification (@nomicfoundation/hardhat-verify) ---
 // hardhat-verify 2.x selects Etherscan API V2 (the unified endpoint
 // api.etherscan.io/v2/api?chainid=<id>) ONLY when etherscan.apiKey is a STRING; a
@@ -214,30 +252,27 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD).setAction(async (args, hre, runSup
 // modes are mutually exclusive in one config, and Etherscan V2 does NOT cover
 // Blockscout chains (Ethereum Classic 61 / Mordor 63). So pick the right shape from
 // the --network being acted on:
-//   * Etherscan family (polygon 137, amoy 80002) -> V2 unified, single ETHERSCAN_API_KEY
-//     (Polygonscan V1 keys/endpoints were shut off 2025-08-15; mint the key at etherscan.io).
+//   * Etherscan family (mainnet 1, optimism 10, polygon 137, base 8453, arbitrum 42161,
+//     amoy 80002) -> V2 unified, single ETHERSCAN_API_KEY. One key covers every one of
+//     those chains — there is no per-chain key to mint (Polygonscan V1 keys/endpoints were
+//     shut off 2025-08-15; mint the key at etherscan.io).
 //   * Blockscout (etc 61, mordor 63) -> V1 object + customChains pointing at <host>/api.
 //     Blockscout ignores the key value but hardhat-verify needs a non-empty placeholder.
-function verifyTargetNetwork() {
-  const i = process.argv.indexOf("--network");
-  if (i !== -1) return process.argv[i + 1];
-  // Hardhat also accepts the network via the HARDHAT_NETWORK env var (no --network flag).
-  return process.env.HARDHAT_NETWORK;
-}
-const BLOCKSCOUT_VERIFY_NETWORKS = new Set(["etc", "mordor"]);
-const etherscanConfig = BLOCKSCOUT_VERIFY_NETWORKS.has(verifyTargetNetwork())
-  ? {
-      // Blockscout (Ethereum Classic mainnet + Mordor). Key value is ignored by the
-      // server but must be a non-empty string for hardhat-verify to resolve the chain.
-      apiKey: { etc: "empty", mordor: "empty" },
-      customChains: [
-        { network: "etc", chainId: 61, urls: { apiURL: "https://etc.blockscout.com/api", browserURL: "https://etc.blockscout.com" } },
-        { network: "mordor", chainId: 63, urls: { apiURL: "https://etc-mordor.blockscout.com/api", browserURL: "https://etc-mordor.blockscout.com" } },
-      ],
-    }
+//
+// WHICH chain belongs to WHICH family is not decided here: it comes from
+// scripts/deploy/lib/explorers.js, the same table scripts/deploy/verify.js pre-flights
+// against. Keeping one list means a new network can never be verifiable-per-verify.js but
+// unconfigured-per-hardhat (which fails as a confusing "chain not supported" mid-run).
+const EXPLORERS = require("./scripts/deploy/lib/explorers");
+const BLOCKSCOUT_VERIFY_NETWORKS = new Set(EXPLORERS.blockscoutNetworkNames());
+const etherscanConfig = BLOCKSCOUT_VERIFY_NETWORKS.has(targetNetworkName())
+  ? // Blockscout (Ethereum Classic mainnet + Mordor). Key value is ignored by the
+    // server but must be a non-empty string for hardhat-verify to resolve the chain.
+    EXPLORERS.blockscoutVerifyConfig()
   : {
-      // Etherscan V2 unified key (covers Polygon 137 + Amoy 80002 via the built-in
-      // chain list — no customChains needed). Mint at etherscan.io (NOT polygonscan.com).
+      // Etherscan V2 unified key (covers Ethereum 1, Optimism 10, Polygon 137, Base 8453,
+      // Arbitrum One 42161 and Amoy 80002 via the built-in chain list — no customChains
+      // needed). Mint at etherscan.io (NOT polygonscan.com / basescan.org / arbiscan.io).
       apiKey: process.env.ETHERSCAN_API_KEY || "",
     };
 
@@ -421,18 +456,57 @@ module.exports = {
       accounts: floppyKeys,
       ...(process.env.GAS_PRICE_WEI ? { gasPrice: Number(process.env.GAS_PRICE_WEI) } : {}),
     },
-    // Example: Mainnet with floppy keystore (uncomment when ready to use)
-    // Requires: npm run floppy:mount && npm run floppy:create (one-time setup)
-    // "mainnet-floppy": {
-    //   url: process.env.MAINNET_RPC_URL || "https://eth.llamarpc.com",
-    //   chainId: 1,
-    //   accounts: async () => {
-    //     if (!isFloppyMounted() || !keystoreExists()) {
-    //       throw new Error("Floppy not mounted or keystore not found. Run: npm run floppy:mount");
-    //     }
-    //     return getFloppyPrivateKeys({ count: 5 });
-    //   },
-    // },
+    // ------------------------------------------------------------------------
+    // Control-plane mainnets: Ethereum 1, Optimism 10, Base 8453, Arbitrum 42161.
+    // Targets for FeeRouter (spec 060) and BridgeRouter/LiquidityRouter (spec 067),
+    // which ship on all five EVM mainnets alongside Polygon above.
+    //
+    // Shape matches `polygon`: explicit chainId (so a mis-set RPC is REJECTED rather
+    // than deployed against), floppy-keystore deployer with the .env PRIVATE_KEY
+    // fallback, endpoint from .env via requiredRpcUrl (no public default — see the
+    // helper). All four are MAINNETS: they are in MAINNET_CHAIN_IDS
+    // (scripts/deploy/lib/constants.js), so deploy scripts demand CONFIRM_MAINNET=true
+    // and refuse to substitute mock tokens.
+    //
+    // GAS: none of these reads GAS_PRICE_WEI, and that omission is deliberate. That
+    // variable pins a LEGACY (type-0) gasPrice and exists for the pre-EIP-1559 Classic
+    // chains (and as an escape hatch on Polygon, whose ~25-30 gwei bor minimum makes an
+    // under-quote fatal). It is one global env var, so honouring it here would mean a
+    // shell that still had the Polygon value exported would silently send Polygon-priced
+    // legacy transactions to Ethereum and the L2s — overpaying by orders of magnitude on
+    // the L2s, and opting out of the 1559 fee market these chains' providers price
+    // correctly on their own. Let the provider price each chain. If a specific deploy
+    // genuinely needs a fee override, set it on that transaction, not on the network.
+    mainnet: {
+      url: requiredRpcUrl("mainnet", "MAINNET_RPC_URL"),
+      chainId: 1,
+      // Deployer key: floppy keystore when mounted, else PRIVATE_KEY from .env
+      // (loadFloppyKeysSync allowFallback=true) — keep the production key on the floppy.
+      accounts: floppyKeys,
+    },
+    // OP Stack. The L1 data fee is charged by the chain outside the gas price we set,
+    // so an L2-shaped priority fee here does NOT mean the transaction is cheap overall;
+    // that is another reason not to pin one.
+    optimism: {
+      url: requiredRpcUrl("optimism", "OPTIMISM_RPC_URL"),
+      chainId: 10,
+      accounts: floppyKeys,
+    },
+    base: {
+      url: requiredRpcUrl("base", "BASE_RPC_URL"),
+      chainId: 8453,
+      accounts: floppyKeys,
+    },
+    // Arbitrum One. Its gas LIMIT (not price) absorbs the L1 calldata cost, so estimates
+    // look large and vary between blocks — that is expected; do not pin `gas` to "fix" it.
+    arbitrum: {
+      url: requiredRpcUrl("arbitrum", "ARBITRUM_RPC_URL"),
+      chainId: 42161,
+      accounts: floppyKeys,
+    },
+    // NOTE: there used to be a commented-out "mainnet-floppy" example here that defaulted
+    // to a public endpoint. The real `mainnet` entry above supersedes it: floppy loading is
+    // already handled once by loadFloppyKeysSync() and the endpoint must come from .env.
     // Mordor testnet with floppy keystore
     // Note: Use `mordor` network for regular testing, or set PRIVATE_KEY env var
     // "mordor-floppy": {
@@ -458,7 +532,8 @@ module.exports = {
     noColors: process.env.REPORT_GAS ? true : false,
     coinmarketcap: process.env.COINMARKETCAP_API_KEY,
   },
-  // Network-aware: Etherscan V2 for polygon/amoy, Blockscout for etc/mordor.
-  // See verifyTargetNetwork()/etherscanConfig above.
+  // Network-aware: Etherscan V2 for the Etherscan-family chains (1/10/137/8453/42161/80002),
+  // Blockscout for etc/mordor. Family per chain lives in scripts/deploy/lib/explorers.js;
+  // see targetNetworkName()/etherscanConfig above for how the shape is chosen.
   etherscan: etherscanConfig,
 };

--- a/scripts/deploy/deploy-fee-router.js
+++ b/scripts/deploy/deploy-fee-router.js
@@ -4,17 +4,32 @@
  * network's recorded treasury address and APPENDS the new addresses to its
  * `deployments/<net>-chain<id>-v2.json` record (never overwrites).
  *
- * Registers the launch fee services with their hard caps (rates all start at 0 — fees are enabled
- * later from the AdminPanel Fees tab):
+ * Registers the launch fee services from `lib/feeServices.js` with their hard caps (rates all start
+ * at 0 — fees are enabled later from the AdminPanel Fees tab); that table is the source of truth,
+ * reproduced here only as a reader's map:
  *   earn.lend         Wrapped     cap 250 bps  (Earn/Morpho vault deposits, spec 050 consumer)
  *   polymarket.taker  ConfigOnly  cap 100 bps  (relay-gateway reads; spec 057 cap)
  *   polymarket.maker  ConfigOnly  cap  50 bps  (relay-gateway reads; spec 057 cap)
+ *   stake.lido        ConfigOnly  cap 250 bps  (StakingRouter skims itself; spec 066)
+ *   stake.polygon     ConfigOnly  cap 250 bps  (StakingRouter skims itself; spec 066)
+ * The spec-067 `bridge.transfer` / `liquidity.deposit` services are registered by
+ * `deploy-bridge-liquidity.js` on the router this script deploys.
  *
- *   npx hardhat run scripts/deploy/deploy-fee-router.js --network polygon
+ * RESUMABLE: re-running on a network that already has a recorded feeRouter does NOT redeploy the
+ * proxy — it reconciles the deployments record and registers whatever services are still missing.
+ * That path is the whole point: setup after the proxy is a sequence of registerService txs, any one
+ * of which can die on an RPC hiccup, and a half-registered router is not a cosmetic problem
+ * (`quoteFee` REVERTS ServiceUnknown for an unregistered id, and the spec-067 bridge/liquidity
+ * routers quote on every member action — so a missing service breaks every bridge and every supply).
+ *
+ *   CONFIRM_MAINNET=true npx hardhat run scripts/deploy/deploy-fee-router.js --network polygon
  *   GAS_PRICE_WEI=100000000000 npx hardhat run scripts/deploy/deploy-fee-router.js --network mordor
  *
  * Then: npm run sync:frontend-contracts  (frontend picks up the feeRouter address), and set
  * FEE_ROUTER_ADDRESS on the relay-gateway so Predict serves the on-chain Polymarket bps.
+ *
+ * To register a service on a router this script can no longer administer (roles handed off to the
+ * multisig) or to inspect the live table, use `scripts/ops/register-fee-service.js`.
  */
 const hre = require("hardhat");
 const { ethers } = require("hardhat");
@@ -22,19 +37,54 @@ const fs = require("fs");
 const path = require("path");
 
 const { saveDeployment, getDeploymentFilename } = require("./lib/helpers");
-const { deployProxy } = require("./lib/upgradeable");
+const { deployProxy, getImplementation } = require("./lib/upgradeable");
 const { LAUNCH_FEE_SERVICES } = require("./lib/feeServices");
+const { MAINNET_CHAIN_IDS } = require("./lib/constants");
+
+/**
+ * The gate below is the CONFIRM_MAINNET pattern scripts/deploy/deploy.js and
+ * deploy-verifying-paymaster.js already use, keyed off the shared MAINNET_CHAIN_IDS list — this
+ * script deliberately does NOT keep a second "is this mainnet" list of its own.
+ *
+ * What it does keep is a load-time assertion that the five mainnets this control plane targets
+ * (spec 060 FeeRouter + spec 067 routers) are actually IN that shared list. Dropping one there
+ * would not break anything visibly; it would just quietly delete the prompt in front of a live
+ * chain. Failing at require-time makes that regression impossible to miss.
+ */
+const CONTROL_PLANE_MAINNETS = [1, 10, 137, 8453, 42161]; // Ethereum, Optimism, Polygon, Base, Arbitrum One
+const UNGATED = CONTROL_PLANE_MAINNETS.filter((id) => !MAINNET_CHAIN_IDS.includes(id));
+if (UNGATED.length) {
+  throw new Error(
+    `MAINNET_CHAIN_IDS in scripts/deploy/lib/constants.js is missing chain id(s) ${UNGATED.join(", ")}, ` +
+      `so this script would deploy there with no CONFIRM_MAINNET prompt. Add them back before deploying.`
+  );
+}
+
+const KIND_LABELS = { 0: "Unregistered", 1: "Wrapped", 2: "ConfigOnly" };
 
 async function main() {
   const network = await ethers.provider.getNetwork();
   const networkName = hre.network.name;
   const chainId = Number(network.chainId);
-  const [deployer] = await ethers.getSigners();
 
   console.log("=".repeat(60));
   console.log("Fee Router (spec 060) — targeted deploy");
   console.log("=".repeat(60));
   console.log(`Network:  ${networkName} (chainId ${chainId})`);
+
+  // Mainnet gate, checked BEFORE a signer is even fetched (same position as deploy.js). Without it
+  // this script deploys a value-path contract to a live chain on a bare `--network polygon` typo
+  // with no prompt at all.
+  if (MAINNET_CHAIN_IDS.includes(chainId)) {
+    if (!process.env.CONFIRM_MAINNET) {
+      throw new Error(
+        `Mainnet deployment requires CONFIRM_MAINNET=true env var (network ${networkName}, chainId ${chainId}).`
+      );
+    }
+  }
+
+  const [deployer] = await ethers.getSigners();
+  if (!deployer) throw new Error(`No signer for network '${networkName}'`);
   console.log(`Deployer: ${deployer.address}`);
 
   const filename = getDeploymentFilename(network, "v2");
@@ -53,41 +103,125 @@ async function main() {
       : record.treasury && ethers.isAddress(record.treasury)
         ? record.treasury
         : ethers.ZeroAddress;
-  console.log(`Treasury: ${treasury === ethers.ZeroAddress ? "(unset — fees skipped until setTreasury)" : treasury}`);
 
+  // ---------------------------------------------------------------- 1. deploy OR resume
+  // A recorded feeRouter means the proxy already exists, and this script must never deploy a second
+  // one: a fresh proxy would strand the registered services, their caps and their rates on the old
+  // address and split the source of truth. But "don't redeploy" is NOT "don't finish" — the earlier
+  // run may have died between the proxy and the last registerService, and the only way back from
+  // that is to re-run. So the already-deployed path falls through to the same reconcile-and-register
+  // tail as a fresh deploy; it just skips the proxy.
+  let router;
   if (contracts.feeRouter) {
-    console.log(`\n⚠️  feeRouter already recorded (${contracts.feeRouter}). To change logic,`);
-    console.log(`   run an in-place upgrade (lib/upgradeable.js upgradeProxy), not this script. Aborting.`);
-    return;
+    console.log(`\nfeeRouter already recorded (${contracts.feeRouter}) — resuming setup, not redeploying.`);
+    console.log("   (to change LOGIC, run an in-place upgrade via lib/upgradeable.js upgradeProxy)");
+    // Refuse to "resume" against an address that isn't a contract here. That means the record
+    // belongs to another network, or the recorded deploy never actually landed — and continuing
+    // would fire admin transactions into the void and report success.
+    const code = await ethers.provider.getCode(contracts.feeRouter);
+    if (code === "0x") {
+      throw new Error(
+        `deployments/${filename} records feeRouter ${contracts.feeRouter}, but that address has NO ` +
+          `bytecode on ${networkName} (chainId ${chainId}). Fix the record (wrong network? deploy that ` +
+          `never landed?) before re-running — this script will not silently deploy a second proxy.`
+      );
+    }
+    router = await ethers.getContractAt("FeeRouter", contracts.feeRouter);
+    // Report the treasury the router ACTUALLY holds, not the one this run would have initialized it
+    // with — on a resume the init arg was never applied, and printing it would tell the operator
+    // fees go somewhere they do not.
+    const liveTreasury = await router.treasury();
+    console.log(
+      `Treasury (live on router): ${liveTreasury === ethers.ZeroAddress ? "(unset — fees skipped until setTreasury)" : liveTreasury}`
+    );
+    if (liveTreasury.toLowerCase() !== treasury.toLowerCase()) {
+      console.log(`   note: the record/TREASURY says ${treasury}. Change it with setTreasury (DEFAULT_ADMIN),`);
+      console.log(`   never by redeploying — this script cannot and must not move it.`);
+    }
+  } else {
+    console.log(
+      `Treasury: ${treasury === ethers.ZeroAddress ? "(unset — fees skipped until setTreasury)" : treasury}`
+    );
+    console.log("\nDeploying FeeRouter behind a UUPS proxy...");
+    const proxy = await deployProxy({
+      name: "FeeRouter",
+      initArgs: [deployer.address, treasury],
+    });
+    router = proxy.contract;
+    contracts.feeRouter = proxy.proxy;
+    record.feeRouterDeployedAt = new Date().toISOString();
+    // Record the deploy block alongside the address: every later log scan over this router (role
+    // holders, FeeBpsChanged rate history) needs a fromBlock, and scanning from 0 is refused
+    // outright by most public mainnet RPCs — which turns "who holds DEFAULT_ADMIN?" into a shrug
+    // exactly when it matters. Best-effort: a missing block never blocks the deploy.
+    const deployTx = proxy.contract.deploymentTransaction();
+    const blockNumber = deployTx ? (await deployTx.wait()).blockNumber : null;
+    if (blockNumber != null) {
+      record.deployBlocks = record.deployBlocks || {};
+      record.deployBlocks.feeRouter = blockNumber;
+    }
   }
 
-  console.log("\nDeploying FeeRouter behind a UUPS proxy...");
-  const proxy = await deployProxy({
-    name: "FeeRouter",
-    initArgs: [deployer.address, treasury],
-  });
-
-  // Persist the proxy address IMMEDIATELY (before the registration loop) so an interrupted run —
-  // e.g. an RPC timeout on a registerService tx — leaves a RECORDED proxy rather than an orphan.
-  contracts.feeRouter = proxy.proxy;
-  contracts.feeRouterImpl = proxy.implementation;
+  // ---------------------------------------------------------------- 2. reconcile the record
+  // Written on BOTH paths, and BEFORE the registration loop, so an interrupted run — e.g. an RPC
+  // timeout on a registerService tx — leaves a RECORDED proxy rather than an orphan, and so a
+  // resumed run repairs a record that was written before an upgrade (or never written, if the first
+  // run died between the deploy tx and the save). The implementation comes from the proxy's
+  // ERC-1967 slot rather than from memory: that is the on-chain truth, and a stale feeRouterImpl
+  // would point `npm run verify:<net>` at bytecode that is no longer behind the proxy.
+  contracts.feeRouterImpl = await getImplementation(contracts.feeRouter);
   record.constructorArgs = record.constructorArgs || {};
-  record.constructorArgs.feeRouterImpl = [];
-  record.feeRouterDeployedAt = new Date().toISOString();
+  record.constructorArgs.feeRouterImpl = []; // UUPS implementations take no constructor args
+  record.feeRouterDeployedAt = record.feeRouterDeployedAt || new Date().toISOString();
   saveDeployment(filename, record);
 
-  // Register launch services idempotently (rates start at 0; enable from the Fees admin tab). A
-  // resumed run skips services already registered (AlreadyRegistered), so re-running finishes setup.
-  const router = proxy.contract;
+  // ---------------------------------------------------------------- 3. register launch services
+  // registerService is ONE-SHOT per id (the router reverts AlreadyRegistered) and gated on
+  // DEFAULT_ADMIN_ROLE, so read the live table first and only send transactions for what is
+  // genuinely missing. Rates all start at 0 — they are enabled later from the AdminPanel Fees tab.
+  console.log("\nLaunch fee services (live table):");
+  const adminRole = await router.DEFAULT_ADMIN_ROLE();
+  const missing = [];
+  const drift = [];
   for (const svc of LAUNCH_FEE_SERVICES) {
     const id = ethers.keccak256(ethers.toUtf8Bytes(svc.label));
     const existing = await router.getService(id);
-    if (Number(existing.kind) !== 0) {
-      console.log(`  • ${svc.label} already registered — skipping`);
+    const kind = Number(existing.kind);
+    if (kind === 0) {
+      console.log(`  · ${svc.label.padEnd(18)} NOT registered (cap ${svc.capBps} bps, ${KIND_LABELS[svc.kind]})`);
+      missing.push({ ...svc, id });
       continue;
     }
-    await (await router.registerService(id, svc.capBps, svc.kind)).wait();
-    console.log(`  ✓ registered ${svc.label} (cap ${svc.capBps} bps, kind ${svc.kind})`);
+    console.log(
+      `  • ${svc.label.padEnd(18)} registered — cap ${existing.capBps} bps, rate ${existing.feeBps} bps, ${KIND_LABELS[kind] || kind}`
+    );
+    if (Number(existing.capBps) !== svc.capBps || kind !== svc.kind) {
+      drift.push(
+        `${svc.label}: on-chain cap ${existing.capBps} bps / ${KIND_LABELS[kind] || kind} vs. ` +
+          `lib/feeServices.js cap ${svc.capBps} bps / ${KIND_LABELS[svc.kind]}`
+      );
+    }
+  }
+
+  if (missing.length) {
+    // Fail loudly rather than "warn and continue": services are missing AND this signer cannot add
+    // them, so nobody would notice until a member's bridge quote reverted ServiceUnknown.
+    if (!(await router.hasRole(adminRole, deployer.address))) {
+      throw new Error(
+        `${missing.length} launch fee service(s) are unregistered (${missing.map((s) => s.label).join(", ")}) ` +
+          `and the deployer ${deployer.address} does NOT hold DEFAULT_ADMIN_ROLE on ${contracts.feeRouter} ` +
+          `(roles handed off?). Register them from the role holder — see ` +
+          `scripts/ops/register-fee-service.js — before any member surface quotes them: ` +
+          `FeeRouter.quoteFee reverts ServiceUnknown for an unregistered id.`
+      );
+    }
+    console.log("\nRegistering missing services (rate 0)...");
+    for (const svc of missing) {
+      await (await router.registerService(svc.id, svc.capBps, svc.kind)).wait();
+      console.log(`  ✓ registered ${svc.label} (cap ${svc.capBps} bps, ${KIND_LABELS[svc.kind]}, rate 0)`);
+    }
+  } else {
+    console.log("  (all launch services already registered — nothing to send)");
   }
 
   console.log("\n" + "=".repeat(60));
@@ -102,6 +236,23 @@ async function main() {
   console.log("operations runbook before this router carries production fees.");
   console.log("!".repeat(60));
   console.log(`\nNext: npm run sync:frontend-contracts, then set FEE_ROUTER_ADDRESS on the relay-gateway.`);
+
+  // Reported LAST, and as a failure, because it is real config drift that no script can repair:
+  // registration is one-shot and the cap is fixed for the entry's life, so a router registered with
+  // the wrong cap/kind can only be fixed by a new service id. Everything above already ran (the
+  // record is saved and the missing services are registered) — this exit code exists so a wrong
+  // table can never be mistaken for a clean deploy.
+  if (drift.length) {
+    console.error("\n" + "!".repeat(60));
+    console.error("FEE SERVICE DRIFT — the live router disagrees with scripts/deploy/lib/feeServices.js:");
+    for (const d of drift) console.error(`  ✗ ${d}`);
+    console.error("!".repeat(60));
+    throw new Error(
+      "Live fee-service table does not match lib/feeServices.js. registerService is one-shot and the " +
+        "cap is fixed for the entry's life, so this cannot be corrected in place: reconcile the table " +
+        "(or register a new service id) before enabling any rate."
+    );
+  }
 }
 
 main()

--- a/scripts/deploy/init-deployment-record.js
+++ b/scripts/deploy/init-deployment-record.js
@@ -1,0 +1,272 @@
+/**
+ * init-deployment-record.js — create an EMPTY deployment record for a network that has none.
+ *
+ * IT DEPLOYS NOTHING. It sends no transaction, needs no gas, and touches no chain state. The only
+ * thing it produces is `deployments/<network>-chain<id>-v2.json` with `contracts: {}` — the file the
+ * targeted deploy scripts append to.
+ *
+ * Why this exists
+ * ---------------
+ * `deploy-fee-router.js` and `deploy-bridge-liquidity.js` both open with:
+ *
+ *     No existing deployment record at deployments/<file>. Run the core deploy first.
+ *
+ * That instruction is correct on Polygon/Amoy/Mordor and WRONG on the spec-067 control-plane
+ * networks. Ethereum (1), Optimism (10), Base (8453) and Arbitrum One (42161) are ROUTER-ONLY: the
+ * frontend gives them maps containing just `bridgeRouter` + `liquidityRouter`
+ * (`frontend/src/config/contracts.js`), there is no wager/membership/oracle deployment planned for
+ * them, and running the full `deploy.js` core there would spend real ETH deploying an escrow,
+ * membership manager, voucher NFT and oracle adapters that nothing will ever call — on four chains.
+ * So on those four networks the refusal above was a dead end: no legitimate way to get the record
+ * that the FeeRouter and the two routers require. This is that way.
+ *
+ * The record is deliberately EMPTY. It asserts nothing about what is deployed, because nothing is:
+ * `deploy-fee-router.js` fills in `feeRouter`, `deploy-bridge-liquidity.js` fills in the two
+ * routers, and each writes its own addresses as it goes. Downstream tooling already behaves
+ * correctly against an empty record — `scripts/deploy/verify.js` refuses a record with no addresses
+ * rather than printing "Done", and `sync-frontend-contracts.js` copies only the keys that are
+ * present. What it does establish, once, is the two facts those scripts cannot derive themselves:
+ * which chain the record belongs to, and where the platform's fee revenue goes.
+ *
+ * Usage
+ * -----
+ *   TREASURY=0xabc… npx hardhat run scripts/deploy/init-deployment-record.js --network base
+ *
+ *   # local sandbox, where hardhat.config.js pins no chainId, so state it:
+ *   TREASURY=0xabc… EXPECT_CHAIN_ID=31337 npx hardhat run … --network localhost
+ *
+ * Env (or the equivalent `-- --flag value` after the script path):
+ *   TREASURY        / --treasury    REQUIRED. Fee/revenue destination. No default — see below.
+ *   DEPLOYER        / --deployer    Recorded deployer address. Defaults to the configured signer.
+ *   EXPECT_CHAIN_ID / --chain-id    Required only when the hardhat network pins no chainId.
+ *
+ * There is deliberately no CONFIRM_MAINNET gate here, unlike the deploy scripts: this run cannot
+ * spend anything or change a live contract, and `git checkout` undoes it completely. The hazard it
+ * does have — a record created for the wrong chain — is not a mainnet-specific hazard and is guarded
+ * directly, below.
+ *
+ * Then, in order:
+ *   1. CONFIRM_MAINNET=true npx hardhat run scripts/deploy/deploy-fee-router.js       --network <net>
+ *   2. CONFIRM_MAINNET=true npx hardhat run scripts/deploy/deploy-bridge-liquidity.js --network <net>
+ *   3. npm run sync:frontend-contracts -- --network <net> --chainId <id>
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const { saveDeployment, getDeploymentFilename, loadDeployment } = require("./lib/helpers");
+const { SALT_PREFIXES } = require("./lib/constants");
+
+function argVal(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+/**
+ * Resolve the chain id from TWO independent sources and require them to agree.
+ *
+ * This is the guard the whole script is built around. A deployment record is keyed by chain id in
+ * its filename AND in its body, and every later tool trusts that: `deploy-fee-router.js` picks its
+ * record by `<network>-chain<id>-v2.json`, `verify.js` submits sources to the explorer for that
+ * chain, `sync-frontend-contracts.js` writes into the contracts.js block for that chain, and the
+ * relay-gateway pins its FeeRouter address by it. A record created under the wrong chain id
+ * therefore does not fail — it succeeds at the wrong thing, repeatedly, and every address that
+ * lands in it afterwards is filed against a chain it does not exist on.
+ *
+ * The realistic way that happens is an RPC env var pointing somewhere else than its name claims:
+ * BASE_RPC_URL still holding an Optimism endpoint after a copy-paste, say. `hre.network.config
+ * .chainId` is what the operator DECLARED for this network; `eth_chainId` is what the endpoint
+ * actually IS. Comparing them catches exactly that, before a file exists to mislead anyone.
+ *
+ * When the network pins no chainId (`localhost`), there is only one source, so demand the operator
+ * supply the second rather than accepting the endpoint's word for it unchallenged.
+ */
+async function resolveChainId(networkName) {
+  let rpcChainId;
+  try {
+    rpcChainId = Number((await ethers.provider.getNetwork()).chainId);
+  } catch (err) {
+    // An unreachable RPC must never be treated as "close enough to write the file anyway": with no
+    // chain to check against, the declared id is unverified and this script has no reason to exist.
+    throw new Error(
+      `Could not read the chain id from the '${networkName}' RPC endpoint, so the record's chain id ` +
+        `cannot be verified: ${err?.message || String(err)}`
+    );
+  }
+
+  const declared = hre.network.config.chainId ? Number(hre.network.config.chainId) : null;
+  if (declared !== null && declared !== rpcChainId) {
+    throw new Error(
+      `Chain id mismatch for network '${networkName}': hardhat.config.js declares ${declared}, but ` +
+        `the configured RPC endpoint reports ${rpcChainId}. The endpoint env var for this network ` +
+        `points at chain ${rpcChainId}. Fix it before creating a record — every address later ` +
+        `written into this file would be filed under the wrong chain.`
+    );
+  }
+
+  const expected = process.env.EXPECT_CHAIN_ID || argVal("--chain-id");
+  if (declared === null && !expected) {
+    throw new Error(
+      `Network '${networkName}' pins no chainId in hardhat.config.js, so the RPC's answer ` +
+        `(${rpcChainId}) is the only statement of which chain this record is for. Set ` +
+        `EXPECT_CHAIN_ID=${rpcChainId} to confirm that is the chain you mean.`
+    );
+  }
+  if (expected && Number(expected) !== rpcChainId) {
+    throw new Error(
+      `EXPECT_CHAIN_ID=${expected} but the '${networkName}' RPC endpoint reports chain ${rpcChainId}. ` +
+        `Refusing to create a record for a chain you did not ask for.`
+    );
+  }
+
+  return rpcChainId;
+}
+
+/**
+ * The treasury MUST be stated. `deploy-fee-router.js` reads `record.treasury` and passes it straight
+ * into `FeeRouter.initialize` as the destination for every platform fee the network ever charges, so
+ * a default here would be a default for where members' money goes. There is no defensible guess:
+ * the Polygon treasury is a hardware wallet that has nothing to do with a new chain, and the
+ * deployer EOA is the address this deploy is explicitly moving AWAY from (Safe-held admin).
+ *
+ * The zero address is rejected too, even though the FeeRouter accepts it (zero ⇒ the charge path
+ * skips the fee, so funds are never lost). Accepting it here would mean this file — created before
+ * anyone has thought about revenue — is what silently produced a router with no fee destination,
+ * needing a later `setTreasury` from whatever holds admin by then. An operator who genuinely wants
+ * to defer that can pass TREASURY=0x0…0 to the FeeRouter deploy itself, where it is a visible
+ * choice about that deployment rather than a fossil in a bootstrap record.
+ */
+function resolveTreasury() {
+  const raw = process.env.TREASURY || argVal("--treasury");
+  if (!raw) {
+    throw new Error(
+      `TREASURY is required. It becomes FeeRouter.treasury on this network — the destination for ` +
+        `every platform fee charged here — and there is nothing safe to default it to. ` +
+        `Pass TREASURY=<address> (the multisig that should receive platform revenue on this chain).`
+    );
+  }
+  if (!ethers.isAddress(raw)) {
+    throw new Error(`TREASURY="${raw}" is not an address.`);
+  }
+  const treasury = ethers.getAddress(raw);
+  if (treasury === ethers.ZeroAddress) {
+    throw new Error(
+      `TREASURY is the zero address. That is a valid FeeRouter state (fees are skipped rather than ` +
+        `lost), but it must not be baked into a bootstrap record — pass TREASURY=0x0…0 to ` +
+        `deploy-fee-router.js instead, where it is a deliberate choice about that deployment.`
+    );
+  }
+  return treasury;
+}
+
+/** Recorded deployer. Defaults to the configured signer; DEPLOYER overrides (e.g. Safe-first setups). */
+async function resolveDeployer() {
+  const override = process.env.DEPLOYER || argVal("--deployer");
+  if (override) {
+    if (!ethers.isAddress(override)) throw new Error(`DEPLOYER="${override}" is not an address.`);
+    return ethers.getAddress(override);
+  }
+  const [signer] = await ethers.getSigners();
+  if (!signer) {
+    throw new Error(
+      `No signer configured for network '${hre.network.name}', so the record's deployer is unknown. ` +
+        `Mount the floppy keystore (or set PRIVATE_KEY in .env), or pass DEPLOYER=<address> if the ` +
+        `deploy will be made from an address this machine does not hold.`
+    );
+  }
+  return signer.address;
+}
+
+async function main() {
+  const networkName = hre.network.name;
+
+  console.log("=".repeat(60));
+  console.log("Initialize deployment record — CREATES A FILE, DEPLOYS NOTHING");
+  console.log("=".repeat(60));
+
+  const chainId = await resolveChainId(networkName);
+  console.log(`Network:  ${networkName} (chainId ${chainId}, confirmed against the RPC endpoint)`);
+
+  // getDeploymentFilename() is the same helper the deploy scripts use to LOOK for this file, so the
+  // record cannot land next to where they read — a mismatch would just reproduce the dead end. It is
+  // handed the id resolveChainId() just verified, not a second read of the network.
+  const filename = getDeploymentFilename({ chainId }, "v2");
+  const filepath = path.join(process.cwd(), "deployments", filename);
+
+  // Refuse to overwrite. This is the destructive risk in this script and the only one: an existing
+  // record holds live proxy addresses (deployments/ is the source of truth for them), and replacing
+  // it with `contracts: {}` would not take those contracts off-chain — it would orphan them. The
+  // proxies would keep holding value with no record of where they are, and a re-run of
+  // deploy-fee-router.js, seeing no recorded feeRouter, would deploy a SECOND router and strand
+  // every registered service, cap and rate on the first. Appending is the deploy scripts' job.
+  if (fs.existsSync(filepath)) {
+    const existing = loadDeployment(filename) || {};
+    const count = Object.keys(existing.contracts || {}).length;
+    throw new Error(
+      `deployments/${filename} already exists (${count} recorded contract address(es)) — refusing to ` +
+        `overwrite it. This script only bootstraps a network that has NO record; the deploy scripts ` +
+        `append to an existing one. If the record is genuinely wrong, fix it in git with the ` +
+        `on-chain addresses in hand; never replace it with an empty one.`
+    );
+  }
+
+  const treasury = resolveTreasury();
+  const deployer = await resolveDeployer();
+  console.log(`Deployer: ${deployer}`);
+  console.log(`Treasury: ${treasury}`);
+
+  /**
+   * Schema mirrors the record `scripts/deploy/deploy.js` writes (see its `const record = {…}`), so
+   * every existing reader — deploy-fee-router.js, deploy-bridge-liquidity.js, verify.js,
+   * scripts/utils/sync-frontend-contracts.js, services/relay-gateway/src/config — finds the shape it
+   * expects. The keys that carry addresses are explicitly null rather than omitted: null says "this
+   * network has none" out loud, and both the sync mapping and verify.js already skip null values,
+   * whereas an absent key reads as an oversight.
+   *
+   * The router-only control-plane networks have no payment token, no wrapped native and no
+   * Polymarket CTF in FairWins' use of them — members bridge and supply their own assets there;
+   * there is no escrow, no membership sale and no prediction market. If a chain later gains a core
+   * deploy, deploy.js sets these itself.
+   */
+  const record = {
+    network: networkName,
+    chainId,
+    deployer,
+    treasury,
+    paymentToken: null,
+    wmatic: null,
+    polymarketCTF: null,
+    contracts: {},
+    mocks: null,
+    constructorArgs: {},
+    saltPrefix: SALT_PREFIXES.V2,
+    timestamp: new Date().toISOString(),
+    // Provenance: this record was bootstrapped empty, not produced by a deploy. Anyone reading it
+    // (or reviewing the commit) can tell the difference without checking git history.
+    bootstrappedBy: "scripts/deploy/init-deployment-record.js",
+    bootstrapNote:
+      "Created empty — no contracts were deployed by this file. Addresses are appended by the " +
+      "targeted deploy scripts (deploy-fee-router.js, deploy-bridge-liquidity.js).",
+  };
+
+  saveDeployment(filename, record);
+
+  console.log("\n" + "=".repeat(60));
+  console.log(`Created deployments/${filename} with contracts: {} — EMPTY.`);
+  console.log("Nothing was deployed and no transaction was sent.");
+  console.log("=".repeat(60));
+  console.log("\nNext:");
+  console.log(`  1. CONFIRM_MAINNET=true npx hardhat run scripts/deploy/deploy-fee-router.js --network ${networkName}`);
+  console.log(`  2. CONFIRM_MAINNET=true npx hardhat run scripts/deploy/deploy-bridge-liquidity.js --network ${networkName}`);
+  console.log(`  3. npm run sync:frontend-contracts -- --network ${networkName} --chainId ${chainId}`);
+  console.log("\n  (drop CONFIRM_MAINNET on a testnet; step 3 needs a contracts.js block for this");
+  console.log("   chain — the sync refuses rather than writing into another chain's block.)");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/deploy/lib/constants.js
+++ b/scripts/deploy/lib/constants.js
@@ -304,7 +304,30 @@ const DEFAULT_MAX_RUNTIME_BYTES = 24_576;
 // MAINNET CHAIN IDS (for safety checks)
 // =============================================================================
 
-const MAINNET_CHAIN_IDS = [1, 61, 137]; // Ethereum, Ethereum Classic, Polygon mainnets
+/**
+ * Chains that hold real money. Deploy scripts treat membership in this list as
+ * "mainnet" and tighten up accordingly — today that means:
+ *   1. `deploy.js` refuses to run without CONFIRM_MAINNET=true, so a mainnet deploy is
+ *      always a deliberate act and never the result of a mistyped --network.
+ *   2. `deploy.js` refuses to substitute a MockERC20 for a missing stake token. On a
+ *      testnet a missing TOKENS[network] entry quietly mints a mock; on a mainnet that
+ *      would allowlist a worthless token as real stake, so it aborts instead.
+ *
+ * Optimism (10), Base (8453) and Arbitrum One (42161) were added for the spec 060 /
+ * spec 067 control-plane rollout. Before that they were ABSENT, which meant those three
+ * production chains were silently classified as testnets and got the loose treatment —
+ * exactly backwards. Anything gating on "is this mainnet" belongs here, not in a
+ * per-script list (see scripts/deploy/archive/deploy-deterministic.js for the stale
+ * copy this list exists to replace).
+ */
+const MAINNET_CHAIN_IDS = [
+  1,      // Ethereum
+  10,     // Optimism
+  61,     // Ethereum Classic
+  137,    // Polygon
+  8453,   // Base
+  42161,  // Arbitrum One
+];
 
 // =============================================================================
 // PER-NETWORK DEPLOY FLAGS

--- a/scripts/deploy/lib/explorers.js
+++ b/scripts/deploy/lib/explorers.js
@@ -1,0 +1,264 @@
+/**
+ * explorers.js — Which block explorer covers which chain, in ONE place.
+ *
+ * Two facts have to agree for `scripts/deploy/verify.js` to work, and they used to be
+ * written down separately (hardhat.config.js knew the Blockscout network names; verify.js
+ * knew nothing at all). When they drift, verification fails in the least useful way
+ * possible: hardhat-verify silently picks Etherscan V2 for a Blockscout chain and reports
+ * "chain not supported", or picks V1 for an Etherscan chain and 404s a dead V1 endpoint.
+ * So both readers import this table:
+ *
+ *   - hardhat.config.js       -> which `etherscan` config shape to build for --network
+ *   - scripts/deploy/verify.js -> the pre-flight (is this chain verifiable at all? is the
+ *                                 API key present?) and the explorer links it prints
+ *
+ * DELIBERATELY DEPENDENCY-FREE. hardhat.config.js requires this file while it is still
+ * building its own config object, so anything that reaches back into `hardhat` (as
+ * lib/constants.js does, for `ethers`) would be a require cycle. Keep it plain data +
+ * pure functions.
+ *
+ * Two explorer families, and the difference is not cosmetic:
+ *   * ETHERSCAN V2 — one unified endpoint (api.etherscan.io/v2/api?chainid=<id>) and ONE
+ *     key for every chain in the family. There is no per-chain key to mint any more; the
+ *     old per-explorer V1 keys and endpoints (polygonscan.com, basescan.org, arbiscan.io)
+ *     were shut off 2025-08-15. Mint the key at etherscan.io.
+ *   * BLOCKSCOUT — self-hosted per chain, no key. hardhat-verify still requires a
+ *     non-empty placeholder string to resolve the chain, which is why the config below
+ *     carries `apiKeyEnv: null` rather than an empty key.
+ */
+
+/**
+ * chainId -> explorer facts. `network` is the hardhat network name that deploys to that
+ * chain (the deployments/ filename is derived from it), and it is what a caller passes to
+ * `--network`, so keep the two in sync with hardhat.config.js `networks`.
+ *
+ * `proxyLinking` records how the explorer connects an ERC-1967 proxy to the verified
+ * implementation behind it. verify.js prints this per proxy so the operator knows whether
+ * a follow-up click is expected — see the PROXIES section of its summary.
+ */
+const EXPLORERS = {
+  1: {
+    network: "mainnet",
+    chainName: "Ethereum",
+    label: "Etherscan",
+    family: "etherscan",
+    browserUrl: "https://etherscan.io",
+    proxyLinking: "on-demand", // "Is this a proxy?" under Contract -> More Options
+  },
+  10: {
+    network: "optimism",
+    chainName: "Optimism",
+    label: "Optimistic Etherscan",
+    family: "etherscan",
+    browserUrl: "https://optimistic.etherscan.io",
+    proxyLinking: "on-demand",
+  },
+  61: {
+    network: "etc",
+    chainName: "Ethereum Classic",
+    label: "Blockscout (ETC)",
+    family: "blockscout",
+    browserUrl: "https://etc.blockscout.com",
+    apiUrl: "https://etc.blockscout.com/api",
+    proxyLinking: "automatic", // Blockscout reads the EIP-1967 slot itself
+  },
+  63: {
+    network: "mordor",
+    chainName: "Mordor (ETC testnet)",
+    label: "Blockscout (Mordor)",
+    family: "blockscout",
+    browserUrl: "https://etc-mordor.blockscout.com",
+    apiUrl: "https://etc-mordor.blockscout.com/api",
+    proxyLinking: "automatic",
+  },
+  137: {
+    network: "polygon",
+    chainName: "Polygon",
+    label: "PolygonScan",
+    family: "etherscan",
+    browserUrl: "https://polygonscan.com",
+    proxyLinking: "on-demand",
+  },
+  8453: {
+    network: "base",
+    chainName: "Base",
+    label: "BaseScan",
+    family: "etherscan",
+    browserUrl: "https://basescan.org",
+    proxyLinking: "on-demand",
+  },
+  42161: {
+    network: "arbitrum",
+    chainName: "Arbitrum One",
+    label: "Arbiscan",
+    family: "etherscan",
+    browserUrl: "https://arbiscan.io",
+    proxyLinking: "on-demand",
+  },
+  80002: {
+    network: "amoy",
+    chainName: "Polygon Amoy",
+    label: "PolygonScan (Amoy)",
+    family: "etherscan",
+    browserUrl: "https://amoy.polygonscan.com",
+    proxyLinking: "on-demand",
+  },
+};
+
+/** The single Etherscan-V2 key covers every `family: "etherscan"` chain above. */
+const ETHERSCAN_API_KEY_ENV = "ETHERSCAN_API_KEY";
+
+/**
+ * Values people paste into .env when they mean "I have not set this yet". Treated as
+ * ABSENT rather than passed to the explorer, so the failure names the real problem
+ * instead of surfacing as an opaque "Invalid API Key" six retries later.
+ */
+const PLACEHOLDER_KEYS = new Set([
+  "your_api_key",
+  "your_api_key_here",
+  "your_etherscan_api_key",
+  "changeme",
+  "todo",
+  "xxx",
+  "empty",
+]);
+
+/** @returns {object|undefined} the explorer entry for `chainId`, or undefined if we have none. */
+function explorerForChain(chainId) {
+  return EXPLORERS[Number(chainId)];
+}
+
+/** Hardhat network names whose explorer is Blockscout. Consumed by hardhat.config.js. */
+function blockscoutNetworkNames() {
+  return Object.values(EXPLORERS)
+    .filter((e) => e.family === "blockscout")
+    .map((e) => e.network);
+}
+
+/**
+ * The legacy-V1 `etherscan` config hardhat-verify needs for the Blockscout chains:
+ * a per-network apiKey OBJECT (which is what forces V1 mode) plus customChains pointing
+ * at each Blockscout /api. Blockscout ignores the key value but hardhat-verify refuses to
+ * resolve a chain whose key is empty, hence the placeholder.
+ */
+function blockscoutVerifyConfig() {
+  const entries = Object.entries(EXPLORERS).filter(([, e]) => e.family === "blockscout");
+  return {
+    apiKey: Object.fromEntries(entries.map(([, e]) => [e.network, "empty"])),
+    customChains: entries.map(([chainId, e]) => ({
+      network: e.network,
+      chainId: Number(chainId),
+      urls: { apiURL: e.apiUrl, browserURL: e.browserUrl },
+    })),
+  };
+}
+
+/** Explorer URL for an address, e.g. for a "check it here" line in a summary. */
+function addressUrl(explorer, address) {
+  return `${explorer.browserUrl}/address/${address}`;
+}
+
+/**
+ * Pre-flight: can we verify on this chain AT ALL, with the environment as it stands?
+ *
+ * Called BEFORE anything is submitted. The point is that a run which cannot possibly
+ * verify anything must say so in one readable sentence up front, rather than making the
+ * operator infer it from a summary of zeros (or worse, from a green exit code) at the end.
+ *
+ * @param {number} chainId
+ * @param {string} networkName  the --network the caller actually used
+ * @returns {object} the explorer entry
+ * @throws {Error} with an actionable message if the chain or the key is unusable
+ */
+function assertExplorerConfigured(chainId, networkName) {
+  const explorer = explorerForChain(chainId);
+
+  if (!explorer) {
+    const known = Object.entries(EXPLORERS)
+      .map(([id, e]) => `${e.network} (${id})`)
+      .join(", ");
+    throw new Error(
+      `No block explorer is configured for chainId ${chainId} (network '${networkName}'), so ` +
+        `source verification is not possible here.\n` +
+        `Local dev chains (hardhat/localhost, 1337) have no explorer and never need this script.\n` +
+        `Chains with an explorer: ${known}.\n` +
+        `If ${networkName} is a real new network, add it to EXPLORERS in scripts/deploy/lib/explorers.js ` +
+        `(and to hardhat.config.js networks) before deploying to it.`
+    );
+  }
+
+  if (explorer.network !== networkName) {
+    throw new Error(
+      `Network name mismatch: --network ${networkName} reports chainId ${chainId}, but ` +
+        `scripts/deploy/lib/explorers.js maps that chain to the '${explorer.network}' network. ` +
+        `One of the two is wrong — check the chainId pinned in hardhat.config.js for '${networkName}'. ` +
+        `Refusing to guess which explorer you meant.`
+    );
+  }
+
+  if (explorer.family === "etherscan") {
+    const raw = process.env[ETHERSCAN_API_KEY_ENV];
+    const key = typeof raw === "string" ? raw.trim() : "";
+    if (!key || PLACEHOLDER_KEYS.has(key.toLowerCase())) {
+      throw new Error(
+        `${ETHERSCAN_API_KEY_ENV} is ${key ? `a placeholder ("${key}")` : "not set"}, so nothing can be ` +
+          `verified on ${explorer.label} (${explorer.chainName}, chainId ${chainId}).\n` +
+          `Mint ONE key at https://etherscan.io/myapikey — the Etherscan V2 API covers Ethereum, ` +
+          `Optimism, Polygon, Base, Arbitrum and Amoy with that single key. Do NOT mint per-explorer ` +
+          `keys at polygonscan.com / basescan.org / arbiscan.io: those V1 keys and endpoints were ` +
+          `retired 2025-08-15.\n` +
+          `Then put it in .env as ${ETHERSCAN_API_KEY_ENV}=<key> and re-run.`
+      );
+    }
+  }
+
+  return explorer;
+}
+
+/**
+ * Does this explorer error mean "your API key is missing/invalid/not authorised for this
+ * chain" rather than "this particular contract did not verify"?
+ *
+ * It matters because the two need opposite handling. A bad key fails EVERY contract
+ * identically, so retrying it six times each across a dozen contracts just buries the one
+ * line that explains the problem under a wall of identical failures. verify.js treats a
+ * key rejection as fatal and stops immediately.
+ *
+ * Etherscan answers a bad key with `{status:"0", message:"NOTOK", result:"Invalid API Key"}`;
+ * hardhat-verify surfaces that string. "Missing/Invalid API Key" and the V2-specific
+ * "not authorized"/"invalid chainid" variants are the other shapes seen in the wild.
+ */
+function isApiKeyProblem(message) {
+  const m = String(message || "").toLowerCase();
+  return (
+    m.includes("invalid api key") ||
+    m.includes("missing/invalid api key") ||
+    m.includes("missing or invalid api key") ||
+    m.includes("api key is invalid") ||
+    m.includes("invalid apikey") ||
+    m.includes("apikey is not valid") ||
+    (m.includes("api key") && m.includes("not authorized"))
+  );
+}
+
+/** One-liner an operator can act on after a key rejection. */
+function apiKeyHelp(explorer) {
+  return (
+    `${ETHERSCAN_API_KEY_ENV} was REJECTED by ${explorer.label}. The key exists but the explorer ` +
+    `will not accept it for chainId — check it is a current Etherscan V2 key from ` +
+    `https://etherscan.io/myapikey (a legacy per-explorer V1 key looks valid but is rejected on the ` +
+    `V2 endpoint), that it is not rate-limited, and that .env has no stray quotes or whitespace.`
+  );
+}
+
+module.exports = {
+  EXPLORERS,
+  ETHERSCAN_API_KEY_ENV,
+  explorerForChain,
+  blockscoutNetworkNames,
+  blockscoutVerifyConfig,
+  addressUrl,
+  assertExplorerConfigured,
+  isApiKeyProblem,
+  apiKeyHelp,
+};

--- a/scripts/deploy/verify.js
+++ b/scripts/deploy/verify.js
@@ -1,24 +1,59 @@
 /**
- * verify.js — Source-verify the deployed v2 FairWins contracts on the active
- * network's block explorer.
+ * verify.js — Source-verify the deployed FairWins contracts on the active network's
+ * block explorer, and ACCOUNT FOR EVERY ADDRESS in that network's deployments record.
  *
- *   - Polygon (137) / Amoy (80002): Polygonscan via Etherscan API V2 (ETHERSCAN_API_KEY)
- *   - Mordor (63) / Ethereum Classic (61): Blockscout (no real API key needed)
+ * Supported networks (family + key handling live in scripts/deploy/lib/explorers.js):
+ *   - Ethereum 1, Optimism 10, Polygon 137, Base 8453, Arbitrum One 42161, Amoy 80002
+ *     -> Etherscan API V2, one ETHERSCAN_API_KEY for all of them
+ *   - Ethereum Classic 61, Mordor 63 -> Blockscout, no API key
  *
- * Reads the deployment record deployments/<network>-chain<id>-v2.json and submits
- * each contract WE deployed (not external tokens) with its constructor arguments.
- * Idempotent and re-runnable: "already verified" is treated as success, and it
- * retries with backoff while the explorer is still indexing fresh bytecode.
+ * ── WHY THIS SCRIPT IS SHAPED THE WAY IT IS ────────────────────────────────────────────
+ * The previous version built its plan with an `add()` helper that RETURNED EARLY when an
+ * address was absent. That is fine for "this network has no UMA adapter" and catastrophic
+ * for everything else: eight contracts (feeRouter, stakingRouter, bridgeRouter,
+ * liquidityRouter, callsignRegistry, wagerPoolFactory, accountFactory, verifyingPaymaster)
+ * had no entry at all, so `npm run verify:polygon` exited 0 having verified NOTHING NEW and
+ * printed a cheerful "Done". A verification tool that reports success without verifying is
+ * worse than no tool: it manufactures confidence at the exact moment someone is checking
+ * whether a mainnet deploy is sound.
  *
- * The hardhat.config.js `etherscan` block auto-selects Etherscan-V2 vs Blockscout
- * from the --network flag, so no extra config is needed here.
+ * So the plan is now built by ENUMERATING THE RECORD, not by listing what we remembered to
+ * add. Every key under `contracts` and `mocks` lands in exactly one bucket:
+ *
+ *   VERIFY       we have a source path + constructor args -> submit it
+ *   PROXY        an ERC-1967 proxy; the IMPLEMENTATION is what carries the source, so we
+ *                verify that and report how this explorer links the pair
+ *   SKIPPED      deliberately not ours to verify (external protocol, EOA), with the reason
+ *   UNVERIFIABLE we cannot verify it and someone should FIX that — no catalog entry, no
+ *                reconstructable constructor args, source not compiled, proxy with no
+ *                recorded implementation. This bucket FAILS the run: a key nobody taught
+ *                this script about is exactly the silent skip being removed here.
+ *   HISTORICAL   we deployed it, its source is no longer in this repo, and no action will
+ *                ever change that (the Semaphore-era pool contracts on Mordor). Reported in
+ *                full every run, but does not fail it — a permanently-red exit code teaches
+ *                operators to ignore red, which costs more than it buys.
  *
  * Usage:
- *   npx hardhat run scripts/deploy/verify.js --network polygon   # needs ETHERSCAN_API_KEY
- *   npx hardhat run scripts/deploy/verify.js --network amoy      # needs ETHERSCAN_API_KEY
- *   npx hardhat run scripts/deploy/verify.js --network mordor    # Blockscout, no key
- *   npx hardhat run scripts/deploy/verify.js --network etc       # Blockscout, no key
- *   DRY_RUN=true npx hardhat run scripts/deploy/verify.js --network <net>   # print plan only
+ *   npx hardhat run scripts/deploy/verify.js --network polygon    # needs ETHERSCAN_API_KEY
+ *   npx hardhat run scripts/deploy/verify.js --network mainnet    # (also optimism|base|arbitrum)
+ *   npx hardhat run scripts/deploy/verify.js --network mordor     # Blockscout, no key
+ *   DRY_RUN=true npx hardhat run scripts/deploy/verify.js --network base   # plan only, no network calls
+ *
+ * Env:
+ *   DRY_RUN=true         print the plan (and the skip/unverifiable reasons) and submit nothing.
+ *   VERIFY_PROXIES=true  ALSO submit the ERC-1967 proxies themselves via the OpenZeppelin
+ *                        upgrades plugin. Off by default — see the PROXY notes below.
+ *   PM_OWNER=0x...       owner passed to FairWinsVerifyingPaymaster at deploy time, if it was
+ *                        not the deployer (it is not persisted in the record).
+ *
+ * Exit code is 0 ONLY when every address in the record was verified, already verified,
+ * deliberately skipped with a recorded reason, or HISTORICAL as defined above. A missing or
+ * rejected API key, a failed submission, an unaccounted-for key, an empty record and a chain
+ * with no explorer all exit 1 — and each says which one it was, in words.
+ *
+ * `npm run verify:<net>` exists for mordor/etc/amoy/polygon; the four control-plane mainnets
+ * are run with the explicit `npx hardhat run ... --network <mainnet|optimism|base|arbitrum>`
+ * form above.
  */
 
 const hre = require("hardhat");
@@ -27,8 +62,16 @@ const fs = require("fs");
 const path = require("path");
 
 const { CHAINLINK_FUNCTIONS_ROUTER, UMA_OOV3 } = require("./lib/constants");
+const {
+  addressUrl,
+  apiKeyHelp,
+  assertExplorerConfigured,
+  explorerForChain,
+  isApiKeyProblem,
+} = require("./lib/explorers");
 
 const DRY_RUN = String(process.env.DRY_RUN || "").toLowerCase() === "true";
+const VERIFY_PROXIES = String(process.env.VERIFY_PROXIES || "").toLowerCase() === "true";
 const ZERO = "0x0000000000000000000000000000000000000000";
 
 // Real Chainalysis sanctions oracle per chain (mirrors deploy.js). Testnets deploy a
@@ -38,30 +81,617 @@ const CHAINALYSIS_ORACLE = { 137: "0x40C57923924B5c5c5455c48D93317139ADDaC8fb" }
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const isAddr = (a) => typeof a === "string" && ethers.isAddress(a) && a.toLowerCase() !== ZERO;
 
-async function verifyOne(name, address, constructorArguments, contract) {
-  const params = { address, constructorArguments };
-  if (contract) params.contract = contract;
+/** Shared reason for the Semaphore-era pool contracts (see the "Retired" block in CATALOG). */
+const RETIRED_SEMAPHORE =
+  "source removed from the repo when spec 034 dropped Semaphore from wager pools; this " +
+  "checkout cannot reproduce the deployed bytecode. Verify from the commit that deployed it " +
+  "(git log -- contracts/pools) or leave it unverified — it is not on any live value path.";
 
-  if (DRY_RUN) {
-    console.log(`  [dry-run] ${name} @ ${address}`);
-    console.log(`            contract=${contract}`);
-    console.log(`            args=${JSON.stringify(constructorArguments)}`);
-    return "dry-run";
+// =============================================================================
+// THE CATALOG — every key that can appear under record.contracts / record.mocks
+// =============================================================================
+/**
+ * One entry per recorded key. `kind` decides the bucket:
+ *
+ *   "impl"     UUPS implementation. Verify it; its `proxyKey` is what the app talks to.
+ *   "contract" plain contract we deployed. Verify it.
+ *   "template" immutable ERC-1167 clone template. Verify it (clones need no verification
+ *              of their own — explorers resolve a minimal proxy to its template).
+ *   "mock"     test double we deployed on a testnet. Verify it so its source is readable.
+ *   "proxy"    ERC-1967 proxy. `implKey` names the implementation that carries the source.
+ *   "external" someone else's contract, recorded so the app can find it. Never ours to verify.
+ *   "eoa"      an externally-owned account recorded among the contracts. Nothing to verify.
+ *   "retired"  we deployed it, but its source is no longer in this repo, so this checkout
+ *              CANNOT produce matching bytecode. Reported as unverifiable, with why.
+ *
+ * `args(ctx)` reconstructs the constructor arguments for records that predate
+ * `record.constructorArgs` (the current amoy/polygon records predate it for the core
+ * contracts). Persisted args always win — they are the exact deploy-time values. Returning
+ * `null` from `args` means "cannot reconstruct", which puts the entry in UNVERIFIABLE with
+ * the entry's `argsNote` as the reason rather than submitting a guess that would fail
+ * against the explorer's bytecode comparison anyway.
+ *
+ * WHEN YOU ADD A CONTRACT TO A DEPLOY SCRIPT, ADD IT HERE. A recorded key with no entry
+ * fails the run by design.
+ */
+const CATALOG = {
+  // --- Access / membership -------------------------------------------------------------
+  membershipManager: {
+    kind: "proxy",
+    label: "MembershipManager",
+    implKey: "membershipManagerImpl",
+    // Pre-spec-027 records have no membershipManagerImpl: back then this key WAS the
+    // contract, not a proxy. buildPlan() detects that and verifies it directly.
+    legacy: {
+      fqn: "contracts/access/MembershipManager.sol:MembershipManager",
+      args: (ctx) => [ctx.deployer, ctx.record.paymentToken, ctx.treasury],
+    },
+  },
+  membershipManagerImpl: {
+    kind: "impl",
+    label: "MembershipManager (implementation)",
+    fqn: "contracts/access/MembershipManager.sol:MembershipManager",
+    proxyKey: "membershipManager",
+    args: () => [],
+  },
+  membershipVoucher: {
+    kind: "contract",
+    label: "MembershipVoucher",
+    fqn: "contracts/access/MembershipVoucher.sol:MembershipVoucher",
+    args: (ctx) => [ctx.deployer, ctx.c.membershipManager],
+  },
+  voucherBatchMinter: {
+    kind: "contract",
+    label: "VoucherBatchMinter",
+    fqn: "contracts/access/VoucherBatchMinter.sol:VoucherBatchMinter",
+    args: (ctx) => [ctx.c.membershipVoucher],
+  },
+  sanctionsGuard: {
+    kind: "contract",
+    label: "SanctionsGuard",
+    fqn: "contracts/access/SanctionsGuard.sol:SanctionsGuard",
+    // The oracle arg differs per chain (real Chainalysis on 137, the deployed mock on
+    // testnets). Guessing it wrong verifies nothing, so refuse rather than submit.
+    args: (ctx) => (isAddr(ctx.sanctionsOracle) ? [ctx.deployer, ctx.sanctionsOracle] : null),
+    argsNote:
+      "SanctionsGuard's oracle constructor arg could not be resolved for this chain " +
+      "(expected record.mocks.mockSanctionsOracle on a testnet, or the Chainalysis oracle on 137). " +
+      "Set CHAINALYSIS_SANCTIONS_ORACLE_137, or add the deploy-time args to record.constructorArgs.",
+  },
+
+  // --- Wagers --------------------------------------------------------------------------
+  wagerRegistry: {
+    kind: "proxy",
+    label: "WagerRegistry",
+    implKey: "wagerRegistryImpl",
+    // Pre-spec-025 records have no wagerRegistryImpl: this key was the contract itself.
+    legacy: {
+      fqn: "contracts/wagers/WagerRegistry.sol:WagerRegistry",
+      args: (ctx) => [
+        ctx.deployer,
+        ctx.c.membershipManager,
+        isAddr(ctx.c.polymarketAdapter) ? ctx.c.polymarketAdapter : ZERO,
+        [ctx.record.paymentToken, ctx.record.wmatic].filter(isAddr),
+      ],
+    },
+  },
+  wagerRegistryImpl: {
+    kind: "impl",
+    label: "WagerRegistry (main implementation)",
+    fqn: "contracts/wagers/WagerRegistry.sol:WagerRegistry",
+    proxyKey: "wagerRegistry",
+    args: () => [],
+  },
+  wagerRegistryIntents: {
+    kind: "impl",
+    label: "WagerRegistryIntents (gasless facet)",
+    fqn: "contracts/wagers/WagerRegistryIntents.sol:WagerRegistryIntents",
+    // Second facet behind the SAME proxy (specs 035+036): the main impl delegatecalls
+    // unknown selectors here. It is not a proxy of its own — it is reached through
+    // wagerRegistry, which is why it points at that proxy too.
+    proxyKey: "wagerRegistry",
+    args: () => [],
+  },
+  keyRegistry: {
+    kind: "contract",
+    label: "KeyRegistry",
+    fqn: "contracts/privacy/KeyRegistry.sol:KeyRegistry",
+    args: () => [],
+  },
+
+  // --- Wager pools (spec 034) ----------------------------------------------------------
+  wagerPoolFactory: { kind: "proxy", label: "WagerPoolFactory", implKey: "wagerPoolFactoryImpl" },
+  wagerPoolFactoryImpl: {
+    kind: "impl",
+    label: "WagerPoolFactory (implementation)",
+    fqn: "contracts/pools/WagerPoolFactory.sol:WagerPoolFactory",
+    proxyKey: "wagerPoolFactory",
+    args: () => [],
+  },
+  poolImpl: {
+    kind: "template",
+    label: "WagerPool (ERC-1167 clone template)",
+    fqn: "contracts/pools/WagerPool.sol:WagerPool",
+    args: () => [],
+  },
+
+  // --- Tokens (spec 028) ---------------------------------------------------------------
+  tokenFactory: { kind: "proxy", label: "TokenFactory", implKey: "tokenFactoryImpl" },
+  tokenFactoryImpl: {
+    kind: "impl",
+    label: "TokenFactory (implementation)",
+    fqn: "contracts/tokens/TokenFactory.sol:TokenFactory",
+    proxyKey: "tokenFactory",
+    args: () => [],
+  },
+  openERC20Impl: {
+    kind: "template",
+    label: "OpenERC20 (clone template)",
+    fqn: "contracts/tokens/templates/OpenERC20.sol:OpenERC20",
+    args: () => [],
+  },
+  openERC721Impl: {
+    kind: "template",
+    label: "OpenERC721 (clone template)",
+    fqn: "contracts/tokens/templates/OpenERC721.sol:OpenERC721",
+    args: () => [],
+  },
+  restrictedERC20Impl: {
+    kind: "template",
+    label: "RestrictedERC20 (clone template)",
+    fqn: "contracts/tokens/templates/RestrictedERC20.sol:RestrictedERC20",
+    args: () => [],
+  },
+  openERC20V2Impl: {
+    kind: "template",
+    label: "OpenERC20V2 (clone template)",
+    fqn: "contracts/tokens/templates/OpenERC20V2.sol:OpenERC20V2",
+    args: () => [],
+  },
+  openERC721V2Impl: {
+    kind: "template",
+    label: "OpenERC721V2 (clone template)",
+    fqn: "contracts/tokens/templates/OpenERC721V2.sol:OpenERC721V2",
+    args: () => [],
+  },
+  restrictedERC20V2Impl: {
+    kind: "template",
+    label: "RestrictedERC20V2 (clone template)",
+    fqn: "contracts/tokens/templates/RestrictedERC20V2.sol:RestrictedERC20V2",
+    args: () => [],
+  },
+
+  // --- Oracle adapters (only on Polymarket/Chainlink/UMA-enabled networks) --------------
+  polymarketAdapter: {
+    kind: "contract",
+    label: "PolymarketOracleAdapter",
+    fqn: "contracts/oracles/PolymarketOracleAdapter.sol:PolymarketOracleAdapter",
+    args: (ctx) => (isAddr(ctx.record.polymarketCTF) ? [ctx.deployer, ctx.record.polymarketCTF] : null),
+    argsNote: "record.polymarketCTF is missing, so the adapter's CTF constructor arg cannot be reconstructed.",
+  },
+  chainlinkDataFeedAdapter: {
+    kind: "contract",
+    label: "ChainlinkDataFeedOracleAdapter",
+    fqn: "contracts/oracles/ChainlinkDataFeedOracleAdapter.sol:ChainlinkDataFeedOracleAdapter",
+    args: (ctx) => [ctx.deployer],
+  },
+  chainlinkFunctionsAdapter: {
+    kind: "contract",
+    label: "ChainlinkFunctionsOracleAdapter",
+    fqn: "contracts/oracles/ChainlinkFunctionsOracleAdapter.sol:ChainlinkFunctionsOracleAdapter",
+    args: (ctx) =>
+      isAddr(CHAINLINK_FUNCTIONS_ROUTER[ctx.networkName])
+        ? [ctx.deployer, CHAINLINK_FUNCTIONS_ROUTER[ctx.networkName]]
+        : null,
+    argsNote:
+      "CHAINLINK_FUNCTIONS_ROUTER has no entry for this network in scripts/deploy/lib/constants.js, " +
+      "so the router constructor arg cannot be reconstructed.",
+  },
+  umaAdapter: {
+    kind: "contract",
+    label: "UMAOptimisticOracleV3Adapter",
+    fqn: "contracts/oracles/UMAOptimisticOracleV3Adapter.sol:UMAOptimisticOracleV3Adapter",
+    args: (ctx) => (isAddr(UMA_OOV3[ctx.networkName]) ? [ctx.deployer, UMA_OOV3[ctx.networkName]] : null),
+    argsNote:
+      "UMA_OOV3 has no entry for this network in scripts/deploy/lib/constants.js, so the " +
+      "OptimisticOracleV3 constructor arg cannot be reconstructed.",
+  },
+
+  // --- Control plane: fees (060), staking (066), bridge + liquidity (067) ---------------
+  feeRouter: { kind: "proxy", label: "FeeRouter", implKey: "feeRouterImpl" },
+  feeRouterImpl: {
+    kind: "impl",
+    label: "FeeRouter (implementation)",
+    fqn: "contracts/fees/FeeRouter.sol:FeeRouter",
+    proxyKey: "feeRouter",
+    args: () => [],
+  },
+  stakingRouter: { kind: "proxy", label: "StakingRouter", implKey: "stakingRouterImpl" },
+  stakingRouterImpl: {
+    kind: "impl",
+    label: "StakingRouter (implementation)",
+    fqn: "contracts/staking/StakingRouter.sol:StakingRouter",
+    proxyKey: "stakingRouter",
+    args: () => [],
+  },
+  bridgeRouter: { kind: "proxy", label: "BridgeRouter", implKey: "bridgeRouterImpl" },
+  bridgeRouterImpl: {
+    kind: "impl",
+    label: "BridgeRouter (implementation)",
+    fqn: "contracts/bridge/BridgeRouter.sol:BridgeRouter",
+    proxyKey: "bridgeRouter",
+    args: () => [],
+  },
+  liquidityRouter: { kind: "proxy", label: "LiquidityRouter", implKey: "liquidityRouterImpl" },
+  liquidityRouterImpl: {
+    kind: "impl",
+    label: "LiquidityRouter (implementation)",
+    fqn: "contracts/liquidity/LiquidityRouter.sol:LiquidityRouter",
+    proxyKey: "liquidityRouter",
+    args: () => [],
+  },
+
+  // --- Identity (spec 054) -------------------------------------------------------------
+  callsignRegistry: { kind: "proxy", label: "CallsignRegistry", implKey: "callsignRegistryImpl" },
+  callsignRegistryImpl: {
+    kind: "impl",
+    label: "CallsignRegistry (implementation)",
+    fqn: "contracts/naming/CallsignRegistry.sol:CallsignRegistry",
+    proxyKey: "callsignRegistry",
+    args: () => [],
+  },
+
+  // --- DAO connector (spec 030) --------------------------------------------------------
+  externalDAORegistry: { kind: "proxy", label: "ExternalDAORegistry", implKey: "externalDAORegistryImpl" },
+  externalDAORegistryImpl: {
+    kind: "impl",
+    label: "ExternalDAORegistry (implementation)",
+    fqn: "contracts/clearpath/ExternalDAORegistry.sol:ExternalDAORegistry",
+    proxyKey: "externalDAORegistry",
+    args: () => [],
+  },
+
+  // --- Backup pointer (spec 032) -------------------------------------------------------
+  backupPointerRegistry: {
+    kind: "contract",
+    label: "BackupPointerRegistry",
+    fqn: "contracts/privacy/BackupPointerRegistry.sol:BackupPointerRegistry",
+    args: () => [],
+  },
+
+  // --- Custody (specs 043 + 049) -------------------------------------------------------
+  safePolicyGuard: {
+    kind: "contract",
+    label: "SafePolicyGuard",
+    fqn: "contracts/custody/SafePolicyGuard.sol:SafePolicyGuard",
+    args: () => [],
+  },
+  policyGuardSetup: {
+    kind: "contract",
+    label: "PolicyGuardSetup",
+    fqn: "contracts/custody/PolicyGuardSetup.sol:PolicyGuardSetup",
+    args: () => [],
+  },
+  safeProposalHub: {
+    kind: "contract",
+    label: "SafeProposalHub",
+    fqn: "contracts/custody/SafeProposalHub.sol:SafeProposalHub",
+    args: () => [],
+  },
+
+  // --- Passkey account stack (spec 041) + sponsored paymaster (spec 050) ----------------
+  accountImpl: {
+    kind: "contract",
+    label: "CoinbaseSmartWallet (account implementation)",
+    fqn: "contracts/account/CoinbaseSmartWallet.sol:CoinbaseSmartWallet",
+    args: () => [],
+  },
+  accountFactory: {
+    kind: "contract",
+    label: "CoinbaseSmartWalletFactory",
+    fqn: "contracts/account/CoinbaseSmartWalletFactory.sol:CoinbaseSmartWalletFactory",
+    // CREATE2-deployed with the account implementation as its single constructor arg
+    // (deploy-account-stack.js). Same address on every chain, by design.
+    args: (ctx) => (isAddr(ctx.c.accountImpl) ? [ctx.c.accountImpl] : null),
+    argsNote:
+      "contracts.accountImpl is missing from the record, and it is the factory's only " +
+      "constructor arg. Re-run deploy-account-stack.js (idempotent) to record it.",
+  },
+  verifyingPaymaster: {
+    kind: "contract",
+    label: "FairWinsVerifyingPaymaster",
+    fqn: "contracts/account/FairWinsVerifyingPaymaster.sol:FairWinsVerifyingPaymaster",
+    // constructor(entryPoint, verifyingSigner, owner). deploy-verifying-paymaster.js does
+    // NOT persist these, and `owner` defaults to the deployer but can be overridden with
+    // PM_OWNER — so we reconstruct with that same precedence and say so. If the deploy used
+    // a custom owner, re-run this script with PM_OWNER set; a wrong arg fails the explorer's
+    // bytecode comparison, it does not verify the wrong source.
+    args: (ctx) =>
+      isAddr(ctx.c.entryPoint) && isAddr(ctx.c.verifyingPaymasterSigner)
+        ? [ctx.c.entryPoint, ctx.c.verifyingPaymasterSigner, process.env.PM_OWNER || ctx.deployer]
+        : null,
+    argsNote:
+      "contracts.entryPoint and/or contracts.verifyingPaymasterSigner are missing, and both are " +
+      "constructor args of the paymaster.",
+    note: "owner arg assumed = PM_OWNER or the recorded deployer (not persisted at deploy time)",
+  },
+  verifyingPaymasterSigner: {
+    kind: "eoa",
+    label: "Paymaster verifying signer",
+    reason: "an EOA (the KMS-held ERC-7677 signer address), not a contract — there is no source to verify",
+  },
+  entryPoint: {
+    kind: "external",
+    label: "ERC-4337 EntryPoint v0.6",
+    reason: "canonical EntryPoint deployed and verified by the ERC-4337 team; FairWins only records the address",
+  },
+  p256Verifier: {
+    kind: "external",
+    label: "P-256 verifier",
+    reason:
+      "external RIP-7212 precompile / third-party verifier where one exists; recorded null when the " +
+      "account falls back to inlined FreshCryptoLib",
+  },
+
+  // --- Mocks (testnets only) -----------------------------------------------------------
+  mockSanctionsOracle: {
+    kind: "mock",
+    label: "MockSanctionsOracle",
+    fqn: "contracts/mocks/MockSanctionsOracle.sol:MockSanctionsOracle",
+    args: () => [],
+  },
+  mockUSDC: {
+    kind: "mock",
+    label: "MockERC20 (USDC)",
+    fqn: "contracts/mocks/MockERC20.sol:MockERC20",
+    args: () => ["USD Coin", "USDC", 0],
+  },
+  mockWMATIC: {
+    kind: "mock",
+    label: "MockERC20 (WMATIC)",
+    fqn: "contracts/mocks/MockERC20.sol:MockERC20",
+    args: () => ["Wrapped Matic", "WMATIC", 0],
+  },
+  mockPolymarketCTF: {
+    kind: "mock",
+    label: "MockPolymarketCTF",
+    fqn: "contracts/test/MockPolymarketCTF.sol:MockPolymarketCTF",
+    args: () => [],
+  },
+
+  // --- Retired: deployed once, source since removed from the repo -----------------------
+  // Spec 034 dropped Semaphore/anonymity from pools and DELETED these sources. The Mordor
+  // record still carries the addresses (deployments/ is a historical record, not a wish
+  // list). This checkout cannot reproduce their bytecode, so they can never verify from
+  // here — that is a fact to state, not a failure to hide behind a silent skip.
+  zkWagerPoolFactory: { kind: "retired", label: "ZKWagerPoolFactory (proxy)", reason: RETIRED_SEMAPHORE },
+  zkWagerPoolFactoryImpl: { kind: "retired", label: "ZKWagerPoolFactory (implementation)", reason: RETIRED_SEMAPHORE },
+  zkWagerPoolSemaphore: { kind: "retired", label: "ZKWagerPool (Semaphore clone template)", reason: RETIRED_SEMAPHORE },
+  semaphoreVerifier: {
+    kind: "retired",
+    label: "SemaphoreVerifier",
+    reason:
+      "vendored Semaphore verifier, removed with the anonymity path in spec 034. Verify from the " +
+      "Semaphore release that was vendored at deploy time, or leave unverified.",
+  },
+  poseidonT3: {
+    kind: "retired",
+    label: "PoseidonT3",
+    reason:
+      "Poseidon hasher generated by poseidon-solidity, removed with the anonymity path in spec 034. " +
+      "Its bytecode is generated, not stored in this repo.",
+  },
+};
+
+/**
+ * Top-level record keys that hold addresses but are NOT things we deployed. Listed so the
+ * summary can say so explicitly instead of leaving the operator to wonder why USDC never
+ * appears in the plan.
+ */
+const EXTERNAL_TOP_LEVEL = {
+  paymentToken: "stake/settlement stablecoin (e.g. Circle USDC) — deployed and verified by its issuer",
+  wmatic: "wrapped native token — deployed and verified by its issuer",
+  polymarketCTF: "Polymarket/Gnosis Conditional Tokens Framework — third-party protocol",
+};
+
+// =============================================================================
+// PLAN CONSTRUCTION
+// =============================================================================
+
+/** Does this checkout actually contain the source behind `fqn`? */
+async function sourceExists(fqn) {
+  try {
+    await hre.artifacts.readArtifact(fqn);
+    return true;
+  } catch {
+    return false;
   }
+}
+
+/**
+ * Turn a deployment record into an ordered, fully-accounted plan.
+ *
+ * Every key under contracts/mocks with a usable address lands in exactly one of `verify`,
+ * `proxies`, `skipped`, `historical` or `unverifiable`. Nothing is dropped on the floor: an
+ * address that goes nowhere is the bug this function exists to prevent. The ONLY silent
+ * case is an explicit null (recorded on purpose to mean "not deployed here").
+ */
+async function buildPlan(ctx) {
+  // `recordTop` carries the record's top-level address fields (paymentToken, wmatic,
+  // polymarketCTF) so the summary can list them as deliberately-external rather than
+  // leaving them unmentioned — "unmentioned" is how an address gets forgotten.
+  const plan = { verify: [], proxies: [], skipped: [], unverifiable: [], historical: [], recordTop: ctx.record };
+
+  const sections = [
+    ["contracts", ctx.c],
+    ["mocks", ctx.m],
+  ];
+
+  for (const [section, bag] of sections) {
+    for (const [key, value] of Object.entries(bag || {})) {
+      // An explicit null/absent address means "not deployed on this network" — normal, and
+      // the only case where saying nothing is correct (p256Verifier is recorded as null on
+      // purpose so the frontend capability check stays honest).
+      if (value === null || value === undefined || value === "") continue;
+
+      if (!isAddr(value)) {
+        plan.unverifiable.push({
+          key,
+          address: String(value),
+          label: key,
+          reason: `record.${section}.${key} is not a usable address ("${value}").`,
+        });
+        continue;
+      }
+
+      const entry = CATALOG[key];
+      if (!entry) {
+        plan.unverifiable.push({
+          key,
+          address: value,
+          label: key,
+          reason:
+            `no entry in CATALOG (scripts/deploy/verify.js) for record.${section}.${key}. ` +
+            `Something deployed a contract and recorded it without teaching this script how to ` +
+            `verify it. Add an entry — that is what keeps "verified nothing" from reading as "all good".`,
+        });
+        continue;
+      }
+
+      // Non-verifiable-by-design buckets.
+      if (entry.kind === "external" || entry.kind === "eoa") {
+        plan.skipped.push({ key, address: value, label: entry.label, reason: entry.reason });
+        continue;
+      }
+      if (entry.kind === "retired") {
+        plan.historical.push({ key, address: value, label: entry.label, reason: entry.reason });
+        continue;
+      }
+
+      // Proxies: the implementation carries the source. Report the pairing, and only
+      // complain if the implementation is missing from the record — in that case nobody can
+      // read this proxy's source on the explorer, which is worth failing over.
+      if (entry.kind === "proxy") {
+        const impl = ctx.c[entry.implKey];
+        if (isAddr(impl)) {
+          plan.proxies.push({ key, address: value, label: entry.label, implKey: entry.implKey, impl });
+          continue;
+        }
+        if (entry.legacy && (await sourceExists(entry.legacy.fqn))) {
+          // Pre-UUPS record: this key IS the contract (spec 025 for wagerRegistry, spec 027
+          // for membershipManager both migrated an already-deployed non-proxy contract).
+          const args = resolveArgs(ctx, key, entry.legacy);
+          pushVerifyOrUnverifiable(plan, {
+            key,
+            address: value,
+            label: `${entry.label} (pre-proxy deployment)`,
+            fqn: entry.legacy.fqn,
+            args,
+            entry,
+          });
+          continue;
+        }
+        plan.unverifiable.push({
+          key,
+          address: value,
+          label: entry.label,
+          reason:
+            `proxy recorded without its implementation (contracts.${entry.implKey} is missing), so there ` +
+            `is nothing to verify and the explorer has no source to link. Record the implementation ` +
+            `(scripts/deploy/lib/upgradeable.js getImplementation) and re-run.`,
+        });
+        continue;
+      }
+
+      // Verifiable kinds: impl / contract / template / mock.
+      if (!(await sourceExists(entry.fqn))) {
+        plan.unverifiable.push({
+          key,
+          address: value,
+          label: entry.label,
+          reason:
+            `${entry.fqn} is not in this checkout's artifacts. Either the contract was renamed/removed ` +
+            `since it was deployed (verify from the deploying commit instead), or you need to run ` +
+            `\`npx hardhat compile\` first.`,
+        });
+        continue;
+      }
+
+      pushVerifyOrUnverifiable(plan, {
+        key,
+        address: value,
+        label: entry.label,
+        fqn: entry.fqn,
+        args: resolveArgs(ctx, key, entry),
+        entry,
+      });
+    }
+  }
+
+  // Verify implementations before proxies, and keep a stable, readable order otherwise.
+  const rank = { impl: 0, contract: 1, template: 2, mock: 3 };
+  plan.verify.sort((a, b) => (rank[a.entry.kind] ?? 9) - (rank[b.entry.kind] ?? 9));
+
+  return plan;
+}
+
+/** Persisted deploy-time args win; otherwise reconstruct; `null` means "cannot". */
+function resolveArgs(ctx, key, entry) {
+  const persisted = ctx.record.constructorArgs || {};
+  if (persisted[key] !== undefined) return persisted[key];
+  return typeof entry.args === "function" ? entry.args(ctx) : null;
+}
+
+function pushVerifyOrUnverifiable(plan, item) {
+  if (item.args === null || item.args === undefined) {
+    plan.unverifiable.push({
+      key: item.key,
+      address: item.address,
+      label: item.label,
+      reason:
+        (item.entry.argsNote ||
+          `constructor arguments are neither recorded in record.constructorArgs.${item.key} nor ` +
+            `reconstructable here`) +
+        ` Submitting a guess would fail the explorer's bytecode comparison, so it is not attempted.`,
+    });
+    return;
+  }
+  plan.verify.push(item);
+}
+
+// =============================================================================
+// SUBMISSION
+// =============================================================================
+
+/** Raised when the explorer rejects our credentials — fatal for the whole run, not one contract. */
+class ApiKeyRejected extends Error {}
+
+async function verifyOne({ label, address, args, fqn }, explorer) {
+  const params = { address, constructorArguments: args, contract: fqn };
+
+  // A dry run submits nothing; the plan is reported once, in the summary (which prints the
+  // source path and the exact constructor args it WOULD send).
+  if (DRY_RUN) return { status: "planned" };
 
   const maxAttempts = 6;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       await hre.run("verify:verify", params);
-      console.log(`  ✓ verified ${name} @ ${address}`);
-      return "verified";
+      console.log(`  ✓ verified ${label} @ ${address}`);
+      return { status: "verified" };
     } catch (err) {
       const msg = String((err && err.message) || err);
 
       // Already verified -> success (re-runnable). Covers Etherscan + Blockscout strings.
       if (/already verified|already been verified|smart-contract already verified/i.test(msg)) {
-        console.log(`  • already verified ${name} @ ${address}`);
-        return "already-verified";
+        console.log(`  • already verified ${label} @ ${address}`);
+        return { status: "already-verified" };
+      }
+
+      // A rejected key fails every contract identically. Retrying it 6 times each just
+      // buries the one line that explains the problem, so stop the run here.
+      if (isApiKeyProblem(msg)) {
+        throw new ApiKeyRejected(`${apiKeyHelp(explorer)}\n  Explorer said: ${msg.split("\n")[0]}`);
       }
 
       // Explorer hasn't indexed the bytecode yet, or transient network error -> backoff.
@@ -70,17 +700,57 @@ async function verifyOne(name, address, constructorArguments, contract) {
         /does not have bytecode|has not been deployed|Unable to locate ContractCode|not found|Pending in queue|rate limit|ECONNRESET|ETIMEDOUT|50[23]/i.test(msg)
       ) {
         const wait = Math.min(2000 * 2 ** (attempt - 1), 30000); // 2s,4s,8s,16s,30s
-        console.log(`  … ${name} attempt ${attempt} not ready (${msg.split("\n")[0]}); retry in ${wait}ms`);
+        console.log(`  … ${label} attempt ${attempt} not ready (${msg.split("\n")[0]}); retry in ${wait}ms`);
         await sleep(wait);
         continue;
       }
 
-      console.error(`  ✗ ${name} @ ${address} failed: ${msg.split("\n")[0]}`);
-      throw err;
+      // One contract failing is not a reason to skip the rest — collect it and carry on so
+      // the summary shows the WHOLE picture in one run.
+      console.error(`  ✗ ${label} @ ${address} failed: ${msg.split("\n")[0]}`);
+      return { status: "failed", reason: msg.split("\n")[0] };
     }
   }
-  throw new Error(`gave up verifying ${name} @ ${address}`);
+  return { status: "failed", reason: "explorer never indexed the bytecode (gave up after 6 attempts)" };
 }
+
+/**
+ * Optional: submit the ERC-1967 proxy itself.
+ *
+ * OFF by default. Both explorer families already resolve a proxy to its implementation
+ * (Blockscout reads the EIP-1967 slot automatically; Etherscan does it on demand behind
+ * "Is this a proxy?"), so the implementation being verified is what actually makes the
+ * source readable. Submitting the proxy adds the OpenZeppelin plugin's own ERC1967Proxy
+ * artifact into the mix, which fails confusingly when the deployed proxy came from a
+ * different @openzeppelin/contracts version than the one installed today. Opt in with
+ * VERIFY_PROXIES=true when you want the explicit link recorded.
+ */
+async function verifyProxy(item, explorer) {
+  if (DRY_RUN) {
+    console.log(`  [plan] proxy ${item.label} @ ${item.address} -> impl ${item.impl}`);
+    return { status: "planned" };
+  }
+  try {
+    // The @openzeppelin/hardhat-upgrades plugin extends the top-level `verify` task to
+    // understand proxies; the low-level verify:verify task does not.
+    await hre.run("verify", { address: item.address, constructorArgsParams: [] });
+    console.log(`  ✓ proxy linked ${item.label} @ ${item.address}`);
+    return { status: "verified" };
+  } catch (err) {
+    const msg = String((err && err.message) || err);
+    if (/already verified|already been verified|smart-contract already verified/i.test(msg)) {
+      console.log(`  • proxy already verified ${item.label} @ ${item.address}`);
+      return { status: "already-verified" };
+    }
+    if (isApiKeyProblem(msg)) throw new ApiKeyRejected(apiKeyHelp(explorer));
+    console.warn(`  ⚠ proxy ${item.label} @ ${item.address} not linked: ${msg.split("\n")[0]}`);
+    return { status: "manual", reason: msg.split("\n")[0] };
+  }
+}
+
+// =============================================================================
+// MAIN
+// =============================================================================
 
 async function main() {
   const networkName = hre.network.name;
@@ -88,146 +758,330 @@ async function main() {
   const chainId = hre.network.config.chainId
     ? Number(hre.network.config.chainId)
     : Number((await ethers.provider.getNetwork()).chainId);
-  const recordPath = path.join(__dirname, "..", "..", "deployments", `${networkName}-chain${chainId}-v2.json`);
 
+  // Pre-flight FIRST: if this chain has no explorer, or the key is absent, say so before
+  // touching anything. A run that cannot verify must never reach a summary an operator could
+  // mistake for a clean result.
+  //
+  // The one concession: a DRY RUN whose ONLY problem is the API key still prints its plan,
+  // because "what would this attempt on Base?" is a question worth answering before the key
+  // is minted. It states the pre-flight failure at the top, repeats it in the verdict, and
+  // exits non-zero — the plan is informative, not a pass.
+  let explorer;
+  let preflightError = null;
+  try {
+    explorer = assertExplorerConfigured(chainId, networkName);
+  } catch (err) {
+    const known = explorerForChain(chainId);
+    // Only the key problem is survivable. An unknown chain (no explorer facts at all) or a
+    // network/chainId mismatch means every address and URL below would be wrong.
+    if (!DRY_RUN || !known || known.network !== networkName) throw err;
+    explorer = known;
+    preflightError = err;
+    console.error(`\nPRE-FLIGHT FAILED — nothing could be submitted even if this were not a dry run:\n`);
+    console.error(`${err.message}\n`);
+    console.error(`Continuing to print the PLAN ONLY, because this is a dry run.\n`);
+  }
+
+  const recordPath = path.join(__dirname, "..", "..", "deployments", `${networkName}-chain${chainId}-v2.json`);
   if (!fs.existsSync(recordPath)) {
     throw new Error(
-      `No deployment record at ${recordPath}.\n` +
-        `Deploy first: npx hardhat run scripts/deploy/deploy.js --network ${networkName}`
+      `No deployment record at ${recordPath}, so there is nothing to verify on ${networkName}.\n` +
+        `Deploy first (deployments/ is the source of truth — this script only reads it):\n` +
+        `  full stack (wagers + membership + oracles):\n` +
+        `    npx hardhat run scripts/deploy/deploy.js --network ${networkName}\n` +
+        `  control plane only (FeeRouter + BridgeRouter/LiquidityRouter, no core):\n` +
+        `    npx hardhat run scripts/deploy/init-deployment-record.js --network ${networkName}\n` +
+        `    then deploy-fee-router.js and deploy-bridge-liquidity.js --network ${networkName}`
     );
   }
 
   const record = JSON.parse(fs.readFileSync(recordPath, "utf8"));
   const c = record.contracts || {};
   const m = record.mocks || {};
-  const deployer = record.deployer;
-  const treasury = record.treasury;
 
-  console.log("=".repeat(60));
-  console.log(`Verify v2 contracts — ${networkName} (chainId ${chainId})${DRY_RUN ? "  [DRY RUN]" : ""}`);
-  console.log(`Record: ${recordPath}`);
-  console.log("=".repeat(60) + "\n");
+  console.log("=".repeat(72));
+  console.log(
+    `Verify FairWins contracts — ${networkName} (chainId ${chainId})${DRY_RUN ? "  [DRY RUN — nothing submitted]" : ""}`
+  );
+  console.log(`Explorer: ${explorer.label} ${explorer.browserUrl} (${explorer.family})`);
+  console.log(`Record:   ${recordPath}`);
+  console.log("=".repeat(72) + "\n");
 
-  // SanctionsGuard oracle arg: real Chainalysis on 137, else the deployed mock (testnets).
-  const sanctionsOracle = chainId === 137
-    ? (process.env.CHAINALYSIS_SANCTIONS_ORACLE_137 || CHAINALYSIS_ORACLE[137])
-    : m.mockSanctionsOracle;
-
-  // WagerRegistry stake-token allowlist, in deploy order: [paymentToken, wmatic].filter.
-  const initialTokens = [record.paymentToken, record.wmatic].filter(isAddr);
-
-  // Build the ordered plan. Only OUR contracts (skip external stable/wrapped tokens).
-  // Entries whose address is absent (core-only Mordor omits oracle adapters + token
-  // mocks) are silently skipped. Prefer the constructor args PERSISTED in the record
-  // (exact deploy-time values); the fallback reconstruction is for older records that
-  // predate record.constructorArgs (e.g. the current amoy/polygon records).
-  const persisted = record.constructorArgs || {};
-  const plan = [];
-  const add = (name, address, key, fallbackArgs, fqn) => {
-    if (!isAddr(address)) return;
-    const args = persisted[key] !== undefined ? persisted[key] : fallbackArgs;
-    plan.push({ name, address, args, fqn });
+  const ctx = {
+    record,
+    c,
+    m,
+    chainId,
+    networkName,
+    deployer: record.deployer,
+    treasury: record.treasury,
+    // SanctionsGuard oracle arg: real Chainalysis on 137, else the deployed mock (testnets).
+    sanctionsOracle:
+      chainId === 137
+        ? process.env.CHAINALYSIS_SANCTIONS_ORACLE_137 || CHAINALYSIS_ORACLE[137]
+        : m.mockSanctionsOracle,
   };
 
-  // MembershipManager is a UUPS proxy (spec 027): verify the IMPLEMENTATION (no constructor args — init data
-  // lives in the proxy). Explorers detect the ERC1967 proxy and link it to this verified implementation.
-  // Older (pre-027, non-proxy) records have no membershipManagerImpl: fall back to verifying the address under
-  // `membershipManager` with the legacy constructor args.
-  if (isAddr(c.membershipManagerImpl)) {
-    add("MembershipManager", c.membershipManagerImpl, "membershipManagerImpl", [],
-      "contracts/access/MembershipManager.sol:MembershipManager");
-  } else {
-    add("MembershipManager", c.membershipManager, "membershipManager",
-      [deployer, record.paymentToken, treasury],
-      "contracts/access/MembershipManager.sol:MembershipManager");
-  }
-  // WagerRegistry is a UUPS proxy: verify the IMPLEMENTATION (no constructor args — init data lives in the
-  // proxy). Explorers detect the ERC1967 proxy and link it to this verified implementation automatically.
-  // Older (pre-025, non-proxy) records have no wagerRegistryImpl: fall back to verifying the address under
-  // `wagerRegistry` with the legacy constructor args.
-  if (isAddr(c.wagerRegistryImpl)) {
-    add("WagerRegistry", c.wagerRegistryImpl, "wagerRegistryImpl", [],
-      "contracts/wagers/WagerRegistry.sol:WagerRegistry");
-  } else {
-    add("WagerRegistry", c.wagerRegistry, "wagerRegistry",
-      [deployer, c.membershipManager, isAddr(c.polymarketAdapter) ? c.polymarketAdapter : ZERO, initialTokens],
-      "contracts/wagers/WagerRegistry.sol:WagerRegistry");
-  }
-  add("MembershipVoucher", c.membershipVoucher, "membershipVoucher",
-    [deployer, c.membershipManager],
-    "contracts/access/MembershipVoucher.sol:MembershipVoucher");
-  add("VoucherBatchMinter", c.voucherBatchMinter, "voucherBatchMinter",
-    [c.membershipVoucher],
-    "contracts/access/VoucherBatchMinter.sol:VoucherBatchMinter");
-  add("KeyRegistry", c.keyRegistry, "keyRegistry", [],
-    "contracts/privacy/KeyRegistry.sol:KeyRegistry");
-  add("SanctionsGuard", c.sanctionsGuard, "sanctionsGuard", [deployer, sanctionsOracle],
-    "contracts/access/SanctionsGuard.sol:SanctionsGuard");
+  const plan = await buildPlan(ctx);
+  const totalAddresses =
+    plan.verify.length + plan.proxies.length + plan.skipped.length + plan.unverifiable.length + plan.historical.length;
 
-  // TokenFactory (spec 028) is a UUPS proxy: verify the IMPLEMENTATION (no constructor args — init data lives in
-  // the proxy). The clone templates are immutable with no constructor args. Present only once the factory is
-  // deployed on this network.
-  add("TokenFactory", c.tokenFactoryImpl, "tokenFactoryImpl", [],
-    "contracts/tokens/TokenFactory.sol:TokenFactory");
-  add("OpenERC20", c.openERC20Impl, "openERC20Impl", [],
-    "contracts/tokens/templates/OpenERC20.sol:OpenERC20");
-  add("OpenERC721", c.openERC721Impl, "openERC721Impl", [],
-    "contracts/tokens/templates/OpenERC721.sol:OpenERC721");
-  add("RestrictedERC20", c.restrictedERC20Impl, "restrictedERC20Impl", [],
-    "contracts/tokens/templates/RestrictedERC20.sol:RestrictedERC20");
-
-  // Oracle adapters — present only on Polymarket/Chainlink/UMA-enabled networks.
-  add("PolymarketOracleAdapter", c.polymarketAdapter, "polymarketAdapter", [deployer, record.polymarketCTF],
-    "contracts/oracles/PolymarketOracleAdapter.sol:PolymarketOracleAdapter");
-  add("ChainlinkDataFeedOracleAdapter", c.chainlinkDataFeedAdapter, "chainlinkDataFeedAdapter", [deployer],
-    "contracts/oracles/ChainlinkDataFeedOracleAdapter.sol:ChainlinkDataFeedOracleAdapter");
-  add("ChainlinkFunctionsOracleAdapter", c.chainlinkFunctionsAdapter, "chainlinkFunctionsAdapter", [deployer, CHAINLINK_FUNCTIONS_ROUTER[networkName]],
-    "contracts/oracles/ChainlinkFunctionsOracleAdapter.sol:ChainlinkFunctionsOracleAdapter");
-  add("UMAOptimisticOracleV3Adapter", c.umaAdapter, "umaAdapter", [deployer, UMA_OOV3[networkName]],
-    "contracts/oracles/UMAOptimisticOracleV3Adapter.sol:UMAOptimisticOracleV3Adapter");
-
-  // Mocks we deployed (testnets / no-real-token networks). Verifying them lets users
-  // read the source on the explorer.
-  add("MockSanctionsOracle", m.mockSanctionsOracle, "mockSanctionsOracle", [],
-    "contracts/mocks/MockSanctionsOracle.sol:MockSanctionsOracle");
-  add("MockERC20 (USDC)", m.mockUSDC, "mockUSDC", ["USD Coin", "USDC", 0],
-    "contracts/mocks/MockERC20.sol:MockERC20");
-  add("MockERC20 (WMATIC)", m.mockWMATIC, "mockWMATIC", ["Wrapped Matic", "WMATIC", 0],
-    "contracts/mocks/MockERC20.sol:MockERC20");
-  add("MockPolymarketCTF", m.mockPolymarketCTF, "mockPolymarketCTF", [],
-    "contracts/test/MockPolymarketCTF.sol:MockPolymarketCTF");
-
-  if (plan.length === 0) {
-    console.log("Nothing to verify (no recorded contract addresses).");
-    return;
-  }
-
-  // Guard against a SanctionsGuard with an unknown oracle arg (would mis-verify).
-  const sg = plan.find((p) => p.name === "SanctionsGuard");
-  if (sg && !isAddr(sg.args[1])) {
+  // A record with no addresses at all is not a success state. Refuse rather than print
+  // "Done": an empty record means either nothing is deployed yet (a freshly initialized
+  // record from init-deployment-record.js), or the deploy died before recording, or this is
+  // the wrong network — and all three deserve a stop, not a green tick.
+  if (totalAddresses === 0) {
     throw new Error(
-      `Cannot reconstruct SanctionsGuard oracle arg for chain ${chainId}. ` +
-        `Expected record.mocks.mockSanctionsOracle (testnet) or CHAINALYSIS_ORACLE[137].`
+      `${recordPath} records no contract addresses at all, so nothing was verified.\n` +
+        `If the record was just created by init-deployment-record.js, deploy something first ` +
+        `(deploy-fee-router.js / deploy-bridge-liquidity.js). Otherwise check that you targeted the ` +
+        `right network and that the deploy actually completed and wrote its addresses.`
     );
   }
 
-  const results = { verified: 0, "already-verified": 0, "dry-run": 0 };
-  for (const item of plan) {
-    const outcome = await verifyOne(item.name, item.address, item.args, item.fqn);
-    results[outcome] = (results[outcome] || 0) + 1;
+  // On-chain pre-flight: is there actually CODE at each address, on THIS chain?
+  //
+  // The same contract name lives at a different address on every chain (only the CREATE2
+  // account stack is address-identical), so the classic multi-chain mistake is a record entry
+  // copied from a sibling network. The explorer's answer to that is "Unable to locate
+  // ContractCode", which this script would otherwise retry six times before giving up — six
+  // backoffs per address, and a failure message that describes the explorer rather than the
+  // mistake. One eth_getCode call each says it plainly and immediately instead.
+  if (!DRY_RUN) {
+    const toCheck = [...plan.verify, ...plan.proxies];
+    console.log(`Checking ${toCheck.length} address(es) actually carry bytecode on chain ${chainId}…`);
+    for (const item of toCheck) {
+      let code;
+      try {
+        code = await ethers.provider.getCode(item.address);
+      } catch (err) {
+        // A dead RPC is not a verification result; refuse rather than guess.
+        throw new Error(
+          `Could not read code at ${item.address} on ${networkName} (chainId ${chainId}): ` +
+            `${err.message || err}\nThe RPC endpoint for this network is unreachable — fix it (see ` +
+            `requiredRpcUrl in hardhat.config.js for which variable it reads) and re-run. Nothing was submitted.`
+        );
+      }
+      if (code && code !== "0x") continue;
+
+      plan.unverifiable.push({
+        key: item.key,
+        address: item.address,
+        label: item.label,
+        reason:
+          `NO BYTECODE at this address on ${networkName} (chainId ${chainId}). The record claims a ` +
+          `contract here and the chain disagrees, so nothing can be verified against it. Almost always ` +
+          `an address copied from another network, or a record written for a deploy that reverted — ` +
+          `fix deployments/ (the source of truth) rather than this script.`,
+      });
+      plan.verify = plan.verify.filter((i) => i !== item);
+      plan.proxies = plan.proxies.filter((i) => i !== item);
+    }
+    console.log("");
   }
 
-  console.log("\n" + "=".repeat(60));
+  const results = [];
+  let fatal = null;
+
+  // --- implementations, standalone contracts, templates, mocks ---
+  if (plan.verify.length) {
+    console.log(`Submitting ${plan.verify.length} contract source(s):\n`);
+    for (const item of plan.verify) {
+      try {
+        const r = await verifyOne(item, explorer);
+        results.push({ ...item, ...r });
+      } catch (err) {
+        if (err instanceof ApiKeyRejected) {
+          fatal = err;
+          results.push({ ...item, status: "not-attempted", reason: "run aborted: API key rejected" });
+          break;
+        }
+        throw err;
+      }
+    }
+    // Anything we never reached after a fatal still has to appear in the summary.
+    if (fatal) {
+      const done = new Set(results.map((r) => r.key));
+      for (const item of plan.verify.filter((i) => !done.has(i.key))) {
+        results.push({ ...item, status: "not-attempted", reason: "run aborted: API key rejected" });
+      }
+    }
+  }
+
+  // --- proxies ---
+  const proxyResults = [];
+  if (plan.proxies.length && !fatal) {
+    if (VERIFY_PROXIES) {
+      console.log(`\nSubmitting ${plan.proxies.length} ERC-1967 proxy/proxies (VERIFY_PROXIES=true):\n`);
+      for (const item of plan.proxies) {
+        try {
+          proxyResults.push({ ...item, ...(await verifyProxy(item, explorer)) });
+        } catch (err) {
+          if (err instanceof ApiKeyRejected) {
+            fatal = err;
+            break;
+          }
+          throw err;
+        }
+      }
+    } else {
+      for (const item of plan.proxies) proxyResults.push({ ...item, status: "not-submitted" });
+    }
+  }
+
+  printSummary({ plan, results, proxyResults, explorer, recordPath, fatal, preflightError });
+
+  const implVerified = results.filter((r) => r.status === "verified" || r.status === "already-verified").length;
+  const failures =
+    results.filter((r) => r.status === "failed" || r.status === "not-attempted").length + plan.unverifiable.length;
+
+  if (preflightError) return 1;
+  if (fatal) {
+    console.error(`\nFATAL: ${fatal.message}\n`);
+    return 1;
+  }
+  if (failures > 0) return 1;
+  // In a dry run nothing is verified by definition; the plan itself is the deliverable.
+  if (!DRY_RUN && implVerified === 0 && plan.verify.length > 0) return 1;
+  return 0;
+}
+
+/**
+ * The summary is the whole point of this script. It must be impossible to read
+ * "nothing was verified" as "everything is fine", so:
+ *   - every recorded address appears in exactly one section, with a reason if not verified;
+ *   - the headline states the counts AND a verdict, and the verdict is FAILED whenever a
+ *     recorded contract was left unaccounted for.
+ */
+function printSummary({ plan, results, proxyResults, explorer, recordPath, fatal, preflightError }) {
+  const count = (...statuses) => results.filter((r) => statuses.includes(r.status)).length;
+  const verified = count("verified");
+  const already = count("already-verified");
+  const planned = count("planned");
+  const failed = count("failed");
+  const notAttempted = count("not-attempted");
+  const externalTop = Object.entries(EXTERNAL_TOP_LEVEL).filter(([k]) => isAddr(plan.recordTop?.[k]));
+  const totalAddresses =
+    plan.verify.length +
+    plan.proxies.length +
+    plan.skipped.length +
+    plan.unverifiable.length +
+    plan.historical.length +
+    externalTop.length;
+
+  console.log("\n" + "=".repeat(72));
+  console.log(`VERIFICATION SUMMARY — ${explorer.chainName} via ${explorer.label}`);
+  console.log(`${totalAddresses} address(es) recorded in ${path.basename(recordPath)}, all accounted for below`);
+  console.log("=".repeat(72));
+
+  if (results.length) {
+    console.log(`\nCONTRACT SOURCES (${results.length})`);
+    for (const r of results) {
+      const mark =
+        { verified: "✓", "already-verified": "•", planned: "→", failed: "✗", "not-attempted": "?" }[r.status] || "?";
+      console.log(`  ${mark} [${r.status}] ${r.label}`);
+      console.log(`      ${r.address}  ${addressUrl(explorer, r.address)}`);
+      if (DRY_RUN) {
+        console.log(`      contract=${r.fqn}`);
+        console.log(`      args=${JSON.stringify(r.args)}`);
+      }
+      if (r.entry?.note) console.log(`      note: ${r.entry.note}`);
+      if (r.reason) console.log(`      reason: ${r.reason}`);
+    }
+  }
+
+  if (proxyResults.length) {
+    console.log(`\nPROXIES (${proxyResults.length}) — the IMPLEMENTATION above carries the source`);
+    for (const p of proxyResults) {
+      const linking =
+        explorer.proxyLinking === "automatic"
+          ? "explorer reads the EIP-1967 slot automatically"
+          : 'click "Is this a proxy?" on the explorer once to link it';
+      const state =
+        p.status === "not-submitted"
+          ? `not submitted (${linking}; set VERIFY_PROXIES=true to submit it explicitly)`
+          : p.status === "manual"
+            ? `NOT LINKED — ${p.reason}; ${linking}`
+            : p.status;
+      console.log(`  ▸ ${p.label} proxy ${p.address}`);
+      console.log(`      impl (${p.implKey}) ${p.impl}`);
+      console.log(`      ${state}`);
+      console.log(`      ${addressUrl(explorer, p.address)}`);
+    }
+  }
+
+  const skippedTotal = plan.skipped.length + externalTop.length;
+  if (skippedTotal) {
+    console.log(`\nINTENTIONALLY SKIPPED (${skippedTotal}) — not ours to verify`);
+    for (const s of plan.skipped) console.log(`  – ${s.label} ${s.address}\n      ${s.reason}`);
+    for (const [k, why] of externalTop) console.log(`  – ${k} ${plan.recordTop[k]}\n      ${why}`);
+  }
+
+  if (plan.historical.length) {
+    console.log(
+      `\nHISTORICAL — NOT VERIFIABLE FROM THIS CHECKOUT (${plan.historical.length}), and no run will change that`
+    );
+    for (const h of plan.historical) {
+      console.log(`  ~ ${h.label} (record key: ${h.key})`);
+      console.log(`      ${h.address}  ${addressUrl(explorer, h.address)}`);
+      console.log(`      ${h.reason}`);
+    }
+  }
+
+  if (plan.unverifiable.length) {
+    console.log(`\nUNVERIFIABLE (${plan.unverifiable.length}) — recorded on-chain, NOT verified, needs a fix`);
+    for (const u of plan.unverifiable) {
+      console.log(`  ✗ ${u.label} (record key: ${u.key})`);
+      console.log(`      ${u.address}  ${addressUrl(explorer, u.address)}`);
+      console.log(`      ${u.reason}`);
+    }
+  }
+
+  const problems = failed + notAttempted + plan.unverifiable.length;
+  // "OK" never hides a caveat: a run with historical addresses says so in the verdict itself,
+  // because those addresses ARE part of this deployment and a reader deserves to know they
+  // will never carry source.
+  const okVerdict = plan.historical.length
+    ? `OK (${plan.historical.length} historical, source gone — see above)`
+    : "OK";
+  const verdict = preflightError
+    ? "FAILED (pre-flight: nothing could be submitted)"
+    : fatal
+      ? "FAILED (aborted)"
+      : problems > 0
+        ? "FAILED"
+        : DRY_RUN
+          ? "DRY RUN — nothing submitted"
+          : verified + already === 0 && plan.verify.length > 0
+            ? "FAILED"
+            : okVerdict;
+
+  console.log("\n" + "-".repeat(72));
   console.log(
-    `Done — ${results.verified} verified, ${results["already-verified"]} already verified` +
-      (DRY_RUN ? `, ${results["dry-run"]} planned (dry run)` : "")
+    `Result: ${verdict} — ${verified} verified, ${already} already verified, ${planned} planned, ` +
+      `${failed} failed, ${notAttempted} not attempted, ${plan.unverifiable.length} unverifiable, ` +
+      `${plan.historical.length} historical, ${skippedTotal} skipped by design ` +
+      `(${totalAddresses} recorded address(es) in total)`
   );
-  console.log("=".repeat(60));
+  if (preflightError) {
+    console.log(
+      `NOTHING WAS SUBMITTED — the plan above is what this run WOULD attempt once the pre-flight ` +
+        `failure at the top of the output is fixed. Do not read it as a verified deployment.`
+    );
+  }
+  if (problems > 0) {
+    console.log(
+      `${problems} recorded contract(s) are NOT verified. Read the reasons above — an unverified ` +
+        `contract on a mainnet is an unreadable contract for everyone auditing this deployment.`
+    );
+  }
+  console.log("-".repeat(72));
 }
 
 main()
-  .then(() => process.exit(0))
+  .then((code) => process.exit(code))
   .catch((err) => {
-    console.error(err);
+    console.error(`\n${err.message || err}\n`);
     process.exit(1);
   });

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -134,18 +134,88 @@ function updateObjectLiteralValue(source, key, newValueLiteral, blockName = null
 }
 
 /**
- * Map chainId to the corresponding contracts block name in contracts.js.
- * Returns null if no block is known for this chain (caller falls back to whole-file update).
+ * chainId → the name of that chain's contracts block in contracts.js.
+ *
+ * This table MUST cover every chain in `NETWORK_CONTRACTS` (frontend/src/config/contracts.js).
+ * An unmapped chain is not a harmless gap — it is a silent cross-chain corruption. With a null
+ * blockName, `updateObjectLiteralValue` rewrites the FIRST `key:` line anywhere in the file, and
+ * the first block in contracts.js is MORDOR_CONTRACTS. So before this table covered chain 1,
+ * syncing an Ethereum-mainnet record wrote Ethereum's `bridgeRouter`/`liquidityRouter` addresses
+ * into the MORDOR block and left ETHEREUM_CONTRACTS empty: the frontend then handed Mordor users
+ * a contract address that only exists on chain 1, and the chain it was actually deployed on still
+ * read as undeployed. Nothing failed; the sync printed "Synced".
+ *
+ * Hence `resolveBlockName()` below refuses instead of falling back whenever the file uses the
+ * per-chain layout. Add a chain here AND add its block to contracts.js — one without the other is
+ * caught, loudly, at sync time.
  */
+const CHAIN_BLOCK_NAMES = {
+  1: 'ETHEREUM_CONTRACTS', // spec 067 — router-only control-plane network
+  10: 'OPTIMISM_CONTRACTS', // spec 067 — router-only control-plane network
+  61: 'ETC_CONTRACTS', // Ethereum Classic mainnet (hardhat network `etc`)
+  63: 'MORDOR_CONTRACTS',
+  137: 'POLYGON_CONTRACTS',
+  8453: 'BASE_CONTRACTS', // spec 067 — router-only control-plane network
+  42161: 'ARBITRUM_CONTRACTS', // spec 067 — router-only control-plane network
+  80002: 'AMOY_CONTRACTS',
+  1337: 'HARDHAT_CONTRACTS',
+  31337: 'HARDHAT_CONTRACTS',
+}
+
 function blockNameForChain(chainId) {
-  const map = {
-    63: 'MORDOR_CONTRACTS',
-    80002: 'AMOY_CONTRACTS',
-    137: 'POLYGON_CONTRACTS',
-    1337: 'HARDHAT_CONTRACTS',
-    31337: 'HARDHAT_CONTRACTS',
+  return CHAIN_BLOCK_NAMES[chainId] || null
+}
+
+/**
+ * Does this contracts file use the per-chain block layout, or the older flat single-network one
+ * (`export const DEPLOYED_CONTRACTS = { ... }`)?
+ *
+ * Only the flat layout has an unambiguous "the whole file is the block" meaning, so it is the one
+ * and only case where a whole-file update is safe. Detection is by NAME, not by shape: a loose
+ * `[A-Z_]+_CONTRACTS` pattern also matches the flat file's own `DEPLOYED_CONTRACTS`, which would
+ * misread the legacy layout as multi-network and refuse to sync it at all.
+ */
+function usesPerChainBlocks(source) {
+  if (/(?:const|let|var)\s+NETWORK_CONTRACTS\s*=\s*\{/.test(source)) return true
+  return Object.values(CHAIN_BLOCK_NAMES).some((name) =>
+    new RegExp(`(?:const|let|var)\\s+${name}\\s*=\\s*\\{`).test(source)
+  )
+}
+
+/**
+ * Decide which named block this deployment record may write into — or refuse.
+ *
+ * Refusing is the point. Every alternative to a correct block name writes the addresses of one
+ * chain into another chain's map (see blockNameForChain above), and a wrong address in
+ * contracts.js is indistinguishable from a right one until someone sends funds to it.
+ */
+function resolveBlockName(source, chainId, contractsFile) {
+  if (!usesPerChainBlocks(source)) {
+    // Flat legacy/fixture layout: one network per file, so there is nothing to target wrongly.
+    return null
   }
-  return map[chainId] || null
+
+  const blockName = blockNameForChain(chainId)
+  if (!blockName) {
+    throw new Error(
+      `No contracts block is mapped for chainId ${chainId}. ${contractsFile} uses the per-chain ` +
+        `layout, so writing without a target block would rewrite whichever block happens to be ` +
+        `first in the file (currently MORDOR_CONTRACTS) with this chain's addresses. ` +
+        `Add the chain to blockNameForChain() in ${path.relative(process.cwd(), __filename)} and ` +
+        `add its block + NETWORK_CONTRACTS entry to contracts.js, then re-run.`
+    )
+  }
+
+  const hasBlock = new RegExp(`(?:const|let|var)\\s+${blockName}\\s*=\\s*\\{`).test(source)
+  if (!hasBlock) {
+    throw new Error(
+      `chainId ${chainId} maps to block ${blockName}, but ${contractsFile} has no such block. ` +
+        `Add "const ${blockName} = { ... }" and register it in NETWORK_CONTRACTS (contracts.js) ` +
+        `before syncing this network — otherwise these addresses land in another chain's map.`
+    )
+  }
+
+  return blockName
 }
 
 function main() {
@@ -174,7 +244,19 @@ function main() {
 
   const deployment = readJson(deploymentFile)
   const deployed = deployment.contracts || {}
-  const isV2 = Boolean(deployed.wagerRegistry || deployed.membershipManager && deployed.keyRegistry)
+
+  // Which mapping applies. The old test — "does the record have a wagerRegistry?" — assumed every
+  // v2 record contains the core escrow, which stopped being true with the spec-067 control-plane
+  // networks: Ethereum/Optimism/Base/Arbitrum host ONLY feeRouter + bridgeRouter + liquidityRouter
+  // and have no wagerRegistry at all. Such a record fell through to the v1 mapping, which carries
+  // none of those keys, so the sync copied nothing and still printed "Synced" — the exact silent
+  // no-op this file must not produce. The `-v2.json` filename and the v2 salt prefix are both
+  // written by the v2 deploy tooling, so either one is a positive statement of the record's shape;
+  // the contract probe stays as a fallback for hand-written records that predate both.
+  const isV2 =
+    /-v2\.json$/.test(deploymentFile) ||
+    String(deployment.saltPrefix || '').startsWith('FairWins-P2P-v2') ||
+    Boolean(deployed.wagerRegistry || (deployed.membershipManager && deployed.keyRegistry))
 
   let source = fs.readFileSync(contractsFile, 'utf8')
 
@@ -234,15 +316,11 @@ function main() {
         nullifierRegistry: deployed.nullifierRegistry,
       }
 
-  // Determine target block in contracts.js (multi-network layout). If the file
-  // doesn't have a per-chain block, blockName stays null and we update globally
-  // (preserves backwards compatibility with the test fixture).
+  // Determine the target block in contracts.js. Null means (and now ONLY means) the flat
+  // single-network layout, where a whole-file update is unambiguous; anything else refuses
+  // rather than writing this chain's addresses into another chain's block.
   const deploymentChainId = Number(deployment.chainId) || chainId
-  let blockName = blockNameForChain(deploymentChainId)
-  if (blockName) {
-    const hasBlock = new RegExp(`(?:const|let|var)\\s+${blockName}\\s*=\\s*\\{`).test(source)
-    if (!hasBlock) blockName = null
-  }
+  const blockName = resolveBlockName(source, deploymentChainId, contractsFile)
 
   for (const [key, value] of Object.entries(mapping)) {
     if (!value) continue


### PR DESCRIPTION
Preparation for #966 (deploy the admin/control plane on all five EVM mainnets). **Tooling only — no contract changes, nothing deployed.**

## Four mainnets were unreachable

`hardhat.config.js` had no network entry for Ethereum 1, Optimism 10, Base 8453 or Arbitrum 42161 — every deploy script failed `HH100` on 4 of the 5 targets. Added all four, modelled on `polygon`, each with:

- an explicit `chainId`, so a wrong RPC is caught rather than trusted;
- a `requiredRpcUrl` guard that **refuses loudly** when the env var is unset rather than defaulting to a public endpoint that might be the wrong chain;
- no `GAS_PRICE_WEI` — it pins a legacy type-0 price for the Classic chains, and honouring it here would let a shell with the Polygon value still exported send Polygon-priced transactions to Ethereum.

Verified each reaches the script rather than `HH100`, with the chain id confirmed in the expected record filename.

## Three L2s were being treated as testnets

`MAINNET_CHAIN_IDS` was `[1, 61, 137]`. The consequence that matters: `deploy.js` mints mock tokens and allowlists them as `WagerRegistry` stake tokens on anything it thinks is a testnet — so **a full-stack deploy to Base would have produced a live registry escrowing worthless mocks.** It now aborts asking for real addresses.

## The FeeRouter deploy could not be resumed

The `if (contracts.feeRouter) return` guard sat *above* the registration loop, so a re-run after a failed `registerService` could never finish setup — despite a comment claiming it could. Since `quoteFee` reverts `ServiceUnknown` for an unregistered service and both spec-067 routers call it on every member action, **a half-registered FeeRouter means every bridge and supply reverts**, with no recovery path anywhere in the repo.

The resume branch now reconciles the record and registers only missing services, refuses if the recorded address has no bytecode, and fails loudly if the deployer no longer holds `DEFAULT_ADMIN`. `scripts/ops/register-fee-service.js` is the standalone recovery tool that didn't exist — it also replaces the `print-fee-services.js` the quickstart references but which was never written.

## Verification reported success having verified nothing

`verify.js` had no entry for `feeRouter`, `stakingRouter`, `bridgeRouter`, `liquidityRouter`, `callsignRegistry`, `wagerPoolFactory`, `accountFactory` or `verifyingPaymaster` — and its `add()` silently skipped absent addresses, so `npm run verify:polygon` exited green having verified nothing new. On Polygon it now plans **30 addresses / 25 contracts** and runs live against PolygonScan. Explorer config extended to all five mainnets.

## Bootstrap for router-only chains

`scripts/deploy/init-deployment-record.js` — chains 1/10/8453/42161 have no deployment record and both deploy scripts hard-throw without one, but running the full core deploy there is wrong. It refuses to overwrite, requires the treasury explicitly, and validates the chainId against the connected RPC.

## Not in this PR

Three agents hit a session limit before completing. These are **still open** and tracked in #966:

- `scripts/ops/transfer-admin.js` + `docs/runbooks/admin-handoff.md` — **the Safe handoff.** This is the prerequisite for the chosen "Safe first, then deploy" sequence, so it blocks the deploy.
- `CONFIRM_MAINNET` gates on `deploy-bridge-liquidity.js` and `deploy-staking-router.js`.
- The bytecode guard for `deploy-staking-router.js`, which still **deploys blind** off chain 1 against Ethereum-L1 Lido defaults on nothing but a console warning.

Refs #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBMvFqhjqsXyUVF2hEFoNc