### PR TITLE
Make the admin section rail a collapsible side panel

### DIFF
--- a/docs/runbooks/operations-control-plane.md
+++ b/docs/runbooks/operations-control-plane.md
@@ -33,6 +33,23 @@ Related: [operator onboarding](operator-onboarding.md) ·
 | Access Control | Admin Roles | `DEFAULT_ADMIN_ROLE` | role-defining contracts |
 | Infrastructure | Services | admin or guardian | read-only + paymaster |
 
+## Navigating: the collapsible section rail
+
+The groups above render as a side panel down the left of `/admin`, with the
+hamburger (☰) pinned to its **top left**. The panel has two widths and the
+hamburger switches between them:
+
+- **Expanded** — group headings plus the full label of every view.
+- **Collapsed** — an icon-only rail. Every view you can use is still listed and
+  still one click away; only the text is hidden (hover for the name). Collapsing
+  never removes a section from reach, so you can work from a wide content column
+  and still jump straight to Emergency.
+
+It opens expanded on desktop and collapsed on mobile, where expanding slides the
+panel over the content — pick a view, tap the dimmed area, or press `Esc` to
+close it again. Mobile also keeps the bottom icon bar for switching between
+views without opening the panel at all.
+
 ## How-to: common procedures
 
 ### Emergency-pause the protocol (Guardian)
@@ -143,6 +160,7 @@ on-chain; the view exists so operators can act without CLI tooling.
 |---|---|
 | "Access Restricted" on `/admin` | Connected wallet holds no operator role on this chain. Roles are chain-scoped — check the network selector first. |
 | A group/view is missing from the rail | You lack the gating role; the rail only shows what you can use. |
+| The rail is a strip of icons with no labels | It is collapsed, not broken — every view is still there. Hover for a name, or click the hamburger at its top left to expand. |
 | A view shows "not deployed on this network" | Address not in the frontend address book for this chain — run `npm run sync:frontend-contracts` after deploy. |
 | Gasless card shows "No relay gateway configured" | `VITE_RELAYER_URL` unset in this build; gasless flows self-submit. Expected in local dev. |
 | Runway numbers missing from the health card | The gateway only discloses operator telemetry to origin-authenticated callers; the public subset (RPC up/down) still renders. |

--- a/frontend/src/components/AdminPanel.css
+++ b/frontend/src/components/AdminPanel.css
@@ -202,18 +202,6 @@
   min-height: 100%;
 }
 
-.admin-portal-topbar {
-  display: flex;
-  align-items: center;
-  padding: 1.25rem 2rem 0;
-}
-
-@media (max-width: 768px) {
-  .admin-portal-topbar {
-    padding: 1rem 1rem 0;
-  }
-}
-
 /* ===================================
    Content Area
    =================================== */

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -25,7 +25,9 @@ import ServiceHealthCard from './admin/ServiceHealthCard'
 import PaymasterOpsCard from './admin/PaymasterOpsCard'
 import { buildAdminNavGroups, flattenNavGroups } from './admin/adminNav'
 import PortalNav from './ui/PortalNav'
+import NavIcon from './nav/NavIcon'
 import SectionIconNav from './nav/SectionIconNav'
+import { useIsMobile } from '../hooks/useMediaQuery'
 import './AdminPanel.css'
 
 const TIER_NAMES = { 1: 'Bronze', 2: 'Silver', 3: 'Gold', 4: 'Platinum' }
@@ -124,7 +126,11 @@ function AdminPanel() {
   const canOpenFees = isAdmin || isFeeAdmin
 
   const [activeTab, setActiveTab] = useState('overview')
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  // The section rail collapses to an icon-only strip rather than disappearing.
+  // It starts collapsed on mobile, where expanded it covers the content it is
+  // navigating; on desktop it opens alongside and starts expanded.
+  const isMobile = useIsMobile()
+  const [sidebarOpen, setSidebarOpen] = useState(!isMobile)
   const [pendingTx, setPendingTx] = useState(false)
   const [contractState, setContractState] = useState({
     isPaused: false,
@@ -372,6 +378,23 @@ function AdminPanel() {
   })
   const adminTabs = flattenNavGroups(navGroups)
 
+  // On mobile the expanded rail sits ON TOP of the view it just switched to, so
+  // picking a section collapses it back to icons. On desktop it stays open.
+  const handleSelectTab = useCallback((id) => {
+    setActiveTab(id)
+    if (isMobile) setSidebarOpen(false)
+  }, [isMobile])
+
+  // Escape closes the overlay rail, matching the global nav drawer.
+  useEffect(() => {
+    if (!sidebarOpen || !isMobile) return
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') setSidebarOpen(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [sidebarOpen, isMobile])
+
   if (!hasAdminAccess) {
     return (
       <div className="admin-panel">
@@ -428,29 +451,42 @@ function AdminPanel() {
       </header>
 
       <div className={`portal-shell admin-portal-shell ${sidebarOpen ? '' : 'portal-collapsed'}`}>
-        <aside className="portal-sidebar admin-portal-sidebar">
-          <PortalNav
-            groups={navGroups}
-            activeId={activeTab}
-            onSelect={setActiveTab}
-            ariaLabel="Operations sections"
+        {/* Only the mobile rail overlays anything, so only it has something to dismiss. */}
+        {isMobile && sidebarOpen && (
+          <button
+            type="button"
+            className="portal-sidebar-backdrop"
+            aria-label="Close sections menu"
+            onClick={() => setSidebarOpen(false)}
           />
-        </aside>
+        )}
 
-        <div className="portal-main">
-          <div className="admin-portal-topbar">
+        <aside className="portal-sidebar admin-portal-sidebar">
+          <div className="portal-sidebar-header">
             <button
               type="button"
               className="portal-sidebar-toggle"
               aria-expanded={sidebarOpen}
-              aria-label={sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+              aria-controls="admin-portal-nav"
+              aria-label={sidebarOpen ? 'Collapse sections menu' : 'Expand sections menu'}
               onClick={() => setSidebarOpen((o) => !o)}
             >
-              <span aria-hidden="true">{'☰'}</span>
-              <span className="portal-sidebar-toggle-label">Menu</span>
+              <NavIcon name="menu" size={20} />
             </button>
+            {sidebarOpen && <span className="portal-sidebar-title">Sections</span>}
           </div>
 
+          <PortalNav
+            id="admin-portal-nav"
+            groups={navGroups}
+            activeId={activeTab}
+            onSelect={handleSelectTab}
+            ariaLabel="Operations sections"
+            collapsed={!sidebarOpen}
+          />
+        </aside>
+
+        <div className="portal-main">
           <main className="admin-panel-content">
         {/* Overview */}
         {activeTab === 'overview' && (

--- a/frontend/src/components/nav/NavIcon.jsx
+++ b/frontend/src/components/nav/NavIcon.jsx
@@ -29,6 +29,8 @@ const ICON_PATHS = {
   star: <><path d="m12 3.6 2.6 5.2 5.8.9-4.2 4.1 1 5.7-5.2-2.7-5.2 2.7 1-5.7-4.2-4.1 5.8-.9L12 3.6Z" /></>,
   key: <><circle cx="8" cy="12" r="3.5" /><path d="M11.3 11h8.9M17 11v3M20.2 11v2.4" /></>,
   power: <><path d="M12 3.5v8" /><path d="M6.8 7a8 8 0 1 0 10.4 0" /></>,
+  // Hamburger — opens/closes the collapsible section rail.
+  menu: <><path d="M4 7h16M4 12h16M4 17h16" /></>,
   grid: <><rect x="4" y="4" width="7" height="7" rx="1.5" /><rect x="13" y="4" width="7" height="7" rx="1.5" /><rect x="4" y="13" width="7" height="7" rx="1.5" /><rect x="13" y="13" width="7" height="7" rx="1.5" /></>,
   alert: <><path d="M12 4 2.8 20h18.4L12 4Z" /><path d="M12 10v5M12 17.6v.01" /></>,
   layers: <><path d="M12 4 3 9l9 5 9-5-9-5Z" /><path d="m3 14 9 5 9-5" /></>,

--- a/frontend/src/components/ui/PortalNav.css
+++ b/frontend/src/components/ui/PortalNav.css
@@ -8,27 +8,44 @@
  */
 
 .portal-shell {
+  --portal-rail-expanded: 216px;
+  --portal-rail-collapsed: 64px;
   display: flex;
   align-items: stretch;
   gap: 0;
   min-height: 320px;
+  position: relative;
 }
 
 .portal-sidebar {
-  flex: 0 0 200px;
+  flex: 0 0 var(--portal-rail-expanded);
+  width: var(--portal-rail-expanded);
   display: flex;
   flex-direction: column;
   border-right: 1px solid var(--border-color, var(--color-border, #e5e7eb));
   background: var(--bg-secondary, var(--color-surface-secondary, #f9fafb));
+  overflow-x: hidden;
+  transition: flex-basis 0.22s ease, width 0.22s ease;
 }
 
+/* Collapsed is an ICON RAIL, not a hidden sidebar: every section stays one
+   click away and the panel visibly slides open from the left edge rather than
+   appearing out of nothing. */
 .portal-shell.portal-collapsed .portal-sidebar {
-  display: none;
+  flex-basis: var(--portal-rail-collapsed);
+  width: var(--portal-rail-collapsed);
 }
 
 .portal-main {
   flex: 1 1 auto;
   min-width: 0;
+}
+
+/* Backdrop for the mobile overlay rail. The host only renders it on mobile;
+   this keeps it inert if a wider surface ever renders one, since expanding the
+   rail there pushes the content across instead of covering it. */
+.portal-sidebar-backdrop {
+  display: none;
 }
 
 .portal-nav {
@@ -121,13 +138,106 @@
   outline-offset: -2px;
 }
 
-/* Sidebar show/hide toggle (☰) */
+/* ---------------------------------------------------------------------------
+   Collapsed (icon-only) rail
+   --------------------------------------------------------------------------- */
+
+.portal-nav--collapsed {
+  padding: 8px 0;
+  align-items: center;
+}
+
+.portal-nav--collapsed .portal-nav-item {
+  width: 44px;
+  justify-content: center;
+  gap: 0;
+  padding: 7px 0;
+  border-left-width: 0;
+}
+
+/* Visually hidden, NOT removed: the button keeps its accessible name, so the
+   collapsed rail reads identically to the expanded one for assistive tech. */
+.portal-nav--collapsed .portal-nav-item-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* The active marker moves off the left border (there is no room for a 3px rule
+   plus a centred 30px tile) and onto the tile itself. */
+.portal-nav--collapsed .portal-nav-item.active {
+  background: transparent;
+}
+
+.portal-nav--collapsed .portal-nav-item.active .portal-nav-item-icon {
+  box-shadow: 0 0 0 1px var(--brand-primary, var(--color-primary, #36B37E));
+}
+
+.portal-nav-item-initial {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+/* Group headings collapse to a hairline: the grouping stays legible without a
+   200px word in a 64px rail. */
+.portal-nav--collapsed .portal-nav-group-label {
+  width: 32px;
+  height: 0;
+  padding: 0;
+  margin: 6px 0;
+  overflow: hidden;
+  border-top: 1px solid var(--border-color, var(--color-border, #e5e7eb));
+  color: transparent;
+}
+
+.portal-nav--collapsed .portal-nav-group-label:first-child {
+  display: none;
+}
+
+/* Sidebar header — the hamburger sits at the TOP LEFT of the rail, in both
+   states, so the control that opens the panel never moves. */
+.portal-sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  min-height: 52px;
+  border-bottom: 1px solid var(--border-color, var(--color-border, #e5e7eb));
+}
+
+.portal-shell.portal-collapsed .portal-sidebar-header {
+  justify-content: center;
+  padding: 10px 0;
+}
+
+.portal-sidebar-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: var(--text-tertiary, var(--color-text-secondary, #8895A1));
+}
+
+/* Sidebar show/hide toggle (hamburger) */
 .portal-sidebar-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex: 0 0 auto;
   gap: 8px;
-  padding: 8px 12px;
+  width: 36px;
+  height: 36px;
+  padding: 0;
   border: 1px solid var(--border-color, var(--color-border, #e5e7eb));
   border-radius: 8px;
   background: var(--bg-secondary, var(--color-surface, #fff));
@@ -135,7 +245,7 @@
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
-  transition: border-color 0.15s ease;
+  transition: border-color 0.15s ease, background 0.15s ease;
 }
 
 .portal-sidebar-toggle:hover {
@@ -148,7 +258,46 @@
 }
 
 @media (max-width: 768px) {
+  /* Mobile: expanding must not squeeze the content column to nothing, so the
+     open rail floats OVER it. Sticky (not fixed) keeps it inside the panel —
+     it never covers the app header — while following the page as the operator
+     scrolls, so the hamburger is always reachable on a long view. */
+  .portal-shell {
+    --portal-rail-expanded: 232px;
+    --portal-rail-collapsed: 52px;
+  }
+
   .portal-sidebar {
-    flex-basis: 150px;
+    position: sticky;
+    top: 0;
+    align-self: flex-start;
+    z-index: 30;
+    max-height: 100vh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  /* The rail keeps taking only its COLLAPSED width in the flex line, so opening
+     it slides the panel across the content rather than reflowing the page. */
+  .portal-shell:not(.portal-collapsed) .portal-sidebar {
+    margin-right: calc(var(--portal-rail-collapsed) - var(--portal-rail-expanded));
+    box-shadow: 2px 0 16px rgba(0, 0, 0, 0.18);
+  }
+
+  .portal-shell:not(.portal-collapsed) .portal-sidebar-backdrop {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 29;
+    border: none;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.4);
+    cursor: pointer;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .portal-sidebar {
+    transition: none;
   }
 }

--- a/frontend/src/components/ui/PortalNav.jsx
+++ b/frontend/src/components/ui/PortalNav.jsx
@@ -14,12 +14,27 @@
  *   - 'nav': a navigation landmark of plain buttons that route ELSEWHERE (active
  *     reflected via aria-current="page"). Use this when selecting an entry
  *     navigates between routes rather than swapping an in-page panel.
+ *
+ * `collapsed` renders the icon-only rail: every entry still renders, so the whole
+ * section list stays one tap away, but the text label is visually hidden rather
+ * than dropped — the button keeps its accessible name, so screen readers and
+ * `getByRole('tab', { name })` see the same rail collapsed or expanded. Group
+ * headings become hairline rules (a 200px-wide word cannot survive a 64px rail).
  */
 import { Fragment } from 'react'
 import NavIcon from '../nav/NavIcon'
 import './PortalNav.css'
 
-export default function PortalNav({ items, groups, activeId, onSelect, ariaLabel, variant = 'tabs' }) {
+export default function PortalNav({
+  items,
+  groups,
+  activeId,
+  onSelect,
+  ariaLabel,
+  variant = 'tabs',
+  collapsed = false,
+  id,
+}) {
   const isTabs = variant === 'tabs'
 
   const renderItem = (item) => (
@@ -30,11 +45,17 @@ export default function PortalNav({ items, groups, activeId, onSelect, ariaLabel
       aria-selected={isTabs ? item.id === activeId : undefined}
       aria-current={!isTabs && item.id === activeId ? 'page' : undefined}
       className={`portal-nav-item ${item.id === activeId ? 'active' : ''}`}
+      // Collapsed, the glyph is the only thing on screen; the native tooltip is
+      // what tells a mouse user which area it is.
+      title={collapsed ? item.label : undefined}
       onClick={() => onSelect(item.id)}
     >
-      {item.icon && (
+      {/* Collapsed, an icon-less item would be an unreadable blank row, so the
+          rail falls back to its initial. Expanded, it keeps rendering exactly
+          what it did before: nothing at all. */}
+      {(item.icon || collapsed) && (
         <span className="portal-nav-item-icon" aria-hidden="true">
-          <NavIcon name={item.icon} />
+          {item.icon ? <NavIcon name={item.icon} /> : <span className="portal-nav-item-initial">{item.label?.[0]}</span>}
         </span>
       )}
       <span className="portal-nav-item-label">{item.label}</span>
@@ -43,7 +64,8 @@ export default function PortalNav({ items, groups, activeId, onSelect, ariaLabel
 
   return (
     <nav
-      className="portal-nav"
+      id={id}
+      className={`portal-nav ${collapsed ? 'portal-nav--collapsed' : ''}`}
       role={isTabs ? 'tablist' : undefined}
       aria-orientation={isTabs ? 'vertical' : undefined}
       aria-label={ariaLabel}

--- a/frontend/src/test/PortalNav.test.jsx
+++ b/frontend/src/test/PortalNav.test.jsx
@@ -125,6 +125,73 @@ describe('PortalNav (grouped rail)', () => {
   })
 })
 
+// --- Collapsed (icon-only) rail -----------------------------------------------------------------
+// Collapsing must not amputate the nav: every section stays clickable and keeps its accessible
+// name, so the rail is one control in two widths rather than two different navigations.
+
+describe('PortalNav (collapsed icon rail)', () => {
+  const ICON_GROUPS = [
+    { label: 'Control Room', items: [{ id: 'overview', label: 'Overview', icon: 'grid' }] },
+    {
+      label: 'Compliance',
+      items: [
+        { id: 'deny-list', label: 'Deny-list', icon: 'ban' },
+        { id: 'members', label: 'Members', icon: 'users' },
+      ],
+    },
+  ]
+
+  it('still renders every item, with its label as the accessible name', () => {
+    render(<PortalNav groups={ICON_GROUPS} activeId="overview" onSelect={vi.fn()} collapsed ariaLabel="Sections" />)
+    expect(screen.getAllByRole('tab')).toHaveLength(3)
+    for (const group of ICON_GROUPS) {
+      for (const item of group.items) {
+        expect(screen.getByRole('tab', { name: item.label })).toBeInTheDocument()
+      }
+    }
+  })
+
+  it('marks the rail collapsed and gives each item a tooltip', () => {
+    const { container } = render(
+      <PortalNav groups={ICON_GROUPS} activeId="overview" onSelect={vi.fn()} collapsed ariaLabel="Sections" />
+    )
+    expect(container.querySelector('.portal-nav')).toHaveClass('portal-nav--collapsed')
+    expect(screen.getByRole('tab', { name: 'Members' })).toHaveAttribute('title', 'Members')
+  })
+
+  it('renders an icon for every item so the collapsed rail is never blank', () => {
+    const { container } = render(
+      <PortalNav items={ITEMS} activeId="account" onSelect={vi.fn()} collapsed ariaLabel="Sections" />
+    )
+    // ITEMS carry no icon; each falls back to its initial rather than an empty square.
+    expect(container.querySelectorAll('.portal-nav-item-icon')).toHaveLength(ITEMS.length)
+    expect(screen.getByText('A')).toBeInTheDocument()
+  })
+
+  it('leaves the expanded rail unchanged (no icon tile for icon-less items)', () => {
+    const { container } = render(
+      <PortalNav items={ITEMS} activeId="account" onSelect={vi.fn()} ariaLabel="Sections" />
+    )
+    expect(container.querySelector('.portal-nav')).not.toHaveClass('portal-nav--collapsed')
+    expect(container.querySelectorAll('.portal-nav-item-icon')).toHaveLength(0)
+    expect(screen.getByRole('tab', { name: 'Account' })).not.toHaveAttribute('title')
+  })
+
+  it('still selects when a collapsed item is clicked', () => {
+    const onSelect = vi.fn()
+    render(<PortalNav groups={ICON_GROUPS} activeId="overview" onSelect={onSelect} collapsed ariaLabel="Sections" />)
+    fireEvent.click(screen.getByRole('tab', { name: 'Deny-list' }))
+    expect(onSelect).toHaveBeenCalledWith('deny-list')
+  })
+
+  it('has no axe violations when collapsed', async () => {
+    const { container } = render(
+      <PortalNav groups={ICON_GROUPS} activeId="overview" onSelect={vi.fn()} collapsed ariaLabel="Sections" />
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
 // --- Spec 067 US1 (T062): "Pay & Transfer" is now "Transfer" ------------------------------------
 // The rename is label-only. Every entry point that worked before — drawer item, mobile icon bar
 // sibling, and the saved `/wallet?tab=paytransfer` deep link — must still land on the section.

--- a/frontend/src/test/admin/adminSidePanel.test.jsx
+++ b/frontend/src/test/admin/adminSidePanel.test.jsx
@@ -1,0 +1,158 @@
+/**
+ * The Operations section rail is a COLLAPSIBLE SIDE PANEL, not a show/hide sidebar.
+ *
+ * The old behaviour hid the rail outright (`display: none`), which meant collapsing it cost the
+ * operator the whole navigation: from a collapsed panel there was no way to see, let alone reach,
+ * any section without expanding again. It now collapses to an icon rail — every section still
+ * rendered, still clickable, still carrying its label as its accessible name — with the hamburger
+ * pinned to the top left of the rail in BOTH states so the control that opens the panel never moves.
+ *
+ * These tests pin the three things that make it a panel rather than a toggle:
+ *   1. collapsed still lists every section (icons), and clicking one still switches the view;
+ *   2. the toggle lives inside the rail, at the top, and reports its state via aria-expanded;
+ *   3. on mobile — where the expanded rail covers the content it navigates — picking a section
+ *      closes it again, and there is a backdrop to dismiss it without picking anything.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+
+const m = vi.hoisted(() => ({ isMobile: false }))
+
+vi.mock('../../hooks/useMediaQuery', () => ({
+  useIsMobile: () => m.isMobile,
+  useMediaQuery: () => false,
+  useIsTablet: () => false,
+  useIsExtraSmall: () => false,
+}))
+
+vi.mock('../../hooks/useRoles', () => ({
+  useRoles: () => ({ hasRole: () => true, hasAnyRole: () => true }),
+}))
+vi.mock('../../hooks/useWeb3', () => ({
+  useWeb3: () => ({
+    account: '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+    signer: null,
+    provider: null,
+    chainId: 137,
+  }),
+}))
+vi.mock('../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: vi.fn() }) }))
+vi.mock('../../hooks/useChainTokens', () => ({ useChainTokens: () => ({ native: 'POL', capabilities: {} }) }))
+vi.mock('../../hooks/useEnsResolution', () => ({
+  useEnsResolution: () => ({ resolvedAddress: '', isEns: false, isLoading: false }),
+}))
+vi.mock('../../utils/blockchainService', () => ({ getProvider: () => null }))
+vi.mock('../../config/contracts', () => ({
+  NETWORK_CONFIG: { name: 'Polygon', blockExplorer: 'https://polygonscan.com' },
+  DEPLOYED_CONTRACTS: {},
+  getContractAddressForChain: () => '',
+}))
+
+// The overview cards each go to chain on mount; the rail is what is under test, so they are stubbed.
+vi.mock('../../components/admin/ServiceHealthCard', () => ({ default: () => <div data-testid="service-health" /> }))
+vi.mock('../../components/admin/PaymasterOpsCard', () => ({ default: () => <div data-testid="paymaster-ops" /> }))
+vi.mock('../../components/admin/MembershipTreasuryOverview', () => ({ default: () => <div data-testid="treasury" /> }))
+vi.mock('../../components/admin/MaintenanceTab', () => ({ default: () => <div data-testid="maintenance-tab" /> }))
+
+import AdminPanel from '../../components/AdminPanel'
+
+const railToggle = () => screen.getByRole('button', { name: /^(Collapse|Expand) sections menu$/ })
+
+beforeEach(() => {
+  m.isMobile = false
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('Operations rail — collapsible side panel', () => {
+  it('starts expanded on desktop, with the hamburger at the top of the rail', () => {
+    const { container } = render(<AdminPanel />)
+    const rail = container.querySelector('.portal-sidebar')
+    const toggle = railToggle()
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(toggle).toHaveAccessibleName('Collapse sections menu')
+    // Inside the rail (top left), not floating in the content column beside it.
+    expect(rail).toContainElement(toggle)
+    expect(within(rail).getByText('Sections')).toBeInTheDocument()
+    expect(container.querySelector('.portal-shell')).not.toHaveClass('portal-collapsed')
+  })
+
+  it('collapses to an icon rail that still lists every section', () => {
+    const { container } = render(<AdminPanel />)
+    const sectionNames = screen.getAllByRole('tab').map((tab) => tab.getAttribute('aria-label') || tab.textContent)
+
+    fireEvent.click(railToggle())
+
+    expect(container.querySelector('.portal-shell')).toHaveClass('portal-collapsed')
+    expect(container.querySelector('.portal-nav')).toHaveClass('portal-nav--collapsed')
+    // Not hidden — the same sections, same accessible names, now as icons.
+    expect(screen.getAllByRole('tab').map((tab) => tab.getAttribute('aria-label') || tab.textContent))
+      .toEqual(sectionNames)
+    expect(screen.getByRole('tab', { name: 'Maintenance' })).toBeInTheDocument()
+    // The toggle stays put and now offers the opposite action.
+    expect(railToggle()).toHaveAttribute('aria-expanded', 'false')
+    expect(railToggle()).toHaveAccessibleName('Expand sections menu')
+  })
+
+  it('switches sections from the collapsed rail without expanding first', () => {
+    render(<AdminPanel />)
+    fireEvent.click(railToggle())
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Maintenance' }))
+
+    expect(screen.getByTestId('maintenance-tab')).toBeInTheDocument()
+    // Selecting did not force the panel back open on desktop.
+    expect(railToggle()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('points the toggle at the nav it controls', () => {
+    const { container } = render(<AdminPanel />)
+    expect(railToggle()).toHaveAttribute('aria-controls', 'admin-portal-nav')
+    expect(container.querySelector('#admin-portal-nav')).toHaveClass('portal-nav')
+  })
+})
+
+describe('Operations rail — mobile overlay behaviour', () => {
+  beforeEach(() => {
+    m.isMobile = true
+  })
+
+  it('starts collapsed on mobile, where an expanded rail would cover the view', () => {
+    const { container } = render(<AdminPanel />)
+    expect(container.querySelector('.portal-shell')).toHaveClass('portal-collapsed')
+    expect(railToggle()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('closes itself once a section is picked', () => {
+    render(<AdminPanel />)
+    fireEvent.click(railToggle())
+    expect(railToggle()).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Maintenance' }))
+
+    expect(screen.getByTestId('maintenance-tab')).toBeInTheDocument()
+    expect(railToggle()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('can be dismissed by the backdrop or Escape without changing section', () => {
+    render(<AdminPanel />)
+
+    fireEvent.click(railToggle())
+    fireEvent.click(screen.getByRole('button', { name: 'Close sections menu' }))
+    expect(railToggle()).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(railToggle())
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(railToggle()).toHaveAttribute('aria-expanded', 'false')
+    // Still on the section it opened from.
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('renders no backdrop while collapsed', () => {
+    render(<AdminPanel />)
+    expect(screen.queryByRole('button', { name: 'Close sections menu' })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What

The Operations rail at `/admin` is now a **collapsible side panel** that slides out from the left, with the hamburger pinned to its **top left** — the same shape as the global app menu. Collapsed, it becomes an **icon rail** showing every area rather than disappearing.

## Why

The old "Menu" button set `display: none` on the whole sidebar, so collapsing it cost the operator the entire navigation: from a collapsed panel there was no way to see, let alone reach, any section without expanding again. The toggle also sat in the content column to the *right* of the rail it controlled, so the control that opened the panel wasn't where the panel was.

## Changes

**`components/ui/PortalNav.jsx`** — new opt-in `collapsed` prop (plus `id`, for `aria-controls`).
- Every item still renders. The label is **visually hidden, not dropped**, so the button keeps its accessible name and the collapsed rail reads identically to the expanded one for assistive tech; a `title` gives mouse users the name on hover.
- An item with no icon falls back to its initial, so a collapsed rail is never a column of blank squares.
- Expanded rendering is byte-identical to before — the global nav drawer and every other consumer are untouched.

**`components/ui/PortalNav.css`**
- `.portal-collapsed` now narrows the rail (216px → 64px, animated) instead of hiding it.
- Collapsed styling: centred icon tiles, active state moves from the left border onto the tile, group headings become hairline rules.
- New `.portal-sidebar-header` holds the hamburger at the rail's top left in both states.
- Mobile: the open rail **floats over** the content instead of squeezing the column to nothing, with a dismiss backdrop. It's `sticky` rather than `fixed`, so it stays inside the panel (never covering the app header) while keeping the hamburger reachable part-way down a long view.

**`components/AdminPanel.jsx`** — toggle moved out of the content column and into the rail header; starts collapsed on mobile; on mobile, picking a view / tapping the backdrop / pressing `Esc` closes it.

**`components/nav/NavIcon.jsx`** — added the `menu` (hamburger) glyph so the toggle matches the rest of the icon set instead of using a `☰` text character.

## Behaviour notes

- **Nothing about role gating changed.** The rail still only lists views the connected wallet can use, and each view is still gated on render by the same predicate.
- Desktop opens expanded and stays open when you pick a view; only mobile auto-closes, because only there does the open rail cover what it just navigated to.
- `prefers-reduced-motion` disables the slide.

## Testing

- New `src/test/admin/adminSidePanel.test.jsx` (8 tests) renders the real `AdminPanel` and pins: the hamburger lives inside the rail and reports `aria-expanded`; collapsing keeps **every** section with its accessible name intact; you can switch views from the collapsed rail; and the mobile open/dismiss paths (select, backdrop, `Esc`).
- `src/test/PortalNav.test.jsx` extended (6 tests) for the collapsed rail, including an axe pass and an explicit assertion that the **expanded** rail is unchanged.
- Ran every suite touching `PortalNav` / `NavIcon` / `AdminPanel` / `AppNavDrawer` / `SectionIconNav` / `WalletPage`: **158 tests, all passing**.
- Full frontend suite run separately; the failures it reports (e.g. `clearpath/ProposalBuilder`) are pre-existing and unrelated to these files.
- `eslint` clean on all changed files.

## Docs

`docs/runbooks/operations-control-plane.md` gains a "Navigating: the collapsible section rail" section and a troubleshooting row for "the rail is a strip of icons" — so an operator who finds it collapsed knows it isn't broken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1FMyMAhgkDcbYVVTvGj1W)_