### PR TITLE
Spec 070: Safe Receiver — research + design (paused with open issues)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/068-protect-multi-chain-policies"
+  "feature_directory": "specs/070-safe-receiver"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,5 +257,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/068-protect-multi-chain-policies/plan.md
+at specs/070-safe-receiver/plan.md
 <!-- SPECKIT END -->

--- a/specs/070-safe-receiver/checklists/requirements.md
+++ b/specs/070-safe-receiver/checklists/requirements.md
@@ -1,0 +1,83 @@
+# Specification Quality Checklist: Safe Receiver — counterparty-segregated receive addresses
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-27
+**Updated**: 2026-07-27 (reframed from "Safe Request" after measurement — see [research.md](../research.md))
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — all four resolved in the 2026-07-27 session
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded (explicit Out of Scope section)
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Honesty gate (feature-specific)
+
+This feature exists because the originally-requested guarantee was not
+deliverable. These items are checked explicitly because they are the ones most
+likely to regress back into an overstated claim.
+
+- [x] The spec never claims deposits are screened or blocked (FR-006, SC-015)
+- [x] The impossible-as-asked premise is stated openly in the Overview, with
+      evidence in `research.md` §R1
+- [x] Native vs. token attribution asymmetry is stated rather than smoothed over
+      (FR-014, US2 scenario 4)
+- [x] Public linkability of receive addresses is disclosed, not implied away
+      (FR-007)
+- [x] Uncertainty withholds and never permits (FR-012, FR-013, FR-016)
+- [x] Per-network capability differences are required to be stated
+      (FR-031 … FR-034, SC-014)
+
+## Notes
+
+- Four clarifications were resolved with the repo owner on 2026-07-27:
+  framing (segregation, not deposit screening), disposition of the earlier
+  "Safe Request" draft (rewritten; pull design preserved in `research.md` §R2
+  Design B), change addresses (dropped), and linkability (accepted + disclosed).
+- The rejected designs and all gas measurements are preserved in
+  `research.md` so the reasoning is not re-derived later.
+
+### Post-review status (2026-07-27)
+
+The **spec** passes this checklist. The **design** built on it does not —
+adversarial review upheld 31 findings, 4 critical, recorded in
+[review-findings.md](../review-findings.md).
+
+Two of those findings reach back into the spec itself and must be resolved here
+before the design is reworked:
+
+- [ ] **Native coin has no exit path.** FR-023/SC-006 forbid sweeping withheld
+      value, the clearance rule withholds 100% of native permanently, yet US1
+      AS-2 invites native payments and an edge case claims native is "retained
+      in full and is sweepable". Pick a disposition (member attestation,
+      acknowledge-and-sweep, or tokens-only) and reconcile every artifact.
+- [ ] **FR-021 overstates gas.** "Gas is paid once" holds only on the batching
+      passkey rail; a classic wallet pays deploy + transfer per address on first
+      sweep. SC-010 is already worded correctly — align FR-021 to it.
+
+Also open, spec-level: FR-027 is internally contradictory (derivation is
+scan-free, discovery is not); the "never word uncertainty as guilt" rule is
+anchored to no FR; and portfolio aggregation is neither designed nor declared
+out of scope.
+
+**Not ready for implementation.** Re-run `/speckit-analyze` once the artifacts
+agree again.

--- a/specs/070-safe-receiver/contracts/ISafeReceiveAddress.md
+++ b/specs/070-safe-receiver/contracts/ISafeReceiveAddress.md
@@ -1,0 +1,175 @@
+# Contract: `ISafeReceiveAddress`
+
+> ⚠️ **Superseded pending rework.** Design review found 4 critical and 18 major
+> issues in this feature's design — see [review-findings.md](../review-findings.md).
+> Several statements in this document are falsified there. Do not implement from it as it stands.
+
+
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md) | **Data model**: [../data-model.md](../data-model.md)
+
+The member's receive address. An ERC-1167 minimal clone of an **immutable**
+template, deployed lazily by `SafeReceiverFactory` at a deterministic address.
+
+**Deployment key** (template only): `safeReceiveAddressImpl`
+**Clones are never recorded in `deployments/` or `contracts.js`** — they are
+derived, not registered.
+
+---
+
+## The one invariant that matters
+
+```
+transferOut  requires  msg.sender == owner
+```
+
+**Not `onlyFactory`.** The factory supplies screening configuration and is never
+consulted for authorization. Consequences, all of them intended:
+
+- A hostile factory upgrade cannot move a single wei (FR-008, FR-010, SC-016).
+- There is no platform rescue path. The member's own `transferOut` is the only
+  exit — the absence *is* the safety property, following `IBridgeRouter.sol:10-13`
+  (FR-009).
+- Batching is the member's account's job, not the factory's. A passkey account
+  batches with `executeBatch`; a classic wallet sends sequentially.
+
+`owner` is written once at `initialize` and has **no setter and no transfer**.
+
+---
+
+## Lifecycle
+
+```solidity
+function initialize(address owner_, address factory_) external initializer;
+```
+
+Called by the factory immediately after `cloneDeterministic`. The template's
+constructor calls `_disableInitializers()` so the template itself can never be
+initialized or used to hold value.
+
+**Reverts**: `ZeroAddress()` on either argument; re-initialization reverts via
+the initializer guard.
+
+Because `initialize` is called in the same transaction as the clone deployment
+and the derived address depends only on `(owner, index)`, there is **no
+initialization front-running surface** — a front-runner who deploys the clone
+first still produces a clone owned by the salt's owner.
+
+---
+
+## Receiving
+
+```solidity
+receive() external payable;
+```
+
+**Deliberately empty.** No screening, no event, no bookkeeping.
+
+This is the direct consequence of `research.md` §R1:
+
+- Screening here cannot fit the 2300-gas stipend a `.transfer()`/`.send()` payer
+  forwards, so it would lock out contract payers and — worse — make `.send()`
+  payers lose money silently.
+- It would achieve nothing for tokens, which invoke no recipient code at all.
+- Any code here, even an event, breaks payers that hardcode a 21,000-gas limit.
+
+Keeping it empty maximises payability (FR-002). Deposits are unscreened, the
+feature says so plainly (FR-006), and the control lives at `transferOut`.
+
+There is no `fallback()`. An unexpected call with data reverts rather than being
+silently accepted.
+
+---
+
+## Moving funds out
+
+```solidity
+function transferOut(address token, address to, uint256 amount) external;
+```
+
+The only path by which value leaves. `token == address(0)` means the network's
+native coin. `amount == 0` means the entire balance of that asset.
+
+**Order of operations** (checks-effects-interactions; every check precedes every
+transfer):
+
+1. `msg.sender == owner`, else `NotOwner()`
+2. `to != address(0)`, else `ZeroAddress()`
+3. `factory.screen(owner)` — the member (the named actor)
+4. `factory.screen(to)` — the destination
+5. `factory.screen(counterparty)` when `factory.committedCounterparty(owner, index) != 0` — FR-018
+6. resolve `amount` (0 ⇒ full balance); revert `NothingToTransfer()` if zero
+7. transfer — `SafeERC20.safeTransfer` for tokens; for native,
+   `(bool ok, ) = to.call{value: amount}("")` with the return value checked,
+   reverting `NativeTransferFailed()` (the `BridgeRouter.sol:363-368` pattern —
+   **never** `.transfer()` or `.send()`)
+
+Guarded by `nonReentrant`. Steps 3–5 are STATICCALLs and cannot reenter; step 7
+is the only external call that can, and it happens after every check with no
+state left to corrupt.
+
+**Reverts**
+
+| Condition | Error |
+|---|---|
+| caller is not the owner | `NotOwner()` |
+| `to == address(0)` | `ZeroAddress()` |
+| owner, destination, or committed counterparty is blocked | `SanctionedAddress(address)` (from the guard) |
+| screening required but unconfigured | `ScreeningNotConfigured()` (from the factory) |
+| nothing to move | `NothingToTransfer()` |
+| native send rejected by the destination | `NativeTransferFailed()` |
+
+Emits `TransferredOut(token, to, amount)`.
+
+### How the index is known
+
+The clone needs its own `index` to look up a committed counterparty. Two options
+for the implementer, decided at build time and recorded here so the choice is
+not silently made:
+
+- **Store it**: add `uint256 index` alongside `owner`, set at `initialize`. One
+  extra SSTORE per deployment (~20k gas, once).
+- **Reverse-lookup**: the factory records `indexOf[clone]` at deploy. Also one
+  SSTORE, but on the factory, and it adds factory state.
+
+**Recommendation: store it in the clone.** It keeps the clone self-contained,
+keeps the factory's state minimal, and avoids a second cross-contract read on
+every transfer.
+
+---
+
+## What this contract deliberately does not have
+
+| Absent | Why |
+|---|---|
+| `rescue` / `sweepTo` callable by anyone but the owner | It would be custody (FR-009) |
+| owner transfer | An owner that can change is an owner that can be stolen |
+| upgradeability | A platform upgrade key over member funds is the backdoor `SafePolicyGuardV2.sol:36-38` refuses (FR-010) |
+| pause | Pausing a member's withdrawal is custody |
+| fee logic | Launch rate is zero; dead fee code in an immutable value-holding contract is a review liability. A fee means a new template version. |
+| `fallback()` | Unexpected calldata should revert, not be absorbed |
+| deposit accounting | Impossible for tokens (`research.md` §R1.3); a partial implementation would imply a completeness it cannot have |
+
+---
+
+## Invariants the test suite must prove
+
+1. **Only the owner can move funds** — the factory cannot, the admin cannot, an
+   arbitrary caller cannot. Include a hostile-factory-upgrade test: upgrade the
+   factory to an implementation that tries to drain a clone, and assert it
+   fails.
+2. **Value sent before deployment is fully retained** and sweepable after lazy
+   deployment, for both native and tokens.
+3. **A screening failure moves nothing** — assert balances unchanged for the
+   owner-blocked, destination-blocked, and counterparty-blocked cases.
+4. **`amount == 0` sweeps exactly the full balance** and leaves zero residual.
+5. **`receive()` accepts a plain 21,000-gas transfer** once deployed — the
+   payability property the empty body exists to protect. (Note: this asserts the
+   *deployed* case; the undeployed case is a codeless address and trivially
+   accepts one.)
+6. **Reentrancy**: a malicious destination that reenters `transferOut` during the
+   native send cannot double-spend. Use `contracts/mocks/ReentrantToken.sol` and
+   a reentrant native receiver.
+7. **A fee-on-transfer token either delivers the exact amount or the call
+   reverts** — the payee is never quietly short-paid (spec edge case).
+8. **The template itself cannot be initialized** (`_disableInitializers`) and
+   holds no value.

--- a/specs/070-safe-receiver/contracts/ISafeReceiverFactory.md
+++ b/specs/070-safe-receiver/contracts/ISafeReceiverFactory.md
@@ -1,0 +1,230 @@
+# Contract: `ISafeReceiverFactory`
+
+> ⚠️ **Superseded pending rework.** Design review found 4 critical and 18 major
+> issues in this feature's design — see [review-findings.md](../review-findings.md).
+> Several statements in this document are falsified there. Do not implement from it as it stands.
+
+
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md) | **Data model**: [../data-model.md](../data-model.md)
+
+Platform-singleton UUPS contract. It derives receive addresses, deploys them
+lazily, records write-once counterparty commitments, and supplies screening
+configuration to clones.
+
+> **It is never on the authorization path for member funds.** No function here
+> can move, freeze, or redirect value. That property is what makes FR-008,
+> FR-009, FR-010 and SC-016 literally true, and it must survive every future
+> change to this interface.
+
+**Deployment keys**: `safeReceiverFactory` (proxy), `safeReceiverFactoryImpl`
+**Base**: `UUPSManaged` (bundles `UUPSUpgradeable` + `AccessControlUpgradeable`, defines `UPGRADER_ROLE`, reserves 50 slots)
+
+---
+
+## Roles
+
+| Role | Powers | Explicitly NOT |
+|---|---|---|
+| `DEFAULT_ADMIN_ROLE` | `setSanctionsGuard`, `setScreeningRequired` | any access to member funds |
+| `UPGRADER_ROLE` | upgrade the factory implementation | change `receiveAddressImpl`; move funds; alter any deployed clone |
+
+There is no guardian role and no pause. See `../plan.md` Constitution Check
+note 2 — a pause on `deploy` would strand funds at undeployed addresses.
+
+---
+
+## Initialization
+
+```solidity
+function initialize(
+    address admin,
+    address receiveAddressImpl_,
+    address sanctionsGuard_,
+    bool screeningRequired_
+) external initializer;
+```
+
+Calls `__UUPSManaged_init(admin)` **first**, per `docs/developer-guide/upgradeable-contracts.md`.
+
+**Reverts**
+
+| Condition | Error |
+|---|---|
+| `admin == address(0)` | `ZeroAddress()` |
+| `receiveAddressImpl_ == address(0)` | `ZeroAddress()` |
+| `screeningRequired_ && sanctionsGuard_ == address(0)` | `ScreeningNotConfigured()` |
+
+`receiveAddressImpl_` has **no setter**. Its init-code hash feeds address
+derivation, so changing it would move every future derived address (FR-030). A
+new template ships as a new factory deployment.
+
+---
+
+## Derivation
+
+```solidity
+function receiveAddressImpl() external view returns (address);
+
+function receiveAddressOf(address owner, uint256 index) external view returns (address);
+
+function isDeployed(address owner, uint256 index) external view returns (bool);
+```
+
+`receiveAddressOf` is **pure derivation** — it reads only the immutable template
+pointer and touches no per-address state:
+
+```
+salt = keccak256(abi.encode(owner, index))
+addr = Clones.predictDeterministicAddress(receiveAddressImpl, salt, address(this))
+```
+
+It returns the same address whether or not code exists there, and it never
+reverts for an unissued index — there is no on-chain notion of "issued". The
+client mirrors this computation exactly (`frontend/src/lib/receiver/deriveAddress.js`),
+and a test MUST assert client-derived == contract-derived == deployed.
+
+---
+
+## Deployment
+
+```solidity
+function deploy(address owner, uint256 index) external returns (address);
+```
+
+Deploys the clone at the derived address and calls
+`SafeReceiveAddress.initialize(owner, address(this))`.
+
+- **Permissionless.** The owner comes from the salt, not from `msg.sender`, so
+  deploying another member's address grants the caller nothing. Permissionless
+  deployment means a member is never blocked from reaching their funds by a
+  platform gate.
+- **Idempotent.** A second call for an already-deployed index returns the
+  existing address without reverting. Two concurrent batch sweeps must not make
+  one of them fail.
+- **Not pausable.** Pausing this would strand funds already sitting at the
+  address.
+
+Emits `ReceiveAddressDeployed(owner, index, addr)` on first deployment only.
+
+---
+
+## Counterparty commitment
+
+```solidity
+function commitCounterparty(uint256 index, address counterparty) external;
+
+function committedCounterparty(address owner, uint256 index) external view returns (address);
+```
+
+Records, **write-once**, the counterparty an address was issued to. Once
+committed, every `transferOut` from that address screens the counterparty
+on-chain (FR-018) — the member's declaration becomes chain-enforced rather than
+app-recorded.
+
+`msg.sender` is the owner; a member can only commit their own indices.
+
+**Reverts**
+
+| Condition | Error |
+|---|---|
+| already committed | `CounterpartyAlreadyCommitted(index)` |
+| `counterparty == address(0)` | `ZeroAddress()` |
+| `counterparty == msg.sender` | `SelfCounterparty()` |
+
+A commitment that could be changed later would not be a commitment, so there is
+deliberately no update and no clear.
+
+Emits `CounterpartyCommitted(owner, index, counterparty)`.
+
+---
+
+## Screening
+
+```solidity
+function screen(address account) external view;
+
+function sanctionsGuard() external view returns (address);
+function screeningRequired() external view returns (bool);
+```
+
+`screen` is the indirection clones call (the `WagerPool.sol:13-17` callback
+pattern — clones do not hold their own guard pointer, so a guard redeploy does
+not orphan them).
+
+Semantics — the fail-closed tri-state from `WagerPoolFactory.sol:285-303`, **not**
+the silent no-op of `WagerRegistryCore._screen`:
+
+| `screeningRequired` | guard set | Behaviour |
+|---|---|---|
+| `true` | yes | delegates to `guard.checkBlocked(account)`; reverts `SanctionedAddress(account)` when blocked |
+| `true` | no | reverts `ScreeningNotConfigured()` — **never proceeds unscreened** (FR-020) |
+| `false` | either | no-op — segregation and client clearance still apply; the UI states no on-chain screening applies here (FR-031) |
+
+`checkBlocked` is `external view` ⇒ STATICCALL ⇒ no reentrancy surface, so it is
+safe as the first check before any effect.
+
+---
+
+## Admin
+
+```solidity
+function setSanctionsGuard(address guard) external;      // DEFAULT_ADMIN_ROLE
+function setScreeningRequired(bool required) external;   // DEFAULT_ADMIN_ROLE
+```
+
+- `setSanctionsGuard(address(0))` reverts `ScreeningNotConfigured()` while
+  `screeningRequired` is true — an admin cannot silently disable screening by
+  nulling the guard.
+- `setScreeningRequired(true)` reverts `ScreeningNotConfigured()` when no guard
+  is set.
+
+Emits `SanctionsGuardUpdated(guard)`, `ScreeningRequiredUpdated(required)`.
+
+**These are the factory's entire mutable surface, and none of it touches funds.**
+
+---
+
+## Events
+
+```solidity
+event ReceiveAddressDeployed(address indexed owner, uint256 indexed index, address indexed receiveAddress);
+event CounterpartyCommitted(address indexed owner, uint256 indexed index, address indexed counterparty);
+event SanctionsGuardUpdated(address indexed guard);
+event ScreeningRequiredUpdated(bool required);
+```
+
+`ReceiveAddressDeployed` is indexed by owner so a client can enumerate deployed
+addresses from logs as a cross-check — but enumeration never *depends* on it,
+because derivation already covers recovery (FR-027).
+
+---
+
+## Errors
+
+```solidity
+error ZeroAddress();
+error ScreeningNotConfigured();
+error CounterpartyAlreadyCommitted(uint256 index);
+error SelfCounterparty();
+```
+
+`SanctionedAddress(address)` propagates from `ISanctionsGuard` unchanged, so the
+client can distinguish "screening refused this" from every other failure and
+name the party (FR-028).
+
+---
+
+## Invariants the test suite must prove
+
+1. `receiveAddressOf(o, i)` is stable across a factory **upgrade** — the whole
+   point of an immutable template.
+2. No function on this interface can transfer, approve, or otherwise move value
+   held by any clone. Assert by upgrading the factory to a hostile
+   implementation that *tries* and showing the clone still refuses.
+3. `deploy` is idempotent and never reverts on a redeploy.
+4. `screen` reverts `ScreeningNotConfigured()` — not silence — whenever
+   `screeningRequired && guard == address(0)`, on every path that consumes it.
+5. `commitCounterparty` is genuinely write-once, including across a factory
+   upgrade.
+6. Client-side derivation matches on-chain derivation for a spread of
+   `(owner, index)` values including index 0 and a large index.

--- a/specs/070-safe-receiver/contracts/clearance-model.md
+++ b/specs/070-safe-receiver/contracts/clearance-model.md
@@ -1,0 +1,194 @@
+# Contract: Clearance model (client-side)
+
+> ⚠️ **Superseded pending rework.** Design review found 4 critical and 18 major
+> issues in this feature's design — see [review-findings.md](../review-findings.md).
+> Several statements in this document are falsified there. Do not implement from it as it stands.
+
+
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md) | **Data model**: [../data-model.md](../data-model.md)
+
+Clearance is the client-side determination of **how much of a receive address's
+balance the member may spend**. It is client-side because no on-chain mechanism
+can attribute a token deposit to its sender (`research.md` §R1.3) — and the
+design says so rather than approximating it.
+
+This document is the behavioural contract for
+`frontend/src/lib/receiver/clearance.js` and `attribution.js`. It exists because
+the fail-safe direction is easy to reverse by accident, and reversing it is the
+one bug this feature cannot ship.
+
+---
+
+## The rule
+
+> **`spendable` is a positive assertion.** Value is spendable only when every
+> contributing deposit has been positively established *and* positively cleared.
+> Every other outcome — including every failure, every unknown, and every path
+> the author did not think about — withholds.
+
+Ported directly from the Bitcoin coin-selection rule
+(`frontend/src/lib/bitcoin/coinSelection.js:79-86`), which the platform already
+ships and which already survived review for exactly this class of risk.
+
+**Restated as an implementation obligation**: the classifier's default branch
+withholds. There is no code path that reaches `spendable` without an explicit
+positive verdict for every unit of value it counts.
+
+---
+
+## Inputs
+
+| Input | Source | Failure mode |
+|---|---|---|
+| `total` | `balanceOf(address)` / `getBalance(address)` | read failure ⇒ **entire balance withheld** `read-failed`; **never rendered as zero** (FR-016) |
+| `deposits[]` | `Transfer` logs filtered by recipient (tokens only) | missing deploy block, provider range cap, or RPC error ⇒ `scan-incomplete` |
+| `screening(addr)` | `useAddressScreening` with `{ force: true }` against the on-chain guard | `restricted` ⇒ `sanctioned-depositor`; anything else non-clear ⇒ `indeterminate-depositor`; guard unreadable ⇒ `screening-unavailable` |
+| `availability` | `lib/receiver/availability.js` | `not-deployed` / `screening-not-configured` short-circuits |
+
+**Screening must be forced.** The default screening path serves cached results
+up to `SCREENING_TTL_MS` (60s) old (`frontend/src/lib/addressBook/constants.js:28`).
+A cached result can predate a deny-list change, so clearance passes
+`{ force: true }` — the seam documented at
+`frontend/src/hooks/useAddressScreening.js:50-53`.
+
+---
+
+## Algorithm
+
+```
+classify(address, asset, total, deposits, availability) -> AssetClearance
+
+1. if total read failed
+     -> withheld[ all, 'read-failed' ]; spendable = 0; RETURN
+
+2. if total == 0
+     -> spendable = 0, withheld = []; RETURN
+
+3. if availability is 'not-deployed'
+     -> withheld[ total, 'screening-not-configured' ]; RETURN
+     (segregation still shown; nothing is claimed as screened)
+
+4. if asset is NATIVE
+     -> withheld[ total, 'unattributable' ]; RETURN
+     (no log records a plain native transfer's sender — research.md §R1.3)
+
+5. if the log scan did not cover the full range
+     -> withheld[ total, 'scan-incomplete' ]; RETURN
+     (a partial scan must never produce a partial clearance)
+
+6. accounted = Σ deposits[].amount
+   if accounted < total
+     -> unaccounted = total - accounted
+        withheld[ unaccounted, 'unattributable' ]
+     (force-sent value, an unscanned deposit, or a direct balance write)
+
+7. for each deposit:
+     screening = screen(deposit.from, { force: true })
+       'clear'          -> spendable += amount
+       'restricted'     -> withheld[ amount, 'sanctioned-depositor', from ]
+       'unavailable'    -> withheld[ amount, 'screening-unavailable' ]
+       anything else    -> withheld[ amount, 'indeterminate-depositor' ]
+
+8. ASSERT spendable + Σ withheld.amount == total
+     violation -> withheld[ total, 'read-failed' ]; spendable = 0
+     (an indecomposable balance is fully withheld, never partly guessed)
+```
+
+**Step 8 is not defensive decoration.** It is the invariant that makes the
+displayed decomposition trustworthy, and it must be a hard assertion in code and
+a test case — not a comment.
+
+---
+
+## Withhold reasons
+
+Every withheld portion carries exactly one. The set is closed; adding a case
+means adding a reason, never reusing an approximate one.
+
+| Reason | Member-facing meaning | Recoverable by |
+|---|---|---|
+| `sanctioned-depositor` | A payer failed screening | nothing — this is the feature working |
+| `indeterminate-depositor` | A payer's status could not be determined | retrying later |
+| `unattributable` | The sender could not be established | nothing on-chain; the member may know out-of-band |
+| `screening-unavailable` | The guard is deployed but unreadable right now | retrying later |
+| `screening-not-configured` | No guard on this network | switching to a network that has one |
+| `scan-incomplete` | Deposit history could not be fully read | retrying, or a better RPC endpoint |
+| `read-failed` | A balance or log read failed | retrying |
+
+### Wording rules (FR-028, FR-029)
+
+- `screening-unavailable` and `scan-incomplete` MUST NOT be worded as though the
+  payer is sanctioned. *"We couldn't complete the check"* — never *"this payer is
+  blocked."*
+- `screening-not-configured` MUST NOT be worded as a clearance. It means no
+  on-chain screening exists here at all.
+- `unattributable` MUST NOT imply wrongdoing. Native coin is *always*
+  unattributable; that is a property of the chain, not of the payer.
+- A withheld amount MUST never be described with a word that suggests the member
+  has lost it. It is theirs, in their own address, not spendable through this
+  feature's cleared path.
+
+---
+
+## Aggregation
+
+Address-level and section-level totals aggregate the per-asset objects and keep
+the same decomposition. A section total MUST NOT present a single spendable
+figure without its withheld counterpart (FR-015).
+
+Cross-network aggregation is **forbidden** (FR-035): balances on different
+networks cannot be swept together, so summing them would imply an action that
+does not exist.
+
+---
+
+## Freshness
+
+Clearance is **never persisted**. It is recomputed on every evaluation from
+current chain data and current screening results, so a deny-list update takes
+effect immediately and a previously-spendable balance can become withheld.
+
+There is deliberately no cached verdict — a stored "cleared" flag is exactly the
+stale-authorization bug this feature exists to prevent.
+
+---
+
+## Interaction with sweeping
+
+The sweep consumes `spendable`, never `total`:
+
+- The amount submitted is the spendable amount at the moment of confirmation,
+  recomputed — not the amount rendered when the screen opened.
+- If clearance changed between render and confirm, the member is told before
+  signing rather than silently sweeping a different amount (FR-023 and the
+  balance-changed edge case).
+- Withheld value is never included, and when the sweep moves less than the
+  address holds, the confirm step says so and why (FR-023).
+
+---
+
+## Required test cases
+
+Each of these is a distinct branch and each must be covered:
+
+1. All depositors clear ⇒ `spendable == total`, `withheld` empty.
+2. One depositor restricted ⇒ exactly that amount withheld, reason
+   `sanctioned-depositor`, remainder spendable.
+3. Depositor indeterminate ⇒ withheld, **not** cleared.
+4. Guard unreadable ⇒ `screening-unavailable`, and the wording is distinct from
+   `sanctioned-depositor`.
+5. Native asset ⇒ fully withheld `unattributable`, regardless of any screening
+   result available for other assets at the same address.
+6. Log scan short of the full range ⇒ fully withheld `scan-incomplete`, **not**
+   partially cleared from the logs that were read.
+7. `accounted < total` ⇒ the difference withheld `unattributable`, the accounted
+   cleared portion still spendable.
+8. Balance read fails ⇒ `read-failed`, and the UI shows a failure — asserted to
+   **not** render as `0`.
+9. Decomposition invariant violated (inject an inconsistency) ⇒ everything
+   withheld, nothing spendable.
+10. No guard on the network ⇒ `screening-not-configured`, addresses and balances
+    still listed, nothing claimed as screened.
+11. Screening is called with `{ force: true }` — assert the flag, since a cached
+    result silently passing is invisible in the output.
+12. Clearance recomputes after a deny-list change without any cache clear.

--- a/specs/070-safe-receiver/data-model.md
+++ b/specs/070-safe-receiver/data-model.md
@@ -1,0 +1,276 @@
+# Data Model: Safe Receiver (Spec 070)
+
+> ⚠️ **Superseded pending rework.** Design review found 4 critical and 18 major
+> issues in this feature's design — see [review-findings.md](./review-findings.md).
+> Several statements in this document are falsified there. Do not implement from it as it stands.
+
+
+**Date**: 2026-07-27 | **Plan**: [plan.md](./plan.md) | **Spec**: [spec.md](./spec.md)
+
+Four stores hold this feature's state, and the split between them is the
+feature's central safety property:
+
+| Store | Holds | Authority |
+|---|---|---|
+| **Factory state** (on-chain, upgradeable) | screening config, counterparty commitments | platform admin — **never funds** |
+| **Clone state** (on-chain, immutable) | owner, factory | written once at deploy, no setter |
+| **Client records** (browser, backed up) | labels, cursor, counterparty names | the member |
+| **Derived / computed** (nothing stored) | addresses, balances, clearance | recomputed every time |
+
+Nothing about a member's addresses is stored on a FairWins server.
+
+---
+
+## 1. On-chain — `SafeReceiverFactory`
+
+UUPS proxy. Storage is append-only behind a trailing `__gap`; the contract is
+registered in `scripts/deploy/check-storage-layout.js` so CI validates that.
+
+| Field | Type | Set by | Mutable | Notes |
+|---|---|---|---|---|
+| `receiveAddressImpl` | `address` | `initialize` | **No — no setter** | The ERC-1167 template. Its init-code hash feeds address derivation, so a setter would move every future derived address (FR-030). A new template ships as a new factory. |
+| `sanctionsGuard` | `ISanctionsGuard` | `initialize`, `setSanctionsGuard` | Yes (`DEFAULT_ADMIN_ROLE`) | Compliance config. Cannot be nulled while `screeningRequired` is true. |
+| `screeningRequired` | `bool` | `initialize`, `setScreeningRequired` | Yes (`DEFAULT_ADMIN_ROLE`) | When true and no guard is set, every screened path reverts `ScreeningNotConfigured()` — the `WagerPoolFactory.sol:285-303` fail-closed tri-state, never a silent no-op. |
+| `_committedCounterparty` | `mapping(address owner => mapping(uint256 index => address))` | `commitCounterparty` | **Write-once per (owner, index)** | A commitment the member can later change would not be a commitment. `address(0)` means uncommitted. |
+| `__gap` | `uint256[45]` | — | — | Append-only reserve. |
+
+**Validation rules**
+
+- `initialize` rejects a zero `admin`, a zero `receiveAddressImpl`, and the
+  combination `screeningRequired == true && sanctionsGuard == address(0)`.
+- `setSanctionsGuard(address(0))` reverts while `screeningRequired` is true.
+- `commitCounterparty` reverts if the index is already committed
+  (`CounterpartyAlreadyCommitted`), if `counterparty == address(0)`, or if
+  `counterparty == msg.sender` (an address committed to yourself is meaningless
+  and would make the sweep screen the member twice).
+- `deploy` is permissionless and idempotent: deploying another member's clone is
+  harmless (the clone's owner comes from the salt, not the caller), and a second
+  call on an already-deployed index is a no-op rather than a revert, so a race
+  between two batch sweeps cannot fail one of them.
+
+**No pause.** Deliberate. A pause on `deploy` would strand funds already sitting
+at undeployed counterfactual addresses — the one thing this design must never
+do. See `plan.md` → Constitution Check, note 2.
+
+---
+
+## 2. On-chain — `SafeReceiveAddress` (clone)
+
+ERC-1167 minimal proxy, deployed by `cloneDeterministic`. **Immutable**: no
+UUPS, no owner-transfer, no rescue, no setter of any kind. The template's
+constructor calls `_disableInitializers()`.
+
+| Field | Type | Set by | Mutable |
+|---|---|---|---|
+| `owner` | `address` | `initialize`, once | **No** |
+| `factory` | `ISafeReceiverFactory` | `initialize`, once | **No** |
+
+**The authorization invariant** — this is the load-bearing line of the whole
+feature:
+
+```
+transferOut  requires  msg.sender == owner
+```
+
+Not `onlyFactory`. The factory is consulted for *screening configuration* and is
+never consulted for *authorization*. A compromised or maliciously-upgraded
+factory can change which guard is asked, but cannot move, freeze, or redirect a
+single wei (FR-008, FR-009, FR-010, SC-016).
+
+**Derivation**
+
+```
+salt    = keccak256(abi.encode(owner, index))
+address = Clones.predictDeterministicAddress(receiveAddressImpl, salt, factory)
+```
+
+Pure. No RPC, no state read beyond the factory's immutable template pointer.
+Computable client-side from `(factoryAddress, templateAddress, owner, index)`
+alone, which is what makes backend-free recovery possible (FR-027).
+
+---
+
+## 3. Client records
+
+### 3.1 `ReceiveAddressRecord`
+
+One per issued address. Keyed `(chainId, index)`. Stored in `userStorage` and
+registered in `frontend/src/lib/backup/syncedObjects.js` as
+**`networkScoped: true`**, mirroring `vaultReferences.js:9-36`.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `chainId` | `number` | yes | Strict `NETWORKS[chainId]` lookups only — never `getNetwork()`. |
+| `index` | `number` | yes | The derivation index. Append-only per chain. |
+| `address` | `string` | yes | Cached derivation. Recomputable; stored for display and search. |
+| `label` | `string` | no | Member-authored counterparty name. |
+| `counterparty` | `string` | no | The counterparty's address, if the member recorded one. |
+| `committed` | `boolean` | no | Whether `counterparty` was committed on-chain (FR-018). |
+| `issuedAt` | `number` | yes | Epoch ms. |
+| `retiredAt` | `number` | no | Retirement hides the address from issuance; it is never reissued (FR-003). |
+
+**Loss of these records loses labels, never addresses.** Addresses and balances
+recover from derivation alone (FR-027, FR-028).
+
+### 3.2 Issuance cursor
+
+Derived, not stored: `nextIndex = max(index of records for this chain) + 1`,
+following `frontend/src/lib/bitcoin/wallet.js:45-49`. Issuance is a **write**
+(it creates a record); previewing an address is a read that burns no index —
+the peek/issue split at `useBitcoinWallet.js:462-471`.
+
+The cursor never decreases. Because derivation is deterministic and the record
+set is append-only, the Bitcoin cache-loss reissue hazard does not apply: after
+total data loss, addresses are re-derived rather than re-issued.
+
+---
+
+## 4. Computed — never stored
+
+### 4.1 `Deposit`
+
+One per observed inbound transfer.
+
+| Field | Type | Notes |
+|---|---|---|
+| `asset` | `string` | Token address, or `native`. |
+| `amount` | `bigint` | Base units. |
+| `from` | `string \| null` | **`null` for native.** No log records a plain native transfer's sender (`research.md` §R1.3). |
+| `blockNumber` | `number` | From the log; absent for native. |
+| `screening` | `'clear' \| 'restricted' \| 'indeterminate'` | Result for `from`. `indeterminate` is never treated as clear. |
+
+Token deposits come from `Transfer` logs filtered by recipient. The scan
+**refuses to run** without a recorded deploy block for the chain and says so,
+following `useVaultProposals.js:53-61` — it must never silently return an empty
+set that reads as "no deposits".
+
+### 4.2 `AssetClearance`
+
+Per address, per asset. The value object the UI renders and the sweep consumes.
+
+| Field | Type | Notes |
+|---|---|---|
+| `asset` | `string` | |
+| `total` | `bigint` | On-chain balance. The truth. |
+| `spendable` | `bigint` | **A positive assertion.** Only deposits positively established and cleared. |
+| `withheld` | `WithheldPortion[]` | Every non-spendable part, each with a reason. |
+
+**Invariant**: `spendable + Σ withheld.amount == total`. A balance that cannot
+be decomposed is entirely withheld under `read-failed` — it is never partially
+guessed (FR-015).
+
+`WithheldPortion` = `{ amount: bigint, reason: WithholdReason, detail?: string }`.
+
+`WithholdReason` — the complete enumeration; every branch of the classifier must
+land on one of these, and the default for any unhandled path is withheld:
+
+| Reason | Meaning |
+|---|---|
+| `sanctioned-depositor` | A depositor failed screening. |
+| `indeterminate-depositor` | A depositor's status could not be determined. |
+| `unattributable` | The sender could not be established at all — every native deposit, and any token value not accounted for by a scanned log. |
+| `screening-unavailable` | The guard is deployed but unreadable right now (distinct from not-deployed). |
+| `screening-not-configured` | No guard on this network; no on-chain screening applies. |
+| `scan-incomplete` | The log scan could not cover the full range (missing deploy block, provider range cap, RPC error). |
+| `read-failed` | A balance or log read failed. **Never rendered as zero** (FR-016). |
+
+### 4.3 `SweepOutcome`
+
+Per address, per asset — the shape `legacyKeys.js:396-450` established.
+
+| Field | Type |
+|---|---|
+| `index` | `number` |
+| `address` | `string` |
+| `asset` | `string` |
+| `status` | `'success' \| 'skipped' \| 'failed'` |
+| `amount` | `bigint` |
+| `txHash` | `string` (on success) |
+| `reason` | `string` (on `skipped` / `failed`) |
+
+One failure never aborts the rest (FR-022). `skipped` covers "nothing spendable
+here" and must be reported rather than silently omitted.
+
+### 4.4 `ReceiverAvailability`
+
+Per network, typed like `BRIDGE_UNAVAILABLE_REASON`
+(`useBridgeAvailability.js:38-46`). These must never collapse into one message.
+
+| Value | Meaning | Member-facing consequence |
+|---|---|---|
+| `available-enforcing` | Factory deployed, guard deployed and readable, real oracle | Screening described as enforced on-chain |
+| `available-mock-oracle` | Guard present but backed by a mock oracle | Described in **different terms** — materially weaker (FR-033) |
+| `available-unscreened` | Factory deployed, no guard on this chain | Segregation + clearance work; no on-chain screening claimed (FR-031) |
+| `screening-unreadable` | Guard deployed but not readable right now | Temporarily unavailable — **not** "not supported" (FR-032) |
+| `not-deployed` | No factory on this chain | Section hidden; stated reason if reached by deep link (FR-034) |
+
+---
+
+## 5. State transitions
+
+### Receive address lifecycle
+
+```
+      (derive, client-side, free)
+ ── issued ──────────────────────────────► has code? no
+      │                                          │
+      │ member sends first transferOut            │ payable either way —
+      ▼                                          │ a codeless address accepts
+   deployed (lazy, 118k gas, one time) ◄─────────┘ a plain 21,000-gas transfer
+      │
+      ├── transferOut (partial) ──► remainder stays in place, same address,
+      │                             same counterparty. No change address.
+      │
+      └── retired ──► hidden from issuance, never reissued, still sweepable
+```
+
+An address is **payable in every state**, including before it has code. Value
+sent to an undeployed address is retained in full and swept after lazy
+deployment (`research.md` §R7: measured, 3.0 ETH retained).
+
+### Counterparty commitment
+
+```
+uncommitted ──commitCounterparty──► committed  (terminal — write-once)
+```
+
+Committed counterparties are screened on-chain at every `transferOut` from that
+address (FR-018).
+
+### Clearance
+
+Clearance has **no persisted state**. It is recomputed from current chain data
+and current screening results on every evaluation, so a deny-list change takes
+effect immediately and a previously-cleared balance can become withheld. There
+is no cached "cleared" flag that could go stale — by design (FR-024 in spirit;
+the spec's fail-safe rule requires the current answer, not a remembered one).
+
+---
+
+## 6. Relationships
+
+```
+Member (owner address)
+  └─1..n─ ReceiveAddressRecord           (client, backed up, per chain)
+            └─1─ derived address          (pure function of owner+index+template)
+                  ├─0..1─ SafeReceiveAddress clone   (on-chain, lazy, immutable)
+                  ├─0..1─ committed counterparty     (on-chain, write-once)
+                  ├─0..n─ Deposit                    (computed from logs)
+                  └─1..n─ AssetClearance             (computed per asset)
+                            └─0..n─ WithheldPortion
+```
+
+---
+
+## 7. What is deliberately absent
+
+- **No on-chain record of who deposited.** Impossible to obtain
+  (`research.md` §R1.3); the design does not pretend otherwise.
+- **No persisted clearance verdict.** A stored "cleared" flag would go stale
+  against a deny-list update.
+- **No platform-side registry of member addresses.** Derivation replaces it, and
+  the no-backend rule forbids it.
+- **No pause flag.** See `plan.md` Constitution Check note 2.
+- **No fee state.** Launch rate is zero and no `FeeRouter` is wired; adding one
+  means a new template version.
+- **No change-address linkage.** Dropped — `research.md` §R4.

--- a/specs/070-safe-receiver/plan.md
+++ b/specs/070-safe-receiver/plan.md
@@ -1,0 +1,345 @@
+# Implementation Plan: Safe Receiver — counterparty-segregated receive addresses
+
+**Branch**: `070-safe-receiver` | **Date**: 2026-07-27 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/070-safe-receiver/spec.md`
+
+> ⚠️ **This plan did not survive design review.** See
+> [review-findings.md](./review-findings.md). Four critical findings falsify
+> claims made below — most importantly that no platform key can freeze funds
+> (C1), that `receiveAddressImpl` is immutable (C2), and that a deployed address
+> stays payable by a bare 21,000-gas transfer (C3, which contradicts this
+> feature's own `research.md` §R1.1). The Constitution Check below is therefore
+> **not valid as written**. Rework before implementing.
+
+## Summary
+
+Give each member an unlimited supply of deterministically-derived receive
+addresses, one per counterparty, so an otherwise-unpartitionable balance becomes
+a set of per-payer quarantine units. Deposits are unrestricted and the feature
+says so; the control lands at spend time, where a positive clearance assertion
+gates what is spendable and the on-chain sanctions guard screens the parties the
+transaction can actually name.
+
+**Technical approach.** A platform-singleton UUPS `SafeReceiverFactory` derives
+addresses as ERC-1167 `cloneDeterministic` predictions from
+`salt = keccak256(owner, index)` against an **immutable** template. Minting is
+therefore pure client-side arithmetic — free, instant, and requiring no
+transaction — and the address is a codeless hole that any wallet or exchange can
+pay with a plain 21,000-gas transfer. Code is deployed lazily, only when the
+member first moves funds.
+
+The critical authority decision: **the deployed clone's `transferOut` is
+`onlyOwner`, not `onlyFactory`.** The factory derives, deploys, records
+counterparty commitments and supplies screening config, but it is never on the
+authorization path for funds. This makes FR-008/FR-009/FR-010 literally true —
+no platform key and no factory upgrade can move, freeze, or redirect a member's
+money — at the cost of batching being done by the member's own account
+(`executeBatch` for passkey, sequential for classic) rather than by the factory.
+
+Depositor attribution is client-side: `Transfer` logs give exact per-deposit
+senders for tokens; native coin has no such record and the app says so. The
+clearance classifier is a direct port of the Bitcoin `spendable` rule
+(`coinSelection.js:79-86`) — a positive assertion, with everything unverified,
+indeterminate, or restricted withheld and explained.
+
+## Technical Context
+
+**Language/Version**: Solidity 0.8.24 (`viaIR`, optimizer `runs: 1`); JavaScript (ES2022) for frontend and scripts
+
+**Primary Dependencies**: OpenZeppelin Contracts/Upgradeable **5.4.0** (`Clones`, `AccessControlUpgradeable`, `ReentrancyGuardUpgradeable`, `SafeERC20`) via the repo's `UUPSManaged` base; ethers v6; React 18 + Vite; existing `ISanctionsGuard` (spec 007)
+
+**Storage**: On-chain — factory state (UUPS, append-only, `__gap`) and per-clone state (immutable, no upgrade). Client — `userStorage` records for labels/attribution, riding the spec-032 encrypted backup as a `networkScoped: true` synced object. No server, no indexer.
+
+**Testing**: Hardhat (`test/receiver/**` unit + security + integration; `test/upgradeable/` for the factory upgrade path; `test/fork/` to pin real-oracle screening gas); Vitest for the frontend; axe for accessibility
+
+**Target Platform**: EVM networks in `NETWORKS`; browser SPA (no backend)
+
+**Project Type**: Web application — Solidity contracts + React frontend, per the repo's existing split
+
+**Performance Goals**: Address derivation is client-side and instant (no RPC). Balance reads for N addresses × M assets must stay within one batched round-trip on batching-capable chains and must not degrade to per-address polling on ETC 61 / Mordor 63 where batching is disabled.
+
+**Constraints**: No backend (constitution + spec 043 FR-017). No platform authority over member funds. Published addresses must never move. Uncertainty must withhold, never permit. `PM_MAX_GAS` 3,000,000 and 6 sponsored ops/min bound any batch.
+
+**Scale/Scope**: 2 new contracts + 1 interface; ~6 new frontend modules, 2 hooks, 1 section (4–5 components); 1 deploy script; 5 registration touchpoints. Design target: tens of receive addresses per member per chain, not thousands.
+
+## Constitution Check
+
+*GATE: evaluated before Phase 0 and re-evaluated after Phase 1 design.*
+
+| Principle | Assessment | Verdict |
+|---|---|---|
+| **I. Security-First Smart Contracts** | Two value-bearing contracts. CEI throughout; `nonReentrant` on every fund-moving entry point; checked low-level native forward (`BridgeRouter.sol:363-368` pattern); `SafeERC20` for tokens; screening is a read-only STATICCALL before any effect. No `delegatecall`, no `selfdestruct`, no assembly beyond OZ `Clones`. Immutable clone = no upgrade key over member value. Security-agent review is a merge gate; EthTrust-SL L2 target; accepted Slither findings documented in NatSpec per `SafePolicyGuardV2.sol:63-72`. | **PASS** |
+| **II. Test-First and Comprehensive Coverage** | Tier A (95% statements / 90% branches) for both contracts in `coverage-threshold-policy.json`. Unit + security (full access-control matrix over every admin setter and the upgrade path) + integration lifecycle + upgrade test + a fork test pinning real-oracle screening gas. Frontend logic (derivation, clearance classifier, attribution, store) is pure and unit-tested; the clearance classifier gets adversarial cases for every withhold reason. | **PASS** |
+| **III. Honest State, No Mocks or Placeholders** | This principle *is* the feature. The spec's Overview states the impossible-as-asked premise openly; FR-006/FR-016/FR-031…FR-034 forbid claiming screening that is not delivered, rendering a read failure as zero, or conflating not-deployed with unreadable. A mock oracle on Amoy/Mordor must read differently from the real Chainalysis oracle on Polygon (FR-033). | **PASS** |
+| **IV. Fail Loudly in CI** | New `test/receiver/**` added to the `test:coverage` glob; both contracts added to `coverage-threshold-policy.json` `gated`; factory registered in `check-storage-layout.js`; three `verify.js` CATALOG entries. No `continue-on-error` added. Noted: Slither is already non-gating repo-wide (`|| true`) — not made worse, and the security-agent review is the real gate. | **PASS** |
+| **V. Accessible, Consistent Frontend** | New section meets WCAG 2.1 AA with axe coverage mirroring `home.axe.test.jsx`. Addresses and ABIs come from the sync artifacts and `getContractAddressForChain`, never hardcoded. | **PASS** |
+
+**No violations. Complexity Tracking section is empty.**
+
+Three design choices are worth recording because they *avoid* violations rather
+than justify them:
+
+1. **`transferOut` is `onlyOwner`, not `onlyFactory`.** A factory-authorized
+   fund path would put a platform UUPS upgrade key on the member's money —
+   exactly the backdoor `SafePolicyGuardV2.sol:36-38` refuses. The cost is that
+   the factory cannot batch sweeps; the member's account does.
+2. **No pause anywhere on this path.** A pause on the clone's `transferOut`
+   would be custody. A pause on the factory's `deploy` would be *worse* — it
+   would strand funds already sitting at undeployed counterfactual addresses
+   with no way to reach them. The absence is the safety property, following
+   `IBridgeRouter.sol:10-13`.
+3. **No `FeeRouter` wiring at launch.** The launch fee is zero (FR-036), and
+   dead fee code inside an immutable value-holding contract is a liability at
+   review. Introducing a fee later means a new template version and therefore
+   new addresses — which is honest, and consistent with FR-010.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/070-safe-receiver/
+├── spec.md              # Feature specification (complete)
+├── research.md          # Phase 0 — measurements, rejected designs (complete)
+├── plan.md              # This file
+├── data-model.md        # Phase 1 — entities and state
+├── quickstart.md        # Phase 1 — runnable validation guide
+├── contracts/           # Phase 1 — interface contracts
+│   ├── ISafeReceiverFactory.md
+│   ├── ISafeReceiveAddress.md
+│   └── clearance-model.md
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (complete)
+└── tasks.md             # Phase 2 — /speckit-tasks output (not created here)
+```
+
+### Source Code (repository root)
+
+```text
+contracts/
+├── receiver/
+│   ├── SafeReceiverFactory.sol      # UUPS singleton: derive, deploy, commit, screening config
+│   ├── SafeReceiveAddress.sol       # ERC-1167 template: immutable, onlyOwner transferOut
+│   └── ISafeReceiver.sol            # shared types, events, errors
+└── access/SanctionsGuard.sol        # consumed unchanged (spec 007)
+
+test/
+├── receiver/
+│   ├── SafeReceiverFactory.test.js
+│   ├── SafeReceiverFactory.security.test.js
+│   ├── SafeReceiveAddress.test.js
+│   ├── SafeReceiveAddress.security.test.js
+│   └── integration/receiver-lifecycle.test.js
+├── upgradeable/SafeReceiverFactory.upgrade.test.js
+├── fork/SafeReceiverScreening.fork.test.js
+└── helpers/receiver.js
+
+frontend/src/
+├── lib/receiver/
+│   ├── deriveAddress.js       # pure CREATE2 prediction — no provider, no RPC
+│   ├── receiverStore.js       # per-(chainId,index) records: label, counterparty
+│   ├── attribution.js         # Transfer-log depositor discovery + screening
+│   ├── clearance.js           # fail-safe classifier: spendable is a positive assertion
+│   └── availability.js        # typed per-network reason (deployed / no-guard / unreadable)
+├── hooks/
+│   ├── useSafeReceiver.js     # address list + balances, per-address failure isolation
+│   └── useReceiverSweep.js    # sweep/spend with per-address, per-asset outcomes
+├── components/receiver/
+│   ├── SafeReceiverPanel.jsx  # section shell + availability disclosure
+│   ├── ReceiveAddressList.jsx # per-address balance decomposition
+│   ├── ReceiveAddressCard.jsx # plain address + QR + label + clearance detail
+│   ├── CreateAddressModal.jsx # label + optional on-chain counterparty commitment
+│   └── SweepModal.jsx         # what moves, what is withheld and why, fee/gas disclosure
+├── abis/
+│   ├── SafeReceiverFactory.js # hand-maintained
+│   └── SafeReceiveAddress.js  # hand-maintained
+└── config/appNav.js           # + { id: 'receiver', label: 'Receive' } in Tools
+
+scripts/
+├── deploy/deploy-safe-receiver.js
+├── deploy/verify.js                    # + 3 CATALOG entries
+├── deploy/check-storage-layout.js      # + SafeReceiverFactory
+└── utils/sync-frontend-contracts.js    # + isV2 mapping entries
+
+docs/developer-guide/safe-receiver.md
+docs/runbooks/safe-receiver-operations.md
+```
+
+**Structure Decision**: The repo's established contracts + frontend split. A new
+`contracts/receiver/` domain directory (no hardhat or Slither config change is
+needed — `paths.sources` and `filter_paths` already cover the whole tree). The
+frontend section lives in the **Tools** nav group alongside Protect, since it is
+member-owned-contract infrastructure rather than a spending surface, and it
+**hides entirely** on networks without the factory — the `collectibles` /
+`predict` precedent, filtered through `visibleNavGroups`.
+
+## Architecture
+
+### Contract split and the authority boundary
+
+```text
+SafeReceiverFactory (UUPS, platform-admin config only)
+  ├─ receiveAddressOf(owner, index) view → address     ← pure prediction, no state
+  ├─ deploy(owner, index)                              ← permissionless, idempotent
+  ├─ commitCounterparty(index, counterparty)           ← write-once, owner-only
+  ├─ screen(address) view                              ← guard indirection for clones
+  └─ admin: setSanctionsGuard / setScreeningRequired   ← config, never funds
+
+SafeReceiveAddress (ERC-1167 clone, IMMUTABLE)
+  ├─ initialize(owner, factory)                        ← once, at deploy
+  ├─ receive() external payable {}                     ← empty; no screening (proven futile)
+  └─ transferOut(token, to, amount) onlyOwner          ← THE only exit; screens via factory
+```
+
+**The boundary**: the factory never appears in the clone's authorization check.
+`transferOut` requires `msg.sender == owner`. A malicious or compromised factory
+upgrade can change which guard is consulted (a legitimate compliance-config
+power the platform holds elsewhere) but **cannot move, freeze, or redirect a
+single wei**. The clone's `owner` is written once at `initialize` and has no
+setter.
+
+### Why the template is immutable, not admin-settable
+
+`WagerPoolFactory.sol:453-458` has a `setTemplate`. Copying that here would be a
+correctness bug: the template's init-code hash feeds `predictDeterministicAddress`,
+so changing it **moves every future derived address**. A member who printed
+address #7 on an invoice would find #7 now derives elsewhere. The template is
+therefore set once at `initialize` with no setter (FR-030). A new template ships
+as a **new factory deployment**; the old factory keeps serving existing addresses
+forever.
+
+### Screening placement
+
+Screened at `transferOut`, in this order, before any effect:
+
+1. `owner` — the member moving the funds (the named actor; `WagerPoolFactory.sol:178-186` precedent)
+2. `to` — the destination
+3. `committedCounterparty[owner][index]` — if the member committed one (FR-018)
+
+`checkBlocked` is `external view` ⇒ STATICCALL ⇒ no reentrancy surface. When
+`screeningRequired` is set and no guard is configured, the path reverts
+`ScreeningNotConfigured()` — the `WagerPoolFactory.sol:285-303` fail-closed
+tri-state, **not** the silent-no-op pattern used by `WagerRegistryCore._screen`.
+
+Batch semantics reconciling FR-017 with FR-022: the **member** screen is
+batch-wide (a sanctioned member's whole batch reverts); the **destination** and
+**counterparty** screens are per-item, each item isolated so one failure leaves
+the others to complete with their own reported outcome.
+
+### Clearance — client-side, fail-safe
+
+Attribution and clearance are client-side because no on-chain mechanism exists
+(`research.md` §R1.3). Per address, per asset:
+
+- **Tokens**: filter `Transfer` logs by recipient → exact per-deposit sender →
+  screen each with `{ force: true }` → sum cleared deposits.
+- **Native**: no log exists. Classified `unattributable` and withheld — never
+  silently cleared (FR-014).
+- Any screening result that is `restricted` or indeterminate, any log-scan
+  failure, any unreachable guard ⇒ **withheld with a reason**.
+
+`spendable` is computed as a positive assertion only; the default for every
+unhandled path is withheld. Log scanning refuses to run without a recorded
+deploy block per chain and says so, following `useVaultProposals.js:53-61`.
+
+### Balance reading — the scaling decision
+
+20 addresses × 20 assets = 400 reads. With ethers batching that is ~4 requests;
+on ETC 61 / Mordor 63 batching is disabled (`utils/rpcProvider.js:31,44`) and it
+would become 400 individual requests per poll. Decision:
+
+- Read balances **on demand and on address expand**, not on a 60-second poll.
+- Introduce `Multicall3` deliberately for the list view where the chain has it
+  (`frontend/src/abis/Multicall3.js` exists with zero importers today).
+- Where neither is available, bound the scanned set to addresses with a
+  nonzero last-known balance plus any the member pins, and **disclose** that the
+  list is partial rather than implying completeness.
+
+## Phase 0: Research
+
+**Complete** — see [research.md](./research.md). It records the measurements
+that reframed the feature (§R1), the four designs considered with the two
+rejected and why (§R2), why receive addresses are contracts rather than keys
+(§R3), which half of the UTXO analogy survives (§R4), backend-free discovery
+(§R5), inherited repo patterns (§R6), measured gas (§R7), chain availability
+(§R8), the registration checklist (§R9), and open items carried here (§R10).
+
+Items from §R10 resolved into this plan:
+
+- **Template mutability trap** → template is immutable (above).
+- **`Clones.cloneDeterministic` has zero repo call sites** → first use; the
+  helper and its prediction must be covered by a test asserting predicted ==
+  deployed on every supported chain config.
+- **OZ is 5.4.0, not 5.6.1** → verify the `Clones` API against 5.4.0.
+- **Balance-read scaling** → resolved above.
+- **Unknown tokens** (absent from `getPortfolioRegistry`) → disclosed as a
+  known gap in the UI; a `Transfer`-log sweep-discovery pass is explicitly
+  deferred, not silently omitted.
+- **`getProvider` calling `getNetwork()`** → this feature uses strict
+  `NETWORKS[chainId]` lookups only, per the custody rule.
+- **Real-oracle screening gas** → pinned by a fork test rather than assumed.
+
+## Phase 1: Design & Contracts
+
+Outputs generated alongside this plan:
+
+- **[data-model.md](./data-model.md)** — on-chain factory and clone state, the
+  client record shape and its backup registration, the clearance value object
+  with its complete withhold-reason enumeration, and the sweep-outcome shape.
+- **[contracts/ISafeReceiverFactory.md](./contracts/ISafeReceiverFactory.md)** —
+  functions, events, custom errors, roles, ordering guarantees.
+- **[contracts/ISafeReceiveAddress.md](./contracts/ISafeReceiveAddress.md)** —
+  the clone's minimal surface and its authorization invariant.
+- **[contracts/clearance-model.md](./contracts/clearance-model.md)** — the
+  client-side classifier contract: inputs, the withhold-reason enumeration, and
+  the fail-safe default that every branch must land on.
+- **[quickstart.md](./quickstart.md)** — runnable validation: derive, pay from
+  an external wallet, observe clearance, sweep, and prove the negative cases
+  (withheld value never moves; a factory upgrade cannot move funds).
+
+### Agent context update
+
+`CLAUDE.md`'s Spec Kit pointer is updated to reference this plan.
+
+## Registration checklist (from `research.md` §R9)
+
+Fail **loud** if missed:
+
+- [ ] `scripts/deploy/verify.js` CATALOG — three entries: `safeReceiverFactory`
+      (proxy), `safeReceiverFactoryImpl` (impl), `safeReceiveAddressImpl` (template)
+- [ ] `frontend/src/config/contracts.js` — address slots in each per-chain
+      `*_CONTRACTS` block being deployed to
+
+Fail **silent** if missed:
+
+- [ ] `scripts/deploy/check-storage-layout.js` `UPGRADEABLE_CONTRACTS` —
+      `{ name: "SafeReceiverFactory", deploymentsKey: "safeReceiverFactory" }`
+- [ ] `scripts/utils/sync-frontend-contracts.js` `isV2` mapping
+- [ ] `package.json` `test:coverage` testfiles glob — add `test/receiver/**`
+- [ ] `coverage-threshold-policy.json` `gated` — both contracts at Tier A
+- [ ] `medusa.json` `targetContracts` — if a stateful invariant harness ships
+
+Also: `frontend/src/abis/*.js` are hand-maintained — the sync script emits
+addresses only.
+
+## Deployment sequence
+
+1. Deploy `SafeReceiveAddress` template (plain, `_disableInitializers()` in constructor).
+2. Deploy `SafeReceiverFactory` proxy via `scripts/deploy/lib/upgradeable.js#deployProxy`, initialized with `(admin, template, sanctionsGuard, screeningRequired)`.
+3. Record `safeReceiverFactory` / `safeReceiverFactoryImpl` / `safeReceiveAddressImpl` and `constructorArgs.safeReceiverFactoryImpl = []` in `deployments/` **immediately**.
+4. `npm run verify:<net>` — fails on any unregistered key.
+5. `npm run sync:frontend-contracts`.
+6. Record a `deployBlocks` entry — depositor attribution scans `Transfer` logs and is silently dead without it.
+
+**Launch networks**: Polygon 137 (real Chainalysis oracle) is the only network
+where screening is fully meaningful. Amoy 80002 and Mordor 63 have guards backed
+by `MockSanctionsOracle` and must be described differently (FR-033). Networks
+without a guard can still host segregation and clearance if the factory is
+deployed with `screeningRequired = false` — but the UI must state that no
+on-chain screening applies there (FR-031). Sequencing per-network is a
+`/speckit-tasks` concern.
+
+## Complexity Tracking
+
+*No constitution violations. Section intentionally empty.*

--- a/specs/070-safe-receiver/quickstart.md
+++ b/specs/070-safe-receiver/quickstart.md
@@ -1,0 +1,272 @@
+# Quickstart: Safe Receiver (Spec 070)
+
+> ⚠️ **Superseded pending rework.** Design review found 4 critical and 18 major
+> issues in this feature's design — see [review-findings.md](./review-findings.md).
+> Several statements in this document are falsified there. Do not implement from it as it stands.
+
+
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+Runnable validation for the feature. The positive path proves it works; the
+**negative paths prove the guarantees**, and those are the ones that matter —
+this feature's value is entirely in what it refuses to do.
+
+---
+
+## Prerequisites
+
+```bash
+npm install
+npm run compile
+```
+
+For frontend work:
+
+```bash
+cd frontend && npm install
+```
+
+Note: `npm run build` is blocked locally by `VITE_PINATA_JWT` in `.env` (CI is
+clean). Frontend tests run under `TZ=UTC` for CI parity.
+
+---
+
+## 1. Contract suite
+
+```bash
+npx hardhat test test/receiver/
+npx hardhat test test/upgradeable/SafeReceiverFactory.upgrade.test.js
+```
+
+Expected: all green, including the negative cases below.
+
+### Coverage gate
+
+```bash
+npm run test:coverage
+```
+
+`test/receiver/**` must be in the `test:coverage` testfiles glob in
+`package.json`, and both contracts must be in `coverage-threshold-policy.json`
+`gated` at **Tier A** (95% statements / 90% branches). If either registration is
+missing the gate passes while measuring nothing — verify the contracts appear by
+name in the coverage output, not just that the command exits 0.
+
+### Storage layout
+
+```bash
+npm run check:storage-layout
+```
+
+Must list `SafeReceiverFactory`. If it does not, the append-only gate is not
+covering it and an unsafe upgrade would pass CI silently.
+
+---
+
+## 2. Local end-to-end
+
+```bash
+npx hardhat node          # terminal 1
+npx hardhat run scripts/deploy/deploy-safe-receiver.js --network localhost
+```
+
+Then, in a hardhat console:
+
+```js
+const f = await ethers.getContractAt('SafeReceiverFactory', FACTORY)
+const [member, payer] = await ethers.getSigners()
+
+// 1. Derive — free, no transaction, no code at the address yet
+const addr0 = await f.receiveAddressOf(member.address, 0)
+console.log(addr0, await ethers.provider.getCode(addr0))   // 0x — codeless
+
+// 2. Pay it as a plain address, with a bare transfer gas limit
+await payer.sendTransaction({ to: addr0, value: ethers.parseEther('1'), gasLimit: 21000 })
+console.log(await ethers.provider.getBalance(addr0))       // 1.0 ETH — accepted
+
+// 3. Deploy lazily, then sweep — the member pays gas from their own account,
+//    and the receive address never had to hold any
+await f.deploy(member.address, 0)
+const r = await ethers.getContractAt('SafeReceiveAddress', addr0)
+await r.connect(member).transferOut(ethers.ZeroAddress, member.address, 0)  // 0 = all
+console.log(await ethers.provider.getBalance(addr0))       // 0
+```
+
+**What step 2 proves**: the payability property. A `gasLimit: 21000` transfer
+succeeds because the address has no code. This is the measured behaviour that
+ruled out putting a screening `receive()` at the address — see `research.md`
+§R1.2.
+
+---
+
+## 3. The negative paths — the actual guarantees
+
+Each of these must **fail**, and each corresponds to a spec requirement. A green
+suite that does not include these has not validated the feature.
+
+### 3.1 The platform cannot move member funds (FR-008, FR-010, SC-016)
+
+```js
+// Upgrade the factory to a hostile implementation that tries to drain a clone
+const Hostile = await ethers.getContractFactory('MockHostileReceiverFactory')
+await upgrades.upgradeProxy(FACTORY, Hostile)
+await expect(hostileFactory.drain(addr0, attacker.address)).to.be.reverted   // NotOwner()
+```
+
+The clone's `transferOut` is `onlyOwner`, so no factory implementation — present
+or future — can reach the funds. **This is the single most important test in the
+feature.**
+
+### 3.2 A sanctioned member cannot sweep (FR-017)
+
+```js
+await guard.setDenied(member.address, true, 'test')
+await expect(r.connect(member).transferOut(token, member.address, 0))
+  .to.be.revertedWithCustomError(guard, 'SanctionedAddress')
+// and the balance is unchanged
+```
+
+### 3.3 A sanctioned destination is refused (FR-017)
+
+Same shape, with the destination deny-listed. Assert the error names the
+destination so the UI can say which side failed (FR-028).
+
+### 3.4 A committed counterparty is enforced by the chain (FR-018)
+
+```js
+await f.connect(member).commitCounterparty(1, acme.address)
+await guard.setDenied(acme.address, true, 'test')
+await expect(r1.connect(member).transferOut(token, member.address, 0)).to.be.reverted
+// and: the commitment cannot be changed
+await expect(f.connect(member).commitCounterparty(1, other.address))
+  .to.be.revertedWithCustomError(f, 'CounterpartyAlreadyCommitted')
+```
+
+### 3.5 Screening required but unconfigured refuses to act (FR-020)
+
+```js
+// screeningRequired = true, guard = 0 must be unreachable via the setter...
+await expect(f.setSanctionsGuard(ethers.ZeroAddress))
+  .to.be.revertedWithCustomError(f, 'ScreeningNotConfigured')
+```
+
+...and if reached by any path, `screen` reverts rather than passing silently.
+
+### 3.6 A published address never moves (FR-030, SC-013)
+
+```js
+const before = await f.receiveAddressOf(member.address, 7)
+await upgrades.upgradeProxy(FACTORY, await ethers.getContractFactory('SafeReceiverFactoryV2'))
+expect(await f.receiveAddressOf(member.address, 7)).to.equal(before)
+```
+
+And assert there is **no** `setReceiveAddressImpl` on the interface at all.
+
+### 3.7 Value sent before deployment is fully retained
+
+Pay an address, then deploy, then sweep, and assert the full amount arrives.
+Measured at 118,001 gas for the lazy deploy (`research.md` §R7).
+
+### 3.8 Reentrancy cannot double-spend
+
+Sweep to a destination that reenters `transferOut` during the native send.
+Assert the second call reverts and the total moved equals the balance once. Use
+`contracts/mocks/ReentrantToken.sol` for the token variant.
+
+---
+
+## 4. Client derivation matches the chain
+
+```bash
+cd frontend && TZ=UTC npx vitest run src/lib/receiver/
+```
+
+The critical assertion: `deriveAddress.js` output equals
+`factory.receiveAddressOf(owner, index)` for a spread of indices including 0 and
+a large value. If these ever diverge, a member's published address points
+somewhere their funds cannot be reached — verify this before anything else.
+
+---
+
+## 5. Clearance classifier
+
+```bash
+cd frontend && TZ=UTC npx vitest run src/lib/receiver/clearance.test.js
+```
+
+All twelve cases in [contracts/clearance-model.md](./contracts/clearance-model.md)
+must be present. Spot-check the ones most likely to regress:
+
+- Native asset ⇒ fully withheld `unattributable` (never silently cleared).
+- Balance read failure ⇒ `read-failed`, asserted to **not** render as `0`.
+- Screening called with `{ force: true }` — assert the flag itself, because a
+  cached result passing silently is invisible in the output.
+- Decomposition invariant `spendable + Σ withheld == total` — inject an
+  inconsistency and assert everything withholds.
+
+---
+
+## 6. Availability walk (FR-031 … FR-034, SC-014)
+
+Load Safe Receiver against each network state and confirm the wording differs:
+
+| State | How to produce | Expected |
+|---|---|---|
+| enforcing | Polygon 137 config | "screened on-chain at settlement" |
+| mock oracle | Amoy 80002 / Mordor 63 | described differently — materially weaker |
+| no guard | a chain with the factory, no `sanctionsGuard` | segregation works; no screening claimed; names where it is available |
+| unreadable | guard address with a failing provider | "temporarily unavailable" — **not** "not supported" |
+| not deployed | a chain with no factory | section hidden; stated reason on deep link |
+
+The failure this catches: collapsing "no guard here" and "guard unreadable" into
+one message. They mean different things to a member deciding whether to accept a
+payment.
+
+---
+
+## 7. Accessibility
+
+```bash
+cd frontend && TZ=UTC npx vitest run src/test/receiver.axe.test.jsx
+```
+
+Mirrors `src/test/home.axe.test.jsx`. Zero new violations.
+
+---
+
+## 8. Honesty review (manual, blocking)
+
+Not automatable, and the reason this feature exists. Read every string the
+member can see and confirm:
+
+- [ ] Nothing states or implies that deposits are screened or blocked (FR-006, SC-015)
+- [ ] Withheld amounts always carry a reason (FR-015, SC-007)
+- [ ] "Check unavailable" never reads as "this payer is sanctioned" (FR-029)
+- [ ] Public linkability of the member's addresses is disclosed (FR-007)
+- [ ] Native coin's unattributability is stated, not glossed (FR-014)
+- [ ] A mock-oracle network is not described like a real-oracle one (FR-033)
+- [ ] No surface implies privacy or unlinkability
+- [ ] A sponsored sweep is only labelled sponsored when the submission actually
+      returned sponsored (FR-037)
+
+---
+
+## 9. Deployment validation
+
+After deploying to a network:
+
+```bash
+npm run verify:<net>              # fails on any unregistered CATALOG key
+npm run sync:frontend-contracts   # throws if the per-chain block is missing
+```
+
+Then confirm by hand — these fail **silently** if missed:
+
+- [ ] `deployments/` records `safeReceiverFactory`, `safeReceiverFactoryImpl`,
+      `safeReceiveAddressImpl`, and `constructorArgs.safeReceiverFactoryImpl = []`
+- [ ] a `deployBlocks` entry exists — depositor attribution scans `Transfer`
+      logs and is silently dead without it
+- [ ] `frontend/src/abis/SafeReceiverFactory.js` and `SafeReceiveAddress.js`
+      match the compiled artifacts (ABIs are hand-maintained; the sync script
+      emits addresses only)
+- [ ] `frontend/src/config/contracts.js` carries the address for this chain

--- a/specs/070-safe-receiver/research.md
+++ b/specs/070-safe-receiver/research.md
@@ -1,0 +1,397 @@
+# Research: Safe Receiver (Spec 070)
+
+**Date**: 2026-07-27
+**Feature**: [spec.md](./spec.md)
+**Origin**: GitHub issue #929 — *"Safe Request" — sanctions-screened payments (on-chain enforced settlement)*
+
+This document records the measurements that reframed the feature, the designs
+that were rejected and why, and the repo patterns the implementation inherits.
+Everything marked **MEASURED** was reproduced on hardhat against the repo's real
+`contracts/access/SanctionsGuard.sol` and `contracts/mocks/MockSanctionsOracle.sol`.
+Probe contracts were removed afterwards; no measurement artefact remains in the
+tree.
+
+---
+
+## R1. Can a receive address reject a deposit from a sanctioned sender?
+
+This is the question the whole feature turned on, because issue #929 and the
+owner's follow-up direction both assumed the answer was yes.
+
+### R1.1 Native coin — yes for direct sends, with three holes
+
+Probe: a contract whose `receive() external payable { guard.checkBlocked(msg.sender); }`.
+
+| Payer shape | Result | Verdict |
+|---|---|---|
+| Clean EOA, full gas | status 1, 34,251 gas, 1.0 ETH delivered | works |
+| Sanctioned EOA, full gas | reverts `SanctionedAddress(0x3C44…)`, **0 wei moved** | works |
+| Contract using `.transfer()` | reverts (out of gas in callee) | payer locked out |
+| Contract using `.send()` | **payer tx SUCCEEDS, 0 wei delivered** | **silent loss** |
+| Any payer with `gasLimit: 21000` | fails against *any* contract, incl. an empty `receive()` | payer locked out |
+| Sanctioned EOA via `SELFDESTRUCT` | 2.0 ETH delivered, `receive()` never ran | guard bypassed |
+
+**MEASURED** on `evmVersion: paris` (`hardhat.config.js:332`).
+
+### R1.2 The 2300-gas stipend is not negotiable
+
+**MEASURED** marginal cost of the guard call inside `receive()`:
+
+```
+empty receive()             21,019
+receive(){ checkBlocked }   34,251   → marginal 13,232
+receive(){ no-op guard }    24,089   → marginal  3,070
+```
+
+A *literal no-op* external staticcall costs 3,070 gas — already above the 2300
+stipend that Solidity's `transfer()`/`send()` forward. EIP-2929
+`COLD_ACCOUNT_ACCESS_COST` alone is 2,600. No amount of `immutable` caching,
+assembly, or guard-side tuning closes that gap; the 13,232 decomposes as
+~2,600 (cold guard) + ~2,100 (cold `_denied` SLOAD) + ~2,600 (cold oracle) +
+~2,100 (cold SLOAD inside the oracle) + dispatch, and the nested staticcall is
+structural to `SanctionsGuard.sol:93-101`.
+
+Two consequences matter more than the cost:
+
+1. **`.send()` fails silently.** It returns `false`, the payer's transaction
+   succeeds, and the money never arrives. This is the worst failure mode in the
+   entire design space — worse than a revert, because nobody learns anything.
+2. **Code at the address is itself a payability regression.** A payer that
+   hardcodes `gasLimit: 21000` — the classic "plain transfer" limit — fails
+   against *any* contract, including one that does nothing at all. This breaks
+   the owner's core requirement ("payable by a plain address QR from any wallet
+   or exchange") before sanctions logic even enters the picture.
+
+### R1.3 ERC-20 — no, and not partially
+
+**MEASURED**: a sanctioned signer's `transfer(guardedReceiver, 500)` →
+status 1, exactly one log (the token's own `Transfer`), recipient balance 500.
+**Zero recipient code ran.**
+
+- EIP-20 `transfer` has no recipient callback. OZ `ERC20._update`
+  (`ERC20.sol:176`) only mutates balances.
+- All six configured stablecoins (five Circle USDC deployments + USC) were
+  bytecode-scanned for ERC-1363 / ERC-777 / ERC-223 / ERC-677 selectors behind
+  their proxies. **None present**; control selectors were present, so the scan
+  method is sound. (`frontend/src/config/networks.js:165,252,338,415,496,536,585,638`)
+- The only hook-bearing token in the curated registry is LINK on Ethereum
+  (ERC-677), and `transferAndCall` is an **opt-in second entrypoint the payer
+  chooses**. A hook the payer can decline is not enforcement.
+
+**And the identity is unrecoverable later.** At sweep time a contract can read
+`balanceOf(self)` — an amount with no identity. `LOG0`–`LOG4` are write-only and
+no opcode reads receipts. The only authenticated-`from` paths
+(`transferFrom` / `permit` / EIP-3009) all require the payer to do something
+FairWins-shaped, which a plain address cannot demand.
+
+### R1.4 Conclusion
+
+> *"Receive addresses which allow deposit from any non-sanctioned address"*
+
+is **not deliverable as written**. It is impossible for the asset members
+actually use, and for native coin it holds only against direct full-gas EOA
+sends while locking out two payer shapes, silently losing money from a third,
+and remaining bypassable by `SELFDESTRUCT`.
+
+The spec is therefore written to what *is* deliverable: **segregation at
+receive time, and enforcement at spend time.**
+
+---
+
+## R2. Designs considered
+
+### Design A — Eagerly-deployed native gate *(rejected)*
+
+Each receive address is deployed up front with a screening `receive()`.
+
+- **Enforces**: direct full-gas EOA native sends from sanctioned addresses
+  revert atomically.
+- **Cannot enforce**: any ERC-20; contract payers; 21000-gas payers;
+  `SELFDESTRUCT`; anything that arrived before deployment.
+- **Cost**: ~90k–118k gas per address to mint, +13,232 gas on every payer's
+  deposit (a ~63% surcharge over a 21,000-gas transfer).
+- **Rejected because** it advertises a guarantee it does not deliver on the
+  dominant asset, and its failure modes are silent. A member would believe
+  sanctioned funds cannot reach their address while sanctioned USDC arrives
+  without a murmur.
+
+### Design B — Pull-based screened deposit *(rejected here; viable as its own feature)*
+
+The payer signs an EIP-3009 `ReceiveWithAuthorization` (or `permit` +
+`transferFrom`) and the receiving contract pulls, screening both parties
+atomically.
+
+- **Enforces**: genuine, atomic, both-sides screening for USDC. `from` is
+  signature-authenticated *by the token*, so `guard.checkBlocked(from)` is
+  trustworthy. Selector `ef55bec6` verified present in all five deployed USDC
+  contracts; `contracts/interfaces/IERC3009.sol:22-32` already exists in-tree.
+- **Cannot serve this feature**: the payer must sign a FairWins-shaped struct.
+  An exchange, a cold wallet, a payroll system, or any third-party app cannot.
+  The "pay me from anywhere with a plain address" property is lost.
+- **Also bypassable by construction**: the destination is still a plain
+  address, so anyone can `transfer()` into it unscreened. The screened path is
+  opt-in *for the payer*.
+- **Status**: this was the original 070 draft ("Safe Request"). It is the only
+  design that genuinely screens a stablecoin payment in both directions and
+  remains available as future work — but it is a different feature, not this
+  one.
+
+### Design C — Quarantine-then-attest *(chosen — the product shape)*
+
+One receive address per counterparty. Deposits are unrestricted. Value is
+spendable only on a positive clearance assertion; withheld value is visible and
+explained.
+
+- **Enforces**: the member never commingles un-vetted funds into their main
+  account. One address per payer turns an unpartitionable fungible balance into
+  a **per-address quarantine unit** — this is the mechanism that makes ERC-20
+  attribution tractable at all.
+- **Cannot enforce**: anything at deposit time. The money is already in the
+  member's contract when the decision is made.
+- **Handles tainted funds correctly**: they sit in their own address, marked,
+  and are simply never swept. This is exactly Bitcoin's model — accept
+  everything, protect at spend time.
+
+### Design D — Screen the named actor *(chosen — the on-chain control inside C)*
+
+Screening applies to the party the transaction can attribute: the member
+sweeping, the destination, and any counterparty the member committed on-chain.
+
+- Matches every existing FairWins consumer — `WagerPoolFactory.sol:178-186`
+  screens `creator` (`msg.sender` for self-submit, the recovered signer for the
+  gasless twin), never an inferred upstream party.
+- Cheap, precedented, fail-closed, and it screens somebody the contract can
+  actually name.
+
+**Shipped design: C (product) + D (on-chain control).**
+
+---
+
+## R3. Why receive addresses are contracts and not plain keys
+
+A serious alternative is N ordinary EOAs derived from the member's existing
+seed (spec 041's passkey master seed, or spec 062's key vault). That would give
+segregation with zero contracts, zero minting cost, full plain-address
+payability, and — unlike the chosen design — *unlinkable* addresses.
+
+It was rejected on one decisive practical point:
+
+> **Value cannot leave a plain address until that address itself holds gas.**
+
+Collecting from 20 EOAs means 20 gas top-ups before 20 sweeps, on every
+network, forever. With member-owned contracts the member's own account pays gas
+once and directs the sweep, and the addresses never need to hold the gas token
+at all (spec FR-021). Contracts also make the on-chain screening of Design D
+possible — an EOA can enforce nothing.
+
+Secondary reasons: derivation from the owner's address recovers without the
+seed (R5), and the member-owns-the-deployed-contract shape matches the Protect
+model the owner asked for.
+
+---
+
+## R4. The UTXO analogy — which half survives
+
+The owner's direction described a UTXO model with change addresses. Half of it
+translates and half does not.
+
+**Survives — rotation and per-address quarantine.** Change is a *Bitcoin
+protocol necessity*: a UTXO must be consumed whole, so the remainder has to go
+somewhere. That pressure does not exist on EVM.
+
+**Does not survive — change addresses.** `transfer(to, amount)` moves exactly
+`amount` and leaves the remainder in place. After a partial spend, value left
+sitting in address `R` is **exactly as segregated** as value moved to a fresh
+`R'`, still attributed to the same counterparty — and **MEASURED** ~90,300 gas
+cheaper per spend.
+
+**And the privacy motive does not transfer either.** Bitcoin change addresses
+are unlinkable without the xpub. EVM factory clones are publicly linked: anyone
+can re-derive `keccak(owner, i)` for `i = 0,1,2…` and enumerate every address a
+member owns. Shipping change addresses would *imply* an unlinkability the
+architecture does not have — which is worse than not shipping them.
+
+Decision: keep rotation and one-address-per-payer; drop change addresses; state
+the linkability plainly (spec FR-007).
+
+---
+
+## R5. Discovery and recovery without a backend
+
+Deterministic derivation makes this strictly better than the Bitcoin precedent
+it borrows from.
+
+- Bitcoin needs gap-limit-20 probing because HD addresses leave no registry
+  (`frontend/src/lib/bitcoin/wallet.js:120-182`), and it accepts two known
+  weaknesses: a payment more than 20 indices ahead is undiscoverable, and an
+  issued-but-never-paid address is not recovered after cache loss — so the
+  cursor can roll back and **reissue an address**.
+- On EVM, address *N* for owner *O* is a pure function of the factory, the
+  template's init-code hash, and `salt = keccak(O, N)`. **MEASURED**: predicted
+  address matched the deployed address exactly. A fresh device derives
+  addresses 0..N locally with **zero RPC calls and zero scanning**, so the
+  reissue hazard disappears rather than being inherited.
+- Spec 061's research rejected a server-side registry of issued addresses
+  because the server would learn the wallet graph. An on-chain factory *is*
+  that registry — the trade inverts, and the privacy cost lands publicly. That
+  cost is accepted and disclosed (spec FR-007).
+
+**Two traps to avoid:**
+
+1. Both existing clone factories use non-deterministic `Clones.clone`
+   (`contracts/pools/WagerPoolFactory.sol:199`; `TokenFactory` ×6).
+   `cloneDeterministic` exists in the pinned OZ but has **zero call sites in
+   this repo** — this would be the first use, and it is mandatory.
+2. If the factory's template pointer is admin-mutable (the
+   `WagerPoolFactory.sol:453-458` pattern), changing it changes the init-code
+   hash and therefore **moves every future derived address**. A printed address
+   must never move (spec FR-030) — bind the template version into the salt, or
+   make the template immutable.
+
+**The real cost problem is balance reading, not enumeration.**
+`getPortfolioRegistry` yields ~20 assets on Ethereum and ~12 on Polygon
+(`frontend/src/config/assetTaxonomy.js:421-497`), polled every 60s
+(`usePortfolio.js:41`). Twenty receive addresses × twenty assets = **400 balance
+reads per poll**. With ethers batching (`batchMaxCount` 100,
+`utils/rpcProvider.js:11`) that is ~4 HTTP requests — tolerable. But batching is
+**disabled on ETC 61 and Mordor 63** (`NO_BATCH_CHAIN_IDS`,
+`utils/rpcProvider.js:31,44`), which would mean 400 individual requests per
+poll. `frontend/src/abis/Multicall3.js` exists with **zero importers**. The plan
+must bound the scanned set, introduce Multicall3 deliberately, or replace the
+poll with an explicit check — not inherit a 60-second 400-read loop.
+
+---
+
+## R6. Patterns this feature inherits
+
+| Piece | Reuse | Location |
+|---|---|---|
+| Member deploys and owns; no platform key | Safe vault initializer names only member owners | `frontend/src/lib/custody/safeVault.js:30-43` |
+| No upgrade key over member value | "No owner, no admin role, deliberately NOT upgradeable" | `contracts/custody/SafePolicyGuardV2.sol:33-42` |
+| Preview an address before signing | The repo's only pure, provider-free CREATE2 predictor | `safeVault.js:64-78`, `:84-97` |
+| Preview invalidated on any config change | Whole initializer hashed into the salt | `CreateVaultWizard.jsx:41-46` |
+| Member-instantiated clones, admin = config only | `createPool` is `msg.sender`-attributed | `WagerPoolFactory.sol:137-143`, `:454-475` |
+| Fail-closed tri-state screening config | `screeningRequired` + `ScreeningNotConfigured()`; setters refuse to null a guard | `WagerPoolFactory.sol:68-70,112-114,285-303,461-465` |
+| Clone → factory screening callback | Clones call back rather than holding a guard pointer | `WagerPool.sol:13-17` |
+| CEI on issuance + provenance guard | Screen → clone → init → registry write; 1-based ids so `id == 0` means unknown | `WagerPoolFactory.sol:184-186,198-208,316-320` |
+| Counterfactual address funded before code | Shipped and tested (spec 041 FR-007) | `specs/041-passkey-wallet-login/spec.md:388-391` |
+| First-use deploy folded into the first action | Gated on `isDeployed()` | `frontend/src/lib/passkey/smartAccount.js:314-324` |
+| Rotation cursor = max(issued)+1, append-only | Issuance is a **write**, not a read | `frontend/src/lib/bitcoin/wallet.js:45-49,75-89` |
+| Peek vs. issue split | Abandoned plans never burn an index | `useBitcoinWallet.js:462-471,493-500` |
+| **Fail-safe taint rule** | `spendable` is a *positive assertion*; protected/unverified/pending/unknown all withheld | `frontend/src/lib/bitcoin/coinSelection.js:79-86` |
+| Explained balance decomposition | `{confirmed, pending, protected, spendable}` so total ≠ spendable is never mysterious | `coinSelection.js:88-101` |
+| Bare, parameter-free QR | EVM QR is bare EIP-55, "no URI scheme" | `components/ui/AddressQRCode.jsx:18-19` |
+| Per-asset sweep outcomes | quote → ordered loop → `{asset, status, txHash?, error?}`; one failure never aborts the rest | `frontend/src/lib/recovery/legacyKeys.js:396-450` |
+| Gas reserve against a **contract** recipient | `estimateGas` against the real destination, ×1.2, same limit reused at send | `legacyKeys.js:376-391` |
+| Per-instance failure isolation | One dead RPC degrades one row, never the estate | `useCustodyVaults.js:116-129` |
+| `unreachable` ≠ `not found` | A dead endpoint must never say "your money isn't there" | `safeVault.js:222-253` |
+| Strict chain identity | `NETWORKS[chainId]` with an explicit unknown branch, never `getNetwork()` | `useCustodyVaults.js:55-64` |
+| Client records keyed (chainId, address), backed up | `{address, chainId, label, addedAt, role}` + `networkScoped: true` | `vaultReferences.js:9-36`; `syncedObjects.js:70-86` |
+
+**Two things that are not free**: custody today has **zero** `FeeRouter` and
+**zero** `ISanctionsGuard` references, and spec 061 never screens a payer.
+Depositor screening is new surface, not reuse.
+
+---
+
+## R7. Measured gas
+
+None of these figures existed in the repo before this research.
+
+| Operation | Gas |
+|---|---|
+| `Clones.clone` mint (non-deterministic — **do not use**) | 134,605 |
+| `Clones.cloneDeterministic` mint, first | 117,989 |
+| Batched mint, marginal per address (n=20) | **90,299** |
+| Batched mint, 20 addresses total | 1,805,981 |
+| `sweepERC20`, per address | **55,742** |
+| `sweepNative`, per address | **33,350** |
+| Lazy deploy at a pre-funded counterfactual address | 118,001 |
+| `checkBlocked` inside `receive()` (payer pays) | +13,232 |
+
+Against the paymaster's `PM_MAX_GAS = 3,000,000`
+(`services/relay-gateway/src/config/index.js:312`): roughly **33 mints** or
+**53 ERC-20 sweeps** per sponsored operation before overhead. The per-account
+burst limit is 6 operations/minute (`PM_ACCOUNT_QUOTA_PER_MIN`), so batching
+into a single `executeBatch` is mandatory, not an optimisation.
+
+---
+
+## R8. Chain availability
+
+`sanctionsGuard` is recorded on **3 of 9** deployments:
+
+| Chain | Guard | Oracle |
+|---|---|---|
+| Polygon 137 | `0x2Dc53d91…` | real Chainalysis `0x40C57923…` |
+| Amoy 80002 | `0xdF41355d…` | `MockSanctionsOracle` |
+| Mordor 63 | `0xdF41355d…` | `MockSanctionsOracle` |
+| Ethereum 1, Optimism 10, Base 8453, Arbitrum 42161, ETC 61 | **absent** | — |
+
+Sponsorship is Polygon-only; Protect custody spans six chains. These three sets
+do not coincide, so availability must be the honest intersection stated per
+surface (spec FR-031 … FR-034).
+
+**Availability hazard to design around**: the guard is fail-closed
+(`SanctionsGuard.sol:45`). If the oracle is unreachable, `isAllowed` returns
+false for *everyone*. For a wager entry-point that is correct. This feature
+inherits it deliberately — an unreadable guard withholds rather than clears
+(spec FR-032) — but the UI must never render that as "you are sanctioned"
+(spec FR-029 equivalent, FR-016).
+
+---
+
+## R9. Registration checklist — 2 fail loud, 3 fail silent
+
+Verified failure modes for a new contract in this repo:
+
+**Fail loud** (the run stops):
+- `scripts/deploy/verify.js` CATALOG needs **three** entries — proxy, impl, and
+  the clone template — mirroring `wagerPoolFactory` / `wagerPoolFactoryImpl` /
+  `poolImpl` at `verify.js:203-216`. A missing entry exits 1 on every chain
+  carrying the address.
+- A missing per-chain `*_CONTRACTS` block makes the sync **throw**
+  (`scripts/utils/sync-frontend-contracts.js:209-216`).
+
+**Fail silent** (no error, no coverage):
+- `scripts/deploy/check-storage-layout.js:20-31` — unregistered means the
+  append-only gate never covers it.
+- The `isV2` mapping in `sync-frontend-contracts.js:263-286` — unmapped means
+  the sync copies nothing and still reports success.
+- The `test:coverage` testfiles glob in `package.json` — a new `test/<domain>/`
+  directory not added is never measured.
+- `medusa.json` `targetContracts` — already stale (two existing harnesses on
+  disk are unlisted), and Medusa only runs in the weekly torture workflow.
+
+Also: **Slither is non-gating** (`|| true`,
+`.github/workflows/security-testing.yml:172-174`), so the security-agent review
+is the real gate. Frontend ABIs are **hand-maintained**
+(`frontend/src/abis/*.js`); the sync script only emits addresses.
+
+---
+
+## R10. Open items carried into planning
+
+- **Real Chainalysis oracle gas** on Polygon is unmeasured; the 13,232 figure
+  used `MockSanctionsOracle` (one cold SLOAD) and the production oracle is
+  itself a proxy. Treat it as a floor. `test/fork/ChainalysisSanctions.fork.test.js`
+  is the harness to pin it.
+- **Which named venues hardcode `gasLimit: 21000`** is unverified. The EVM
+  consequence is proven; the venue list is not. Check before promising "any
+  exchange can pay it" — though the chosen counterfactual design sidesteps this
+  entirely, since a codeless address accepts a 21,000-gas transfer normally.
+- **Unknown tokens**: a receive address can be paid a token absent from
+  `getPortfolioRegistry` (pure bundled config). It would be invisible on every
+  balance surface and effectively unsweepable. No `Transfer`-log scan exists to
+  cover this. The plan must decide whether to add one or disclose the gap.
+- **`getProvider(chainId)`** (`blockchainService.js:120-126`) internally calls
+  `getNetwork()`, the fallback CLAUDE.md forbids in custody code. Latent today;
+  a receive address on a chain absent from `NETWORKS` would silently read the
+  wrong chain.
+- **OZ version**: `package.json` pins **5.4.0**, not the 5.6.1 stated in
+  `CLAUDE.md`. Verify any `Clones` API against 5.4.0.
+- **`eth_getLogs` limits**: depositor attribution reads `Transfer` logs filtered
+  by recipient. Some providers cap the block range aggressively (a QuickNode
+  Polygon 5-block cap has been observed), and log scanning needs a recorded
+  deploy block per chain or it is silently dead — follow the
+  `useVaultProposals.js:53-61` precedent of refusing to scan and saying so.

--- a/specs/070-safe-receiver/review-findings.md
+++ b/specs/070-safe-receiver/review-findings.md
@@ -1,0 +1,286 @@
+# Design Review Findings — Safe Receiver (Spec 070)
+
+**Date**: 2026-07-27
+**Status**: **OPEN — the design in `plan.md` and `contracts/*.md` does not yet hold.**
+**Method**: 4 independent adversarial reviewers (security, honest-state, completeness, repo-fact-check) against `spec.md` / `plan.md` / `research.md` / `data-model.md` / `contracts/*` / `quickstart.md`, then per-finding verification against the repo. 36 findings verified, **31 upheld, 5 refuted**. 26 further verifications did not run (session limit) — their candidate findings are listed in §5 as unverified.
+
+Read this before resuming. Several findings falsify claims the design documents currently assert, so the documents are wrong as written, not merely incomplete.
+
+---
+
+## 1. Critical — the design does not currently hold
+
+### C1. The platform can freeze every member's funds
+
+The clone's `transferOut` is its only exit and calls back into the **upgradeable**
+factory (`screen(owner)`, `screen(to)`, `committedCounterparty(...)`) before any
+transfer, with no try/catch and no rescue by construction. Anything that makes
+those calls revert freezes 100% of member funds permanently.
+
+Two one-transaction triggers, both behind a single key
+(`UUPSManaged.sol:32-37` grants `DEFAULT_ADMIN_ROLE` and `UPGRADER_ROLE` to the
+same address):
+
+- `UPGRADER_ROLE` upgrades the factory to an implementation whose `screen()`
+  reverts unconditionally.
+- `DEFAULT_ADMIN_ROLE` calls `setSanctionsGuard(x)` with any codeless or
+  reverting address — the only stated validation is the zero-address case.
+  (Verified empirically: a void-returning external call like `checkBlocked`
+  emits `EXTCODESIZE` under the repo's solc 0.8.24, so a codeless guard
+  **reverts** rather than silently no-oping.)
+
+A **third** trigger needs no platform key at all: `SanctionsGuard` is fail-closed
+(`SanctionsGuard.sol:45,99`), so a Chainalysis oracle outage reverts
+`checkBlocked` for everyone. On an exit path, "fail closed" is a fund freeze,
+not a withhold — which contradicts `spec.md`'s own Assumption that the
+fail-closed behaviour is inherited safely.
+
+**The design inverts its own cited precedent.** `WagerPool.sol:225-227` screens
+only on the ENTRY path; its exits `_claimBy` (`:415-427`) and `_refundBy`
+(`:447-455`) make **no** factory call. The shipped precedent deliberately keeps
+the upgradeable factory off the withdrawal path. Spec 070 puts it on the only
+withdrawal path while citing that precedent as straightforward reuse.
+
+Falsifies: FR-008 ("no platform key may … freeze"), and the "cannot move,
+freeze, or redirect a single wei" sentence in `plan.md:28`, `plan.md:190`,
+`data-model.md:72`, `ISafeReceiverFactory.md:10`.
+
+**Unfixable after deployment**: the clone is immutable, so remediation needs a
+new factory + template, which moves every derived address and orphans any
+address already printed on an invoice (breaking FR-030, SC-013).
+
+**Direction**: make `SafeReceiverFactory` **non-upgradeable**, exactly as
+`SafePolicyGuardV2.sol:36` does for the identical reason (which `research.md`
+§R6 already cites approvingly). Pinning the guard into clone immutable state is
+necessary but **not sufficient** — it leaves the fail-closed oracle trigger open.
+The exit path needs a liveness answer for a dead oracle.
+
+### C2. `receiveAddressImpl` is not immutable
+
+It is ordinary UUPS proxy storage. "Set by `initialize` … no setter" is a
+property of *one implementation*, not of the proxy — any upgrade can rewrite the
+slot, change the ERC-1167 init-code hash, and move every derived address.
+`ISafeReceiverFactory.md` invariant #1, FR-030 and SC-013 are asserted with
+nothing enforcing them.
+
+Widened by the verifier: pinning the template alone still leaves a hostile-owner
+deploy path, because the upgradeable factory is the CREATE2 deployer and chooses
+the `owner` passed to `initialize`. Derivation **and** deployment authority must
+leave upgradeable code together.
+
+Compounding: `frontend/src/config/contracts.js` carries no `*Impl` slot, so the
+client cannot obtain the template address through the normal sync pipeline —
+which client-side derivation requires (see also M-fact-1 in §3).
+
+### C3. A deployed address stops accepting the payments the feature exists to accept
+
+`ISafeReceiveAddress.md` invariant #5 — "`receive()` accepts a plain 21,000-gas
+transfer **once deployed**" — is **false, and is falsified by this feature's own
+`research.md` §R1.1**. A deployed ERC-1167 stub pays ~2,600 gas for a cold
+`DELEGATECALL` before the empty `receive()` body runs. After the design's own
+lazy-deploy step a published address permanently stops accepting bare
+`gasLimit: 21000` transfers, and `.transfer()`/`.send()` from contract payers
+fail — the latter *silently*, which `research.md` §R1.2 itself calls "the worst
+failure mode in the entire design space".
+
+**Requires a product decision** (raised with the owner, not yet answered):
+rotate-on-sweep so every advertised address is always codeless (matching spec
+061's never-reuse rule), keep persistent per-payer addresses and disclose the
+degradation, or rotate the address behind a stable label.
+
+### C4. Recovery cannot bound its walk, and can reissue a published address
+
+No artifact defines how a fresh device learns **how many** indices were issued.
+The cursor is `max(local records) + 1`, which is 0 on a device with no records
+and no backup, so recovery cannot bound a derive-and-probe walk.
+
+An index that was issued and published but never paid and never deployed has
+**no on-chain trace at all** and is unrecoverable by any mechanism the design
+describes — so a no-backup recovery rebuilds a cursor below it and reissues that
+address to a different counterparty.
+
+Falsifies: FR-003/SC-004 (never reissue) and FR-027/SC-012 (100% recovery with
+no local data). `data-model.md` §3.2 and `research.md` §R5 currently claim the
+Bitcoin reissue hazard "does not apply" / "disappears" — **delete those claims**.
+Deterministic derivation removes Bitcoin's *discovery* weakness; it does not
+remove *cursor* loss.
+
+Note: an on-chain `issuedCount` bumped at issuance would conflict with FR-001
+("at no cost and with no transaction").
+
+---
+
+## 2. Major — 18 upheld
+
+### Contract semantics
+
+- **M1. Permissionless `deploy(owner, index)` is a griefing weapon.** Addresses
+  are publicly enumerable by design, so anyone can irreversibly place code at a
+  chosen member's entire future index range and destroy bare-transfer payability
+  (C3 weaponised). → gate on `msg.sender`; add an EIP-712 `deployWithSig` twin
+  via `SignerIntentBase.sol` for the sponsored path.
+- **M2. `amount == 0 ⇒ entire balance` moves withheld value by construction**,
+  resolving the balance at mining time — including value that arrived after
+  clearance was computed. Contradicts FR-023, SC-006 and the balance-changed
+  edge case. → the app must never pass 0; consider `ZeroAmount()` (consistent
+  with `StakingRouter.sol:228`).
+- **M3. `commitCounterparty` is an irreversible fund trap.** Write-once with no
+  clear, screened on every `transferOut`: a counterparty that later becomes
+  deny-listed permanently freezes that address in an immutable contract with no
+  rescue. It also buys little — the counterparty is member-asserted and never
+  verified against who actually paid, so it constrains only honest members.
+  → timelocked clear (request → 7 days → clear), both evented.
+- **M4. `SanctionedAddress` cannot distinguish "sanctioned" from "oracle
+  unreachable"** — the guard is fail-closed, so both produce the identical
+  revert. `spec.md`'s edge case, FR-032, `research.md` §R8 and
+  `clearance-model.md`'s wording rules have **no mechanism behind them**.
+  → client-side three-way disambiguation using `isDenied()` + `sanctionsOracle()`
+  + an oracle probe. Probe the oracle's *answer*, not just its presence, or a
+  genuine Chainalysis hit is under-accused as "unavailable".
+
+### Clearance and availability
+
+- **M5. The decomposition invariant fires after any partial spend.** Steps 6–8
+  compare full inbound history against current balance with no accounting for
+  outflow, so `Σ deposits > balanceOf` and step 8 permanently withholds the
+  entire remainder under a fabricated `read-failed`. This breaks US4, the
+  feature's own partial-spend story. → net outflow into `accounted`, or
+  attribute against `total` explicitly.
+- **M6. `ReceiverAvailability` ignores `screeningRequired`.** The reachable
+  state (guard deployed, readable, real oracle, `screeningRequired == false`)
+  renders as `available-enforcing` — "screened on-chain at settlement" — while
+  `screen()` is a documented no-op. Fix the **contract semantics first**;
+  patching only the client ratifies a `screen()` behaviour that contradicts both
+  FR-017 and the `WagerPoolFactory.sol:285-291` precedent it cites.
+- **M7. `available-mock-oracle` has no detection design.** Nothing says how the
+  client tells a real Chainalysis oracle from `MockSanctionsOracle`, so
+  `availability.js` cannot produce the state FR-033 exists for. (Accessor is
+  `sanctionsOracle()`, not `oracle()`.)
+
+### Native coin — two upheld findings, same root
+
+- **M8/M9. Native has no exit path.** `clearance-model.md` step 4 withholds 100%
+  of native permanently as `unattributable`; FR-023/SC-006 forbid sweeping
+  withheld value; the withheld-only-address edge case forbids even offering a
+  sweep. Yet `spec.md` invites native (US1 AS-2), states an edge case
+  ("retained in full and is sweepable") that is false for it, and `quickstart.md`
+  §2 ships a native sweep as the canonical happy path. **Requires a product
+  decision** (raised, unanswered): member attestation, acknowledge-and-sweep, or
+  tokens-only. Whichever is chosen, the consequence must be disclosed *before*
+  the member publishes an address.
+
+### Batching, gas and recovery
+
+- **M10/M11. Per-item failure isolation is unachievable on the passkey rail.**
+  `CoinbaseSmartWallet.executeBatch` bubbles any inner revert, so one item's
+  `NothingToTransfer()` / `SanctionedAddress` / `NativeTransferFailed()` reverts
+  the whole batch — contradicting FR-022/SC-011 and `plan.md`'s own "Batch
+  semantics" paragraph. → make `transferOut` return `bool moved` instead of
+  reverting on zero, and manufacture isolation client-side by pre-flight
+  filtering before submission. State the atomicity honestly.
+- **M12. "Gas is paid once" is false for classic wallets.** The first sweep of
+  each address is two signed transactions (`deploy` then `transferOut`), so
+  collecting from N payers costs up to 2N. FR-021 and US3's narrative overstate
+  it; SC-010 is already worded correctly. Also: `research.md` §R7's "53 ERC-20
+  sweeps per sponsored op" omits the lazy deploy and is ~3× optimistic.
+- **M13. FR-027 is internally contradictory.** The non-batching fallback bounds
+  reads by local state that does not exist on a fresh device, so recovery must
+  either scan (forbidden by FR-027) or be silently partial (forbidden by
+  SC-012). → split into FR-027a (derivation is scan-free — holds) and FR-027b
+  (discovery, narrowed and honest).
+- **M14. Backend-free recovery breaks across the design's own upgrade path.**
+  `plan.md` mandates that a new template ships as a new factory, but nothing
+  records the historical generation set, and `getContractAddressForChain`
+  returns exactly one address per key per chain. Addresses from generation 1
+  become underivable after generation 2 ships. → carry an ordered per-chain
+  generation list, or use coexisting versioned keys (the spec-068 precedent).
+- **M15. Retirement has a field and a lifecycle arrow but no flow** — no FR, no
+  UI, no semantics, and no mechanism that can uphold "never reissued after
+  retirement" across a fresh-device recovery.
+
+---
+
+## 3. Minor — 9 upheld
+
+- **Fee-on-transfer invariant is unsatisfiable.** `ISafeReceiveAddress.md`
+  invariant #7 promises exact-or-revert, but `SafeERC20.safeTransfer` validates
+  only the return value. It also cites a `spec.md` edge case that does not
+  exist, and `TransferredOut` reports the requested amount, not the delivered
+  one. → report delivered rather than revert; reverting would permanently strand
+  such tokens in a no-rescue clone.
+- **`clearance-model.md` step 7's `'unavailable'` branch is unreachable** —
+  `useAddressScreening` emits only `clear | restricted | uncertain`, so
+  `screening-unavailable` is never produced and the document's own test cases 4
+  and 10 cannot pass. Fail-safe, but the doc is wrong.
+- **The "never word uncertainty as guilt" rule is anchored to nothing.** Six
+  documents assert it citing FR-028/FR-029, which are about backup labels and
+  address-ownership lookup. → add a real FR.
+- **Hiding the section entirely on undeployed networks** is the "silently inert
+  surface" FR-034 forbids, and a member with funded addresses elsewhere gets no
+  signal. → follow the CustodyPanel pattern the plan already cites, not
+  Collect/Predict.
+- **`screening-not-configured`'s "recoverable by switching networks"** names an
+  action that cannot recover the value.
+- **No disclosure of confirmation count** before the first signature on the
+  classic rail, while the sponsored rail has exactly that duty (FR-037).
+- **Portfolio aggregation** is neither designed nor declared out of scope.
+- **The new "Receive" nav label already means Bitcoin rotating addresses
+  in-product** (`NetworkPanel.jsx:19`). Two of the reviewer's sub-claims were
+  wrong (Request is not under Transfer and is not a nav item), but the label
+  collision is real.
+- **`deployBlocks` names the wrong store** in the registration checklist.
+
+---
+
+## 4. Refuted (5)
+
+Recorded so they are not re-raised: five candidate findings did not survive
+verification, including the US7 batch-split sizing sub-claim and parts of the
+nav-collision framing.
+
+---
+
+## 5. Unverified candidates (26)
+
+The verification pass hit the session limit before reaching these. They come
+from the same reviewers and are plausible but **unconfirmed** — verify before
+acting. Themes: `__gap` sizing vs `UUPSManaged`'s own 50-slot reservation;
+Multicall3 config absence; the `evmVersion: paris` citation in `research.md`
+§R1.1; the `screeningRequired == false` row's divergence from
+`WagerPoolFactory` semantics; missing address-book / activity-ledger /
+notification integration; no admin surface or role-handoff plan for the
+factory's setters; no oracle-outage runbook; FR-018 vs FR-019 reconciliation;
+three FR citations in the contract docs pointing at the wrong requirements;
+forced-screening call volume; and several `quickstart.md` coverage gaps.
+
+Full detail: workflow run `wf_6ce24ec2-e82`.
+
+---
+
+## 6. What survives
+
+The **product framing is not in question**. Nothing here challenges:
+
+- the measurements in `research.md` §R1 (deposit screening is undeliverable),
+- segregation-with-spend-time-control as the honest reframe,
+- one-address-per-payer as the mechanism that makes token attribution tractable,
+- dropping change addresses,
+- accepting and disclosing public linkability.
+
+What failed review is the **contract architecture and several algorithm
+details** — principally putting an upgradeable factory on the only exit path,
+treating proxy storage as immutable, and asserting a payability property the
+feature's own research refutes.
+
+## 7. Resuming
+
+1. Answer the two open product questions (C3 address reuse, M8/M9 native coin).
+2. Rework the contract architecture around a non-upgradeable derivation +
+   deployment authority (C1, C2, M1) and give the exit path a dead-oracle
+   liveness answer.
+3. Fix the algorithm defects (M2, M4, M5, M6) and the recovery model (C4, M13,
+   M14, M15).
+4. Correct every falsified claim in `plan.md`, `data-model.md`,
+   `contracts/*.md`, `research.md` §R5 and `quickstart.md` — several documents
+   currently assert things that are not true.
+5. Re-run `/speckit-analyze` once the artifacts agree again.

--- a/specs/070-safe-receiver/spec.md
+++ b/specs/070-safe-receiver/spec.md
@@ -1,0 +1,667 @@
+# Feature Specification: Safe Receiver — counterparty-segregated receive addresses
+
+**Feature Branch**: `070-safe-receiver`
+
+**Created**: 2026-07-27
+
+**Status**: Draft — **paused with open design issues**. The product framing below
+stands; the implementation design in `plan.md` and `contracts/*.md` does **not**
+yet hold. See [review-findings.md](./review-findings.md): 31 verified findings,
+4 critical, plus two open product questions (address reuse after deployment, and
+native-coin handling). Do not implement from these artifacts as they stand.
+
+**Input**: GitHub issue #929 — "Safe Request" — sanctions-screened payments (on-chain enforced settlement) — reframed after measurement (see `research.md`). Owner direction: *"The safe receive addresses should be unique to the member and not require special URI parameters. Similar to how we are deploying multisigs in the Protect section, we should allow a user to setup a safe receiver which is a contract they deploy and own which is a contract factory for receive addresses which allow deposit from any non-sanctioned address. The user can later deploy the contract sweeping the funds into their account or send from one of the addresses with the change moving to a new address similar to a utxo model."*
+
+## Overview
+
+FairWins members receive money at a single address. Every payer they have ever
+given it to pays the same place, so every payment commingles the moment it
+lands. If one of those payers turns out to be sanctioned, there is no way to
+separate their money from anyone else's — the balance is a single fungible
+number with no memory of where it came from. Today the only defence is a
+client-side check that gates a button, which does nothing about money already
+received.
+
+**Safe Receiver** gives each member an unlimited supply of their own receive
+addresses and one rule for using them: **one address per payer.** Because
+nothing else ever pays that address, its whole balance is attributable to one
+counterparty — which turns an unpartitionable commingled balance into a
+**per-address quarantine unit**. Money is then held, not blocked: it sits
+segregated in its own address until the member has positively established who
+paid and that they are clear. Only then can it be swept into the member's
+account. Anything unverified stays exactly where it is.
+
+This is Bitcoin's model, and FairWins already implements its core rule for
+Bitcoin: `spendable` is a **positive assertion**, and anything unverified,
+pending, or protected is withheld rather than spent. Safe Receiver applies
+that same fail-safe discipline to EVM networks.
+
+### What this feature does and does not promise
+
+Issue #929 asked for receive addresses that *"allow deposit from any
+non-sanctioned address."* Measurement established that this is not deliverable,
+and the spec is written to the truth rather than the ask (full evidence in
+`research.md`):
+
+- **A stablecoin transfer runs no code on the recipient.** A sanctioned
+  holder's USDC lands unconditionally, and nothing at the receiving address can
+  observe, refuse, or even later identify it. This is true of every stablecoin
+  FairWins configures.
+- **Putting code at a receive address makes it less payable, not more.** A
+  payment sent with a bare-transfer gas limit fails against *any* contract,
+  including one that does nothing. Some payers would be unable to pay at all,
+  and one common payer shape loses the money silently — the payer's
+  transaction succeeds and nothing arrives.
+
+So Safe Receiver **does not block deposits, and never claims to.** It says
+plainly: anyone can pay these addresses. The control it does deliver is real,
+enforceable, and placed where a contract can actually act — at the moment the
+member moves the money:
+
+- **Segregation** — one payer per address, so a bad payment is isolated rather
+  than mixed.
+- **Positive clearance before spending** — funds are spendable only when the
+  member has established who paid and screening cleared them. Uncertainty
+  withholds; it never permits.
+- **On-chain screening of the parties a contract can actually name** — the
+  member sweeping, the destination receiving, and (where the member committed
+  one) the counterparty the address was issued to. These are checked in the
+  same transaction that moves the money, and a failure reverts it.
+
+The member's own addresses are **deployed and owned by the member**; FairWins
+holds no key over them, cannot move the funds, and cannot rescue them. The
+member's sweep is the only exit, which is the same safety property the
+platform's routers get from having no rescue function at all.
+
+## Clarifications
+
+### Session 2026-07-27
+
+- Q: Deposit-time screening is impossible for stablecoins and holed for native coin. Keep the compliance claim or reframe? → A: **Reframe as segregation with spend-time control.** No deposit-screening claim is made anywhere; the on-chain guard screens named actors at sweep/spend, and clearance is a positive assertion.
+- Q: What happens to the drafted "Safe Request" screened-pull spec answering the same issue? → A: **Rewrite 070 as Safe Receiver.** The screened-pull design is recorded in `research.md` as a rejected alternative with its measurements, since it is the only design that genuinely screens both parties for a stablecoin — but it cannot be paid by a plain address.
+- Q: Keep the UTXO change-address mechanic? → A: **No.** Rotation and one-address-per-payer are kept; change addresses are dropped. On EVM a transfer takes an exact amount, so leaving the remainder in place is equally segregated and materially cheaper, and change addresses would imply an unlinkability this architecture does not have.
+- Q: Receive addresses are publicly derivable from the owner's address, so anyone can enumerate every address a member owns. Acceptable? → A: **Yes, and disclosed plainly.** Deterministic derivation is what lets a member recover every address on a fresh device with no backend, no indexer, and no scanning. The linkability cost is stated in the UI; no privacy is implied.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Give each payer their own address (Priority: P1)
+
+A member who takes money from more than one source — a treasurer collecting
+from members, a contractor with several clients, anyone who wants to know which
+payment came from whom — opens Safe Receiver and creates a receive address for
+a specific payer, labelling it with that payer's name. They get an ordinary
+address they can show as a QR code, copy, paste into an invoice, or hand to an
+exchange withdrawal form. It costs nothing to create and works immediately.
+When they need one for a different payer, they create another. Each address
+shows only what that one payer sent.
+
+**Why this priority**: Segregation is the foundation everything else rests on.
+One address per payer is what makes a balance attributable at all — without it
+there is no quarantine unit and no clearance decision to make. It delivers
+value on its own: a member who does nothing else gets per-counterparty
+bookkeeping they cannot get today.
+
+**Independent Test**: Create three labelled receive addresses, pay each from a
+different account, and verify the member sees three separate balances correctly
+attributed to the three labels, with no commingling, and that each address was
+payable as a plain address by an ordinary wallet with no special formatting.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected member on a supported network, **When** they create a
+   receive address and label it with a counterparty, **Then** an address is
+   produced immediately, at no cost, and is displayed as a plain copyable
+   address and QR code with no special parameters or prefix.
+2. **Given** a receive address, **When** an ordinary external wallet sends the
+   network's native coin or a supported token to it, **Then** the funds arrive
+   and appear against that address, attributed to its label.
+3. **Given** several receive addresses, **When** the member views Safe
+   Receiver, **Then** each address shows its own balance and label, and no
+   payment appears under an address that did not receive it.
+4. **Given** a member who wants a new address, **When** they create one,
+   **Then** it is a different address from every address they have previously
+   been issued, and no previously issued address is ever reissued.
+5. **Given** a member with existing addresses, **When** they view the feature
+   for the first time, **Then** it is stated plainly that anyone can pay these
+   addresses and that deposits are not blocked.
+6. **Given** any receive address, **When** the member views its details,
+   **Then** it is disclosed that the member's addresses are publicly linkable
+   to one another and to their account.
+
+---
+
+### User Story 2 - Nothing leaves an address until you know who paid you (Priority: P1)
+
+Before the member can move money out of a receive address, the app establishes
+who actually paid it and screens them. For token payments this is exact: the
+chain records each transfer's sender, so every depositor is identified and
+screened individually. For native-coin payments no such record exists, and the
+app says so rather than pretending. The balance is offered as spendable **only**
+when every contributing payer has been positively established and cleared.
+Anything else — a payer that failed screening, a payer whose status could not
+be determined, a deposit whose sender could not be established — leaves that
+value withheld, visibly, with the reason given. Withheld value is never swept
+by accident, and the member is never shown a "spendable" figure that includes
+money they have not cleared.
+
+**Why this priority**: This is the actual control the feature delivers. Without
+it, segregation is just tidy bookkeeping. The fail-safe direction — uncertainty
+withholds, never permits — is what makes the feature trustworthy, and it is the
+rule the platform already applies to Bitcoin.
+
+**Independent Test**: Pay one receive address from a clean account and another
+from a deny-listed account. Verify the first shows as spendable and sweeps; the
+second shows as withheld with the reason, cannot be swept, and does not appear
+in any spendable total. Then make the screening source unavailable and verify
+previously-cleared value becomes withheld rather than staying spendable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a receive address paid only by cleared token depositors, **When**
+   the member views it, **Then** the full balance is shown as spendable.
+2. **Given** a receive address paid by a depositor who fails screening,
+   **When** the member views it, **Then** that value is shown as withheld,
+   the reason is stated, and it is excluded from every spendable total.
+3. **Given** a receive address whose depositors' screening status cannot be
+   determined, **When** the member views it, **Then** the value is withheld —
+   an indeterminate result is never treated as cleared.
+4. **Given** a receive address holding native coin, **When** the member views
+   it, **Then** the app states that the sender of a native payment cannot be
+   established from the chain, and treats the value according to the same
+   fail-safe rule rather than silently clearing it.
+5. **Given** any address balance, **When** it is displayed, **Then** the total
+   is decomposed into its spendable and withheld parts with a reason for each
+   withheld part, so a total that exceeds the spendable amount is never
+   mysterious.
+6. **Given** withheld value, **When** the member attempts any sweep or spend,
+   **Then** the withheld portion is not moved, and the action does not silently
+   move less than the member expected without saying so.
+7. **Given** a failure to read balances or screening data, **When** it occurs,
+   **Then** it is reported as a failure — never rendered as a zero balance or
+   as a clear result.
+
+---
+
+### User Story 3 - Sweep cleared funds into your account (Priority: P1)
+
+When a receive address holds cleared funds, the member sweeps them into their
+main account in one action. They pay gas once, from their own account — they do
+not have to fund each receive address with gas first. The transaction checks the
+parties it can name — the member sweeping, the destination, and the counterparty
+the address was committed to — against the on-chain sanctions guard, and reverts
+in full if any of them fails. Sweeping several addresses reports a result per
+address: one failure never aborts the rest.
+
+**Why this priority**: Without a sweep the money is segregated but unusable.
+This is the point at which the on-chain control actually fires, and it is the
+reason the addresses are contracts rather than ordinary keys — a plain address
+would have to be individually funded with gas before anything could leave it.
+
+**Independent Test**: Sweep a cleared address and verify the funds arrive in the
+member's account, that the member paid gas only once from their own account,
+and that no gas had to be sent to the receive address first. Then deny-list the
+member and verify the sweep reverts with nothing moved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a receive address holding cleared funds, **When** the member
+   sweeps it, **Then** the funds arrive at the member's chosen destination and
+   the receive address is left holding nothing but withheld value.
+2. **Given** a sweep, **When** it is performed, **Then** the member funds gas
+   from their own account only, and no separate funding of the receive address
+   is required.
+3. **Given** a sweep where the **member** fails screening, **When** it is
+   attempted, **Then** the whole transaction reverts, nothing moves, and the
+   member is told screening refused it.
+4. **Given** a sweep whose **destination** fails screening, **When** it is
+   attempted, **Then** it reverts the same way with the destination named as
+   the cause.
+5. **Given** a receive address the member committed to a named counterparty on
+   creation, **When** that counterparty fails screening at sweep time, **Then**
+   the sweep reverts — the commitment is enforced by the chain, not just
+   recorded by the app.
+6. **Given** a member sweeping several addresses at once, **When** one fails,
+   **Then** the others still complete and each address reports its own outcome
+   with a reason for any failure.
+7. **Given** a sweep of an address holding several assets, **When** it runs,
+   **Then** each asset reports its own outcome and one asset's failure does not
+   abort the others.
+8. **Given** any sweep, **When** it completes, **Then** the receive address
+   retains no residual balance of the swept asset beyond value deliberately
+   withheld.
+
+---
+
+### User Story 4 - Spend directly from a receive address (Priority: P2)
+
+Rather than sweeping into their account and paying onward, the member pays a
+third party straight out of a receive address. The remainder stays where it is —
+still segregated, still attributed to the same payer, with no extra cost. The
+same clearance rule applies: only cleared value can be spent, and the
+destination is screened in the same transaction.
+
+**Why this priority**: It saves a hop and a fee for members who are passing
+money through, but sweeping already makes the funds fully usable, so this is an
+efficiency rather than a capability.
+
+**Independent Test**: Spend part of a cleared receive address balance to an
+external address, and verify the payee receives the exact amount, the remainder
+stays in the same receive address still attributed to the original payer, and
+the destination was screened.
+
+**Acceptance Scenarios**:
+
+1. **Given** a receive address with cleared funds, **When** the member spends
+   part of it to an external address, **Then** the payee receives exactly the
+   amount specified.
+2. **Given** that spend, **When** it completes, **Then** the remainder stays in
+   the same receive address, still labelled with the same counterparty, and no
+   new address is created.
+3. **Given** a spend whose destination fails screening, **When** it is
+   attempted, **Then** it reverts with nothing moved and the destination named.
+4. **Given** an attempt to spend more than the cleared amount, **When** it is
+   made, **Then** it is refused before any signature, stating how much is
+   actually spendable.
+
+---
+
+### User Story 5 - Recover every address on a new device (Priority: P2)
+
+A member who reinstalls, switches device, or loses their local data opens Safe
+Receiver and finds every receive address they were ever issued, with its
+balance. This works with no backup, no server, and no scanning — the addresses
+follow from the member's own account. Their labels come back from the member's
+encrypted backup where one exists; without it the addresses and balances are
+still all there, unlabelled.
+
+**Why this priority**: Money sitting at an address the member cannot rediscover
+is money lost. Recovery must not depend on anything optional. It ranks below
+the core flows only because it matters on a bad day rather than every day.
+
+**Independent Test**: Create several funded receive addresses, clear all local
+application data, reconnect the same account on a fresh profile, and verify
+every address and balance reappears without restoring a backup — then restore
+the backup and verify labels return.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member with issued receive addresses, **When** they connect the
+   same account on a device with no local data and no backup, **Then** all
+   their receive addresses and balances are recovered.
+2. **Given** that recovery, **When** it runs, **Then** it requires no platform
+   service, no indexer, and no address scanning.
+3. **Given** a restored encrypted backup, **When** it is applied, **Then**
+   counterparty labels reappear against the correct addresses.
+4. **Given** no backup, **When** the member recovers, **Then** addresses are
+   listed without labels and the member is told the labels are missing rather
+   than shown blank entries that look like new addresses.
+5. **Given** a member who knows only a receive address, **When** they enter it,
+   **Then** the app can confirm whether it belongs to them and act on it.
+
+---
+
+### User Story 6 - Honest availability across networks (Priority: P2)
+
+Safe Receiver states what it can do on the network the member is actually on.
+Where the sanctions guard is deployed, the sweep-time screening is real and is
+described as enforced. Where it is not, segregation and clearance still work but
+no on-chain screening is claimed. A guard whose data source is unreachable reads
+differently from a guard that is not there. No surface asserts a control the
+chain will not deliver.
+
+**Why this priority**: The constitution forbids UX implying a guarantee the
+chain has not reached, and the guard exists on a minority of supported networks.
+This is a release gate rather than a nice-to-have, but it is testable
+independently of the mechanics.
+
+**Independent Test**: Walk Safe Receiver on a network with an enforcing guard, a
+network with no guard, and a network whose guard cannot be read, and verify each
+produces distinct, accurate wording — and that no state claims enforcement it
+cannot deliver.
+
+**Acceptance Scenarios**:
+
+1. **Given** a network where the guard is deployed and readable, **When** the
+   member uses Safe Receiver, **Then** sweep-time screening is described as
+   enforced on-chain.
+2. **Given** a network with no guard, **When** the member uses Safe Receiver,
+   **Then** segregation and clearance are still offered, and it is stated that
+   on-chain screening is not available on this network — naming where it is.
+3. **Given** a guard that is deployed but unreadable, **When** the member acts,
+   **Then** the condition is reported as temporarily unavailable, distinct from
+   not-supported, and clearance fails safe rather than clearing.
+4. **Given** a network where the guard's data source is not configured, **When**
+   the member uses Safe Receiver, **Then** the weaker guarantee is described in
+   different terms from a fully-configured guard.
+5. **Given** an unsupported network, **When** the member opens Safe Receiver,
+   **Then** they get a stated reason, not a broken or empty screen.
+
+---
+
+### User Story 7 - Sweep without holding gas (Priority: P3)
+
+A member whose FairWins account is a passkey account sweeps one or several
+receive addresses with a single confirmation, and — where the platform sponsors
+it — without holding the network's gas token at all. If sponsorship is
+unavailable they can still sweep by paying their own gas; the option is never
+the only way through.
+
+**Why this priority**: It removes the last friction from collecting money, but
+every member can already sweep by paying gas, so it is additive.
+
+**Independent Test**: With a passkey account on a network where sponsorship is
+available, sweep several addresses in one confirmation and verify the member
+spent no gas token. Then disable sponsorship and verify the same sweep still
+completes with the member paying.
+
+**Acceptance Scenarios**:
+
+1. **Given** a passkey member and several cleared addresses, **When** they
+   sweep, **Then** one confirmation covers all of them.
+2. **Given** sponsorship is available, **When** the sweep runs, **Then** the
+   member spends no gas token and the confirm step says the fee is sponsored.
+3. **Given** sponsorship is unavailable, **When** the member sweeps, **Then**
+   the sweep still completes with the member paying, and the confirm step says
+   so before they sign.
+4. **Given** a batch too large to sponsor in one operation, **When** the member
+   sweeps, **Then** they are told the limit and the work is split rather than
+   failing opaquely.
+
+---
+
+### Edge Cases
+
+- **A payer pays a receive address that was never intended for them** →
+  attribution is by actual depositor where the chain records it, so the extra
+  payer is identified and screened like any other; the member is shown that
+  more than one party paid an address they meant for one.
+- **Two payers pay the same address** → both are screened; if either fails, the
+  address's value is withheld, because the balance cannot be partitioned
+  between them.
+- **A token arrives that the app does not recognise** → the member is told
+  something arrived that the app cannot value or sweep, rather than the deposit
+  being invisible.
+- **Value arrives before the address has ever been used** → it is retained in
+  full and is sweepable; nothing is lost by the address not yet having been
+  activated on-chain.
+- **Value is force-sent in a way that leaves no record** → it appears in the
+  balance with no establishable sender and is therefore withheld under the
+  fail-safe rule, not silently cleared.
+- **The member sweeps an address whose balance changes between viewing and
+  signing** → the member never sweeps more than they cleared, and a newly
+  arrived unverified deposit is not swept along with cleared value.
+- **A sweep is attempted twice** → the second finds nothing to move and reports
+  that plainly; the member is not charged twice or shown a false success.
+- **Screening data is unavailable at sweep time** → the transaction fails
+  closed and the member is told the check could not be completed, not that they
+  or their counterparty are sanctioned.
+- **The member's own account fails screening** → they cannot sweep. This is
+  stated clearly, and it does not imply their payers are at fault.
+- **A receive address holds only withheld value** → it is shown with its reason
+  and no sweep is offered, rather than offering an action that would do nothing.
+- **The member requests very many addresses** → creation stays free and instant,
+  and the balance display remains usable and honest about how much it is
+  checking.
+- **The member is on a network where Safe Receiver has never been deployed** →
+  addresses that exist on other networks are not shown as if they exist here.
+- **The same address on two networks** → balances are per network and never
+  aggregated across networks in a way that implies they can be swept together.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Addresses and segregation**
+
+- **FR-001**: Members MUST be able to create receive addresses that belong to
+  them alone, at no cost and with no transaction, and use them immediately.
+- **FR-002**: A receive address MUST be payable as a plain address by any
+  external wallet, exchange, or service, with no FairWins-specific URI, prefix,
+  parameter, or payload.
+- **FR-003**: Every receive address MUST be distinct, and an address that has
+  been issued MUST NEVER be reissued to a different counterparty or reused
+  after being retired.
+- **FR-004**: A member MUST be able to label each receive address with the
+  counterparty it is intended for, and MUST be able to commit that counterparty
+  in a form the sweep can enforce (FR-018).
+- **FR-005**: Balances MUST be presented per receive address; the feature MUST
+  NOT present a single commingled total as if it were attributable.
+- **FR-006**: The member MUST be told plainly, on the feature's own surface,
+  that deposits are **not** blocked and that anyone can pay these addresses.
+  No surface may state or imply that deposits are screened.
+- **FR-007**: The member MUST be told that their receive addresses are publicly
+  linkable to each other and to their account, so no privacy is implied.
+
+**Ownership and custody**
+
+- **FR-008**: Receive addresses MUST be owned and controlled by the member. No
+  platform key may move, freeze, redirect, or rescue their funds.
+- **FR-009**: The member's own sweep or spend MUST be the only path by which
+  value leaves a receive address. There MUST be no platform-callable rescue
+  path; its absence is a safety property, not an omission.
+- **FR-010**: No platform upgrade authority may exist over a deployed receive
+  address. Improvements ship as new addresses, never by mutating an address
+  already holding a member's money.
+- **FR-011**: A member MUST be able to reach and sweep their funds without the
+  platform's optional infrastructure — no relayer, no sponsorship service, and
+  no platform-operated data store may be required.
+
+**Clearance — the fail-safe rule**
+
+- **FR-012**: Value MUST be spendable only when it is a **positive assertion**
+  that every establishable depositor to that address has been screened and
+  cleared. Absence of evidence MUST withhold, never permit.
+- **FR-013**: Any depositor that fails screening, any depositor whose status is
+  indeterminate, and any deposit whose sender cannot be established MUST cause
+  the affected value to be withheld.
+- **FR-014**: Where the chain records a deposit's sender, that sender MUST be
+  the party screened for that deposit. Where it does not, the app MUST state
+  that the sender cannot be established rather than substituting a guess.
+- **FR-015**: A balance display MUST decompose into spendable and withheld
+  parts with a stated reason for each withheld part, so that a total exceeding
+  the spendable amount is always explained.
+- **FR-016**: A failure to read balances or screening data MUST be reported as
+  a failure. It MUST NEVER render as a zero balance, an empty address, or a
+  cleared result.
+
+**Sweep and spend — the on-chain control**
+
+- **FR-017**: A sweep or spend MUST screen the parties the transaction can
+  name — the member performing it and the destination receiving the funds —
+  against the on-chain sanctions guard, in the same transaction that moves the
+  funds, reverting in full on failure.
+- **FR-018**: Where the member committed a counterparty to a receive address,
+  the sweep MUST screen that counterparty on-chain too, so the commitment is
+  enforced by the chain rather than only recorded by the app.
+- **FR-019**: The screened party MUST always be an actor the transaction can
+  attribute — the caller or an authenticated signer — never an inferred or
+  upstream party.
+- **FR-020**: Where the sanctions guard is required but not configured, the
+  path MUST refuse to act rather than proceeding unscreened.
+- **FR-021**: A member MUST be able to sweep without first funding the receive
+  address with gas; gas is paid once, by the member, from their own account.
+- **FR-022**: Sweeping multiple addresses or multiple assets MUST report a
+  per-address and per-asset outcome. One failure MUST NOT abort the others.
+- **FR-023**: A sweep MUST NOT move withheld value, and MUST state when it is
+  moving less than the address holds.
+- **FR-024**: After a spend, the remainder MUST stay in the same receive
+  address, retaining its counterparty attribution. No change address is
+  created.
+- **FR-025**: A repeated sweep MUST NOT double-charge the member or report a
+  false success when there is nothing to move.
+- **FR-026**: A sweep MUST leave no residual balance of the swept asset in the
+  receive address beyond value deliberately withheld.
+
+**Recovery**
+
+- **FR-027**: A member MUST be able to recover every receive address they were
+  ever issued, and its balance, from their account alone — with no local data,
+  no backup, no platform service, no indexer, and no address scanning.
+- **FR-028**: Counterparty labels MUST ride the member's existing encrypted
+  backup. Their absence MUST degrade to unlabelled addresses with an
+  explanation, never to missing addresses.
+- **FR-029**: A member MUST be able to identify whether a given address belongs
+  to them and act on it directly.
+- **FR-030**: The address a member has already published MUST NOT change
+  meaning or move as a result of any later platform change.
+
+**Availability and disclosure**
+
+- **FR-031**: On networks where the sanctions guard is deployed and readable,
+  sweep-time screening MUST be described as enforced on-chain. Where it is not
+  deployed, segregation and clearance MUST still function and the absence of
+  on-chain screening MUST be stated, naming where it is available.
+- **FR-032**: A guard that is deployed but unreadable MUST be reported as
+  temporarily unavailable, distinct from not-supported, and MUST cause
+  clearance to fail safe.
+- **FR-033**: A guard with no sanctions data source configured MUST NOT be
+  described in the same terms as a fully-configured one.
+- **FR-034**: An unsupported network MUST produce a stated reason, never a
+  broken, empty, or silently inert surface.
+- **FR-035**: Balances and addresses MUST be scoped to their network and MUST
+  NOT be aggregated across networks in a way that implies a single sweep.
+- **FR-036**: Where a fee is charged it MUST come from the platform's single
+  fee source of truth, be disclosed before signature, and honour the member's
+  agreed maximum. At launch the rate is zero (see Assumptions).
+- **FR-037**: Where gas sponsorship is used, the confirm step MUST say whether
+  the fee is sponsored or member-paid, and MUST NOT claim sponsorship unless
+  the submission actually returned sponsored.
+- **FR-038**: New surfaces MUST meet the project's accessibility bar.
+
+### Key Entities
+
+- **Safe Receiver**: A member's receiving capability on a network — the root
+  from which all their receive addresses follow, owned by the member.
+- **Receive Address**: One address issued to one counterparty. Payable by
+  anyone as a plain address, holds value in isolation from every other receive
+  address, and is swept or spent only by its owner.
+- **Counterparty Attribution**: The link between a receive address and the
+  payer it was issued to — a member-authored label, optionally committed in a
+  form the chain enforces at sweep time.
+- **Deposit**: Value that arrived at a receive address, with its sender where
+  the chain records one, and its screening outcome.
+- **Clearance**: The per-address, per-asset determination of how much value is
+  spendable — a positive assertion, with every withheld portion carrying a
+  reason.
+- **Sweep Outcome**: The per-address, per-asset result of a sweep or spend,
+  including its reason on failure.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member can create a labelled receive address in under 10
+  seconds, with no transaction and no gas.
+- **SC-002**: 100% of receive addresses are payable by an ordinary external
+  wallet using only the plain address, with no special formatting.
+- **SC-003**: Zero payments are ever attributed to a receive address that did
+  not receive them.
+- **SC-004**: Zero receive addresses are ever issued twice or reissued after
+  retirement.
+- **SC-005**: 100% of value from a depositor who fails screening, whose status
+  is indeterminate, or whose identity cannot be established is withheld from
+  the spendable total.
+- **SC-006**: Zero instances of withheld value being swept or spent.
+- **SC-007**: Every withheld amount shown to a member carries a stated reason,
+  100% of the time.
+- **SC-008**: Zero instances of a read failure being rendered as a zero
+  balance, an empty address list, or a cleared screening result.
+- **SC-009**: 100% of sweeps and spends where the member, the destination, or a
+  committed counterparty fails screening revert with no value moved.
+- **SC-010**: 100% of sweeps are completed without the member first sending gas
+  to the receive address.
+- **SC-011**: In a multi-address or multi-asset sweep, one failure never
+  prevents the remaining outcomes from completing; every item reports its own
+  result.
+- **SC-012**: 100% of receive addresses and balances are recovered on a device
+  with no local data and no backup, using only the member's account, with zero
+  calls to any platform service.
+- **SC-013**: Zero published receive addresses change or become unrecoverable
+  as a result of any later platform change.
+- **SC-014**: On every supported network, the stated screening capability
+  matches the network's actual capability — verified by walking all supported
+  networks including those with no guard.
+- **SC-015**: Zero surfaces state or imply that deposits are screened or
+  blocked.
+- **SC-016**: Zero member funds are ever movable by any platform-held key.
+- **SC-017**: New surfaces pass the project's accessibility bar in CI with no
+  new violations.
+- **SC-018**: The contracts introduced by this feature pass the project's
+  smart-contract security review and coverage gates with no unaccepted high or
+  critical findings.
+
+## Assumptions
+
+- **Segregation is the product; screening is a control applied at spend time.**
+  The feature makes no deposit-screening claim anywhere, because measurement
+  established that claim cannot be honoured (`research.md`).
+- **One address per payer is a convention the member follows, not a rule the
+  chain enforces.** Anyone can pay any address. The app surfaces when more than
+  one party paid an address so the member knows their convention was broken.
+- **Depositor attribution is exact for tokens and unavailable for native
+  coin.** Token transfers are recorded with their sender; plain native transfers
+  are not. The fail-safe rule covers the gap rather than a guess covering it.
+- **Screening semantics come from spec 007 unchanged** — deny-list first,
+  fail-closed on an unreachable data source, deny-list-only when no data source
+  is configured. This feature consumes that behaviour and does not redefine it.
+- **The guard's fail-closed behaviour is inherited deliberately.** An
+  unreachable data source withholds rather than clears, consistent with the
+  fail-safe rule.
+- **Receive addresses are contracts rather than plain keys** for one decisive
+  reason: value cannot leave a plain address until that address itself holds
+  gas, which would force the member to fund every address before collecting
+  from it. Contracts let the member pay gas once, from their own account.
+  Alternatives are recorded in `research.md`.
+- **Addresses derive deterministically from the member's account**, which is
+  what makes backend-free recovery possible and what makes them publicly
+  linkable. Both consequences are accepted and disclosed.
+- **No platform fee at launch.** The rate is zero, so members see no fee line.
+- **Sponsorship is optional everywhere.** Every flow works with the member
+  paying their own gas.
+- **Labels and attribution are client-side**, riding the member's existing
+  encrypted backup; nothing about a counterparty is stored on a platform
+  server.
+- **Non-EVM networks are out of scope.** Bitcoin already has this model
+  natively.
+- **The ordinary Pay and Request flows are unchanged.** Safe Receiver is an
+  additional way to receive, not a replacement for the existing one.
+
+## Out of Scope
+
+- **Blocking or screening deposits.** Not deliverable; not claimed. See
+  `research.md` for the measurements.
+- **Change addresses.** Rotation and per-payer segregation are kept; moving a
+  spend's remainder to a fresh address is dropped — it costs more and buys no
+  unlinkability on EVM.
+- **Unlinkable receive addresses.** Deterministic derivation is chosen for
+  backend-free recovery; secret-salt derivation would break it.
+- **A screened-pull payment path** (payer signs an authorisation so both
+  parties are screened atomically). It is the only design that genuinely
+  screens a stablecoin payment both ways, but it cannot be paid by a plain
+  address, so it does not serve this feature. Recorded in `research.md` as a
+  rejected alternative and available as future work.
+- **Retroactive analysis of payments received before this feature.**
+- **Automated de-mixing of a shared receive address.** An address paid by
+  several parties is withheld as a unit; the feature does not attempt to split
+  a fungible balance between payers.
+- **Non-EVM networks.**
+- **Platform-operated indexing.** Discovery is derivation plus on-chain reads.
+
+## Dependencies
+
+- **Spec 007 (compliance gating)** — the on-chain sanctions guard, its
+  interface, fail-closed semantics, and per-network deployment. Extended, not
+  modified.
+- **Spec 043 / 068 (Protect custody)** — the member-deploys-and-owns pattern,
+  the address-preview-before-signing pattern, per-instance failure isolation,
+  and strict per-chain identity.
+- **Spec 061 (Bitcoin)** — the rotation, positive-clearance and explained-
+  balance rules this feature ports to EVM.
+- **Spec 062 (legacy recovery)** — the per-asset sweep-outcome pattern.
+- **Spec 041 / 050 (passkey accounts, sponsored operations)** — the optional
+  one-confirmation, gas-free sweep.
+- **Spec 032 (encrypted backup)** — where counterparty labels persist.
+- **Spec 060 (platform fees)** — the single source of truth for any fee (zero
+  at launch).
+- **The project constitution** — security-first contracts, test-first coverage,
+  honest state, fail-loudly CI, accessible frontend.

--- a/specs/070-safe-receiver/tasks.md
+++ b/specs/070-safe-receiver/tasks.md
@@ -1,0 +1,303 @@
+---
+description: "Task list for Safe Receiver — counterparty-segregated receive addresses"
+---
+
+# Tasks: Safe Receiver — counterparty-segregated receive addresses
+
+> ⚠️ **Superseded pending rework.** Design review found 4 critical and 18 major
+> issues in this feature's design — see [review-findings.md](./review-findings.md).
+> Several statements in this document are falsified there. Do not implement from it as it stands.
+
+
+**Input**: Design documents from `/specs/070-safe-receiver/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+**Tests**: REQUIRED. Constitution Principle II is NON-NEGOTIABLE — tests are written alongside the behaviour they describe, and contract tests precede implementation.
+
+**Organization**: Grouped by user story. Phase 2 is genuinely blocking — every story needs the contracts to exist and be deployed, because even free client-side derivation needs the factory and template addresses.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on incomplete work)
+- **[Story]**: US1–US7 from spec.md
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Scaffolding and the registrations that silently do nothing if forgotten.
+
+- [ ] T001 Create `contracts/receiver/` and add `contracts/receiver/ISafeReceiver.sol` with the shared events and custom errors from [contracts/ISafeReceiverFactory.md](./contracts/ISafeReceiverFactory.md) and [contracts/ISafeReceiveAddress.md](./contracts/ISafeReceiveAddress.md)
+- [ ] T002 [P] Create `test/receiver/` and `test/receiver/integration/` directories
+- [ ] T003 [P] Add `test/receiver/**` to the `test:coverage` testfiles glob in `package.json` — without this the new contracts are never measured and the gate passes on nothing
+- [ ] T004 [P] Create `frontend/src/lib/receiver/` and `frontend/src/components/receiver/` directories
+
+**Checkpoint**: `npm run compile` succeeds; the coverage glob includes the new path.
+
+---
+
+## Phase 2: Foundational (BLOCKING)
+
+**Purpose**: The two contracts, their full test suite, and every registration touchpoint. No user story can start until the factory and template are deployed, because derivation depends on both addresses.
+
+**⚠️ CRITICAL**: Nothing in Phase 3+ can begin until this checkpoint passes.
+
+### Contract tests (write FIRST — they must fail before implementation)
+
+- [ ] T005 [P] Write `test/receiver/SafeReceiverFactory.test.js` covering derivation stability, idempotent `deploy`, write-once `commitCounterparty`, and the `screen` tri-state per [contracts/ISafeReceiverFactory.md](./contracts/ISafeReceiverFactory.md) "Invariants the test suite must prove"
+- [ ] T006 [P] Write `test/receiver/SafeReceiveAddress.test.js` covering `onlyOwner` `transferOut`, `amount == 0` full sweep with zero residual, pre-deployment value retention (native + token), and the empty `receive()` accepting a 21,000-gas transfer
+- [ ] T007 [P] Write `test/receiver/SafeReceiverFactory.security.test.js` — full access-control matrix over `setSanctionsGuard`, `setScreeningRequired`, `commitCounterparty` and the UUPS upgrade path, plus the required-but-unset-guard unreachability cases (mirror `test/pools/WagerPoolFactory.security.test.js:36-80,192-214`)
+- [ ] T008 [P] Write `test/receiver/SafeReceiveAddress.security.test.js` — the hostile-factory-upgrade drain attempt, reentrancy via a malicious native destination and via `contracts/mocks/ReentrantToken.sol`, fee-on-transfer exact-or-revert, and screening-failure-moves-nothing for all three screened parties
+- [ ] T009 [P] Add `contracts/mocks/MockHostileReceiverFactory.sol` — a factory implementation that attempts to drain a clone, used by T008 to prove the `onlyOwner` boundary holds across an upgrade
+
+### Contract implementation
+
+- [ ] T010 Implement `contracts/receiver/SafeReceiveAddress.sol` — ERC-1167 template, `_disableInitializers()` in the constructor, `owner`/`factory`/`index` written once at `initialize`, empty `receive()`, no `fallback()`, `transferOut` `onlyOwner` + `nonReentrant` with the check order from [contracts/ISafeReceiveAddress.md](./contracts/ISafeReceiveAddress.md); native forward uses checked `call{value:}` per `contracts/bridge/BridgeRouter.sol:363-368`, never `.transfer()`/`.send()`
+- [ ] T011 Implement `contracts/receiver/SafeReceiverFactory.sol` on `UUPSManaged` — `__UUPSManaged_init(admin)` first, **immutable** `receiveAddressImpl` with no setter, `Clones.cloneDeterministic` + `predictDeterministicAddress` against `salt = keccak256(abi.encode(owner, index))`, permissionless idempotent `deploy`, write-once `commitCounterparty`, fail-closed `screen` tri-state per `contracts/pools/WagerPoolFactory.sol:285-303`, trailing `__gap`
+- [ ] T012 Add the accepted-Slither-findings NatSpec block to both contracts with per-detector rationale, in the style of `contracts/custody/SafePolicyGuardV2.sol:63-72` (expect `low-level-calls` and `arbitrary-send-eth` at minimum)
+- [ ] T013 Create `test/helpers/receiver.js` — deploy helper using `upgrades.deployProxy(..., { kind: 'uups' })`, returning factory, template and a funded member
+
+### Integration, upgrade and fork tests
+
+- [ ] T014 Write `test/receiver/integration/receiver-lifecycle.test.js` — derive → pay while codeless → lazy deploy → partial `transferOut` → remainder stays in place with no change address → full sweep leaves zero residual
+- [ ] T015 [P] Write `test/upgradeable/SafeReceiverFactory.upgrade.test.js` — `receiveAddressOf(o, i)` is byte-identical across an upgrade, `commitCounterparty` stays write-once across an upgrade, and no `setReceiveAddressImpl` exists on the ABI
+- [ ] T016 [P] Write `test/fork/SafeReceiverScreening.fork.test.js` pinning the real Chainalysis oracle screening gas on Polygon — `research.md` §R7's 13,232 is a mock-oracle floor, not the production number
+
+### Registration (2 fail loud, 4 fail silent)
+
+- [ ] T017 [P] Add `{ name: "SafeReceiverFactory", deploymentsKey: "safeReceiverFactory" }` to `UPGRADEABLE_CONTRACTS` in `scripts/deploy/check-storage-layout.js:20-31` — **fails silent** if missed
+- [ ] T018 [P] Add both contracts to `coverage-threshold-policy.json` `gated` at **Tier A** (95% statements / 90% branches) — **fails silent** if missed
+- [ ] T019 [P] Add three CATALOG entries to `scripts/deploy/verify.js` — `safeReceiverFactory` (proxy), `safeReceiverFactoryImpl` (impl), `safeReceiveAddressImpl` (template) — **fails loud**: `npm run verify:<net>` exits 1 on an unknown key
+- [ ] T020 [P] Add the deployment keys to the `isV2` mapping in `scripts/utils/sync-frontend-contracts.js:263-286` — **fails silent** if missed
+- [ ] T021 Add `safeReceiverFactory` and `safeReceiveAddressImpl` address slots to each target per-chain `*_CONTRACTS` block in `frontend/src/config/contracts.js` — **fails loud**: the sync throws without the block. The **template address must be present**, not just the factory: client-side derivation needs both.
+
+### Deployment
+
+- [ ] T022 Write `scripts/deploy/deploy-safe-receiver.js` — deploy template, then `deployProxy` the factory with `(admin, template, sanctionsGuard, screeningRequired)`, `CONFIRM_MAINNET` gate before fetching a signer, and record `safeReceiverFactory` / `safeReceiverFactoryImpl` / `safeReceiveAddressImpl` + `constructorArgs.safeReceiverFactoryImpl = []` + a `deployBlocks` entry immediately
+- [ ] T023 [P] Hand-write `frontend/src/abis/SafeReceiverFactory.js` and `frontend/src/abis/SafeReceiveAddress.js` from the compiled artifacts — ABIs are hand-maintained; the sync script emits addresses only
+- [ ] T024 Deploy to a local hardhat node and run `npm run check:storage-layout` and the full `test/receiver/` suite green
+
+**Checkpoint**: Both contracts implemented and deployed locally, all contract tests green, storage-layout gate lists `SafeReceiverFactory`, coverage output names both contracts. User stories can now begin.
+
+---
+
+## Phase 3: User Story 1 — Give each payer their own address (Priority: P1) 🎯 MVP
+
+**Goal**: A member creates labelled receive addresses at zero cost, shows them as plain address QR codes, and sees per-address balances with no commingling.
+
+**Independent Test**: Create three labelled addresses, pay each from a different account, verify three correctly attributed balances and that each was payable as a plain address by an ordinary wallet.
+
+### Tests
+
+- [ ] T025 [P] [US1] Write `frontend/src/lib/receiver/__tests__/deriveAddress.test.js` asserting client derivation equals `factory.receiveAddressOf(owner, index)` for index 0, a mid value, and a large value — **if these ever diverge, a member's published address points where their funds cannot be reached**
+- [ ] T026 [P] [US1] Write `frontend/src/lib/receiver/__tests__/receiverStore.test.js` — append-only cursor `max(index)+1`, peek does not burn an index, retired addresses are never reissued, records are keyed `(chainId, index)`
+
+### Implementation
+
+- [ ] T027 [P] [US1] Implement `frontend/src/lib/receiver/deriveAddress.js` — pure ERC-1167 CREATE2 prediction from `(factoryAddress, templateAddress, owner, index)`, no provider, no RPC, mirroring `frontend/src/lib/custody/safeVault.js:64-78`
+- [ ] T028 [US1] Implement `frontend/src/lib/receiver/receiverStore.js` — `ReceiveAddressRecord` CRUD over `userStorage` per [data-model.md](./data-model.md) §3, cursor derived as `max(index)+1` per `frontend/src/lib/bitcoin/wallet.js:45-49`, peek/issue split per `useBitcoinWallet.js:462-471`
+- [ ] T029 [US1] Register `safeReceiverAddresses` in `frontend/src/lib/backup/syncedObjects.js` as `networkScoped: true`, mirroring the `vaultReferences` shape at `syncedObjects.js:70-86`
+- [ ] T030 [P] [US1] Implement `frontend/src/lib/receiver/availability.js` — the typed five-value `ReceiverAvailability` from [data-model.md](./data-model.md) §4.4, following the `BRIDGE_UNAVAILABLE_REASON` precedent at `useBridgeAvailability.js:38-46`; strict `NETWORKS[chainId]` lookups only, never `getNetwork()`
+- [ ] T031 [US1] Implement `frontend/src/hooks/useSafeReceiver.js` — list addresses, read balances with **per-address failure isolation** (`useCustodyVaults.js:116-129`), on-demand rather than polled, `unreachable` never rendered as `not found`
+- [ ] T032 [US1] Add Multicall3 batching for the list view where available (`frontend/src/abis/Multicall3.js` has zero importers today); where unavailable, bound the scanned set and **disclose the list is partial** rather than implying completeness
+- [ ] T033 [P] [US1] Build `frontend/src/components/receiver/ReceiveAddressCard.jsx` — plain address, QR via `AddressQRCode` (bare EIP-55, no URI scheme, per `AddressQRCode.jsx:18-19`), label, copy
+- [ ] T034 [P] [US1] Build `frontend/src/components/receiver/ReceiveAddressList.jsx` — per-address rows with per-instance failure isolation
+- [ ] T035 [US1] Build `frontend/src/components/receiver/CreateAddressModal.jsx` — label + optional counterparty address, and the optional on-chain `commitCounterparty` with its write-once consequence stated before signing
+- [ ] T036 [US1] Build `frontend/src/components/receiver/SafeReceiverPanel.jsx` — section shell carrying the two mandatory disclosures: **anyone can pay these addresses, deposits are not blocked** (FR-006) and **these addresses are publicly linkable to each other and to your account** (FR-007)
+- [ ] T037 [US1] Add `{ id: 'receiver', label: 'Receive', icon: … }` to the **Tools** group in `frontend/src/config/appNav.js:52-72` and wire it into `visibleNavGroups` so it **hides entirely** on networks without the factory (the `collectibles`/`predict` precedent), plus the `WalletPage.jsx` tab entry
+- [ ] T038 [P] [US1] Write component tests for the panel, list, card and create modal under `frontend/src/test/receiver/`
+
+**Checkpoint**: US1 fully functional and independently demonstrable — addresses created, paid, and listed per counterparty.
+
+---
+
+## Phase 4: User Story 2 — Nothing leaves until you know who paid (Priority: P1)
+
+**Goal**: Clearance is a positive assertion; every withheld portion carries a reason; uncertainty never permits.
+
+**Independent Test**: Pay one address from a clean account and another from a deny-listed account; verify the first is spendable and the second is withheld with its reason and excluded from every total. Make screening unavailable and verify previously-cleared value becomes withheld.
+
+### Tests
+
+- [ ] T039 [P] [US2] Write `frontend/src/lib/receiver/__tests__/clearance.test.js` with **all twelve** cases from [contracts/clearance-model.md](./contracts/clearance-model.md) "Required test cases", including the assertion that screening is called with `{ force: true }` and the decomposition-invariant violation case
+- [ ] T040 [P] [US2] Write `frontend/src/lib/receiver/__tests__/attribution.test.js` — log-scan success, missing deploy block, provider range cap, and RPC error each producing the correct typed outcome and **never** an empty set that reads as "no deposits"
+
+### Implementation
+
+- [ ] T041 [US2] Implement `frontend/src/lib/receiver/attribution.js` — `Transfer` logs filtered by recipient topic, refusing to scan without a recorded deploy block and saying so (the `useVaultProposals.js:53-61` precedent); handle provider block-range caps explicitly
+- [ ] T042 [US2] Implement `frontend/src/lib/receiver/clearance.js` — the eight-step algorithm from [contracts/clearance-model.md](./contracts/clearance-model.md), screening every depositor with `{ force: true }` (`useAddressScreening.js:50-53`), the closed `WithholdReason` enumeration, and the hard `spendable + Σ withheld == total` assertion
+- [ ] T043 [US2] Extend `ReceiveAddressCard.jsx` with the balance decomposition — spendable and withheld shown together, every withheld portion carrying its reason, so a total exceeding spendable is never mysterious (FR-015)
+- [ ] T044 [US2] Write the member-facing copy for all seven withhold reasons per the clearance-model wording rules — "check unavailable" must never read as "this payer is sanctioned", and `unattributable` must not imply wrongdoing
+- [ ] T045 [US2] Ensure every read failure surfaces as a failure state, never as `0` or an empty list (FR-016) — add explicit tests asserting the rendered output is not a zero
+
+**Checkpoint**: Clearance drives what the member sees; nothing unverified is presented as spendable.
+
+---
+
+## Phase 5: User Story 3 — Sweep cleared funds (Priority: P1)
+
+**Goal**: Cleared funds move to the member's account in one action, with on-chain screening of named actors, per-address and per-asset outcomes, and no gas ever needed at the receive address.
+
+**Independent Test**: Sweep a cleared address; verify funds arrive, gas was paid once from the member's own account, and nothing was sent to the receive address first. Deny-list the member and verify the sweep reverts with nothing moved.
+
+### Tests
+
+- [ ] T046 [P] [US3] Write `frontend/src/hooks/__tests__/useReceiverSweep.test.js` — per-address and per-asset outcomes, one failure never aborting the rest, `skipped` reported rather than omitted, and the sweep consuming `spendable` rather than `total`
+- [ ] T047 [P] [US3] Extend `test/receiver/integration/receiver-lifecycle.test.js` with the multi-address, multi-asset batch: member-screen is batch-wide, destination and counterparty screens are per-item and isolated
+
+### Implementation
+
+- [ ] T048 [US3] Implement `frontend/src/hooks/useReceiverSweep.js` — lazy `deploy` folded in where the clone has no code, then `transferOut` per address/asset, returning `SweepOutcome[]` in the `legacyKeys.js:396-450` shape with a gas reserve estimated against the real contract destination (`legacyKeys.js:376-391`)
+- [ ] T049 [US3] Map contract reverts to member-facing causes — `SanctionedAddress` must name **which** party failed (payer / recipient / committed counterparty), and `ScreeningNotConfigured` must read as "the check could not be completed", never as a sanctions verdict (FR-028, FR-029)
+- [ ] T050 [US3] Build `frontend/src/components/receiver/SweepModal.jsx` — recipient, amount, asset, network, screening status, any fee, and **what is being withheld and why**; state plainly when the sweep moves less than the address holds (FR-023)
+- [ ] T051 [US3] Recompute clearance at confirmation time and, if it changed since render, tell the member before signing rather than silently sweeping a different amount
+- [ ] T052 [US3] Wire the two-rail write pattern — passkey via `sendCalls`/`executeBatch` for a single confirmation, classic via the sequential path — per `frontend/src/hooks/useOpenChallengeAccept.js:217-256`
+- [ ] T053 [P] [US3] Write component tests for `SweepModal.jsx` including the withheld-disclosure and amount-changed paths
+
+**Checkpoint**: MVP complete — members can create addresses, see honest clearance, and collect their money.
+
+---
+
+## Phase 6: User Story 4 — Spend directly from a receive address (Priority: P2)
+
+**Goal**: Pay a third party straight from a receive address; the remainder stays in place, still attributed, with no change address.
+
+**Independent Test**: Spend part of a cleared balance to an external address; verify the payee receives the exact amount, the remainder stays in the same address with the same counterparty, and the destination was screened.
+
+- [ ] T054 [P] [US4] Write tests asserting the remainder stays in the same address after a partial spend and that **no new address is created** (FR-024)
+- [ ] T055 [US4] Extend `useReceiverSweep.js` with an explicit-amount spend path to an arbitrary destination
+- [ ] T056 [US4] Extend `SweepModal.jsx` (or a sibling) with destination entry using the app's standard address entry, identity resolution and screening
+- [ ] T057 [US4] Refuse an over-spend before any signature, stating how much is actually spendable (FR: US4 scenario 4)
+
+**Checkpoint**: Pass-through payments work without a sweep hop.
+
+---
+
+## Phase 7: User Story 5 — Recover every address on a new device (Priority: P2)
+
+**Goal**: Every address and balance recovers from the member's account alone — no local data, no backup, no platform service, no scanning.
+
+**Independent Test**: Create funded addresses, clear all local data, reconnect on a fresh profile, verify everything reappears without a backup; then restore the backup and verify labels return.
+
+- [ ] T058 [P] [US5] Write `frontend/src/lib/receiver/__tests__/recovery.test.js` — full recovery with an empty store and **zero** calls to any platform service, plus label restoration from backup
+- [ ] T059 [US5] Implement derivation-based rediscovery in `useSafeReceiver.js` — walk indices from 0 and rebuild the list from chain state alone
+- [ ] T060 [US5] Bound the rediscovery walk honestly — decide and document the stopping rule, and **disclose** when the walk stopped early rather than implying the list is complete
+- [ ] T061 [US5] Show unlabelled recovered addresses with an explanation that labels are missing, never as blank entries that look like new addresses (FR-028)
+- [ ] T062 [US5] Implement "is this address mine?" lookup from a pasted address, mirroring `useCustodyVaults.js:164-214` `loadByAddress` (FR-029)
+
+**Checkpoint**: No member can lose access to a receive address.
+
+---
+
+## Phase 8: User Story 6 — Honest availability across networks (Priority: P2)
+
+**Goal**: Every surface states what it can actually do on the active network; the five availability states never collapse into one message.
+
+**Independent Test**: Walk the section on an enforcing network, a mock-oracle network, a no-guard network, an unreadable-guard network and an undeployed network, and verify five distinct, accurate messages.
+
+- [ ] T063 [P] [US6] Write `frontend/src/lib/receiver/__tests__/availability.test.js` covering all five states, asserting that `not-deployed` and `screening-unreadable` produce **different** messages (FR-032)
+- [ ] T064 [US6] Detect the mock-oracle case and describe it in different terms from a real-oracle network (FR-033) — a `MockSanctionsOracle` guarantee is materially weaker and must not read identically
+- [ ] T065 [US6] Render the availability disclosure in `SafeReceiverPanel.jsx`, naming the networks where screening **is** enforced with a switch affordance (FR-031), following `CustodyPanel.jsx:66-80`
+- [ ] T066 [US6] Give an unsupported network reached by deep link a stated reason rather than a broken or empty screen (FR-034)
+- [ ] T067 [US6] Enforce per-network scoping of balances and addresses; assert no cross-network aggregation anywhere (FR-035)
+
+**Checkpoint**: No surface claims a control the chain will not deliver.
+
+---
+
+## Phase 9: User Story 7 — Sweep without holding gas (Priority: P3)
+
+**Goal**: A passkey member sweeps several addresses in one confirmation, sponsored where available, with an honest fallback.
+
+**Independent Test**: Sponsored sweep of several addresses in one confirmation with no gas token spent; then disable sponsorship and verify the same sweep completes with the member paying.
+
+- [ ] T068 [P] [US7] Write tests for the sponsored path, the self-paid fallback, and the batch-too-large split
+- [ ] T069 [US7] Batch deploy+transferOut calls into one `executeBatch` UserOp, sized against `PM_MAX_GAS` 3,000,000 (≈53 ERC-20 sweeps) and the 6 ops/min per-account quota
+- [ ] T070 [US7] Disclose sponsored vs. member-paid at the confirm step, and **never** label a sweep sponsored unless the submission actually returned sponsored (FR-037)
+- [ ] T071 [US7] Split a batch that exceeds the sponsorship limit and tell the member, rather than failing opaquely
+- [ ] T072 [US7] Verify the self-submit fallback works with no gateway, no relayer and no paymaster (FR-011, FR-030)
+
+**Checkpoint**: Collecting money needs no gas token, but never *requires* the platform.
+
+---
+
+## Phase 10: Polish & Cross-Cutting
+
+- [ ] T073 [P] Write `docs/developer-guide/safe-receiver.md` — architecture, the `onlyOwner` authority boundary and why it is not `onlyFactory`, derivation, the clearance model, and the deposit-screening impossibility with its measurements
+- [ ] T074 [P] Write `docs/runbooks/safe-receiver-operations.md` — deploy, verify, sync, guard configuration, what an operator does when the oracle goes down (clearance withholds; this is correct, not an incident to "fix" by disabling screening), and how a new template version ships
+- [ ] T075 [P] Add the Safe Receiver guardrail paragraph to `CLAUDE.md` alongside the other per-spec entries
+- [ ] T076 [P] Write `frontend/src/test/receiver.axe.test.jsx` mirroring `src/test/home.axe.test.jsx` — zero new violations (FR-038)
+- [ ] T077 Add a `contracts/test/SafeReceiverFuzzTest.sol` invariant harness (balance conservation across sweep; no residual after a full sweep) **and** list it in `medusa.json` `targetContracts` — the list is hand-maintained and already stale
+- [ ] T078 Reconcile the two "receive" concepts in the UI — Bitcoin already has rotating receive addresses (spec 061); make sure a member is not presented with two unrelated things both called Receive
+- [ ] T079 Emit a client-ledger entry for a completed sweep so it appears in activity, following the spec-031/051 source pattern
+- [ ] T080 Disclose the unknown-token gap — a token absent from `getPortfolioRegistry` is invisible and effectively unsweepable; state it rather than letting a member believe the list is complete
+- [ ] T081 Run the full gauntlet: `npm test`, `npm run test:coverage` (both contracts named in the output at Tier A), `npm run check:storage-layout`, `TZ=UTC npx vitest run` in `frontend/`
+- [ ] T082 Complete the manual **honesty review** checklist in [quickstart.md](./quickstart.md) §8 — blocking, not automatable
+- [ ] T083 Request the smart-contract security review per `.github/agents/smart-contract-security.agent.md` — a merge gate, and the real gate since Slither is non-gating in CI
+
+---
+
+## Dependencies
+
+```
+Phase 1 Setup
+   └─► Phase 2 Foundational (contracts + deploy + registration)   ← BLOCKS EVERYTHING
+          ├─► Phase 3 US1 (create addresses)          P1  🎯 MVP
+          │      ├─► Phase 4 US2 (clearance)          P1
+          │      │      └─► Phase 5 US3 (sweep)       P1   ← MVP complete
+          │      │             └─► Phase 6 US4 (spend)        P2
+          │      │             └─► Phase 9 US7 (sponsored)    P3
+          │      ├─► Phase 7 US5 (recovery)           P2
+          │      └─► Phase 8 US6 (availability)       P2
+          └─► Phase 10 Polish
+```
+
+**Story independence**: US5 (recovery) and US6 (availability) depend only on US1 and can be built in parallel with US2/US3. US4 and US7 both extend US3's sweep path and are sequential after it.
+
+**Hard ordering inside stories**: tests precede implementation (Constitution II). T027 (derivation) precedes everything else in US1. T042 (clearance) precedes T048 (sweep), because the sweep consumes `spendable`.
+
+---
+
+## Parallel execution examples
+
+**Phase 2, contract tests** — four independent files:
+
+```
+T005  test/receiver/SafeReceiverFactory.test.js
+T006  test/receiver/SafeReceiveAddress.test.js
+T007  test/receiver/SafeReceiverFactory.security.test.js
+T008  test/receiver/SafeReceiveAddress.security.test.js
+```
+
+**Phase 2, registration** — five separate files, no interdependency:
+
+```
+T017  scripts/deploy/check-storage-layout.js
+T018  coverage-threshold-policy.json
+T019  scripts/deploy/verify.js
+T020  scripts/utils/sync-frontend-contracts.js
+T023  frontend/src/abis/*.js
+```
+
+**Phase 3, US1 presentation** — independent components:
+
+```
+T033  ReceiveAddressCard.jsx
+T034  ReceiveAddressList.jsx
+T030  lib/receiver/availability.js
+```
+
+**Cross-story once US1 lands**: Phase 7 (US5) and Phase 8 (US6) run concurrently with Phase 4 (US2).
+
+---
+
+## Implementation strategy
+
+**MVP = Phases 1–5** (Setup + Foundational + US1 + US2 + US3). That delivers the whole point: segregated addresses, honest clearance, and the ability to collect. US2 is not optional in the MVP — shipping US1 and US3 without it would mean a sweep with no clearance rule, which is the feature's one unacceptable failure.
+
+**Incremental delivery**: after the MVP, US4 (spend), US5 (recovery) and US6 (availability) can ship in any order. US6 is a release gate for any network beyond the first, since it is what keeps the per-network claims honest.
+
+**Launch network**: Polygon 137 first — the only network with a real Chainalysis oracle. Amoy 80002 and Mordor 63 have mock oracles and must be described differently (T064). Networks without a guard can host segregation and clearance with `screeningRequired = false`, provided T065 states that no on-chain screening applies there.
+
+**Two tasks worth front-loading despite their phase**: T025 (client derivation matches chain) and T042 (the clearance classifier). A derivation mismatch strands funds at an unreachable address, and an inverted clearance default silently permits what should be withheld. Both are cheap to get right early and expensive to discover late.


### PR DESCRIPTION
Investigation of #929 ("Safe Request" — sanctions-screened payments). **Draft: research and spec artifacts only, no implementation.** The design in `plan.md` did not survive review — opening this so the measurements and reasoning are visible while the open questions are decided.

## The research killed the original ask

#929 asked for receive addresses that "allow deposit from any non-sanctioned address." Measured on hardhat against the repo's real `SanctionsGuard` (probe contracts removed; figures in `research.md` §R1/§R7):

- **A stablecoin deposit cannot be screened. Not partially — at all.** A sanctioned signer's `transfer` lands with **zero recipient code run**. All six configured stablecoins were bytecode-scanned behind their proxies for ERC-1363/777/223/677 selectors — none present. At sweep time the depositor is unrecoverable on-chain (logs are write-only to the EVM).
- **Native screening in `receive()` cannot fit the 2300-gas stipend.** A *no-op* external staticcall costs 3,070; `checkBlocked` costs +13,232. EIP-2929 cold account access alone is 2,600. Not optimizable.
- **Worse, putting code at a receive address is itself a payability regression.** `.send()` payers get a successful tx and deliver nothing — silent loss. A `gasLimit: 21000` transfer fails against **any** contract, including one with an empty `receive()`.
- `SELFDESTRUCT` force-send bypasses a native guard entirely.

Gas (new — no such figures existed in the repo): mint 117,989 / 90,299 marginal batched · sweep ERC-20 55,742 · native 33,350 · lazy deploy at a pre-funded counterfactual address 118,001.

## The reframe

Segregation at receive time, enforcement at spend time. One address per payer converts an unpartitionable fungible balance into a **per-address quarantine unit** — that is what makes token attribution tractable at all. Clearance is a *positive assertion*, porting the spec-061 Bitcoin rule (`coinSelection.js:79-86`): uncertainty withholds, never permits.

Decisions taken with the repo owner:

| Question | Decision |
|---|---|
| Framing | Segregation + spend-time control. **No deposit-screening claim anywhere.** |
| Earlier "Safe Request" pull design | Rewritten; preserved in `research.md` §R2 Design B — it is the only design that genuinely screens a stablecoin both ways, but cannot be paid by a plain address |
| Change addresses | **Dropped.** EVM transfers take exact amounts, so leaving the remainder in place is equally segregated and ~90k gas cheaper — and clones are publicly enumerable, so change would imply an unlinkability this architecture lacks |
| Public linkability | Accepted and disclosed — it is what makes backend-free recovery work |

## Why this is a draft

Adversarial review (4 independent reviewers, per-finding verification) upheld **31 findings, 4 critical**. The product framing survives; the contract architecture does not. See `review-findings.md`.

- **C1** — the upgradeable factory sits on the clone's **only exit path**, so a platform key can permanently freeze every member's funds. This falsifies FR-008 and four prose statements, and it inverts the precedent it cites: `WagerPool` deliberately keeps the factory *off* withdrawal paths (`_claimBy`/`_refundBy` make no factory call). A third trigger needs no platform key at all — the guard is fail-closed, so an oracle outage reverts the exit for everyone.
- **C2** — `receiveAddressImpl` is ordinary proxy storage, not immutable. "No setter" is a property of one implementation.
- **C3** — a deployed clone stops accepting 21,000-gas transfers, **contradicting this feature's own research**. Permissionless `deploy()` lets anyone inflict that on a member's addresses.
- **C4** — recovery cannot bound its walk, so it can reissue a published address.

Plus 18 major (native coin has no exit path; the decomposition invariant fires after any partial spend; `SanctionedAddress` cannot distinguish sanctioned from oracle-unreachable; per-item isolation is unachievable on the atomic passkey rail; "gas paid once" is false for classic wallets).

## Open questions

1. **Address reuse** — rotate on sweep (matching spec 061's never-reuse rule), keep persistent per-payer addresses and disclose the degradation, or rotate behind a stable label?
2. **Native coin** — currently 100% permanently withheld with no remedy, while the spec invites native payments. Member attestation, acknowledge-and-sweep, or tokens-only?

## Review notes

Every artifact carries a "do not implement from this" banner. `review-findings.md` §7 has the resume sequence. Docs only — no contracts, no frontend, no CI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBMvFqhjqsXyUVF2hEFoNc