### PR TITLE
T148: stop leaking RPC keys, make the safety gates actually assert

### DIFF
--- a/frontend/src/components/wallet/AssetDetailSheet.jsx
+++ b/frontend/src/components/wallet/AssetDetailSheet.jsx
@@ -59,7 +59,13 @@ function actionsFor(instance) {
     {
       id: 'trade',
       label: 'Trade',
-      enabled: asset.kind !== 'nft' && Boolean(net?.dex),
+      // `capabilities.dex`, NOT the raw `net.dex` block. The raw block is only "this network has
+      // DEX addresses configured"; the capability additionally requires the network to be in
+      // SWAP_CHAIN_IDS, which is the FR-016a allow-list deciding where in-app swapping is actually
+      // offered. Reading the raw block bypasses that allow-list, so a network whose addresses are
+      // configured but which is deliberately not allow-listed would show an enabled Trade action
+      // leading to a surface that will not serve it.
+      enabled: asset.kind !== 'nft' && Boolean(net?.capabilities?.dex),
       reason: asset.kind === 'nft' ? 'Collectibles cannot be traded here' : 'No in-app trading on this network',
       to: `/wallet?tab=trade&chain=${asset.chainId}&token=${encodeURIComponent(asset.symbol)}`,
     },

--- a/scripts/deploy/deploy-bridge-liquidity.js
+++ b/scripts/deploy/deploy-bridge-liquidity.js
@@ -5,8 +5,8 @@
  * the network (both routers read the rate + treasury from it). APPENDS the new addresses to
  * `deployments/<net>-chain<id>-v2.json` (never overwrites) and registers the two fee services on the
  * EXISTING FeeRouter (idempotent, rate 0 — enabled later from the AdminPanel Fees tab):
- *   bridge.transfer    Wrapped  cap 250 bps  (charged on a bridge submission, value-out)
- *   liquidity.deposit  Wrapped  cap 250 bps  (charged on a Uniswap full-range supply, value-in)
+ *   bridge.transfer    ConfigOnly  cap 250 bps  (charged on a bridge submission, value-out)
+ *   liquidity.deposit  ConfigOnly  cap 250 bps  (charged on a Uniswap full-range supply, value-in)
  *
  * ── THE GUARD THIS SCRIPT EXISTS TO RUN (research R4b) ──────────────────────────────────────────
  * Uniswap's own docs warn integrators not to assume a protocol sits at the same address on every
@@ -36,7 +36,7 @@ const path = require("path");
 
 const { saveDeployment, getDeploymentFilename } = require("./lib/helpers");
 const { deployProxy } = require("./lib/upgradeable");
-const { ServiceKind } = require("./lib/feeServices");
+const { ServiceKind, SERVICE_KIND_LABELS } = require("./lib/feeServices");
 
 /**
  * External protocol addresses per chain, each taken from that chain's own official deployment record
@@ -418,7 +418,13 @@ async function main() {
         continue;
       }
       await (await router.registerService(id, svc.capBps, svc.kind)).wait();
-      console.log(`  ✓ registered ${svc.label} (cap ${svc.capBps} bps, Wrapped, rate 0)`);
+      // Interpolated, not hardcoded. This line used to print "Wrapped" while the call above
+      // registers ConfigOnly — contradicting the paragraph at the top of this file explaining why
+      // these two services must NOT be Wrapped. It is also the line an operator pastes into a
+      // deployment record.
+      console.log(
+        `  ✓ registered ${svc.label} (cap ${svc.capBps} bps, ${SERVICE_KIND_LABELS[svc.kind] || svc.kind}, rate 0)`
+      );
     }
   }
 

--- a/scripts/deploy/deploy-fee-router.js
+++ b/scripts/deploy/deploy-fee-router.js
@@ -38,7 +38,7 @@ const path = require("path");
 
 const { saveDeployment, getDeploymentFilename } = require("./lib/helpers");
 const { deployProxy, getImplementation } = require("./lib/upgradeable");
-const { LAUNCH_FEE_SERVICES } = require("./lib/feeServices");
+const { LAUNCH_FEE_SERVICES, SERVICE_KIND_LABELS } = require("./lib/feeServices");
 const { MAINNET_CHAIN_IDS } = require("./lib/constants");
 
 /**
@@ -60,7 +60,8 @@ if (UNGATED.length) {
   );
 }
 
-const KIND_LABELS = { 0: "Unregistered", 1: "Wrapped", 2: "ConfigOnly" };
+// Shared with deploy-bridge-liquidity.js via lib/feeServices — see the note there.
+const KIND_LABELS = SERVICE_KIND_LABELS;
 
 async function main() {
   const network = await ethers.provider.getNetwork();

--- a/scripts/deploy/lib/feeServices.js
+++ b/scripts/deploy/lib/feeServices.js
@@ -8,6 +8,13 @@
  */
 const ServiceKind = { Wrapped: 1, ConfigOnly: 2 };
 
+// Printable form of a kind, including the 0 the contract returns for an unregistered service.
+// Lives here beside ServiceKind because two scripts previously kept private copies and drifted:
+// deploy-bridge-liquidity.js hardcoded "Wrapped" in its success line while registering ConfigOnly,
+// contradicting its own header. That distinction is load-bearing — it is what keeps
+// `depositToVaultWithFee` from being pointed at a service that is not a vault deposit.
+const SERVICE_KIND_LABELS = { 0: "Unregistered", 1: "Wrapped", 2: "ConfigOnly" };
+
 const LAUNCH_FEE_SERVICES = [
   { label: "earn.lend", capBps: 250, kind: ServiceKind.Wrapped }, // Earn/Morpho vault deposits (spec 050)
   { label: "polymarket.taker", capBps: 100, kind: ServiceKind.ConfigOnly }, // relay-gateway reads; spec-057 cap
@@ -19,4 +26,4 @@ const LAUNCH_FEE_SERVICES = [
   { label: "stake.polygon", capBps: 250, kind: ServiceKind.ConfigOnly }, // sPOL POL→sPOL liquid staking
 ];
 
-module.exports = { LAUNCH_FEE_SERVICES, ServiceKind };
+module.exports = { SERVICE_KIND_LABELS, LAUNCH_FEE_SERVICES, ServiceKind };

--- a/scripts/ops/verify-protocol-addresses.js
+++ b/scripts/ops/verify-protocol-addresses.js
@@ -109,6 +109,27 @@ const CHAIN_SPECIFIC = {
   8453: ['uniswap.factory', 'uniswap.positionManager'],
 }
 
+/**
+ * An endpoint safe to print.
+ *
+ * RPC URLs in this project routinely carry credentials — QuickNode and Alchemy embed the API key in
+ * the PATH, others use a query parameter — and this script's output goes to stdout, into CI logs,
+ * and into terminal transcripts people paste into issues. Printing the resolved URL verbatim leaked
+ * a live key every time it ran against a keyed endpoint. Host only: enough to tell which provider
+ * answered, with nothing worth stealing.
+ */
+function safeRpcLabel(rpcUrl) {
+  try {
+    const u = new URL(rpcUrl)
+    // A path or query beyond "/" is where the credential lives, so say it exists without showing it.
+    const hasSecret = (u.pathname && u.pathname !== '/') || u.search !== ''
+    return `${u.protocol}//${u.host}${hasSecret ? '/…' : ''}`
+  } catch {
+    // Not parseable as a URL — say nothing rather than risk echoing a raw secret.
+    return '(unparseable endpoint)'
+  }
+}
+
 function resolveRpc(target) {
   for (const key of target.rpc) {
     if (process.env[key]) return process.env[key]
@@ -122,7 +143,7 @@ async function getCode(rpcUrl, address) {
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_getCode', params: [address, 'latest'] }),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status} from ${rpcUrl}`)
+  if (!res.ok) throw new Error(`HTTP ${res.status} from ${safeRpcLabel(rpcUrl)}`)
   const body = await res.json()
   if (body.error) throw new Error(`RPC error: ${JSON.stringify(body.error)}`)
   return body.result
@@ -182,7 +203,7 @@ async function main() {
     const results = await verifyChain(Number(id), target)
     all.push(...results)
     if (!asJson) {
-      console.log(`\n${target.name} (${id}) via ${resolveRpc(target)}`)
+      console.log(`\n${target.name} (${id}) via ${safeRpcLabel(resolveRpc(target))}`)
       for (const r of results) {
         const status = r.ok ? `OK ${String(r.bytes).padStart(6)} bytes` : `FAIL ${r.error || 'no bytecode'}`
         console.log(`  ${r.label.padEnd(26)} ${r.address}  ${status}`)

--- a/specs/067-bridge-pool-liquidity/quickstart.md
+++ b/specs/067-bridge-pool-liquidity/quickstart.md
@@ -39,17 +39,30 @@ Never put a private key in `.env` for these — fork tests impersonate accounts.
 ### 1a. The refund address — the one that can silently strand funds
 
 ```bash
-npx hardhat test test/fork/bridgeRouter.fork.test.js --grep "expiry refund"
+npx hardhat test test/fork/bridgeRouter.fork.test.js --grep "MEMBER as depositor"
 ```
 
-**Expected**: an expired deposit refunds to the **member's** address; the `BridgeRouter` balance is zero
-throughout. A happy-path fill passes whether or not `depositor` is set correctly, so this case is the
-only signal — if it is skipped or quarantined, the merge is not safe.
+**Expected**: one test runs and passes — the real SpokePool's own deposit event records the **member**
+as `depositor`, not the router. That is what makes an unfilled deposit refund to the member, and it is
+why the router deliberately has no rescue function.
+
+> **Check the count, not just the exit code.** `--grep` with no match exits **0** reporting
+> "0 passing", so a stale pattern here reads as a green merge gate that asserted nothing. If you see
+> 0 passing, the gate did not run.
+>
+> A direct expired-deposit test is not reproducible on a fork: an Across refund needs an off-chain
+> dataworker to propose a root bundle, a dispute window to elapse, and a merkle-proved refund leaf —
+> staging that would mostly test Across. The `depositor` assertion against the real contract's event
+> encoding is the reproducible form of the same guarantee. See the note at
+> `test/fork/bridgeRouter.fork.test.js:17-26`.
+>
+> This test needs `POLYGON_RPC_URL` (or the configured fork endpoint). **Without it the test SKIPS,
+> and a skip is not a pass.**
 
 ### 1b. Position custody — the member owns the position, always
 
 ```bash
-npx hardhat test test/fork/liquidityRouter.fork.test.js --grep "NFT owner|exit without router"
+npx hardhat test test/fork/liquidityRouter.fork.test.js --grep "OWNED BY THE MEMBER|exit WITHOUT the router|never involved"
 ```
 
 **Expected**: after `mintFullRangeWithFee` the Uniswap position NFT is owned by the member; the member
@@ -59,10 +72,14 @@ the Across `HubPool` round trip never involves the router.
 ### 1c. No residual custody
 
 ```bash
-npx hardhat test test/bridge test/liquidity --grep "balance|allowance"
+npx hardhat test test/bridge/BridgeRouter.test.js test/liquidity/LiquidityRouter.test.js \
+  --grep "residue|balance|allowance|ResidualFunds"
 ```
 
 **Expected**: both routers hold zero token balance and leave zero allowance after every call.
+
+> `hardhat test` takes FILES, not directories — passing `test/bridge` crashes with
+> `MODULE_NOT_FOUND`. And as in 1a, confirm the passing count is non-zero.
 
 ---
 

--- a/specs/067-bridge-pool-liquidity/tasks.md
+++ b/specs/067-bridge-pool-liquidity/tasks.md
@@ -344,14 +344,23 @@ call for the maintainer.
 **Independent Test**: each series contains a new numbered entry in its established structure, with its
 index table updated and internal links resolving.
 
-- [ ] T136 [P] [US5] Write the member feature announcement in `docs/blog/features/02-bridge-and-supply/blog.md` — benefit-first, with the exact confirm-step flow
-- [ ] T137 [P] [US5] Write the promotion kit (X post, LinkedIn post, 16:9 image prompt) in `docs/blog/features/02-bridge-and-supply/social.md`
-- [ ] T138 [P] [US5] Add the announcement row to the index table in `docs/blog/features/README.md`
-- [ ] T139 [P] [US5] Write the engineering post on cross-chain intents and pooled liquidity in `docs/blog/posts/35-cross-chain-intents-and-lp/blog.md`, covering the `depositor` refund invariant and the no-custody fee rule
-- [ ] T140 [P] [US5] Write its promotion kit in `docs/blog/posts/35-cross-chain-intents-and-lp/social.md` and add the index row in `docs/blog/posts/README.md`
-- [ ] T141 [P] [US5] Write the knowledge-base article explaining bridges, liquidity provision, and impermanent loss in plain language in `docs/blog/knowledge/21-bridges-and-liquidity/blog.md`
-- [ ] T142 [P] [US5] Write its promotion kit and add the index row in `docs/blog/knowledge/README.md`
-- [ ] T143 [US5] Fact-check `docs/blog/features/02-bridge-and-supply/blog.md`, `docs/blog/posts/35-cross-chain-intents-and-lp/blog.md`, and `docs/blog/knowledge/21-bridges-and-liquidity/blog.md` against the R8 availability matrix and the zero-rate launch state — a piece implying bridge liquidity beyond Ethereum, or a platform fee that ships at zero, fails FR-058
+- [X] T136 [P] [US5] Write the member feature announcement in `docs/blog/features/02-bridge-and-supply/blog.md` — benefit-first, with the exact confirm-step flow
+- [X] T137 [P] [US5] Write the promotion kit (X post, LinkedIn post, 16:9 image prompt) in `docs/blog/features/02-bridge-and-supply/social.md`
+- [X] T138 [P] [US5] Add the announcement row to the index table in `docs/blog/features/README.md`
+- [X] T139 [P] [US5] Write the engineering post on cross-chain intents and pooled liquidity in `docs/blog/posts/35-cross-chain-intents-and-lp/blog.md`, covering the `depositor` refund invariant and the no-custody fee rule
+- [X] T140 [P] [US5] Write its promotion kit in `docs/blog/posts/35-cross-chain-intents-and-lp/social.md` and add the index row in `docs/blog/posts/README.md`
+- [X] T141 [P] [US5] Write the knowledge-base article explaining bridges, liquidity provision, and impermanent loss in plain language in `docs/blog/knowledge/21-bridges-and-liquidity/blog.md`
+- [X] T142 [P] [US5] Write its promotion kit and add the index row in `docs/blog/knowledge/README.md`
+- [X] T143 [US5] Fact-check `docs/blog/features/02-bridge-and-supply/blog.md`, `docs/blog/posts/35-cross-chain-intents-and-lp/blog.md`, and `docs/blog/knowledge/21-bridges-and-liquidity/blog.md` against the R8 availability matrix and the zero-rate launch state — a piece implying bridge liquidity beyond Ethereum, or a platform fee that ships at zero, fails FR-058
+      **DONE.** Both named failure modes clear. Bridge liquidity is stated ETHEREUM-ONLY in all
+      three pieces with the L1-HubPool reason; Uniswap trading pools on all five EVM mainnets. Both
+      fee services ship at ZERO — the pieces say a zero rate renders no fee line at all and that
+      there is no revenue to FairWins here today, with 250 bps appearing only as the cap that would
+      apply if a rate were raised. Across relayer fees and network gas are disclosed as real and
+      explicitly not ours. The impermanent-loss worked example was recomputed against the
+      constant-product formula rather than taken on trust: 0.5 ETH + 1,000 USDC at ETH $2,000, ETH
+      doubles → 0.3536 ETH + 1,414.21 USDC = $2,828.43 against $3,000 held = $171.57 short = 5.72%;
+      the article's rounded 0.354 / 1,414 / $2,828 / $172 / 5.7% are correct.
 
 **Checkpoint**: all five user stories complete.
 
@@ -362,7 +371,14 @@ index table updated and internal links resolving.
 - [X] T144 [P] Write the developer guide in `docs/developer-guide/bridge-and-liquidity.md` covering both routers, the two fee services, and the R11b predicate inversion
 - [X] T145 [P] Write the operator runbook in `docs/runbooks/bridge-liquidity-operations.md` covering pause/resume, route and pool curation, stuck-bridge triage, and the limits of operator action
 - [X] T146 [P] Add the spec-067 summary block to `CLAUDE.md` following the existing per-spec guardrail format
-- [ ] T147 Run `npm run compile && npm test && npm run test:frontend && npm run check:storage-layout` and confirm all green
+- [X] T147 Run `npm run compile && npm test && npm run test:frontend && npm run check:storage-layout` and confirm all green
+      **DONE on merged main (69d683d5).** compile clean; `npm test` 979 passing with 2 known
+      environmental fork failures (Chainalysis oracle, native-USDC ERC-1271 — both verified
+      identical on a clean tree via git stash); `check:storage-layout` upgrade-safe; frontend 4,487
+      passing / 4 failing, those 4 being the pre-existing ProposalBuilder ×3, UnifiedLookupModal ×1
+      and the useTransfer.balances file error. Failure IDENTITIES confirmed, not just counts, and
+      stable across four full runs — the run that first flagged this was what surfaced the stale
+      `fetchBridgePools` read fixed in #971.
 - [ ] T148 (SC-012, SC-019, SC-020) Run the full `quickstart.md` walkthrough end to end, including the honest-degradation and cross-network selection checks
 - [X] T149 [P] Confirm no `continue-on-error` was added to any lint/test/build/security step in `.github/workflows/`
 - [X] T150 Request the smart-contract security review required by constitution I (`.github/agents/smart-contract-security.agent.md`) for `contracts/bridge/BridgeRouter.sol` and `contracts/liquidity/LiquidityRouter.sol`


### PR DESCRIPTION
Running the spec-067 quickstart end to end (**T148**) found that much of it doesn't work as written — including the three gates it calls merge-blocking. Also closes the T136–T143 / T147 ledger entries, which shipped in #967 but were never marked.

## Credential leak — the reason this isn't just a docs commit

`scripts/ops/verify-protocol-addresses.js` printed the resolved RPC endpoint **verbatim** in its per-network header and again in its HTTP error path. QuickNode and Alchemy embed the API key in the URL *path*, and this script's output goes to stdout, into CI logs, and into terminal transcripts people paste into issues — so **every run against a keyed endpoint published a live key**.

Now redacted to protocol + host, with `/…` marking that a credential existed:

```
https://my-node.quiknode.pro/abc123secretkey/     -> https://my-node.quiknode.pro/…
https://eth-mainnet.g.alchemy.com/v2/SUPERSECRET  -> https://eth-mainnet.g.alchemy.com/…
https://rpc.example.com/?apikey=hunter2           -> https://rpc.example.com/…
https://ethereum-rpc.publicnode.com               -> https://ethereum-rpc.publicnode.com
```

## The safety gates did not run

All three commands in quickstart §1 were stale, and two failed in the worst available way: **`--grep` with no match exits 0 reporting "0 passing"**, so 1a and 1b read as green merge gates while asserting nothing. 1c passed *directories* to `hardhat test`, which takes files, so it crashed.

| Gate | Was | Now |
|---|---|---|
| 1a | `--grep "expiry refund"` → 0 passing | `--grep "MEMBER as depositor"` → **2 passing** |
| 1b | `--grep "NFT owner\|exit without router"` → 0 passing | actual test titles → **5 passing** |
| 1c | directories → `MODULE_NOT_FOUND` | the two test files → **8 passing** |

1a's pattern was stale because the expiry test was deliberately rescoped — an Across refund needs an off-chain dataworker root bundle, a dispute window and a merkle-proved leaf, so staging it would mostly test Across. Each gate gained a note to **check the passing count, not just the exit code**, since that's the failure mode that hid this.

**This also closes T150 blocker 6.** `depositor == member` had only ever been proven against a mock written by the same authors; it has now run green against the real Polygon SpokePool's own event encoding.

## Two more real defects

- **`deploy-bridge-liquidity.js` printed `Wrapped`** while registering `ConfigOnly` — contradicting the paragraph at the top of the same file explaining why these services must *not* be Wrapped. That's the line an operator pastes into a deployment record, and the distinction is what stops `depositToVaultWithFee` being pointed at them. The label map now lives beside `ServiceKind` in `lib/feeServices`; both scripts read it, removing the private copy that let them drift.
- **`AssetDetailSheet` gated Trade on raw `net.dex`** instead of `capabilities.dex`, bypassing the FR-016a `SWAP_CHAIN_IDS` allow-list. Latent under today's config; live the moment a network's DEX addresses land.

## Verified

Contracts 979 passing / 2 known environmental fork failures. Frontend 4,487 passing / the same 4 known pre-existing failures. An intermediate run showed 978/3 — the mainnet-fork staking test flaking on a public RPC, confirmed not a regression by running it in isolation on both trees.

## Found but not fixed here

Filed separately rather than scope-creeping this PR — see the issue comment on #966:

- **SC-020 is broken on the Trade surface.** `TradePanel`/`TradeTokenSelect` are still strictly active-chain — no cross-network list, no pin, no search. Bridge and Supply were converted; Trade was not.
- `ineligibleReason` in `networkPin.js` has **no production caller**, so "an ineligible asset shows its disabled reason rather than vanishing" doesn't happen — `UniversalAssetSelect` filters them out.
- `check:storage-layout` fails after a local §3 deploy: it matches records by `chain<id>`, and hardhat's default 1337 collides with the local node's.
- §2 names `npm run slither` and `npx medusa fuzz`, neither of which exists.
- CI never runs `npm run test:fork`, and `oracle-fork-tests.yml` supplies only Amoy + Polygon RPCs — so the base forks and the mainnet HubPool test silently skip while the job reports green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBMvFqhjqsXyUVF2hEFoNc