### PR TITLE
Vaults are accounts, named in the address book; wire up the deployed spec-067 routers

### DIFF
--- a/frontend/src/components/account/AddressBookPanel.jsx
+++ b/frontend/src/components/account/AddressBookPanel.jsx
@@ -12,6 +12,8 @@ import { useAddressBook } from '../../hooks/useAddressBook'
 import { useAddressScreening } from '../../hooks/useAddressScreening'
 import { getNetwork, getSelectableNetworks, getCurrentChainId } from '../../config/networks'
 import { addressKey, listEntries } from '../../lib/addressBook/addressBookStore'
+import { isVaultAddress } from '../../lib/custody/vaultAddressBook'
+import { loadVaultReferences } from '../../lib/custody/vaultReferences'
 function IconPlus() {
   return (
     <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="ab-icon">
@@ -32,6 +34,9 @@ function networkName(chainId) {
 
 export default function AddressBookPanel({ address }) {
   const wallet = useWallet()
+  // Spec 068 — the member's own vaults, used only to badge matching entries. Nothing is stored on
+  // the entry itself: the book's loader rebuilds a fixed field list, so a type key would be lost.
+  const vaultRefs = useMemo(() => (address ? loadVaultReferences(address) : []), [address])
   const activeChainId = wallet?.chainId ?? getCurrentChainId()
   const {
     book,
@@ -154,6 +159,8 @@ export default function AddressBookPanel({ address }) {
               contact={contact}
               getStatus={getStatus}
               networkName={networkName}
+              // Spec 068 — badge entries that are the member's own multisig vaults.
+              isVault={contact.addresses.some((a) => isVaultAddress(vaultRefs, a.address, a.chainId))}
               onEdit={(c) => setEditing({ contact: c })}
               onDeleteContact={deleteContact}
             />

--- a/frontend/src/components/account/ContactCard.jsx
+++ b/frontend/src/components/account/ContactCard.jsx
@@ -55,6 +55,7 @@ export default function ContactCard({
   networkName = (id) => `Chain ${id}`,
   onEdit,
   onDeleteContact,
+  isVault = false,
 }) {
   const [copiedKey, setCopiedKey] = useState(null)
   const statuses = contact.addresses.map((a) => getStatus(a.address, a.chainId))
@@ -72,6 +73,11 @@ export default function ContactCard({
       <div className="ab-contact-head">
         <div className="ab-contact-name">
           <span className="ab-contact-nickname">{contact.nickname}</span>
+          {/* Spec 068 — a multisig vault is an ordinary address-book entry, badged by matching the
+              member's own vault references rather than by storing a type on the entry (the book is
+              a synced object whose loader rebuilds a fixed field list, so an extra key would be
+              dropped). Renaming it here renames it everywhere the vault appears. */}
+          {isVault && <span className="ab-contact-tag">Multisig</span>}
           {containsRestricted && (
             <span className="ab-contact-restricted-flag">
               <RestrictionTag status="restricted" />

--- a/frontend/src/components/custody/CustodyPanel.jsx
+++ b/frontend/src/components/custody/CustodyPanel.jsx
@@ -31,7 +31,7 @@ function otherCustodyChains(chainId) {
 
 function OnChainSection() {
   const { address, chainId, switchNetwork } = useWallet()
-  const { active, operateAsVault } = useCustody()
+  const { active } = useCustody()
   const {
     vaults,
     activeVault,
@@ -108,7 +108,6 @@ function OnChainSection() {
             <VaultDetail
               vault={activeVault}
               onForget={forget}
-              onOperateAs={operateAsVault}
               isActiveIdentity={active.mode === 'vault' && active.vaultAddress === activeVault.address}
               onProposePolicy={activeVault.owner && onVaultChain ? proposals.propose : undefined}
               onSwitchNetwork={switchNetwork}

--- a/frontend/src/components/custody/VaultDetail.jsx
+++ b/frontend/src/components/custody/VaultDetail.jsx
@@ -14,7 +14,6 @@ import { isPolicyV2Supported } from '../../lib/custody/policyV2'
 export default function VaultDetail({
   vault,
   onForget,
-  onOperateAs,
   isActiveIdentity,
   onProposePolicy,
   onSwitchNetwork,
@@ -127,12 +126,18 @@ export default function VaultDetail({
       ) : (
         <PolicyPanel vault={vault} onPropose={onVaultChain ? onProposePolicy : undefined} />
       )}
+      {/* A vault is an account you can act as, chosen from the account switcher next to your
+          biticon — the same place recovered accounts live. It is not a mode you enter from a
+          separate button here, so there is no "Operate as this vault": one way to switch accounts,
+          wherever you are in the app. This line just says where. */}
+      {vault.owner && onVaultChain && (
+        <p className="custody-hint" role="note">
+          {isActiveIdentity
+            ? 'You are acting as this vault. Switch back from the account menu next to your avatar.'
+            : 'To spend from this vault, pick it in the account menu next to your avatar, then use Transfer as usual.'}
+        </p>
+      )}
       <div className="custody-actions">
-        {vault.owner && onOperateAs && onVaultChain && (
-          <button type="button" onClick={() => onOperateAs(vault)} disabled={isActiveIdentity}>
-            {isActiveIdentity ? 'Operating as this vault' : 'Operate as this vault'}
-          </button>
-        )}
         {onForget && (
           <button type="button" className="custody-link" onClick={() => onForget(vault.address, vault.chainId)}>
             Remove from list

--- a/frontend/src/components/custody/VaultProposalsPanel.jsx
+++ b/frontend/src/components/custody/VaultProposalsPanel.jsx
@@ -4,7 +4,6 @@
 import { useState } from 'react'
 import { useWallet } from '../../hooks'
 import { useVaultProposals } from '../../hooks/useVaultProposals'
-import ProposeTransactionForm from './ProposeTransactionForm'
 import ProposalQueue from './ProposalQueue'
 import OwnersThresholdPanel from './OwnersThresholdPanel'
 
@@ -14,7 +13,6 @@ export default function VaultProposalsPanel({ vault, proposals }) {
   // hook is only live when no instance is passed, so nothing is fetched twice.
   const internal = useVaultProposals(proposals ? null : vault)
   const { queue, history, loading, error, propose, approve, execute, cancel } = proposals || internal
-  const [showPropose, setShowPropose] = useState(false)
   const [busy, setBusy] = useState(false)
   const [actionError, setActionError] = useState(null)
 
@@ -59,15 +57,16 @@ export default function VaultProposalsPanel({ vault, proposals }) {
 
   return (
     <div className="custody-vault-proposals">
+      {/* No vault-only "New transfer" form. Spending from a vault is a normal transfer made while
+          the vault is your acting account — pick it in the account menu and use Home or Transfer.
+          A second, custody-shaped send form here would be a parallel path to maintain, and would
+          quietly diverge from the one members actually use (asset picker, address book, screening,
+          fee disclosure). Governance below stays: changing owners has no equivalent elsewhere. */}
       {vault.owner && (
-        <div className="custody-actions">
-          <button type="button" onClick={() => setShowPropose((s) => !s)}>
-            {showPropose ? 'Close' : 'New transfer'}
-          </button>
-        </div>
-      )}
-      {vault.owner && showPropose && (
-        <ProposeTransactionForm vault={vault} onPropose={run(propose)} onDone={() => setShowPropose(false)} />
+        <p className="custody-hint" role="note">
+          To move funds, pick this vault in the account menu next to your avatar and use Transfer as
+          usual. Anything you submit lands here for the other owners to approve.
+        </p>
       )}
 
       <OwnersThresholdPanel vault={vault} onPropose={run(propose)} busy={busy} />

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -152,9 +152,10 @@ const POLYGON_CONTRACTS = {
   // `deploy-bridge-liquidity.js` runs; `npm run sync:frontend-contracts` populates them.
   // Undeployed ⇒ the Bridge surface hides and Earn → Supply shows its honest
   // per-network empty state (FR-051) — never invented availability.
-  bridgeRouter: '',
-  liquidityRouter: '',
+  bridgeRouter: '0x8064F3Cd9F8f113691B981d2B15EF85D95Abd551',
+  liquidityRouter: '0x13762c059c2A22E3bCd8A44F36EA44e8e3B22B31',
   safePolicyGuardV2: '0xf18B813Ad8C01249FE904A732543A1b8E6CAfd0c',
+  feeRouter: '0xf8161fC26172621E9fbcc6c39500Bb14b0902B35',
 }
 
 // Ethereum Classic mainnet (chainId 61) — CUSTODY ONLY. ETC hosts no FairWins wager/membership
@@ -173,32 +174,40 @@ const ETC_CONTRACTS = {
 // deployment — only the two spec-067 routers — so their maps carry just those keys and
 // every other lookup honestly resolves empty.
 const ETHEREUM_CONTRACTS = {
-  bridgeRouter: '',
-  liquidityRouter: '',
+  bridgeRouter: '0x258181DF2aa45EA3a3eAC748d6491D5e1f2675eE',
+  liquidityRouter: '0x1afcAC1949BD306F7D4818999f509941F2E85582',
+  feeRouter: '0xB9F80D6D4CfD3ecC60b63810aDF9d88931D0e3d3',
+  deployer: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
 }
 
 const OPTIMISM_CONTRACTS = {
-  bridgeRouter: '',
-  liquidityRouter: '',
+  bridgeRouter: '0x1afcAC1949BD306F7D4818999f509941F2E85582',
+  liquidityRouter: '0xA273aF8ebB76d1D0Dcd55692C1f5a7db956F7EED',
   safeProposalHub: '0x94b5b38C247CE51F7C42C83B63115998b7e970E7',
   safePolicyGuardV2: '0xf18B813Ad8C01249FE904A732543A1b8E6CAfd0c',
   policyGuardSetup: '0xD0CB9D0ca2E56e9552cb833eC6D16F86ce818C2b',
+  feeRouter: '0x98218248CA53Dd88159979af20172C86b94e8B29',
+  deployer: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
 }
 
 const BASE_CONTRACTS = {
-  bridgeRouter: '',
-  liquidityRouter: '',
+  bridgeRouter: '0x1afcAC1949BD306F7D4818999f509941F2E85582',
+  liquidityRouter: '0xA273aF8ebB76d1D0Dcd55692C1f5a7db956F7EED',
   safeProposalHub: '0x94b5b38C247CE51F7C42C83B63115998b7e970E7',
   safePolicyGuardV2: '0xf18B813Ad8C01249FE904A732543A1b8E6CAfd0c',
   policyGuardSetup: '0xD0CB9D0ca2E56e9552cb833eC6D16F86ce818C2b',
+  feeRouter: '0x98218248CA53Dd88159979af20172C86b94e8B29',
+  deployer: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
 }
 
 const ARBITRUM_CONTRACTS = {
-  bridgeRouter: '',
-  liquidityRouter: '',
+  bridgeRouter: '0x1afcAC1949BD306F7D4818999f509941F2E85582',
+  liquidityRouter: '0xA273aF8ebB76d1D0Dcd55692C1f5a7db956F7EED',
   safeProposalHub: '0x94b5b38C247CE51F7C42C83B63115998b7e970E7',
   safePolicyGuardV2: '0xf18B813Ad8C01249FE904A732543A1b8E6CAfd0c',
   policyGuardSetup: '0xD0CB9D0ca2E56e9552cb833eC6D16F86ce818C2b',
+  feeRouter: '0x98218248CA53Dd88159979af20172C86b94e8B29',
+  deployer: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
 }
 
 const NETWORK_CONTRACTS = {

--- a/frontend/src/hooks/useCustodyVaults.js
+++ b/frontend/src/hooks/useCustodyVaults.js
@@ -26,6 +26,8 @@ import {
   removeVaultReference,
 } from '../lib/custody/vaultReferences'
 import { readPolicy, summarizeRules } from '../lib/custody/policy'
+import { ensureVaultContact, vaultDisplayName } from '../lib/custody/vaultAddressBook'
+import { loadAddressBook, ADDRESS_BOOK_CHANGED } from '../lib/addressBook/addressBookStore'
 import { getPolicyStatus as getPolicyStatusV2, readPolicyV2 } from '../lib/custody/policyV2'
 
 /**
@@ -86,6 +88,9 @@ export function useCustodyVaults() {
       // Every saved vault, on every chain (FR-003) — the list is the member's whole custody estate,
       // not a view of the connected network.
       const refs = loadVaultReferences(address)
+      // Spec 068 — the NAME comes from the address book, because that is where the member renames
+      // it. The reference's own label is only a fallback for a vault the book has not seen yet.
+      const book = loadAddressBook(address)
       const enriched = await Promise.all(
         refs.map(async (ref) => {
           const refChainId = Number(ref.chainId)
@@ -101,6 +106,7 @@ export function useCustodyVaults() {
               ...ref,
               ...identity,
               ...state,
+              label: vaultDisplayName(book, { ...ref, chainId: refChainId }),
               chainId: refChainId,
               onVaultChain,
               reachable: true,
@@ -113,6 +119,7 @@ export function useCustodyVaults() {
             return {
               ...ref,
               ...identity,
+              label: vaultDisplayName(book, { ...ref, chainId: refChainId }),
               chainId: refChainId,
               onVaultChain,
               reachable: false,
@@ -132,6 +139,15 @@ export function useCustodyVaults() {
 
   useEffect(() => {
     refresh()
+  }, [refresh])
+
+  // A vault's name lives in the address book, so a rename there must show up here. Without this the
+  // list keeps the old name until something unrelated happens to re-run the effect.
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    const onChanged = () => refresh()
+    window.addEventListener(ADDRESS_BOOK_CHANGED, onChanged)
+    return () => window.removeEventListener(ADDRESS_BOOK_CHANGED, onChanged)
   }, [refresh])
 
   /**
@@ -187,6 +203,9 @@ export function useCustodyVaults() {
         { chainId: Number(picked.chainId), address: picked.address, label, role: owner ? 'owner' : 'watch' },
         nowMs || Date.now(),
       )
+      // The vault joins the address book, so it is renamed and managed like any other address.
+      // Non-destructive: an entry the member already renamed is left alone.
+      ensureVaultContact(address, { ...picked, label })
       await refresh()
       setActiveAddress(picked.address)
       return { ...picked, owner, matches, unreachable }
@@ -220,6 +239,7 @@ export function useCustodyVaults() {
         { chainId: Number(chainId), address: vaultAddress, label, role: 'owner' },
         nowMs || Date.now(),
       )
+      ensureVaultContact(address, { address: vaultAddress, chainId: Number(chainId), label })
       await refresh()
       setActiveAddress(vaultAddress)
       return { address: vaultAddress, txHash }

--- a/frontend/src/lib/addressBook/addressBookStore.js
+++ b/frontend/src/lib/addressBook/addressBookStore.js
@@ -142,9 +142,20 @@ export function loadAddressBook(ownerAddress) {
  * @param {string} ownerAddress
  * @param {AddressBook} book
  */
+/** Event fired after any write, so views holding derived copies can re-read. */
+export const ADDRESS_BOOK_CHANGED = 'fairwins:address-book-changed'
+
 export function saveAddressBook(ownerAddress, book) {
   if (!ownerAddress) throw new Error('Wallet address is required')
   saveUserPreference(ownerAddress, STORAGE_KEY, { ...book, updatedAt: Date.now() }, true)
+  // Spec 068 — the book is no longer read only by the address-book screen: a vault's NAME lives
+  // here, so the vault list and account switcher derive from it too. Announcing writes at the one
+  // place they happen means renaming a vault updates it everywhere, rather than everywhere except
+  // wherever the member happens to be looking. Cheap, and it cannot be forgotten by a new caller
+  // the way a per-component refresh call would be.
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent(new CustomEvent(ADDRESS_BOOK_CHANGED, { detail: { ownerAddress } }))
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/custody/vaultAddressBook.js
+++ b/frontend/src/lib/custody/vaultAddressBook.js
@@ -1,0 +1,94 @@
+// Spec 068 — vaults live in the address book, so renaming and managing one happens in the same
+// place as every other address a member keeps.
+//
+// The link is BY ADDRESS, not by a new field. `loadAddressBook` rebuilds each contact from a fixed
+// field list, so any extra key (a `kind: 'vault'` marker, say) would be silently dropped on the next
+// load — and the book is a spec-032 synced object, so a schema change also has to survive the merge
+// on every device. Matching (address, chainId) against the member's own vault references needs
+// neither, and there is exactly one name for a vault either way.
+//
+// Division of responsibility:
+//   vaultReferences  — WHICH vaults are mine, on which chain, and my role. Custody's own record.
+//   address book     — what the vault is CALLED. One rename path, shared with every other address.
+
+import { getAddress } from 'ethers'
+import {
+  addContact,
+  findByAddress,
+  loadAddressBook,
+  saveAddressBook,
+  updateContact,
+} from '../addressBook/addressBookStore'
+
+const shorten = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
+
+/** Default name for a vault that has no address-book entry yet. */
+export function defaultVaultNickname(vault) {
+  return vault?.label?.trim() || `Vault ${shorten(vault?.address)}`
+}
+
+/**
+ * Ensure the member's address book has an entry for this vault, and return the contact.
+ *
+ * Idempotent, and deliberately non-destructive: if an entry already exists for this
+ * (address, chainId) — whatever the member has renamed it to — it is returned untouched. Adding a
+ * vault must never rewrite a name the member chose.
+ */
+export function ensureVaultContact(ownerAddress, vault) {
+  if (!ownerAddress || !vault?.address || vault.chainId == null) return null
+  const book = loadAddressBook(ownerAddress)
+  const existing = findByAddress(book, vault.address, vault.chainId)
+  if (existing) return existing.contact ?? existing
+
+  const { book: next, contact } = addContact(book, {
+    nickname: defaultVaultNickname(vault),
+    addresses: [{ address: getAddress(vault.address), chainId: Number(vault.chainId), notes: '' }],
+  })
+  saveAddressBook(ownerAddress, next)
+  return contact
+}
+
+/**
+ * The name to show for a vault: the address book wins, because that is where the member renames it.
+ * Falls back to the custody reference's own label, then to a shortened address — so a vault always
+ * has a name even before the book knows about it.
+ */
+export function vaultDisplayName(book, vault) {
+  if (!vault?.address) return ''
+  const hit = book ? findByAddress(book, vault.address, vault.chainId) : null
+  const nickname = hit?.contact?.nickname ?? hit?.nickname
+  return nickname || vault.label || shorten(vault.address)
+}
+
+/** Rename a vault by renaming its address-book entry — the single rename path. */
+export function renameVault(ownerAddress, vault, nickname) {
+  if (!ownerAddress || !vault?.address) return null
+  const contact = ensureVaultContact(ownerAddress, vault)
+  if (!contact) return null
+  const book = loadAddressBook(ownerAddress)
+  const next = updateContact(book, contact.id, { nickname })
+  saveAddressBook(ownerAddress, next)
+  return next
+}
+
+/**
+ * Is this address-book entry one of the member's vaults? Used to badge it in the address book
+ * without storing anything extra on the entry.
+ * @param {Array<{address:string, chainId:number}>} vaultRefs
+ */
+export function isVaultAddress(vaultRefs, address, chainId) {
+  if (!address || !Array.isArray(vaultRefs)) return false
+  let target
+  try {
+    target = getAddress(address)
+  } catch {
+    return false
+  }
+  return vaultRefs.some((r) => {
+    try {
+      return getAddress(r.address) === target && (chainId == null || Number(r.chainId) === Number(chainId))
+    } catch {
+      return false
+    }
+  })
+}

--- a/frontend/src/test/custody/VaultDetail.test.jsx
+++ b/frontend/src/test/custody/VaultDetail.test.jsx
@@ -79,14 +79,27 @@ describe('VaultDetail', () => {
     expect(onSwitchNetwork).toHaveBeenCalledWith(63)
   })
 
-  it('offers actions again once the wallet is on the vault chain', () => {
+  // A vault is switched to from the account menu, like a recovered account — not from a
+  // vault-only button here. This asserts the button is GONE and the member is told where to go,
+  // so the two ways of becoming a vault cannot silently come back.
+  it('points at the account switcher instead of offering its own operate-as button', () => {
     const vault = {
       isSafe: true, address: A, chainId: 63, chainName: 'Mordor', owners: [A], threshold: 1,
       owner: true, onVaultChain: true,
     }
-    render(<VaultDetail vault={vault} onOperateAs={vi.fn()} />)
-    expect(screen.getByRole('button', { name: /operate as this vault/i })).toBeInTheDocument()
+    render(<VaultDetail vault={vault} />)
+    expect(screen.queryByRole('button', { name: /operate as this vault/i })).not.toBeInTheDocument()
+    expect(screen.getByText(/account menu next to your avatar/i)).toBeInTheDocument()
     expect(screen.queryByText(/shown read-only/i)).not.toBeInTheDocument()
+  })
+
+  it('says so when the vault is already the acting account', () => {
+    const vault = {
+      isSafe: true, address: A, chainId: 63, chainName: 'Mordor', owners: [A], threshold: 1,
+      owner: true, onVaultChain: true,
+    }
+    render(<VaultDetail vault={vault} isActiveIdentity />)
+    expect(screen.getByText(/you are acting as this vault/i)).toBeInTheDocument()
   })
 
   it('explains an unreachable chain without implying the vault changed', () => {

--- a/frontend/src/test/custody/vaultAddressBook.test.js
+++ b/frontend/src/test/custody/vaultAddressBook.test.js
@@ -1,0 +1,102 @@
+// Spec 068 — a vault is an address-book entry, so it is renamed and managed like any other address.
+//
+// The link is BY ADDRESS rather than a stored type, because `loadAddressBook` rebuilds each contact
+// from a fixed field list — a `kind: 'vault'` key would be dropped on the next load, and the book is
+// a synced object so a schema change also has to survive the merge. These tests pin that choice:
+// naming resolves from the book, adding is non-destructive, and badging works without extra fields.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getAddress } from 'ethers'
+import {
+  defaultVaultNickname,
+  ensureVaultContact,
+  isVaultAddress,
+  renameVault,
+  vaultDisplayName,
+} from '../../lib/custody/vaultAddressBook'
+import { loadAddressBook, saveAddressBook, createEmptyBook, addContact } from '../../lib/addressBook/addressBookStore'
+
+const OWNER = getAddress('0x9999999999999999999999999999999999999999')
+const VAULT = getAddress('0x8cc564E3dF4003c2F0a33C679c8DfE6237c5c3fa')
+const OTHER = getAddress('0x1111111111111111111111111111111111111111')
+
+const vault = (over = {}) => ({ address: VAULT, chainId: 137, label: '', ...over })
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('vaultAddressBook', () => {
+  it('names an unnamed vault after its address, not "undefined"', () => {
+    expect(defaultVaultNickname(vault())).toMatch(/^Vault 0x8cc5/)
+    expect(defaultVaultNickname(vault({ label: 'Team treasury' }))).toBe('Team treasury')
+  })
+
+  it('adds the vault to the address book', () => {
+    const contact = ensureVaultContact(OWNER, vault({ label: 'Team treasury' }))
+    expect(contact.nickname).toBe('Team treasury')
+
+    const book = loadAddressBook(OWNER)
+    expect(book.contacts).toHaveLength(1)
+    expect(book.contacts[0].addresses[0]).toMatchObject({ address: VAULT, chainId: 137 })
+  })
+
+  it('is idempotent — adding the same vault twice does not duplicate it', () => {
+    ensureVaultContact(OWNER, vault())
+    ensureVaultContact(OWNER, vault())
+    expect(loadAddressBook(OWNER).contacts).toHaveLength(1)
+  })
+
+  it('NEVER overwrites a name the member chose', () => {
+    ensureVaultContact(OWNER, vault({ label: 'Original' }))
+    renameVault(OWNER, vault(), 'What I actually call it')
+
+    // Re-adding (e.g. the vault is loaded again, or refresh re-runs) must not reset the name.
+    ensureVaultContact(OWNER, vault({ label: 'Original' }))
+    expect(vaultDisplayName(loadAddressBook(OWNER), vault())).toBe('What I actually call it')
+  })
+
+  it('resolves the display name from the book, falling back sensibly', () => {
+    const empty = createEmptyBook()
+    // Nothing in the book: fall back to the custody reference's own label…
+    expect(vaultDisplayName(empty, vault({ label: 'From reference' }))).toBe('From reference')
+    // …then to a shortened address, so a vault always has SOME name.
+    expect(vaultDisplayName(empty, vault())).toMatch(/^0x8cc5/)
+
+    // Once the book knows it, the book wins — that is where renaming happens.
+    ensureVaultContact(OWNER, vault({ label: 'From reference' }))
+    renameVault(OWNER, vault(), 'From the book')
+    expect(vaultDisplayName(loadAddressBook(OWNER), vault({ label: 'From reference' }))).toBe('From the book')
+  })
+
+  it('matches a vault by address and chain for badging', () => {
+    const refs = [{ address: VAULT, chainId: 137 }]
+    expect(isVaultAddress(refs, VAULT, 137)).toBe(true)
+    expect(isVaultAddress(refs, VAULT.toLowerCase(), 137)).toBe(true) // checksum-insensitive
+    expect(isVaultAddress(refs, VAULT, 8453)).toBe(false) // same address, different chain
+    expect(isVaultAddress(refs, OTHER, 137)).toBe(false)
+    expect(isVaultAddress(refs, 'not-an-address', 137)).toBe(false)
+    expect(isVaultAddress(null, VAULT, 137)).toBe(false)
+  })
+
+  it('leaves an ordinary contact at the same address alone', () => {
+    // A member may already have the vault saved as a normal contact. ensureVaultContact must adopt
+    // that entry rather than creating a second one for the same address.
+    const { book } = addContact(createEmptyBook(), {
+      nickname: 'Saved earlier',
+      addresses: [{ address: VAULT, chainId: 137, notes: '' }],
+    })
+    saveAddressBook(OWNER, book)
+
+    ensureVaultContact(OWNER, vault({ label: 'Team treasury' }))
+    const after = loadAddressBook(OWNER)
+    expect(after.contacts).toHaveLength(1)
+    expect(after.contacts[0].nickname).toBe('Saved earlier')
+  })
+
+  it('ignores incomplete input rather than writing junk', () => {
+    expect(ensureVaultContact(null, vault())).toBeNull()
+    expect(ensureVaultContact(OWNER, { address: VAULT })).toBeNull() // no chainId
+    expect(loadAddressBook(OWNER).contacts).toHaveLength(0)
+  })
+})

--- a/scripts/ops/find-safe-proposals.js
+++ b/scripts/ops/find-safe-proposals.js
@@ -1,0 +1,100 @@
+/**
+ * Find pending SafeProposalHub proposals for a vault, verify each one's hash against the Safe's own
+ * derivation, and report who has approved.
+ *
+ * Read-only. The hub is an events-only broadcaster and the proposer supplies the hash, so a
+ * proposal is NOT trusted as posted: every one is re-hashed from its preimage via the Safe's own
+ * getTransactionHash and discarded if it does not match. That is the whole reason the preimage is in
+ * the event.
+ *
+ * Usage: SAFE=0x… npx hardhat run scripts/ops/find-safe-proposals.js --network <net>
+ */
+const fs = require("fs");
+const path = require("path");
+const hre = require("hardhat");
+const { ethers } = hre;
+const { getDeploymentFilename } = require("../deploy/lib/helpers");
+
+const HUB_ABI = [
+  "event Proposed(address indexed safe, address indexed proposer, bytes32 indexed safeTxHash, address to, uint256 value, bytes data, uint8 operation, uint256 nonce)",
+  "event Cancelled(address indexed safe, address indexed proposer, bytes32 indexed safeTxHash)",
+];
+const SAFE_ABI = [
+  "function nonce() view returns (uint256)",
+  "function getThreshold() view returns (uint256)",
+  "function getOwners() view returns (address[])",
+  "function approvedHashes(address owner, bytes32 hash) view returns (uint256)",
+  "function getTransactionHash(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns (bytes32)",
+];
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const chainId = Number(network.chainId);
+  const safeAddress = ethers.getAddress(process.env.SAFE || "");
+
+  const record = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "..", "deployments", getDeploymentFilename(network, "v2")), "utf8"),
+  );
+  const hubAddress = record.contracts?.safeProposalHub;
+  if (!hubAddress) throw new Error(`no safeProposalHub recorded on chain ${chainId}`);
+  const fromBlock = record.deployBlocks?.safeProposalHub || 0;
+
+  const hub = new ethers.Contract(hubAddress, HUB_ABI, ethers.provider);
+  const safe = new ethers.Contract(safeAddress, SAFE_ABI, ethers.provider);
+  const [currentNonce, threshold, owners] = await Promise.all([
+    safe.nonce(),
+    safe.getThreshold(),
+    safe.getOwners(),
+  ]);
+
+  console.log(`chain ${chainId} — Safe ${safeAddress}`);
+  console.log(`  threshold ${threshold} of ${owners.length}, current nonce ${currentNonce}`);
+  console.log(`  hub ${hubAddress} (from block ${fromBlock})`);
+
+  const proposed = await hub.queryFilter(hub.filters.Proposed(safeAddress), fromBlock, "latest");
+  const cancelled = new Set(
+    (await hub.queryFilter(hub.filters.Cancelled(safeAddress), fromBlock, "latest")).map((e) => e.args.safeTxHash),
+  );
+  if (proposed.length === 0) return console.log("\n  no proposals found");
+
+  for (const ev of proposed) {
+    const { proposer, safeTxHash, to, value, data, operation, nonce } = ev.args;
+
+    // Re-derive the hash from the preimage. A mismatch means the posted hash does not describe the
+    // posted transaction — approving on the strength of the event alone would be approving unknown
+    // calldata.
+    const derived = await safe.getTransactionHash(
+      to, value, data, operation, 0, 0, 0, ethers.ZeroAddress, ethers.ZeroAddress, nonce,
+    );
+    const authentic = derived === safeTxHash;
+
+    const status = cancelled.has(safeTxHash)
+      ? "cancelled"
+      : Number(nonce) < Number(currentNonce)
+        ? "superseded/executed"
+        : "PENDING";
+
+    console.log(`\n  ${status}  nonce ${nonce}  ${safeTxHash}`);
+    console.log(`    hash verifies against the Safe: ${authentic ? "YES" : "NO — DO NOT APPROVE"}`);
+    console.log(`    proposer: ${proposer}`);
+    console.log(`    to:       ${to}`);
+    console.log(`    value:    ${ethers.formatEther(value)} native`);
+    console.log(`    operation:${Number(operation) === 0 ? " CALL" : " DELEGATECALL ⚠️"}`);
+    console.log(`    data:     ${data === "0x" ? "(none — plain transfer)" : data.slice(0, 74) + (data.length > 74 ? "…" : "")}`);
+
+    if (status === "PENDING" && authentic) {
+      let have = 0;
+      for (const o of owners) {
+        const approved = (await safe.approvedHashes(o, safeTxHash)) === 1n;
+        if (approved) have++;
+        console.log(`      ${approved ? "✓" : "·"} ${o}`);
+      }
+      console.log(`    approvals: ${have} of ${threshold} needed${have >= Number(threshold) ? " — READY TO EXECUTE" : ""}`);
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e.message || e);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

A multisig stops being a separate *mode* with its own buttons and becomes an **account you act as** — the same treatment spec-062 recovered accounts already get. Plus it wires the spec-067 routers into the frontend, which were deployed but invisible.

## Vaults as accounts

`useAccountSwitcher` **already** listed vaults (tagged `Multisig`, calling `operateAsVault`), so this was mostly *removing* the second path rather than building a new one:

- **`VaultDetail`'s "Operate as this vault" — removed.** Two ways to become a vault meant two things to keep in step. Now there is one, and the panel says where it is.
- **`VaultProposalsPanel`'s "New transfer" form — removed.** Spending from a vault is a normal transfer made while the vault is your acting account, so it goes through the surface members already use (asset picker, address book, screening, fee disclosure) instead of a parallel custody-shaped form that would quietly diverge from it. **Governance stays** — changing owners has no equivalent elsewhere.

## Vaults in the address book

Renaming a vault now happens where every other address is renamed.

The link is **by address, not a stored type** — deliberately. `loadAddressBook` rebuilds each contact from a fixed field list, so a `kind: 'vault'` key would be silently dropped on the next load; and the book is a spec-032 synced object, so a schema change would also have to survive the merge on every device. Matching `(address, chainId)` against the member's own vault references needs neither.

`ensureVaultContact` is non-destructive: a name the member chose is never overwritten — including when they had already saved the vault as an ordinary contact, in which case that entry is adopted rather than duplicated.

**`saveAddressBook` now announces writes.** A vault's *name* lives in the book but is displayed in the vault list and the account switcher, so without this a rename appeared everywhere except wherever the member happened to be looking. Doing it at the single write path means no future caller can forget it.

> The same staleness exists in `useLegacyAccounts` (dep array `[address]`, so a newly recovered account only appears after a remount). Left alone as pre-existing, but it is the same class of bug and worth its own fix.

## Router wiring

`BridgeRouter` and `LiquidityRouter` were deployed and verified on all five control-plane mainnets earlier, but `contracts.js` still carried `''` for both — so the app rendered Bridge and Supply as **unavailable on every chain**. Now resolvable:

| Chain | BridgeRouter | LiquidityRouter |
|---|---|---|
| Ethereum 1 | `0x258181DF…` | `0x1afcAC19…` |
| Optimism 10 / Base 8453 / Arbitrum 42161 | `0x1afcAC19…` | `0xA273aF8e…` |
| Polygon 137 | `0x8064F3Cd…` | `0x13762c05…` |

**They remain inert** — no route or pool is curated on any chain, so no member action is possible yet. That is what keeps the two open HIGH T150 curation findings out of reach, and why the pool-address validation should land *before* anything is listed.

## Verification

8 new tests (`vaultAddressBook.test.js`), 39 custody/liquidity/bridge suites pass, ESLint clean, production build clean.

Pre-existing failures on `main`, unrelated: `useTransfer.balances`, `ProposalBuilder`, `UnifiedLookupModal`. `AdminSupplyTab` failed once and passed on re-run — **flaky**, not caused here (verified it passes on `main` and in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)