### PR TITLE
Fix the BigInt crash on the Earn → Stake list (#977)

### DIFF
--- a/frontend/src/components/earn/StakeView.jsx
+++ b/frontend/src/components/earn/StakeView.jsx
@@ -9,7 +9,6 @@
  * asset (ETH → liquid; POL → liquid + delegated).
  */
 import { useMemo, useState } from 'react'
-import { formatUnits } from 'ethers'
 import { useStakingOptions } from '../../hooks/useStakingOptions'
 import { useStakingPositions } from '../../hooks/useStakingPositions'
 import { NETWORKS, getStakingNetworks } from '../../config/networks'
@@ -18,15 +17,7 @@ import AssetLogo from '../wallet/AssetLogo'
 import StakeSheet from './StakeSheet'
 import StakingPositionsList from './StakingPositionsList'
 import { STAKING_TIPS, STAKING_DISCLOSURE } from '../../lib/staking/stakingCopy'
-import { formatApy } from '../../lib/earn/format'
-
-function formatStaked(raw, decimals, symbol) {
-  if (raw == null) return '—'
-  const value = Number(formatUnits(BigInt(raw), decimals))
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M ${symbol}`
-  if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K ${symbol}`
-  return `${value.toLocaleString('en-US', { maximumFractionDigits: 2 })} ${symbol}`
-}
+import { formatApy, formatTokenAmount } from '../../lib/earn/format'
 
 export default function StakeView({ tokenFilter: initialTokenFilter = null }) {
   const { options, status, refresh } = useStakingOptions()
@@ -123,7 +114,10 @@ export default function StakeView({ tokenFilter: initialTokenFilter = null }) {
                   <span className="earn-vault-numbers">
                     <span className="earn-vault-apy">{formatApy(option.rewardRateApr)}</span>
                     <span className="earn-vault-tvl">
-                      {formatStaked(option.totalStaked?.raw, option.asset.decimals, option.asset.symbol)} staked
+                      {/* Total staked is an external API field, so it goes through the total
+                          formatter: an unusable amount shows "—" instead of throwing mid-render
+                          and taking the whole page into the error boundary (issue #977). */}
+                      {formatTokenAmount(option.totalStaked?.raw, option.asset.decimals, option.asset.symbol)} staked
                     </span>
                   </span>
                 </button>

--- a/frontend/src/lib/earn/format.js
+++ b/frontend/src/lib/earn/format.js
@@ -3,6 +3,78 @@
  * missing protocol data renders as "—", never a fabricated zero
  * (constitution III).
  */
+import { formatUnits } from 'ethers'
+
+/**
+ * Normalize a base-unit (wei-scale) amount from ANY source into a canonical
+ * integer string, or null when it cannot be represented.
+ *
+ * Why this exists: JSON has a single number type, so an API quoting wei-scale
+ * values delivers them as doubles — the Polygon staking API returns
+ * `totalStaked: 1.2105466892436343e+26`. `String()` on that keeps the
+ * exponent, and `BigInt('1.2105466892436343e+26')` throws a SyntaxError, which
+ * took down the whole panel from a render path (issue #977). Anything that
+ * feeds an external numeric field into BigInt must come through here first.
+ *
+ * Precision past 2^53 is already gone by the time the value reaches us — the
+ * source sent a double. We expand the digits it actually printed and zero-fill
+ * the rest rather than materializing the double's exact binary value, so no
+ * digit appears that the API never sent. That is plenty for the compact
+ * display these amounts feed; what matters is that callers are never handed a
+ * string BigInt() will reject.
+ */
+export function toBaseUnitString(value) {
+  if (value == null) return null
+  if (typeof value === 'bigint') return value.toString()
+  if (typeof value === 'string') return expandToInteger(value)
+  // String(1.21e26) === '1.21e+26' — the same decimal text path handles it.
+  if (typeof value === 'number') return Number.isFinite(value) ? expandToInteger(String(value)) : null
+  return null
+}
+
+// uint256 tops out at 78 digits; anything wider is not a token amount, and
+// refusing it keeps a bogus exponent from asking for a gigabyte of zeros.
+const MAX_BASE_UNIT_DIGITS = 80
+const DECIMAL_RE = /^([+-]?)(\d+)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/
+
+/** Decimal or exponential text → truncated integer string; unusable → null. */
+function expandToInteger(text) {
+  const match = DECIMAL_RE.exec(String(text).trim())
+  if (!match) return null
+  const [, sign, whole, fraction = '', exponent] = match
+  const digits = whole + fraction
+  // Where the decimal point lands once the exponent is applied.
+  const pointIndex = whole.length + (exponent ? Number(exponent) : 0)
+  if (pointIndex > MAX_BASE_UNIT_DIGITS) return null
+  let integerDigits
+  if (pointIndex <= 0) integerDigits = '0' // |value| < 1 ⇒ zero whole base units
+  else if (pointIndex >= digits.length) integerDigits = digits.padEnd(pointIndex, '0')
+  else integerDigits = digits.slice(0, pointIndex) // fractional base units truncate
+  return BigInt(`${sign === '-' ? '-' : ''}${integerDigits}`).toString()
+}
+
+/**
+ * Base-unit amount → compact "1.2M POL" / "450K POL" / "12.34 POL".
+ *
+ * Total by construction: an unusable amount (missing, malformed, or a decimals
+ * value that makes no sense) renders "—" rather than throwing. This runs
+ * during render, where a throw takes the surrounding panel down.
+ */
+export function formatTokenAmount(raw, decimals, symbol) {
+  const base = toBaseUnitString(raw)
+  if (base == null) return '—'
+  let value
+  try {
+    value = Number(formatUnits(BigInt(base), decimals))
+  } catch {
+    return '—'
+  }
+  if (!Number.isFinite(value)) return '—'
+  const unit = symbol ? ` ${symbol}` : ''
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M${unit}`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K${unit}`
+  return `${value.toLocaleString('en-US', { maximumFractionDigits: 2 })}${unit}`
+}
 
 /** Net APY fraction (0.043) → "4.30%"; null → "—". */
 export function formatApy(netApy) {

--- a/frontend/src/lib/staking/polygonDelegation.js
+++ b/frontend/src/lib/staking/polygonDelegation.js
@@ -13,6 +13,7 @@
 import { Contract, Interface } from 'ethers'
 import { POLYGON_VALIDATOR_SHARE_ABI, POL_TOKEN_ABI } from '../../abis/PolygonValidatorShare'
 import { POLYGON_STAKE_MANAGER_ABI } from '../../abis/PolygonStakeManager'
+import { toBaseUnitString } from '../earn/format'
 
 const VS_IFACE = new Interface(POLYGON_VALIDATOR_SHARE_ABI)
 const POL_IFACE = new Interface(POL_TOKEN_ABI)
@@ -41,7 +42,10 @@ export async function fetchValidatorDecoration(stakingApi, allowlistIds) {
       if (!wanted.has(id)) continue // allowlist decoration only — never expand
       out.set(id, {
         commissionPct: row.commissionPercent != null ? Number(row.commissionPercent) : null,
-        totalStakedRaw: row.totalStaked != null ? String(row.totalStaked) : null,
+        // The API quotes wei-scale stake as a JSON double
+        // (`"totalStaked": 1.2105466892436343e+26`), so String() would hand
+        // consumers an exponent BigInt() rejects — normalize at the boundary.
+        totalStakedRaw: toBaseUnitString(row.totalStaked),
         status: row.status || row.currentState || null,
         delegationEnabled: row.delegationEnabled !== false,
       })

--- a/frontend/src/test/earn/format.test.js
+++ b/frontend/src/test/earn/format.test.js
@@ -1,0 +1,77 @@
+/**
+ * Shared Earn formatters (lib/earn/format.js).
+ *
+ * `toBaseUnitString`/`formatTokenAmount` exist because external APIs quote
+ * wei-scale amounts as JSON doubles (issue #977): they must always yield
+ * something BigInt() accepts, or an honest "—" — never a throw on a render path.
+ */
+import { describe, it, expect } from 'vitest'
+import { toBaseUnitString, formatTokenAmount, formatApy, formatTvl } from '../../lib/earn/format'
+
+describe('toBaseUnitString', () => {
+  it('expands exponential notation from a JSON double', () => {
+    expect(toBaseUnitString(1.2105466892436343e26)).toBe('121054668924363430000000000')
+    expect(toBaseUnitString('2.5111200087021933e+24')).toBe('2511120008702193300000000')
+  })
+
+  it('passes integer strings through, canonicalized', () => {
+    expect(toBaseUnitString('1000000000000000000000000')).toBe('1000000000000000000000000')
+    expect(toBaseUnitString('+007')).toBe('7')
+  })
+
+  it('accepts bigints and plain integers', () => {
+    expect(toBaseUnitString(10n ** 30n)).toBe('1000000000000000000000000000000')
+    expect(toBaseUnitString(42)).toBe('42')
+  })
+
+  it('truncates a fractional base unit rather than rejecting the amount', () => {
+    expect(toBaseUnitString('12.9')).toBe('12')
+  })
+
+  it('returns null for anything it cannot represent', () => {
+    expect(toBaseUnitString(null)).toBeNull()
+    expect(toBaseUnitString(undefined)).toBeNull()
+    expect(toBaseUnitString('')).toBeNull()
+    expect(toBaseUnitString('  ')).toBeNull()
+    expect(toBaseUnitString('0x1f')).toBeNull()
+    expect(toBaseUnitString('not-a-number')).toBeNull()
+    expect(toBaseUnitString(Number.NaN)).toBeNull()
+    expect(toBaseUnitString(Number.POSITIVE_INFINITY)).toBeNull()
+    expect(toBaseUnitString({})).toBeNull()
+  })
+})
+
+describe('formatTokenAmount', () => {
+  it('formats wei-scale amounts compactly', () => {
+    expect(formatTokenAmount('1000000000000000000000000', 18, 'POL')).toBe('1.0M POL')
+    expect(formatTokenAmount('5000000000000000000000', 18, 'POL')).toBe('5K POL')
+    expect(formatTokenAmount('12340000000000000000', 18, 'POL')).toBe('12.34 POL')
+  })
+
+  it('formats an exponential-notation amount rather than throwing', () => {
+    expect(formatTokenAmount('1.2105466892436343e+26', 18, 'POL')).toBe('121.1M POL')
+  })
+
+  it('omits the unit when no symbol is given', () => {
+    expect(formatTokenAmount('12340000000000000000', 18)).toBe('12.34')
+  })
+
+  it('is total: unusable input renders "—", never a throw', () => {
+    expect(formatTokenAmount(null, 18, 'POL')).toBe('—')
+    expect(formatTokenAmount('nonsense', 18, 'POL')).toBe('—')
+    expect(formatTokenAmount('100', Number.NaN, 'POL')).toBe('—')
+  })
+})
+
+describe('formatApy / formatTvl', () => {
+  it('renders "—" for missing protocol data', () => {
+    expect(formatApy(null)).toBe('—')
+    expect(formatTvl(null)).toBe('—')
+  })
+
+  it('formats known values', () => {
+    expect(formatApy(0.043)).toBe('4.30%')
+    expect(formatTvl(1_200_000)).toBe('$1.2M')
+    expect(formatTvl(450_000)).toBe('$450K')
+  })
+})

--- a/frontend/src/test/staking/StakeView.test.jsx
+++ b/frontend/src/test/staking/StakeView.test.jsx
@@ -106,4 +106,28 @@ describe('StakeView (spec 065 US1)', () => {
     renderView()
     expect(screen.getByText(/slashing/i)).toBeInTheDocument()
   })
+
+  // Regression (issue #977): the Polygon staking API quotes wei-scale stake as
+  // a JSON double, so a raw amount can arrive in exponential notation. Rendering
+  // it must never throw — a thrown BigInt conversion took the whole wallet page
+  // into the error boundary.
+  it('renders an exponential-notation staked amount instead of crashing', () => {
+    mockOptions.current = {
+      options: [{ ...VALIDATOR, totalStaked: { raw: '1.2105466892436343e+26', usd: null } }],
+      status: 'ready',
+      refresh: () => {},
+    }
+    renderView()
+    expect(screen.getByText(/121\.1M POL staked/)).toBeInTheDocument()
+  })
+
+  it('shows "—" for a staked amount it cannot make sense of', () => {
+    mockOptions.current = {
+      options: [{ ...VALIDATOR, totalStaked: { raw: 'not-a-number', usd: null } }],
+      status: 'ready',
+      refresh: () => {},
+    }
+    renderView()
+    expect(screen.getByText(/— staked/)).toBeInTheDocument()
+  })
 })

--- a/frontend/src/test/staking/polygonDelegation.test.js
+++ b/frontend/src/test/staking/polygonDelegation.test.js
@@ -38,6 +38,29 @@ describe('fetchValidatorDecoration', () => {
     expect(map.has(999)).toBe(false) // never surfaced — allowlist is the boundary
   })
 
+  // Regression (issue #977): the live API sends wei-scale stake as a JSON
+  // double, so the decoration must hand consumers an integer string BigInt()
+  // accepts — never "1.21e+26".
+  it('normalizes an exponential-notation totalStaked into an integer string', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          result: [
+            { id: 47, commissionPercent: 5, status: 'active', totalStaked: 1.2105466892436343e26 },
+            { id: 87, commissionPercent: 2, status: 'active', totalStaked: null },
+          ],
+        }),
+      }),
+    )
+    const map = await fetchValidatorDecoration('x', [47, 87])
+    const raw = map.get(47).totalStakedRaw
+    expect(raw).toMatch(/^\d+$/)
+    expect(BigInt(raw)).toBe(BigInt('121054668924363430000000000'))
+    expect(map.get(87).totalStakedRaw).toBeNull() // missing stays honest, not 0
+  })
+
   it('returns an empty map on failure (honest degradation)', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('down')))
     expect((await fetchValidatorDecoration('x', [47])).size).toBe(0)


### PR DESCRIPTION
Fixes #977.

## What was broken

`SyntaxError: Cannot convert 1.2105466892436343e+26 to a BigInt`, thrown during render and caught by the error boundary.

The minified frames in the report resolve against the deployed bundle (`index-DZfjAQCh.js`) to **`StakeView` inside `EarnPanel`** — the crash is in the Earn → Stake option list, not the collectibles grid. The stack is a render-time throw, so whichever panel was mounted when it fired, the boundary swallowed the page.

Root cause is at the API boundary. The Polygon staking API quotes wei-scale stake as a JSON **double**:

```
$ curl -s 'https://staking-api.polygon.technology/api/v2/validators' | jq '.result[] | select(.id==47) | .totalStaked'
1.2105594171361628e+26
```

`fetchValidatorDecoration` stored it with `String(row.totalStaked)`, which keeps the exponent, and `StakeView`'s `formatStaked` then called `BigInt('1.21…e+26')` → `SyntaxError`. Every one of the eight curated validators comes back in exponential notation today, so the staking list was down for every member, on any account — not only new ones.

## The fix

Two layers, each in its natural home:

- **`toBaseUnitString` (`lib/earn/format.js`)** — normalizes a base-unit amount from any source (double, exponential/decimal text, bigint, integer string) into a canonical integer string, or `null` when it cannot be represented. It expands the digits the source actually printed and zero-fills the rest, rather than materializing the double's exact binary value, so no digit appears that the API never sent. Precision past 2^53 was already gone before the value reached us, and these amounts only feed a compact display.
- **`fetchValidatorDecoration`** — normalizes at the boundary, so no consumer is handed a string `BigInt()` rejects.
- **`formatTokenAmount`** replaces `StakeView`'s local `formatStaked` and is total by construction: a missing, malformed, or nonsensically-scaled amount renders `—` (honest state, constitution III) instead of throwing on a render path.

Same output as before for well-formed values (`1.0M POL`, `5K POL`, `12.34 POL`), so the card is visually unchanged.

## Tests

- `src/test/earn/format.test.js` (new) — exponential expansion, integer passthrough, bigints, fractional truncation, and the full unusable-input set returning `null`/`—`; the formatter never throws.
- `src/test/staking/polygonDelegation.test.js` — decoration turns an exponential-notation `totalStaked` into a `BigInt`-safe integer string; a missing value stays `null` rather than becoming `0`.
- `src/test/staking/StakeView.test.jsx` — an option carrying `'1.2105466892436343e+26'` renders `121.1M POL staked` instead of crashing; an unparseable amount renders `— staked`.

Verified locally before the environment was restricted; leaving the full suite to CI.

## Notes

- No contract, ABI, or deployment changes — frontend only.
- The issue's repro path ("navigate to collectables") doesn't match the resolved stack; Collect itself is unaffected by this change. If the error boundary still appears on the Collect tab after this ships, that's a separate report worth filing with a fresh trace.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeQPCfZV2qvHdcE9pPfm1M)_