### PR TITLE
fix(supply): drop stale HubPool reads; close T144-T150

### DIFF
--- a/frontend/src/components/admin/SupplyTab.jsx
+++ b/frontend/src/components/admin/SupplyTab.jsx
@@ -31,7 +31,7 @@
  * As on the Bridge tab, scope is a NETWORK and not the connected wallet: reads span every
  * Uniswap-capable network from its own RPC, and only writes need the wallet there (FR-050).
  */
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { ethers } from 'ethers'
 import { getContractAddressForChain } from '../../config/contracts'
 import { LIQUIDITY_ROUTER_ABI } from '../../abis/LiquidityRouter'
@@ -338,11 +338,16 @@ export default function SupplyTab({
    * figure at all for the money inside it, while the member screen showed exactly that. One number
    * genuinely cannot be produced; this one can, so it is.
    */
+  // Bumped whenever a newer run starts, so a slow HubPool read cannot land its result after the
+  // scope moved on — or after unmount, which surfaced in tests as a React act() warning and an
+  // intermittent failure in whichever test happened to be running when the late update arrived.
+  const bridgePoolsRun = useRef(0)
   const fetchBridgePools = useCallback(async () => {
     if (!readProvider || !state?.pools) return
+    const run = ++bridgePoolsRun.current
     const bridgePools = state.pools.filter((p) => p.kind === POOL_KIND.BRIDGE_LP)
     if (bridgePools.length === 0) {
-      setBridgeSizes({})
+      if (run === bridgePoolsRun.current) setBridgeSizes({})
       return
     }
     const entries = await Promise.all(
@@ -356,7 +361,8 @@ export default function SupplyTab({
         return [pool.poolId, info]
       }),
     )
-    setBridgeSizes(Object.fromEntries(entries))
+    // Stale runs drop their result rather than overwriting a newer network's.
+    if (run === bridgePoolsRun.current) setBridgeSizes(Object.fromEntries(entries))
   }, [readProvider, state?.pools])
 
   useEffect(() => {

--- a/frontend/src/test/admin/AdminBridgeTab.test.jsx
+++ b/frontend/src/test/admin/AdminBridgeTab.test.jsx
@@ -6,7 +6,7 @@
  * card refusing to invent a rate it could not read, and the per-network scope working while the
  * wallet sits somewhere else. Those are the parts an operator acts on during an incident.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ethers as ethersActual } from 'ethers'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { axe } from 'vitest-axe'
@@ -139,6 +139,20 @@ function props(overrides = {}) {
   }
 }
 
+// `window.confirm` is stubbed by the removeRoute tests. Restoring inside the test body is not
+// enough: any assertion that throws first skips the restore, leaving the stub installed for every
+// later test in the worker — which showed up as two different admin tests failing intermittently
+// depending on run order. `stubConfirm` registers the cleanup so it runs even when a test fails.
+let confirmSpy = null
+function stubConfirm(answer) {
+  confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(answer)
+  return confirmSpy
+}
+afterEach(() => {
+  confirmSpy?.mockRestore()
+  confirmSpy = null
+})
+
 beforeEach(() => {
   m.addr = { 1: ROUTER }
   m.events = {}
@@ -252,13 +266,12 @@ describe('BridgeTab — routes (T124, FR-041/FR-045)', () => {
     // Removal ASKS FIRST, and the question names what it costs — removal is not the harder version
     // of Disable, it is the one that deletes the entry and blinds the Operations panel's lateness
     // detection for transfers still moving on the route.
-    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const confirm = stubConfirm(true)
     fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[0])
     await waitFor(() => expect(runTx.mock.calls.some((c) => /removed/.test(c[1]))).toBe(true))
     expect(confirm).toHaveBeenCalledTimes(1)
     expect(confirm.mock.calls[0][0]).toMatch(/Disable/)
     expect(confirm.mock.calls[0][0]).toMatch(/expected delivery window/i)
-    confirm.mockRestore()
   })
 
   it('does not remove a route when the operator declines the confirm', async () => {
@@ -266,11 +279,10 @@ describe('BridgeTab — routes (T124, FR-041/FR-045)', () => {
     render(<BridgeTab {...node} />)
     await screen.findByRole('table', { name: 'Curated bridge routes' })
 
-    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const confirm = stubConfirm(false)
     fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[0])
     expect(confirm).toHaveBeenCalled()
     expect(runTx).not.toHaveBeenCalled()
-    confirm.mockRestore()
   })
 
   it('refuses an invalid route before the wallet prompt and dispatches a valid one', async () => {

--- a/specs/067-bridge-pool-liquidity/tasks.md
+++ b/specs/067-bridge-pool-liquidity/tasks.md
@@ -359,13 +359,26 @@ index table updated and internal links resolving.
 
 ## Phase 8: Polish & Cross-Cutting Concerns
 
-- [ ] T144 [P] Write the developer guide in `docs/developer-guide/bridge-and-liquidity.md` covering both routers, the two fee services, and the R11b predicate inversion
-- [ ] T145 [P] Write the operator runbook in `docs/runbooks/bridge-liquidity-operations.md` covering pause/resume, route and pool curation, stuck-bridge triage, and the limits of operator action
-- [ ] T146 [P] Add the spec-067 summary block to `CLAUDE.md` following the existing per-spec guardrail format
+- [X] T144 [P] Write the developer guide in `docs/developer-guide/bridge-and-liquidity.md` covering both routers, the two fee services, and the R11b predicate inversion
+- [X] T145 [P] Write the operator runbook in `docs/runbooks/bridge-liquidity-operations.md` covering pause/resume, route and pool curation, stuck-bridge triage, and the limits of operator action
+- [X] T146 [P] Add the spec-067 summary block to `CLAUDE.md` following the existing per-spec guardrail format
 - [ ] T147 Run `npm run compile && npm test && npm run test:frontend && npm run check:storage-layout` and confirm all green
 - [ ] T148 (SC-012, SC-019, SC-020) Run the full `quickstart.md` walkthrough end to end, including the honest-degradation and cross-network selection checks
-- [ ] T149 [P] Confirm no `continue-on-error` was added to any lint/test/build/security step in `.github/workflows/`
-- [ ] T150 Request the smart-contract security review required by constitution I (`.github/agents/smart-contract-security.agent.md`) for `contracts/bridge/BridgeRouter.sol` and `contracts/liquidity/LiquidityRouter.sol`
+- [X] T149 [P] Confirm no `continue-on-error` was added to any lint/test/build/security step in `.github/workflows/`
+- [X] T150 Request the smart-contract security review required by constitution I (`.github/agents/smart-contract-security.agent.md`) for `contracts/bridge/BridgeRouter.sol` and `contracts/liquidity/LiquidityRouter.sol`
+      **DONE — verdict APPROVE_WITH_NITS** (PR #965). Three lenses (value flow & custody / access
+      control & upgradeability / external integration & DoS) over both routers; each of 28 candidate
+      findings handed to an independent skeptic instructed to refute it. Nothing survived above
+      `low`. EthTrust-SL **Level 2** met. Confirmed under active attack: `depositor == member` on
+      both legs (`_deposit` is the single `depositV3` call site; no rescue function exists in the
+      ABI), non-custodial, transient custody, the `MAX_FEE_BPS` amount bound, and fee-on-consumed-
+      capital. Reentrancy protection is structurally sufficient — every external read is `view` and
+      compiles to `STATICCALL`. Fixed in `b4d107b6`: the missing Uniswap slippage bound (the only
+      unprivileged-attacker path), `bool enabled` on `RouteSet`/`PoolListed` so the FR-046 audit
+      history can reconstruct availability, and `TreasuryTransferFailed` replacing a misleading
+      `ResidualFunds`. Carried to #966: the bridge `recipient` screening scope (a compliance
+      decision), proving the fork suite green against the real Across SpokePool, and the FeeRouter
+      service-registration liveness gate.
 - [ ] T158 Run the moderated impermanent-loss comprehension check behind SC-005 before mainnet launch and record the result in `specs/067-bridge-pool-liquidity/checklists/requirements.md` — the in-flow gate (T096) proves the disclosure is *shown*, this proves it is *understood*
 
 ---


### PR DESCRIPTION
Running **T147** against merged `main` surfaced an intermittent failure in the admin suite — a *different* test each run, only under full-suite parallel load, never in isolation. Two real defects, both introduced by this spec's own work.

### 1. `fetchBridgePools` had no cancellation

It awaits a HubPool read per bridge pool and then calls `setBridgeSizes` unconditionally, so a slow read can land after the network scope moved on — or after unmount. React named it precisely in stderr:

```
An update to SupplyTab inside a test was not wrapped in act(...)
```

Under load the late update arrived during whichever test happened to be running next, which is why the failure kept moving. Now guarded by a run counter, mirroring the `live` flag already used for `readRouterAuthority` — a stale run drops its result instead of overwriting a newer network's.

**This isn't only a test artifact.** Switching networks quickly on a slow RPC could paint one network's bridge-pool sizes under another network's name — the FR-050 no-mixing rule this tab exists to uphold.

### 2. The `window.confirm` stub leaked

`mockRestore()` sat at the end of the test body, so any assertion that threw first left the stub installed for every later test in the worker. Moved to `afterEach`, which runs regardless.

### Task ledger

Marks T144 (developer guide), T145 (operator runbook), T146 (CLAUDE.md block), T149 (CI audit) and T150 complete, with the review outcome recorded inline: **APPROVE_WITH_NITS**, EthTrust Level 2, nothing surviving above `low` after adversarial verification of all 28 candidates.

### Verified on merged main

| Gate | Result |
|---|---|
| `npm run compile` | clean |
| `npm test` | 979 passing, 2 known environmental fork failures |
| `npm run check:storage-layout` | upgrade-safe |
| frontend suite | 4,487 passing, same 4 known pre-existing failures — now stable across repeated full runs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBMvFqhjqsXyUVF2hEFoNc