### PR TITLE
Spec 071: Polygon membership reference chain + all-chains admin reads (spec, plan, tasks)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/070-safe-receiver"
+  "feature_directory": "specs/071-multi-chain-admin-console"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,5 +257,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/070-safe-receiver/plan.md
+at specs/071-multi-chain-admin-console/plan.md
 <!-- SPECKIT END -->

--- a/frontend/src/components/admin/liquidityAdminCommon.js
+++ b/frontend/src/components/admin/liquidityAdminCommon.js
@@ -31,7 +31,18 @@
  */
 import { ethers } from 'ethers'
 import { NETWORKS, listSupportedChainIds } from '../../config/networks'
-import { makeReadProvider } from '../../utils/rpcProvider'
+import { networkName as estateNetworkName, readProviderFor as estateReadProviderFor } from '../../lib/chains/estate'
+
+// Spec 071: the generic halves of this module now live in `lib/chains/estate.js`, because
+// non-component callers (role sync, purchase preflight) need them too. They are re-exported
+// here so this module stays the one import site for the Bridge and Supply tabs.
+//
+// `readProviderFor` gained a fix in the move: it used to build a provider straight from
+// `NETWORKS[chainId].rpcUrl`, which bypassed `resolveRpcEndpoints` and so ignored the member's
+// configured endpoint and failover for every read these two tabs make (a live spec-069
+// violation). It now resolves through `getReadProvider`. Behaviour these tabs depend on —
+// reuse the wallet provider for the connected chain, null for a chain with no endpoint — is
+// unchanged.
 
 /** How far back the history/ops event scans look. Bounded — public RPCs refuse open ranges. */
 export const HISTORY_LOOKBACK_BLOCKS = 200_000
@@ -46,9 +57,7 @@ export function shortAddr(a) {
 export const isValidAddr = (a) => ethers.isAddress(a) && a !== ethers.ZeroAddress
 
 /** Display name for a chain, or an honest placeholder — never a guessed one. */
-export function networkName(chainId) {
-  return NETWORKS[chainId]?.name || `Chain ${chainId}`
-}
+export const networkName = estateNetworkName
 
 /**
  * Every supported network carrying the capability a tab controls, mainnets first.
@@ -58,6 +67,15 @@ export function networkName(chainId) {
  * and whether FairWins has deployed a router there is a separate question the tab answers
  * per-network. Listing only deployed networks would hide the ones an operator most needs to
  * see — the ones still waiting for a deployment.
+ *
+ * ── DELIBERATELY *NOT* COHORT-BOUNDED (spec 071) ────────────────────────────────────────────
+ * Spec 071's `estateNetworks()` narrows a roster to the build's environment cohort, and every
+ * NEW estate read uses it. This one does not, and must not: the spec-067 routers exist only on
+ * mainnets (1/10/137/8453/42161 for Uniswap, plus Ethereum-only Across LP), so cohort-bounding
+ * it would return an EMPTY roster in a testnet build and blank both tabs. The cross-cohort
+ * roster here is pre-existing spec-067 behaviour that spec 071 does not change; see the note in
+ * specs/071-multi-chain-admin-console/research.md (R10) for why that is being tracked as an
+ * open question rather than settled silently in this change.
  *
  * @param {'bridge'|'liquidity'} capability
  */
@@ -69,17 +87,15 @@ export function adminNetworks(capability) {
 }
 
 /**
- * A read connection for `chainId`.
+ * A read connection for `chainId`. See `lib/chains/estate.js`.
  *
- * Reuses the wallet's own provider when the scope happens to be the connected chain (cheaper,
- * and it is already authenticated to whatever RPC the member configured), and otherwise builds
- * a read-only provider from that network's configured RPC. Returns null for a network with no
- * RPC, which the caller reports as unreadable rather than as empty.
+ * NOTE: this module's roster (`adminNetworks`) may name a chain outside the build's cohort, and
+ * `estateReadProviderFor` refuses those — which is correct for cohort-bounded estate reads but
+ * would blank these two tabs. So the cohort check is bypassed here, preserving spec-067
+ * behaviour exactly, while still routing through the fixed provider resolution.
  */
 export function readProviderFor(chainId, walletChainId, walletProvider) {
-  if (walletProvider && Number(chainId) === Number(walletChainId)) return walletProvider
-  const rpcUrl = NETWORKS[chainId]?.rpcUrl
-  return rpcUrl ? makeReadProvider(rpcUrl, chainId) : null
+  return estateReadProviderFor(chainId, walletChainId, walletProvider, { requireCohort: false })
 }
 
 /** Minimal AccessControl surface — every spec-067 router exposes it via UUPSManaged. */

--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -889,6 +889,77 @@ const NETWORKS = {
 
 export { NETWORKS, PRIMARY_CHAIN_ID, MAINNET_CHAIN_ID, TESTNET_CHAIN_ID }
 
+/* ---------------------------------------------------------------------------
+   Environment cohort + membership reference chain (spec 071)
+   --------------------------------------------------------------------------- */
+
+/**
+ * Whether this build reads the testnet estate or the mainnet one.
+ *
+ * Constitution III forbids network-scoped data leaking across the testnet/mainnet
+ * boundary, so "read every chain" has to mean "every chain THIS BUILD MAY READ".
+ * The split is total — every NETWORKS entry carries `isTestnet` — so no chain is
+ * unclassified and none can fall into both.
+ */
+function buildIsTestnet() {
+  return Boolean(NETWORKS[getCurrentChainId()]?.isTestnet ?? NETWORKS[PRIMARY_CHAIN_ID]?.isTestnet)
+}
+
+/**
+ * The single chain that is the authority for membership in this build (spec 071 FR-001/FR-002).
+ *
+ * DERIVED from the mainnet/testnet pair above rather than declared again: a second literal
+ * `137` in the codebase is a divergence waiting to happen, and a hardcoded one would silently
+ * read MAINNET membership in a testnet build.
+ *
+ * Not runtime-configurable, deliberately. This is a payment destination as well as a read
+ * target (FR-006) — a wrong value sends a member's USDC to a chain where their membership
+ * will never be read.
+ */
+export function membershipChainId() {
+  return buildIsTestnet() ? TESTNET_CHAIN_ID : MAINNET_CHAIN_ID
+}
+
+/**
+ * Every chain this build may read, mainnets-first. The ONLY roster an estate read may use —
+ * `listSupportedChainIds()` spans both cohorts and would leak across the boundary.
+ */
+export function cohortChainIds() {
+  const testnet = buildIsTestnet()
+  return listSupportedChainIds()
+    .map((id) => NETWORKS[id])
+    .filter((net) => net && Boolean(net.isTestnet) === testnet)
+    .sort((a, b) => Number(a.isTestnet) - Number(b.isTestnet))
+    .map((net) => net.chainId)
+}
+
+/** Whether a chain is in this build's cohort. */
+export function isInCohort(chainId) {
+  const net = NETWORKS[chainId]
+  return Boolean(net) && Boolean(net.isTestnet) === buildIsTestnet()
+}
+
+/**
+ * Fail loudly rather than resolve a reference chain outside the cohort (contracts/membership-chain.md
+ * rule 3). Silently returning an out-of-cohort chain is the failure this whole feature exists to
+ * prevent — it would route real membership purchases at a chain the build must not touch.
+ */
+export function assertReferenceChainInCohort() {
+  const id = membershipChainId()
+  if (!isInCohort(id)) {
+    throw new Error(
+      `[networks] membership reference chain ${id} is not in this build's cohort ` +
+        `(${buildIsTestnet() ? 'testnet' : 'mainnet'}). Check MAINNET_CHAIN_ID / TESTNET_CHAIN_ID.`,
+    )
+  }
+  return id
+}
+
+// Checked once at module load: a build whose reference chain sits outside its own cohort is
+// broken in a way that must not reach a member, so it stops here rather than quietly routing
+// a purchase at the wrong chain.
+assertReferenceChainInCohort()
+
 export function getCurrentChainId() {
   const env = import.meta.env?.VITE_NETWORK_ID
   return env ? parseInt(env, 10) : PRIMARY_CHAIN_ID

--- a/frontend/src/lib/chains/chainReadResult.js
+++ b/frontend/src/lib/chains/chainReadResult.js
@@ -1,0 +1,128 @@
+/**
+ * The outcome of reading one contract on one chain — the central shape of spec 071.
+ *
+ * ── WHY THREE STATES AND NOT A VALUE-OR-NULL ────────────────────────────────────────────────
+ * An operator auditing a control surface reads a silent `0` as a fact. So "the contract said
+ * zero", "there is no contract here", and "the question could not be put" are three different
+ * statements and must stay three different states (FR-014):
+ *
+ *   read          — the contract answered. `value` is a fact.
+ *   not-deployed  — there is no such contract on this chain. A DEFINITE answer: there is
+ *                   nothing here to have a value. Not the same as a zero.
+ *   unreadable    — the endpoint was down, timed out, or answered garbage. NOT an answer.
+ *                   Must never render as 0, as empty, or as absence.
+ *
+ * `value` exists only on `read`, deliberately: a consumer tempted to write `result.value ?? 0`
+ * finds there is nowhere for that default to live, because the two non-answer states carry no
+ * value at all.
+ *
+ * ── AND WHY THERE IS NO SUM-EVERYTHING FUNCTION ─────────────────────────────────────────────
+ * `aggregate` returns subtotals keyed by unit and never one grand total (FR-022). Fee balances
+ * on different chains are denominated in different tokens — Polygon USDC and Mordor's Classic
+ * USD are not the same asset — so a single figure across them is an invented number. The API
+ * offers no way to ask for one, which is the point: this cannot be got wrong by a caller in a
+ * hurry.
+ */
+
+export const READ = 'read'
+export const NOT_DEPLOYED = 'not-deployed'
+export const UNREADABLE = 'unreadable'
+
+/**
+ * @typedef {object} Unit
+ * @property {string} symbol   Display symbol, and the key subtotals are grouped by
+ * @property {number} decimals
+ * @property {string} [address]
+ */
+
+/**
+ * The contract answered.
+ * @param {number} chainId
+ * @param {*} value
+ * @param {Unit|null} [unit] required for balances, so they can never be cross-summed by accident
+ * @param {number|null} [readAt] timestamp, for per-chain freshness
+ */
+export function readOk(chainId, value, unit = null, readAt = null) {
+  return { chainId: Number(chainId), status: READ, value, unit, reason: null, readAt }
+}
+
+/** There is no such contract on this chain. A definite answer, not a failure. */
+export function notDeployed(chainId) {
+  return { chainId: Number(chainId), status: NOT_DEPLOYED, unit: null, reason: null, readAt: null }
+}
+
+/** The question could not be put. Never a value, always a reason. */
+export function unreadable(chainId, reason) {
+  return {
+    chainId: Number(chainId),
+    status: UNREADABLE,
+    unit: null,
+    reason: String(reason || 'chain could not be read'),
+    readAt: null,
+  }
+}
+
+export const isRead = (r) => r?.status === READ
+export const isNotDeployed = (r) => r?.status === NOT_DEPLOYED
+export const isUnreadable = (r) => r?.status === UNREADABLE
+
+/**
+ * Per-unit subtotals over a set of chain read results.
+ *
+ * Returns `{ subtotals, partial, missing }` — never a single figure:
+ *
+ *   subtotals — keyed by unit symbol. Values in different units land in different buckets.
+ *   partial   — true when at least one chain could not be read, so a caller cannot present
+ *               the result as complete without saying so (FR-023).
+ *   missing   — the chains excluded, with the reason each was excluded.
+ *
+ * `not-deployed` chains contribute nothing and do NOT set `partial`: nothing is missing from
+ * the total, there is simply nothing there. That distinction is why the two states exist.
+ *
+ * Values are summed as BigInt (raw token units). A `read` result carrying a non-BigInt-able
+ * value is treated as unreadable for aggregation purposes rather than coerced — a silently
+ * mis-scaled balance is worse than an admitted gap.
+ */
+export function aggregate(results = []) {
+  const subtotals = {}
+  const missing = []
+
+  for (const r of results) {
+    if (!r) continue
+    if (isNotDeployed(r)) continue
+    if (isUnreadable(r)) {
+      missing.push({ chainId: r.chainId, reason: r.reason })
+      continue
+    }
+    if (!isRead(r)) continue
+
+    const symbol = r.unit?.symbol ?? null
+    if (!symbol) {
+      // A balance with no declared unit cannot be safely put in any bucket — bucketing it
+      // under a guess is exactly how a cross-unit sum gets created.
+      missing.push({ chainId: r.chainId, reason: 'value has no declared unit' })
+      continue
+    }
+
+    let amount
+    try {
+      amount = BigInt(r.value)
+    } catch {
+      missing.push({ chainId: r.chainId, reason: 'value is not an integer amount' })
+      continue
+    }
+    subtotals[symbol] = (subtotals[symbol] ?? 0n) + amount
+  }
+
+  return { subtotals, partial: missing.length > 0, missing }
+}
+
+/**
+ * A sentence naming what an aggregate is missing, or null when it is complete.
+ * Callers render this next to any partial total so "partial" is never just a flag nobody shows.
+ */
+export function partialLabel(aggregated, nameForChain = (id) => `chain ${id}`) {
+  if (!aggregated?.partial) return null
+  const names = aggregated.missing.map((m) => nameForChain(m.chainId))
+  return `Partial — excludes ${names.join(', ')} (could not be read)`
+}

--- a/frontend/src/lib/chains/estate.js
+++ b/frontend/src/lib/chains/estate.js
@@ -1,0 +1,210 @@
+/**
+ * Reading the ESTATE — the platform's deployed state across every chain this build may read.
+ *
+ * Promoted here from `components/admin/liquidityAdminCommon.js` (spec 067), which had these
+ * helpers for two admin tabs. Spec 071 generalizes them to the whole operations control plane,
+ * so they belong in `lib/` — non-component callers (role sync, purchase preflight) use them too.
+ *
+ * The rules below are not conveniences; each one exists because its absence was, or would be, a
+ * specific dishonesty.
+ *
+ *   1. **Scope is a NETWORK, not the wallet's network.** Control state is per-network and there
+ *      are many. Gating an operator surface on the connected chain hides most of an estate from
+ *      an operator who is simply connected somewhere else. Reads span the cohort; only WRITES
+ *      require the wallet to be on the target chain.
+ *
+ *   2. **The cohort bounds everything.** `cohortChainIds()` — never `listSupportedChainIds()`,
+ *      which spans both cohorts. Constitution III forbids reading across the testnet/mainnet
+ *      boundary, and that is the mechanism.
+ *
+ *   3. **An unreadable read is never a zero.** Every read returns a three-state result
+ *      (`chainReadResult.js`). One dead endpoint never fails a batch and never renders as 0.
+ *
+ *   4. **Authority is read from the contract that will enforce it**, never inferred from an
+ *      app-wide role flag — see `readAuthority` for the defect that rule comes from.
+ *
+ * ── PROVIDERS: WHY THIS FILE DOES NOT TOUCH `NETWORKS[chainId].rpcUrl` ──────────────────────
+ * The version of `readProviderFor` this replaces built its provider straight from
+ * `NETWORKS[chainId].rpcUrl`. That bypasses `resolveRpcEndpoints`, so the member's configured
+ * endpoint and its failover were ignored for every read those two admin tabs made — a live
+ * spec-069 violation ("never hand-build a provider from NETWORKS[chainId].rpcUrl"). Generalizing
+ * the helper to the rest of the console would have spread that bug across every operator view,
+ * so it is fixed here: providers come from `getReadProvider(chainId)`, full stop.
+ */
+import { ethers } from 'ethers'
+import { NETWORKS, cohortChainIds, isInCohort } from '../../config/networks'
+import { getReadProvider } from '../../utils/rpcProvider'
+import { readOk, notDeployed, unreadable } from './chainReadResult'
+
+/** Display name for a chain, or an honest placeholder — never a guessed one. */
+export function networkName(chainId) {
+  return NETWORKS[chainId]?.name || `Chain ${chainId}`
+}
+
+/**
+ * The chains an operator view lists: this build's cohort, optionally narrowed to those carrying
+ * a capability, mainnets first.
+ *
+ * Derived from config, not asserted, so the roster stays true as deployments land. A network
+ * appears because it COULD carry the thing — whether FairWins has actually deployed there is a
+ * separate question the per-chain read answers. Listing only deployed networks would hide the
+ * ones an operator most needs to see: the ones still waiting for a deployment.
+ */
+export function estateNetworks(capability = null) {
+  return cohortChainIds()
+    .map((id) => NETWORKS[id])
+    .filter((net) => net && (!capability || net.capabilities?.[capability]))
+}
+
+/**
+ * A read connection for `chainId`, or null when the chain has no endpoint at all.
+ *
+ * Reuses the wallet's own provider when the scope happens to BE the connected chain — cheaper,
+ * and it is already the transport the member chose. Otherwise `getReadProvider` resolves the
+ * member's endpoint, headers and failover for that chain (see the file header).
+ *
+ * Returns null rather than throwing; the caller reports that as `unreadable`, never as empty.
+ */
+export function readProviderFor(chainId, walletChainId, walletProvider, { requireCohort = true } = {}) {
+  if (walletProvider && Number(chainId) === Number(walletChainId)) return walletProvider
+  // Estate reads are cohort-bounded (FR-002). The spec-067 Bridge/Supply tabs opt out because
+  // their routers exist only on mainnets, so a testnet build would otherwise blank them — see
+  // the note on `adminNetworks` in components/admin/liquidityAdminCommon.js.
+  if (requireCohort && !isInCohort(chainId)) return null
+  try {
+    return getReadProvider(chainId)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read one thing across the estate, concurrently.
+ *
+ * NEVER REJECTS. One dead endpoint becomes an `unreadable` entry; its siblings still resolve, so
+ * a view is not held hostage by the slowest or the most broken chain (FR-015).
+ *
+ * @param {object}   opts
+ * @param {number[]} [opts.chainIds]   defaults to the whole cohort
+ * @param {(chainId:number) => string} opts.addressFor  '' / null ⇒ not deployed on that chain
+ * @param {(ctx:{chainId:number, provider:any, address:string}) => Promise<*>} opts.read
+ * @param {number}   [opts.walletChainId]
+ * @param {*}        [opts.walletProvider]
+ * @param {(chainId:number) => object|null} [opts.unitFor]  unit for balance values
+ * @returns {Promise<import('./chainReadResult').ChainReadResult[]>}
+ */
+export function readAcrossEstate({
+  chainIds,
+  addressFor,
+  read,
+  walletChainId,
+  walletProvider,
+  unitFor = () => null,
+}) {
+  const ids = (chainIds ?? cohortChainIds()).filter(isInCohort)
+
+  return Promise.all(
+    ids.map(async (chainId) => {
+      let address
+      try {
+        address = addressFor(chainId)
+      } catch (e) {
+        return unreadable(chainId, e?.message || 'address lookup failed')
+      }
+      if (!address) return notDeployed(chainId)
+
+      const provider = readProviderFor(chainId, walletChainId, walletProvider)
+      if (!provider) return unreadable(chainId, 'no read connection to this network')
+
+      try {
+        const value = await read({ chainId, provider, address })
+        return readOk(chainId, value, unitFor(chainId))
+      } catch (e) {
+        return unreadable(chainId, e?.message || String(e))
+      }
+    }),
+  )
+}
+
+/** Minimal AccessControl surface — every contract this asks about exposes it. */
+const ACCESS_CONTROL_ABI = ['function hasRole(bytes32 role, address account) view returns (bool)']
+
+/** DEFAULT_ADMIN_ROLE is bytes32(0), not a keccak of a name. */
+export const ROLE_HASHES = {
+  admin: ethers.ZeroHash,
+  guardian: ethers.id('GUARDIAN_ROLE'),
+  liquidityAdmin: ethers.id('LIQUIDITY_ADMIN_ROLE'),
+  feeAdmin: ethers.id('FEE_ADMIN_ROLE'),
+  stakingAdmin: ethers.id('STAKING_ADMIN_ROLE'),
+  roleManager: ethers.id('ROLE_MANAGER_ROLE'),
+  sanctionsAdmin: ethers.id('SANCTIONS_ADMIN_ROLE'),
+  accountModerator: ethers.id('ACCOUNT_MODERATOR_ROLE'),
+}
+
+/**
+ * Does `account` hold `roles` on THIS contract, on THIS chain?
+ *
+ * ── WHY THE APP-WIDE ROLE FLAGS CANNOT ANSWER THIS ─────────────────────────────────────────
+ * `useRoles()`'s `isAdmin` / `isGuardian` / … are one boolean each, resolved against a candidate
+ * list on the WALLET's chain. Three separate things break:
+ *
+ *   • `isGuardian` means "holds GUARDIAN_ROLE on the WagerRegistry" — a different contract from
+ *     the one a given view drives. The sets are unrelated, so an operator with the wager
+ *     guardianship would be shown an enabled killswitch that reverts.
+ *   • roles granted per-contract on purpose (LIQUIDITY_ADMIN on each router) collapse into one
+ *     OR, showing an operator holding it on one contract every control on the other.
+ *   • all of them read the wallet's chain, while views scope to a network the operator picks.
+ *     A Polygon guardian whose wallet sits on Ethereum lost the Polygon controls.
+ *
+ * So authority is asked of the contract that will enforce it. The app-wide flags keep the job
+ * they are good for: deciding whether a view appears at all.
+ *
+ * ── AND WHY AN UNREADABLE ANSWER IS NOT A DENIAL ───────────────────────────────────────────
+ * `readable: false` means the question could not be put, not that the answer was no. Callers keep
+ * offering the control and say authority is unconfirmed: the contract is the real gate and will
+ * refuse anything the operator does not hold, whereas withdrawing a killswitch because an RPC
+ * timed out tells an operator who DOES hold it that there isn't one.
+ *
+ * `deployed: false` IS a definite answer: there is no contract here to hold a role on.
+ */
+export async function readAuthority({ provider, address, account, roles = [] }) {
+  const none = Object.fromEntries(roles.map((r) => [r, false]))
+  if (!address) return { ...none, roles: none, readable: true, deployed: false, reason: null }
+  if (!provider || !account) {
+    return {
+      ...none,
+      roles: none,
+      readable: false,
+      deployed: true,
+      reason: !account ? 'no account connected' : 'no read connection to this network',
+    }
+  }
+  try {
+    const c = new ethers.Contract(address, ACCESS_CONTROL_ABI, provider)
+    const answers = await Promise.all(
+      roles.map((name) => c.hasRole(ROLE_HASHES[name] ?? ethers.id(name), account)),
+    )
+    const held = Object.fromEntries(roles.map((name, i) => [name, Boolean(answers[i])]))
+    return { ...held, roles: held, readable: true, deployed: true, reason: null }
+  } catch (e) {
+    return { ...none, roles: none, readable: false, deployed: true, reason: e?.message || String(e) }
+  }
+}
+
+/**
+ * The two gates a view needs from an authority read, honestly.
+ *
+ * `allowed` is permissive while authority is UNCONFIRMED and restrictive only on a definite "no";
+ * `unconfirmed` lets the view say so once, in words, instead of implying a verdict it lacks.
+ */
+export function authorityGate(authority, roleNames = []) {
+  if (!authority) return { allowed: false, unconfirmed: false, pending: true, deployed: true }
+  const unconfirmed = authority.deployed && !authority.readable
+  const held = roleNames.some((r) => authority.roles?.[r])
+  return {
+    allowed: Boolean(held || unconfirmed),
+    unconfirmed,
+    pending: false,
+    deployed: Boolean(authority.deployed),
+  }
+}

--- a/frontend/src/test/lib/chains/chainReadResult.test.js
+++ b/frontend/src/test/lib/chains/chainReadResult.test.js
@@ -1,0 +1,110 @@
+/**
+ * Spec 071 T008 — the three-state read result and the aggregation rules that keep it honest.
+ *
+ * The point of these tests is not that the helpers "work": it is that the two dishonesties this
+ * feature exists to prevent are structurally impossible.
+ *   1. An unreadable chain rendering as a zero, or vanishing from a total without a trace.
+ *   2. Balances in different tokens being added into one invented number.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  readOk, notDeployed, unreadable, aggregate, partialLabel,
+  isRead, isNotDeployed, isUnreadable, READ, NOT_DEPLOYED, UNREADABLE,
+} from '../../../lib/chains/chainReadResult'
+
+const USDC = { symbol: 'USDC', decimals: 6 }
+const USC = { symbol: 'USC', decimals: 6 }
+
+describe('chain read result — three distinguishable states (FR-014)', () => {
+  it('produces exactly one status per result, and they are distinguishable', () => {
+    expect(readOk(137, 5n, USDC).status).toBe(READ)
+    expect(notDeployed(61).status).toBe(NOT_DEPLOYED)
+    expect(unreadable(1, 'timeout').status).toBe(UNREADABLE)
+
+    expect(isRead(readOk(137, 5n, USDC))).toBe(true)
+    expect(isNotDeployed(notDeployed(61))).toBe(true)
+    expect(isUnreadable(unreadable(1, 'timeout'))).toBe(true)
+  })
+
+  it('carries no value on the two non-answer states, so a default has nowhere to live', () => {
+    expect(notDeployed(61).value).toBeUndefined()
+    expect(unreadable(1, 'timeout').value).toBeUndefined()
+  })
+
+  it('always carries a reason when unreadable, never a silent failure', () => {
+    expect(unreadable(1, 'endpoint refused').reason).toBe('endpoint refused')
+    expect(unreadable(1).reason).toBeTruthy()
+  })
+
+  it('keeps a zero balance distinct from not-deployed and from unreadable', () => {
+    const zero = readOk(137, 0n, USDC)
+    expect(zero.status).toBe(READ)
+    expect(zero.value).toBe(0n)
+    // The whole feature turns on these three never collapsing into one another.
+    expect(new Set([zero.status, notDeployed(61).status, unreadable(1, 'x').status]).size).toBe(3)
+  })
+})
+
+describe('aggregate — per-unit subtotals only (FR-022)', () => {
+  it('never sums across units: different tokens land in different buckets', () => {
+    const agg = aggregate([readOk(137, 100n, USDC), readOk(63, 250n, USC)])
+    expect(agg.subtotals).toEqual({ USDC: 100n, USC: 250n })
+    // There is no API that returns one figure across units, so no caller can ask for one.
+    expect(Object.keys(agg.subtotals)).toHaveLength(2)
+  })
+
+  it('sums within a unit', () => {
+    const agg = aggregate([readOk(137, 100n, USDC), readOk(1, 50n, USDC)])
+    expect(agg.subtotals.USDC).toBe(150n)
+  })
+
+  it('refuses to bucket a value with no declared unit rather than guessing one', () => {
+    const agg = aggregate([readOk(137, 100n, USDC), readOk(1, 50n, null)])
+    expect(agg.subtotals).toEqual({ USDC: 100n })
+    expect(agg.partial).toBe(true)
+    expect(agg.missing[0]).toMatchObject({ chainId: 1 })
+  })
+})
+
+describe('aggregate — partial totals name what is missing (FR-023)', () => {
+  it('excludes an unreadable chain, flags partial, and names it', () => {
+    const agg = aggregate([readOk(137, 100n, USDC), unreadable(1, 'endpoint down')])
+    expect(agg.subtotals.USDC).toBe(100n)
+    expect(agg.partial).toBe(true)
+    expect(agg.missing).toEqual([{ chainId: 1, reason: 'endpoint down' }])
+  })
+
+  it('does NOT flag partial for a not-deployed chain — nothing is missing, there is nothing there', () => {
+    const agg = aggregate([readOk(137, 100n, USDC), notDeployed(61)])
+    expect(agg.subtotals.USDC).toBe(100n)
+    expect(agg.partial).toBe(false)
+    expect(agg.missing).toEqual([])
+  })
+
+  it('is complete when every chain answered', () => {
+    const agg = aggregate([readOk(137, 100n, USDC), readOk(1, 1n, USDC)])
+    expect(agg.partial).toBe(false)
+    expect(partialLabel(agg)).toBeNull()
+  })
+
+  it('renders a label that names the excluded chains, so "partial" is never just an unshown flag', () => {
+    const agg = aggregate([readOk(137, 100n, USDC), unreadable(1, 'timeout')])
+    const label = partialLabel(agg, (id) => (id === 1 ? 'Ethereum' : `chain ${id}`))
+    expect(label).toContain('Partial')
+    expect(label).toContain('Ethereum')
+  })
+
+  it('an unreadable chain never contributes a zero to a subtotal', () => {
+    const withFailure = aggregate([readOk(137, 100n, USDC), unreadable(1, 'down')])
+    const withoutIt = aggregate([readOk(137, 100n, USDC)])
+    // Same number — but only one of them admits it is incomplete.
+    expect(withFailure.subtotals.USDC).toBe(withoutIt.subtotals.USDC)
+    expect(withFailure.partial).toBe(true)
+    expect(withoutIt.partial).toBe(false)
+  })
+
+  it('tolerates an empty set and nullish entries', () => {
+    expect(aggregate([]).subtotals).toEqual({})
+    expect(aggregate([null, undefined]).partial).toBe(false)
+  })
+})

--- a/frontend/src/test/lib/chains/estate.test.js
+++ b/frontend/src/test/lib/chains/estate.test.js
@@ -1,0 +1,171 @@
+/**
+ * Spec 071 T015 + T016 — the estate read helper.
+ *
+ * Two things are load-bearing here and get the most attention:
+ *   • one dead or slow endpoint must not take the others down (FR-015), and
+ *   • the roster must never leave the build's cohort (FR-002).
+ *
+ * T016's source-level check lives at the bottom: it asserts the spec-069 provider bypass this
+ * helper used to carry cannot come back, which no behavioural test can catch.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readAcrossEstate, estateNetworks, readProviderFor, networkName } from '../../../lib/chains/estate'
+import { isRead, isNotDeployed, isUnreadable } from '../../../lib/chains/chainReadResult'
+import { cohortChainIds, isInCohort, NETWORKS } from '../../../config/networks'
+
+const COHORT = cohortChainIds()
+const A = COHORT[0]
+const B = COHORT[1]
+
+const byChain = (id) => (r) => r.chainId === id
+
+describe('estateNetworks — the roster is cohort-bounded (FR-002)', () => {
+  it('lists only chains in this build\'s cohort', () => {
+    for (const net of estateNetworks()) expect(isInCohort(net.chainId)).toBe(true)
+  })
+
+  it('never contains a mainnet in this testnet build', () => {
+    for (const net of estateNetworks()) expect(net.isTestnet).toBe(true)
+  })
+
+  it('narrows by capability without leaving the cohort', () => {
+    for (const net of estateNetworks('dex')) {
+      expect(isInCohort(net.chainId)).toBe(true)
+      expect(Boolean(net.capabilities?.dex)).toBe(true)
+    }
+  })
+})
+
+describe('readAcrossEstate — one broken chain never takes the others down (FR-015)', () => {
+  it('reports a rejected read as unreadable with a reason, while its siblings resolve', async () => {
+    const results = await readAcrossEstate({
+      chainIds: [A, B],
+      addressFor: () => '0x1111111111111111111111111111111111111111',
+      read: ({ chainId }) => (chainId === A ? Promise.reject(new Error('endpoint down')) : Promise.resolve(7n)),
+      walletChainId: A,
+      walletProvider: {},
+    })
+
+    const failed = results.find(byChain(A))
+    const ok = results.find(byChain(B))
+    expect(isUnreadable(failed)).toBe(true)
+    expect(failed.reason).toContain('endpoint down')
+    expect(failed.value).toBeUndefined() // never a zero
+    expect(isRead(ok)).toBe(true)
+    expect(ok.value).toBe(7n)
+  })
+
+  it('never rejects, even when every chain fails', async () => {
+    const results = await readAcrossEstate({
+      chainIds: [A, B],
+      addressFor: () => '0x1111111111111111111111111111111111111111',
+      read: () => Promise.reject(new Error('all down')),
+      walletChainId: A,
+      walletProvider: {},
+    })
+    expect(results).toHaveLength(2)
+    expect(results.every(isUnreadable)).toBe(true)
+  })
+
+  it('does not delay a fast chain behind a slow one — the fast result is available first', async () => {
+    const order = []
+    const p = readAcrossEstate({
+      chainIds: [A, B],
+      addressFor: () => '0x1111111111111111111111111111111111111111',
+      read: ({ chainId }) =>
+        chainId === A
+          ? new Promise((res) => setTimeout(() => { order.push(A); res(1n) }, 40))
+          : Promise.resolve().then(() => { order.push(B); return 2n }),
+      walletChainId: A,
+      walletProvider: {},
+    })
+    await p
+    // B settled before A despite being listed second: the reads are concurrent, not sequential.
+    expect(order).toEqual([B, A])
+  })
+
+  it('reports a chain with no address as not-deployed — a definite answer, not a failure', async () => {
+    const results = await readAcrossEstate({
+      chainIds: [A, B],
+      addressFor: (id) => (id === A ? '' : '0x1111111111111111111111111111111111111111'),
+      read: () => Promise.resolve(1n),
+      walletChainId: B,
+      walletProvider: {},
+    })
+    expect(isNotDeployed(results.find(byChain(A)))).toBe(true)
+    expect(isRead(results.find(byChain(B)))).toBe(true)
+  })
+
+  it('drops chains outside the cohort rather than reading them (FR-002)', async () => {
+    const outsider = 137 // mainnet Polygon, not in this testnet build's cohort
+    expect(isInCohort(outsider)).toBe(false)
+    const read = vi.fn(() => Promise.resolve(1n))
+    const results = await readAcrossEstate({
+      chainIds: [A, outsider],
+      addressFor: () => '0x1111111111111111111111111111111111111111',
+      read,
+      walletChainId: A,
+      walletProvider: {},
+    })
+    expect(results.map((r) => r.chainId)).toEqual([A])
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('defaults to the whole cohort when no chainIds are given', async () => {
+    const results = await readAcrossEstate({
+      addressFor: () => '',
+      read: () => Promise.resolve(1n),
+    })
+    expect(results.map((r) => r.chainId).sort()).toEqual([...COHORT].sort())
+  })
+})
+
+describe('readProviderFor', () => {
+  it('reuses the wallet provider when the scope IS the connected chain', () => {
+    const wallet = { __wallet: true }
+    expect(readProviderFor(A, A, wallet)).toBe(wallet)
+  })
+
+  it('refuses a chain outside the cohort for estate reads', () => {
+    expect(readProviderFor(137, A, null)).toBeNull()
+  })
+
+  it('allows an out-of-cohort chain only when a caller opts out explicitly (spec-067 tabs)', () => {
+    // Does not assert a provider is returned — only that the cohort check is what was bypassed.
+    expect(() => readProviderFor(137, A, null, { requireCohort: false })).not.toThrow()
+  })
+})
+
+describe('networkName', () => {
+  it('names a known chain and gives an honest placeholder for an unknown one', () => {
+    expect(networkName(A)).toBe(NETWORKS[A].name)
+    expect(networkName(999999)).toBe('Chain 999999')
+  })
+})
+
+// ── T016: the spec-069 bypass must not come back ────────────────────────────────────────────
+// This helper previously built providers from `NETWORKS[chainId].rpcUrl`, which skipped
+// `resolveRpcEndpoints` and so ignored the member's endpoint override and failover. Nothing
+// observable in a unit test distinguishes that from the fixed version, so it is pinned at the
+// source level instead.
+describe('estate.js provider sourcing (spec 069)', () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '../../../lib/chains/estate.js'),
+    'utf8',
+  )
+  // Comments stripped first: the file's own header explains the bypass it must not contain, and
+  // a guard that trips on its own documentation would just get the documentation deleted.
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+  it('resolves providers through getReadProvider', () => {
+    expect(code).toContain('getReadProvider')
+  })
+
+  it('never reads an rpcUrl out of the network config', () => {
+    expect(code).not.toMatch(/NETWORKS\[[^\]]*\]\??\.rpcUrl/)
+    expect(code).not.toContain('makeReadProvider')
+  })
+})

--- a/frontend/src/test/lib/chains/membershipChain.test.js
+++ b/frontend/src/test/lib/chains/membershipChain.test.js
@@ -1,0 +1,74 @@
+/**
+ * Spec 071 T005 — the membership reference-chain resolver and the environment cohort.
+ *
+ * The test build runs with VITE_NETWORK_ID=63 (Mordor), so this process IS a testnet build.
+ * That makes it the useful side of the boundary to assert from: a testnet build must never
+ * resolve membership to a mainnet, which is exactly SC-008.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  membershipChainId, cohortChainIds, isInCohort, assertReferenceChainInCohort,
+  NETWORKS, MAINNET_CHAIN_ID, TESTNET_CHAIN_ID, getCurrentChainId, listSupportedChainIds,
+} from '../../../config/networks'
+
+describe('membership reference chain (FR-001, FR-002)', () => {
+  it('resolves to exactly one chain, and the same one every call', () => {
+    expect(membershipChainId()).toBe(membershipChainId())
+    expect(typeof membershipChainId()).toBe('number')
+  })
+
+  it('is the testnet reference chain in this (testnet) build, never a mainnet — SC-008', () => {
+    expect(NETWORKS[getCurrentChainId()].isTestnet).toBe(true)
+    expect(membershipChainId()).toBe(TESTNET_CHAIN_ID)
+    expect(membershipChainId()).not.toBe(MAINNET_CHAIN_ID)
+    expect(NETWORKS[membershipChainId()].isTestnet).toBe(true)
+  })
+
+  it('is one of the two declared reference chains, not an invented third', () => {
+    expect([MAINNET_CHAIN_ID, TESTNET_CHAIN_ID]).toContain(membershipChainId())
+  })
+
+  it('always sits inside its own cohort, and says so loudly if it ever does not', () => {
+    expect(isInCohort(membershipChainId())).toBe(true)
+    expect(() => assertReferenceChainInCohort()).not.toThrow()
+    expect(assertReferenceChainInCohort()).toBe(membershipChainId())
+  })
+
+  it('names Polygon on mainnet and Amoy on testnet — the pair, not a fresh literal', () => {
+    expect(MAINNET_CHAIN_ID).toBe(137)
+    expect(TESTNET_CHAIN_ID).toBe(80002)
+  })
+})
+
+describe('environment cohort (FR-002, constitution III)', () => {
+  it('contains only chains on this build\'s side of the testnet/mainnet boundary', () => {
+    const ids = cohortChainIds()
+    expect(ids.length).toBeGreaterThan(0)
+    for (const id of ids) expect(NETWORKS[id].isTestnet).toBe(true)
+  })
+
+  it('never contains a mainnet in a testnet build — the leak constitution III forbids', () => {
+    expect(cohortChainIds()).not.toContain(MAINNET_CHAIN_ID)
+    expect(cohortChainIds()).not.toContain(1)
+  })
+
+  it('is a strict subset of the supported chains, never the whole list', () => {
+    const all = listSupportedChainIds()
+    const cohort = cohortChainIds()
+    expect(cohort.length).toBeLessThan(all.length)
+    for (const id of cohort) expect(all).toContain(id)
+  })
+
+  it('classifies every supported chain — no chain is in neither cohort', () => {
+    for (const id of listSupportedChainIds()) {
+      expect(typeof NETWORKS[id].isTestnet).toBe('boolean')
+    }
+  })
+
+  it('isInCohort agrees with the roster in both directions', () => {
+    const cohort = cohortChainIds()
+    for (const id of listSupportedChainIds()) {
+      expect(isInCohort(id)).toBe(cohort.includes(id))
+    }
+  })
+})

--- a/specs/071-multi-chain-admin-console/checklists/requirements.md
+++ b/specs/071-multi-chain-admin-console/checklists/requirements.md
@@ -1,0 +1,65 @@
+# Specification Quality Checklist: Polygon as the membership reference chain, and all-chains reads across the operations console
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+**Validation iteration 1 — issues found and fixed:**
+
+1. *No clarification markers were needed.* The one question with real scope impact — whether
+   anchoring membership to Polygon strands members holding memberships elsewhere — was resolved
+   by checking the deployment record rather than asking: Polygon is the only **mainnet** carrying
+   a MembershipManager (the others are testnet/local). This is recorded in Assumptions, because a
+   future deployment to a second mainnet would invalidate it and reopen the question.
+
+2. *Constitution tension caught and encoded.* Constitution principle III requires network-scoped
+   data to "never leak across testnet/mainnet boundaries", which is in direct tension with a
+   naive reading of "read from all chains". FR-002 and the **environment cohort** entity bound
+   "all chains" to the build's cohort, so the two rules coexist rather than conflict. SC-008
+   makes it verifiable.
+
+3. *Cross-unit summing rejected.* An early draft had a single aggregate accrued-fee figure. Fee
+   balances on different networks are denominated in different tokens (e.g. the Polygon and
+   Ethereum Classic payment tokens are not the same asset), so one sum would be a fabricated
+   number. FR-021–FR-023 require per-unit subtotals and an explicit partial label; SC-004 pins it.
+
+4. *"Unreadable" separated from "zero" and from "not deployed".* These were collapsed in the
+   first draft. Three distinct states are now required by FR-014, because an operator auditing a
+   control surface reads a silent zero as a fact. SC-007 makes the absence of that failure mode
+   measurable.
+
+5. *Entry vs. authority separated.* FR-009 (entry is estate-wide) and FR-019 (authority is
+   per-contract, per-chain) were initially one requirement, which would have let a role held on
+   one network imply the power to write on another. They are now separate, matching the
+   least-privilege behaviour the existing operator surfaces already enforce.
+
+**Deferred to `/speckit-plan`:** which existing module owns the reference-chain constant, how the
+per-chain read helper generalizes from the existing bridge/liquidity surface, and the per-view
+conversion order. All are implementation concerns and are deliberately absent here.

--- a/specs/071-multi-chain-admin-console/checklists/requirements.md
+++ b/specs/071-multi-chain-admin-console/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: Polygon as the membership reference chain, and all-chains reads across the operations console
+# Specification Quality Checklist: Polygon as the membership reference chain, and all-chains reads across the operations control plane
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-07-27

--- a/specs/071-multi-chain-admin-console/contracts/estate-read.md
+++ b/specs/071-multi-chain-admin-console/contracts/estate-read.md
@@ -1,0 +1,87 @@
+# Contract: Estate read helper and chain read result
+
+**Modules**: `frontend/src/lib/chains/estate.js`, `frontend/src/lib/chains/chainReadResult.js`
+**Consumers**: every operator view; `contexts/RoleContext.jsx` role sync.
+**Replaces**: the network/provider helpers currently in
+`frontend/src/components/admin/liquidityAdminCommon.js`, which re-exports from here so the Bridge
+and Supply tabs and their 55 tests continue to work unchanged.
+
+## Surface
+
+```js
+// chainReadResult.js
+export function readOk(chainId, value, unit = null): ChainReadResult
+export function notDeployed(chainId): ChainReadResult
+export function unreadable(chainId, reason): ChainReadResult
+
+/** Per-unit subtotals. NEVER a single cross-unit total. */
+export function aggregate(results: ChainReadResult[]): {
+  subtotals: Record<string, bigint>,
+  partial: boolean,
+  missing: Array<{ chainId: number, reason: string }>,
+}
+
+// estate.js
+/** Cohort chains carrying `capability`, mainnets first. */
+export function estateNetworks(capability?: string): Network[]
+
+/** A read connection for `chainId`, or null when none can be built. */
+export function readProviderFor(chainId, walletChainId, walletProvider): Provider | null
+
+/** Read one contract across the cohort, concurrently; never rejects. */
+export function readAcrossEstate({
+  chainIds, addressFor, read, walletChainId, walletProvider,
+}): Promise<ChainReadResult[]>
+
+/** Does `account` hold `roles` on `contract` on `chainId`? */
+export function readAuthority({ provider, address, account, roles }): Promise<PerChainAuthority>
+```
+
+## Rules
+
+1. **Providers come from `getReadProvider(chainId)`** — never hand-built from
+   `NETWORKS[chainId].rpcUrl`.
+
+   This fixes a live spec-069 violation being carried by the current helper (research R2). The
+   existing code bypasses `resolveRpcEndpoints`, so a member's configured endpoint override and its
+   failover are ignored for every read the Bridge and Supply tabs make. Generalizing the helper
+   without fixing it would spread that bug to all fifteen views.
+
+   The one permitted shortcut is reusing the wallet's own provider when the scoped chain *is* the
+   connected chain — cheaper, and already the member's chosen transport.
+
+2. **Every read returns one of three states.** `read`, `not-deployed`, `unreadable` (FR-014). There
+   is no fourth state and no value on the latter two — the shape gives a default nowhere to live.
+
+3. **A rejected read becomes `unreadable`, never a throw and never a zero.** `readAcrossEstate`
+   never rejects; one dead endpoint does not fail the batch.
+
+4. **Chains resolve independently** (FR-015). Consumers receive results as they arrive; no view
+   blocks on the slowest endpoint.
+
+5. **`aggregate` refuses cross-unit sums** (FR-022). Values whose `unit.symbol` differs land in
+   different subtotals. There is no API that returns one number across units, so no caller can ask
+   for one.
+
+6. **`aggregate` marks partial totals** (FR-023). Any `unreadable` contributor sets `partial` and
+   is named in `missing`. `not-deployed` contributes nothing and does **not** set `partial` —
+   nothing is missing; there is nothing there.
+
+7. **The roster is cohort-bounded.** `estateNetworks` filters through `cohortChainIds()`. It lists
+   chains that *could* carry the capability even where FairWins has not deployed — hiding those
+   would hide the ones an operator most needs to see. Whether a contract exists there is the
+   per-chain read's answer, not the roster's.
+
+8. **`readAuthority` treats unreadable as unknown, not denied** (research R4). `readable: false`
+   leaves controls offered with authority unconfirmed; `deployed: false` is a definite denial.
+
+## Test obligations
+
+- Each of the three states is produced and is distinguishable by a consumer.
+- `aggregate` over mixed units yields separate subtotals and never one figure.
+- `aggregate` including an `unreadable` sets `partial` and names the chain.
+- `aggregate` including a `not-deployed` does **not** set `partial`.
+- A rejected read yields `unreadable` with a reason, and siblings still resolve.
+- `readProviderFor` obtains its provider via `getReadProvider` — asserted at source level, so the
+  spec-069 bypass cannot return.
+- The existing `AdminBridgeTab` and `AdminSupplyTab` suites pass unchanged through the re-export.

--- a/specs/071-multi-chain-admin-console/contracts/estate-read.md
+++ b/specs/071-multi-chain-admin-console/contracts/estate-read.md
@@ -45,7 +45,7 @@ export function readAuthority({ provider, address, account, roles }): Promise<Pe
    This fixes a live spec-069 violation being carried by the current helper (research R2). The
    existing code bypasses `resolveRpcEndpoints`, so a member's configured endpoint override and its
    failover are ignored for every read the Bridge and Supply tabs make. Generalizing the helper
-   without fixing it would spread that bug to all fifteen views.
+   without fixing it would spread that bug to the fifteen remaining views.
 
    The one permitted shortcut is reusing the wallet's own provider when the scoped chain *is* the
    connected chain — cheaper, and already the member's chosen transport.

--- a/specs/071-multi-chain-admin-console/contracts/membership-chain.md
+++ b/specs/071-multi-chain-admin-console/contracts/membership-chain.md
@@ -1,0 +1,60 @@
+# Contract: Membership reference-chain resolver
+
+**Module**: `frontend/src/config/networks.js` (additions)
+**Consumers**: `utils/blockchainService.js`, `components/ui/PremiumPurchaseModal.jsx`, any future
+membership surface.
+
+## Surface
+
+```js
+/** The single chain that is the authority for membership in this build's cohort. */
+export function membershipChainId(): number
+
+/** Every chain this build may read. Mainnets-first ordering. */
+export function cohortChainIds(): number[]
+
+/** Whether a chain is in this build's cohort. */
+export function isInCohort(chainId: number): boolean
+```
+
+## Rules
+
+1. **Exactly one reference chain per build** (FR-001). `membershipChainId()` is a pure function of
+   build configuration and returns the same value for the life of the process.
+
+2. **Derived, not declared** (research R1). The value comes from the existing
+   `MAINNET_CHAIN_ID` / `TESTNET_CHAIN_ID` pair, selected by
+   `NETWORKS[PRIMARY_CHAIN_ID].isTestnet`. A second literal `137` must not appear.
+
+3. **Never crosses the cohort boundary** (FR-002, constitution III). A testnet build returns the
+   testnet reference chain and never `137`. `isInCohort(membershipChainId())` is invariantly true;
+   if it ever is not, the build is misconfigured and resolution must fail loudly rather than return
+   a chain outside the cohort.
+
+4. **Not runtime-configurable.** No setter, no member preference, no operator control, no URL
+   parameter. It is a payment destination (FR-006): a wrong value sends funds to a chain where the
+   membership will never be read.
+
+5. **`cohortChainIds()` is the only roster any estate read may use.** Callers must not build their
+   own list from `listSupportedChainIds()`, which spans both cohorts.
+
+## Consumer obligation
+
+`blockchainService.js` resolves the **membership** branch of `hasRoleOnChain` and
+`getUserTierOnChain` against `membershipChainId()`, ignoring any chain the caller passed. The
+**admin-role** branch continues to honour the caller's explicit chain — admin roles are genuinely
+per-chain (research R3, R4).
+
+This split is the reason the change is two functions rather than six call sites, and the reason a
+future membership caller cannot get it wrong by habit.
+
+## Test obligations
+
+- `membershipChainId()` returns 137 under a mainnet build and 80002 under a testnet build.
+- A testnet build never returns a mainnet chain id (SC-008).
+- `hasRoleOnChain(account, 'WAGER_PARTICIPANT', <any chain>)` reads the reference chain's
+  MembershipManager — asserted by observing the address the contract was constructed against, the
+  technique `adminLeastPrivilege.test.jsx` already uses.
+- `hasRoleOnChain(account, 'GUARDIAN', 8453)` still reads chain 8453 — the admin branch is
+  unaffected.
+- A source-level guard asserts no membership read passes a wallet-derived chain.

--- a/specs/071-multi-chain-admin-console/contracts/view-scope.md
+++ b/specs/071-multi-chain-admin-console/contracts/view-scope.md
@@ -1,0 +1,88 @@
+# Contract: What every converted operator view must honour
+
+**Applies to**: all 15 views of the operations console. Bridge and Supply already comply and are the
+reference implementation.
+
+This is a behavioural contract, not an API. A view "is converted" when it satisfies every clause
+below and has tests proving it.
+
+## 1. Scope is a network the operator picks — not the wallet's
+
+- The view offers a network scope covering the cohort chains where its contract can exist.
+- Default scope: the wallet's chain when it is in the roster, otherwise the first roster entry.
+- **The scope does not change when the wallet changes network** (FR-016). An operator mid-audit must
+  not have their reading silently re-targeted. Only write-control availability reacts.
+- Scope is per view. Scoping Fees to Base does not move Staking.
+
+## 2. Every chain shows one of three states — and a zero is never one of them
+
+Per FR-014, each chain renders as exactly one of:
+
+| State | Renders as |
+|---|---|
+| read | the value |
+| not deployed on this chain | an explicit "not deployed on <chain>" |
+| could not be read | an explicit unreadable marker **with the reason**, plus a retry |
+
+A view may not render `0`, an empty table, or nothing at all for the latter two. This is the single
+most important clause: an operator auditing a control surface reads a silent zero as a fact.
+
+## 3. Chains render as they arrive
+
+No view blocks on the slowest endpoint (FR-015). A slow chain shows as pending; its siblings are
+already readable.
+
+## 4. Writes are single-chain, named, and doubly gated
+
+- A write targets exactly one chain, and **the confirmation names it** (FR-017).
+- The control is withheld unless the wallet is on the scoped chain, and the view **says so before
+  the operator tries** — "switch to <chain> to act" — rather than failing at signature time
+  (FR-018). Zero write attempts should fail for being on the wrong chain (SC-005).
+- The control is withheld unless authority was verified **against the contract on the scoped chain**
+  (FR-019). App-wide role flags decide whether the *view* appears; they never decide whether a
+  *write* is offered.
+- No control performs one action across several chains (FR-020). There is no "pause everywhere".
+
+## 5. Unreadable authority does not withdraw a control
+
+If the authority read fails, the control stays offered and authority is shown as unconfirmed. The
+contract is the real gate and refuses what the operator does not hold. Hiding a killswitch because
+an RPC timed out tells an operator who holds it that there isn't one — the failure mode spec 067
+FR-044 already names.
+
+`deployed: false` is different: there is genuinely no contract to act on, and the control is hidden
+with that stated.
+
+## 6. Aggregates are per unit and labelled when partial
+
+Any view showing a figure across chains uses `aggregate` from the estate helper: per-unit subtotals,
+never one cross-unit number (FR-022), and a `partial` label naming the missing chains whenever an
+unreadable chain was excluded (FR-023).
+
+## 7. Accessibility unchanged
+
+Scope selectors and per-chain state carry accessible names and pass the axe checks already in CI
+(constitution V). Per-chain status is conveyed by text, not colour alone.
+
+---
+
+## Per-view notes
+
+| View | Contract on the scoped chain | Notes |
+|---|---|---|
+| Overview | MembershipManager, WagerRegistry | Fee reporting per research R6: accrued (undrawn) where a MembershipManager exists; treasury received-balance where a FeeRouter routes. Never summed together. |
+| Emergency | WagerRegistry | Pause is per chain. **No cross-chain pause-all** (FR-020). Converted last (research R8). |
+| Account Moderation | WagerRegistry | Freeze is per chain; the confirmation names it. Converted last. |
+| Deny-list | SanctionsGuard | |
+| Tiers | MembershipManager | Reference chain is the only cohort mainnet carrying one — the scope selector shows the rest as not deployed, which is the honest answer. |
+| Members | MembershipManager | As above. |
+| Treasury | MembershipManager | Withdrawal is per chain. |
+| Fees | FeeRouter | Deployed on many chains; rates are per chain and genuinely differ. |
+| Staking | StakingRouter | |
+| Bridge / Supply | BridgeRouter / LiquidityRouter | **Already compliant** — reference implementation. |
+| Wiring & Tokens | WagerRegistry, MembershipManager, SanctionsGuard | |
+| Oracle Adapters | the three adapters | Polygon/Amoy only; elsewhere not deployed. |
+| Maintenance | WagerRegistry (intents facet) | Permissionless calls; still one named chain per call. |
+| Callsigns | CallsignRegistry | |
+| Admin Roles | role-defining contracts | Grants are per contract **per chain** — already true on-chain; the view must stop implying otherwise. |
+| Services | gateway + paymaster | Paymaster deposit is per chain. |

--- a/specs/071-multi-chain-admin-console/contracts/view-scope.md
+++ b/specs/071-multi-chain-admin-console/contracts/view-scope.md
@@ -1,7 +1,13 @@
 # Contract: What every converted operator view must honour
 
-**Applies to**: all 15 views of the operations console. Bridge and Supply already comply and are the
-reference implementation.
+**Applies to**: all **17** views of the operations control plane — the tab ids in
+`components/admin/adminNav.js`. Bridge and Supply already comply **with this scope contract** and are
+the reference implementation, leaving **15** to convert.
+
+Note the scope of that compliance: Bridge and Supply satisfy every clause below, but their reads
+currently reach the chain through a hand-built provider that bypasses the member's endpoint
+override (research R2). Task T010 fixes that while promoting the helper, so their read *behaviour*
+does change even though their scope behaviour does not.
 
 This is a behavioural contract, not an API. A view "is converted" when it satisfies every clause
 below and has tests proving it.

--- a/specs/071-multi-chain-admin-console/data-model.md
+++ b/specs/071-multi-chain-admin-console/data-model.md
@@ -1,0 +1,195 @@
+# Phase 1 Data Model
+
+**Feature**: `specs/071-multi-chain-admin-console/` | **Date**: 2026-07-27
+
+No persisted schema changes and no on-chain state. These are in-memory shapes and the rules that
+govern them. Each entity exists because collapsing it into a neighbour caused, or would cause, a
+specific dishonesty.
+
+---
+
+## 1. Environment cohort
+
+The set of chains a build may read.
+
+| Field | Type | Notes |
+|---|---|---|
+| `isTestnet` | boolean | Taken from the build's primary network (`NETWORKS[PRIMARY_CHAIN_ID].isTestnet`) |
+| `chainIds` | number[] | Every supported chain whose `isTestnet` matches, mainnets-first ordering |
+
+**Rules**
+
+- Membership in the cohort is total: every entry in `NETWORKS` carries `isTestnet`, so no chain is
+  unclassified.
+- **No read may target a chain outside the cohort** (FR-002). This is the mechanism satisfying
+  constitution III's testnet/mainnet clause.
+- The cohort is fixed at build time. Nothing at runtime widens it.
+
+**Derived from**: `config/networks.js` — existing `NETWORKS`, `PRIMARY_CHAIN_ID`, `isTestnet`.
+
+---
+
+## 2. Membership reference chain
+
+The single chain that is the authority for membership.
+
+| Field | Type | Notes |
+|---|---|---|
+| `chainId` | number | `137` (Polygon) for the mainnet cohort; `80002` (Amoy) for the testnet cohort |
+
+**Rules**
+
+- Exactly one per build (FR-001). Derived from the cohort, not declared separately (research R1).
+- Not operator- or member-configurable at runtime. It is a payment destination; a wrong value sends
+  a member's funds to a chain where their membership will never be read.
+- Every membership question resolves here regardless of the wallet's chain (FR-003), and every
+  membership purchase settles here (FR-006).
+
+**Relationships**: always a member of the current cohort. A reference chain outside the cohort is a
+build misconfiguration and must fail loudly rather than resolve.
+
+---
+
+## 3. Chain read result
+
+The outcome of reading one contract on one chain. **The central shape of this feature.**
+
+| Field | Type | Notes |
+|---|---|---|
+| `chainId` | number | Which chain this describes |
+| `status` | `'read' \| 'not-deployed' \| 'unreadable'` | Exactly one |
+| `value` | any \| null | Present only when `status === 'read'` |
+| `unit` | `{ symbol, decimals, address } \| null` | For balances — which token the value is denominated in |
+| `reason` | string \| null | Present only when `status === 'unreadable'`; why the read failed |
+| `readAt` | number \| null | Timestamp of a successful read, for per-chain freshness |
+
+**State meanings — these three are never interchangeable (FR-014)**
+
+- `read` — the contract answered. `value` is a fact.
+- `not-deployed` — there is no such contract on this chain. A *definite* answer: there is nothing
+  here to have a value. Distinct from a zero value.
+- `unreadable` — the question could not be put (endpoint down, timeout, malformed response). **Not**
+  an answer. Must never render as `0`, as empty, or as absence.
+
+**Rules**
+
+- A consumer may not default `value` when `status !== 'read'`. The type carries no value in those
+  states precisely so the default has nowhere to live.
+- `unreadable` is never treated as a denial in an authority context — an authority read that fails
+  leaves the control offered with authority marked unconfirmed, per the rule
+  `liquidityAdminCommon.js` already documents (research R4). Withdrawing a killswitch because an
+  RPC timed out tells an operator who holds it that there isn't one.
+- `not-deployed` **is** a definite denial in an authority context: there is no contract here to hold
+  a role on.
+
+### Aggregation of chain read results
+
+| Field | Type | Notes |
+|---|---|---|
+| `subtotals` | `{ [unitSymbol]: bigint }` | One per unit — never one grand total |
+| `partial` | boolean | True when any contributing chain is `unreadable` |
+| `missing` | number[] | Chain IDs excluded from the subtotals, and why |
+
+**Rules**
+
+- Values with different `unit` are **never summed** (FR-022). Polygon USDC and Mordor Classic USD
+  are different assets; one figure across them is invented.
+- An `unreadable` chain is excluded from every subtotal, and its exclusion sets `partial` (FR-023).
+  A partial total is never presented without saying so and naming what is missing.
+- `not-deployed` chains contribute nothing and do **not** set `partial` — nothing is missing; there
+  is simply nothing there.
+
+---
+
+## 4. Scoped chain
+
+The chain an operator view is currently showing.
+
+| Field | Type | Notes |
+|---|---|---|
+| `chainId` | number | Operator's choice, from the cohort |
+| `isWalletChain` | boolean | Whether the wallet is currently on it — gates writes only |
+
+**Rules**
+
+- Chosen by the operator, defaulting to the wallet's chain when that chain is in the view's roster,
+  otherwise the first roster entry (the behaviour `BridgeTab` already has).
+- **Does not change when the wallet changes network** (FR-016). Read state must not silently
+  re-target under an operator mid-audit; only the availability of write controls changes.
+- Independent per view. Scoping the Fees tab to Base does not move the Staking tab.
+
+---
+
+## 5. Per-chain authority
+
+Whether an account holds a given role on a given contract on a given chain.
+
+| Field | Type | Notes |
+|---|---|---|
+| `chainId` | number | Chain the question was put on |
+| `contract` | string | Which contract was asked — the one that will enforce the write |
+| `roles` | `{ [roleName]: boolean }` | Answers, only meaningful when `readable` |
+| `readable` | boolean | Whether the question could be put at all |
+| `deployed` | boolean | Whether there is a contract here to hold a role on |
+| `reason` | string \| null | Why unreadable |
+
+**Rules**
+
+- Asked of **the contract that will enforce it**, never inferred from an app-wide role flag
+  (FR-019). `GUARDIAN_ROLE` on the WagerRegistry and `GUARDIAN_ROLE` on the BridgeRouter are
+  unrelated sets; treating one as the other showed operators an enabled killswitch that reverts.
+- Distinct from console entry, which is the estate-wide question "do you hold anything anywhere"
+  (FR-009). Entry is a coarse signal and is never authority to act.
+- `readable: false` ⇒ controls stay offered, authority shown as unconfirmed. The contract is the
+  real gate.
+
+---
+
+## Entity relationships
+
+```text
+Environment cohort  ──contains──▶  chain IDs
+        │
+        ├──exactly one──▶  Membership reference chain   (membership reads + purchases)
+        │
+        └──each chain──▶   Chain read result            (per contract, per view)
+                                    │
+                                    └──aggregated──▶  per-unit subtotals + partial flag
+
+Scoped chain  ──selects which──▶  Chain read result a view foregrounds
+      │
+      └──with wallet chain + Per-chain authority──▶  whether a write control is offered
+```
+
+## State transitions
+
+**Membership resolution**
+
+```text
+unresolved ──read reference chain──▶ active(tier, expiry)
+           │                       └▶ none
+           └──read failed─────────▶ unknown  ──retry──▶ (any of the above)
+```
+
+`unknown` is never rendered as `none` (FR-004), and a membership-gated action is refused while
+`unknown` with the refusal attributed to the failed read (FR-005).
+
+**Console entry**
+
+```text
+resolving ──any chain reports a role──▶ granted
+          ──all chains answered, none report a role──▶ refused ("you hold no operator role")
+          ──no chain could be read──▶ refused ("no network could be read")   ← distinct message
+```
+
+An unreadable chain never counts as evidence a role is not held (FR-011).
+
+**Write control availability**
+
+```text
+hidden ──wallet not on scoped chain──▶ shown disabled, with "switch to <chain> to act"
+       ──wallet on scoped chain, authority readable and held──▶ enabled
+       ──wallet on scoped chain, authority readable and NOT held──▶ shown disabled, "role not held here"
+       ──wallet on scoped chain, authority unreadable──▶ enabled, authority marked unconfirmed
+       ──contract not deployed on scoped chain──▶ hidden, "not deployed on <chain>"
+```

--- a/specs/071-multi-chain-admin-console/data-model.md
+++ b/specs/071-multi-chain-admin-console/data-model.md
@@ -29,7 +29,29 @@ The set of chains a build may read.
 
 ---
 
-## 2. Membership reference chain
+## 2. Estate
+
+The platform's deployed state across the whole cohort.
+
+| Field | Type | Notes |
+|---|---|---|
+| `chainIds` | number[] | The cohort's chains — the estate is always cohort-bounded |
+| `results` | ChainReadResult[] | One per chain, for whichever contract is being read |
+
+**Rules**
+
+- The cohort is the **list of chains**; the estate is **what is deployed on them and what it says**.
+  The two are separate words because the distinction is load-bearing: a view can enumerate the
+  cohort correctly and still misreport the estate by dropping a chain it could not read.
+- "Reading the estate" means asking **every** cohort chain and reporting **all** of them —
+  including those that answered *not deployed* and those that could not be asked. A view reading one
+  chain is not reading the estate; a view reading five and silently dropping a sixth is not either.
+- The estate has no existence independent of a contract being read. There is no global "estate
+  object" — each view assembles its own for the contract it manages.
+
+---
+
+## 3. Membership reference chain
 
 The single chain that is the authority for membership.
 
@@ -50,7 +72,7 @@ build misconfiguration and must fail loudly rather than resolve.
 
 ---
 
-## 3. Chain read result
+## 4. Chain read result
 
 The outcome of reading one contract on one chain. **The central shape of this feature.**
 
@@ -101,7 +123,7 @@ The outcome of reading one contract on one chain. **The central shape of this fe
 
 ---
 
-## 4. Scoped chain
+## 5. Scoped chain
 
 The chain an operator view is currently showing.
 
@@ -120,7 +142,7 @@ The chain an operator view is currently showing.
 
 ---
 
-## 5. Per-chain authority
+## 6. Per-chain authority
 
 Whether an account holds a given role on a given contract on a given chain.
 
@@ -152,9 +174,12 @@ Environment cohort  ──contains──▶  chain IDs
         │
         ├──exactly one──▶  Membership reference chain   (membership reads + purchases)
         │
-        └──each chain──▶   Chain read result            (per contract, per view)
-                                    │
-                                    └──aggregated──▶  per-unit subtotals + partial flag
+        └──bounds──────▶   Estate                       (what is deployed on those chains)
+                              │
+                              └──each chain──▶  Chain read result   (per contract, per view)
+                                                        │
+                                                        └──aggregated──▶  per-unit subtotals
+                                                                          + partial flag
 
 Scoped chain  ──selects which──▶  Chain read result a view foregrounds
       │

--- a/specs/071-multi-chain-admin-console/plan.md
+++ b/specs/071-multi-chain-admin-console/plan.md
@@ -146,8 +146,8 @@ rather than staying under `components/admin/` because non-component callers (rol
 
 ## Phase 1 Design Summary
 
-**Entities** — see [data-model.md](./data-model.md). Five: environment cohort, membership reference
-chain, chain read result, scoped chain, per-chain authority.
+**Entities** — see [data-model.md](./data-model.md). Six: environment cohort, estate, membership
+reference chain, chain read result, scoped chain, per-chain authority.
 
 **Module contracts** — see [contracts/](./contracts/). Three, each stating a rule that must hold at a
 seam rather than describing an implementation:

--- a/specs/071-multi-chain-admin-console/plan.md
+++ b/specs/071-multi-chain-admin-console/plan.md
@@ -19,7 +19,7 @@ authority verified against that chain's own contract.
 
 The approach is **generalization, not invention**. The Bridge and Supply tabs (spec 067 FR-050)
 already do all of this for two views; their helper module moves to `lib/`, gets its spec-069
-provider bug fixed (research R2), and the other thirteen views adopt it.
+provider bug fixed (research R2), and the fifteen remaining views adopt it.
 
 ## Technical Context
 
@@ -51,7 +51,8 @@ the connected chain.
 - Reads must never cross the testnet/mainnet cohort boundary (constitution III, FR-002).
 - Balances in different units are never summed (FR-022).
 
-**Scale/Scope**: 15 operator views (2 already converted), 2 membership resolver functions, 1 purchase
+**Scale/Scope**: 17 operator views — the tab ids in `components/admin/adminNav.js` — of which 2
+(Bridge, Supply) are already converted, leaving 15. Plus 2 membership resolver functions, 1 purchase
 flow, ~6,000 lines of admin component code within reach. Cohort size 5–6 chains.
 
 ## Constitution Check

--- a/specs/071-multi-chain-admin-console/plan.md
+++ b/specs/071-multi-chain-admin-console/plan.md
@@ -1,0 +1,185 @@
+# Implementation Plan: Polygon membership reference chain + all-chains admin reads
+
+**Branch**: `claude/multi-chain-admin-polygon-membership` | **Date**: 2026-07-27 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/071-multi-chain-admin-console/spec.md`
+
+## Summary
+
+Stop answering "where does this fact live?" with "wherever the wallet is pointed."
+
+Membership gets one declared home per environment cohort — the **membership reference chain**
+(Polygon on mainnet builds, Amoy on testnet builds), derived from constants `config/networks.js`
+already holds. Every membership read, and every membership purchase, goes there. Operator views stop
+being wallet-scoped and read the whole cohort through one shared estate helper, reporting each chain
+as *read*, *not deployed*, or *unreadable* — never collapsing the last two into a zero.
+
+Writes are untouched in character: one transaction, one named chain, wallet required to be there,
+authority verified against that chain's own contract.
+
+The approach is **generalization, not invention**. The Bridge and Supply tabs (spec 067 FR-050)
+already do all of this for two views; their helper module moves to `lib/`, gets its spec-069
+provider bug fixed (research R2), and the other thirteen views adopt it.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2022+), React 19, JSX. No TypeScript in this codebase.
+
+**Primary Dependencies**: ethers v6 (contract reads), wagmi/viem (wallet transport), React Router.
+No new dependency is introduced by this feature.
+
+**Storage**: Browser local storage for the existing per-`(address, chainId)` role cache. The key
+already carries a chain dimension, so no migration is required — entries simply exist for more
+chains. No server-side or on-chain storage changes.
+
+**Testing**: Vitest + @testing-library/react + vitest-axe (`npm run test:frontend`). Source-level
+guard tests in `frontend/src/test/` for rules that must hold across files.
+
+**Target Platform**: Browser SPA (`frontend/`), desktop and mobile viewports.
+
+**Project Type**: Web application — frontend only for this feature.
+
+**Performance Goals**: A view resolves each chain independently and renders as each arrives
+(FR-015); no view blocks on the slowest endpoint. Estate reads are bounded by the cohort size
+(6 mainnets / 5 testnets today), issued concurrently, and the wallet's own provider is reused for
+the connected chain.
+
+**Constraints**:
+- No contract changes; no ABI, storage-layout, or deployment change (spec Assumptions).
+- Reads must go through `getReadProvider(chainId)` so member endpoint overrides and failover apply
+  (spec 069). The current admin helper bypasses this and is fixed here (research R2).
+- Reads must never cross the testnet/mainnet cohort boundary (constitution III, FR-002).
+- Balances in different units are never summed (FR-022).
+
+**Scale/Scope**: 15 operator views (2 already converted), 2 membership resolver functions, 1 purchase
+flow, ~6,000 lines of admin component code within reach. Cohort size 5–6 chains.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design — result unchanged.*
+
+| Principle | Applies? | Assessment |
+|---|---|---|
+| **I. Security-First Smart Contracts** | Not triggered | No `contracts/` change. No ABI, storage layout, deployment, or access-control logic is altered. The on-chain role model is explicitly out of scope. **PASS (n/a)** |
+| **II. Test-First and Comprehensive Coverage** | Yes | Every converted view gets the case set the existing `AdminBridgeTab`/`AdminSupplyTab` suites already prove (scope-off-wallet renders read state; write controls withheld with a reason; unreadable ≠ zero). Resolver and estate-helper unit tests plus a source-level guard (research R9). **PASS** |
+| **III. Honest State, No Mocks or Placeholders** | Yes — **central** | This principle *is* the feature. FR-014's three-state read result, FR-004's *unknown* membership, and FR-021–FR-023's per-unit partial-labelled totals all exist to stop unread state rendering as fact. The clause "never leak across testnet/mainnet boundaries" is honoured by cohort filtering (research R7) — see the note below. **PASS** |
+| **IV. Fail Loudly in CI** | Yes | No `continue-on-error` added. New tests run in the existing frontend job. **PASS** |
+| **V. Accessible, Consistent Frontend** | Yes | New per-chain state and scope selectors follow the existing admin patterns and must pass the axe checks already in CI. Addresses and ABIs continue to come from the generated sync artifacts — the reference chain is derived from `config/networks.js` constants, never a hand-copied address. **PASS** |
+
+### Note on principle III and "read from all chains"
+
+Read naively, "all admin views must read from all chains" collides with *"Network-scoped data
+(wagers, membership, balances) MUST be scoped to the active network and never leak across
+testnet/mainnet boundaries."*
+
+They are reconciled, not traded off. The principle's concern is **cohort leakage** — a testnet build
+showing mainnet money, or the reverse. This feature's concern is **wallet-position coupling** — a
+mainnet build showing one mainnet's state because that is where the wallet points. Cohort filtering
+(FR-002, the `estate.js` roster) satisfies the first while removing the second. A mainnet build reads
+six mainnets and no testnet; a testnet build reads five testnets and no mainnet.
+
+This is recorded as a **passing gate**, not a justified violation. Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/071-multi-chain-admin-console/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — R1..R9, all unknowns resolved
+├── data-model.md        # Phase 1 output — entities and state transitions
+├── quickstart.md        # Phase 1 output — how to validate the feature
+├── contracts/           # Phase 1 output — module interface contracts
+│   ├── estate-read.md         # Per-chain read result + estate helper contract
+│   ├── membership-chain.md    # Reference-chain resolver contract
+│   └── view-scope.md          # Contract every converted operator view honours
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── config/
+│   └── networks.js                    # + MEMBERSHIP_REFERENCE_CHAIN_ID, membershipChainId(),
+│                                      #   cohortChainIds()  (research R1, R7)
+├── lib/
+│   └── chains/
+│       ├── estate.js                  # NEW — shared per-chain read helper, promoted from
+│       │                              #   components/admin/liquidityAdminCommon.js with the
+│       │                              #   spec-069 provider bypass fixed (research R2)
+│       └── chainReadResult.js         # NEW — read | not-deployed | unreadable, and the
+│                                      #   aggregation rules that refuse cross-unit sums
+├── utils/
+│   └── blockchainService.js           # membership branch of hasRoleOnChain /
+│                                      #   getUserTierOnChain resolves the reference chain;
+│                                      #   admin-role branch keeps its explicit chain (R3)
+├── contexts/
+│   ├── RoleContext.jsx                # estate-wide role sync; records per-chain outcome (R4)
+│   └── WalletContext.jsx              # same sync path
+├── components/
+│   ├── AdminPanel.jsx                 # entry gate + permissions card become estate-wide;
+│   │                                  #   fee overview per chain
+│   ├── admin/
+│   │   ├── liquidityAdminCommon.js    # re-exports from lib/chains/estate.js; Bridge/Supply
+│   │   │                              #   keep working unchanged
+│   │   ├── MembershipTreasuryOverview.jsx
+│   │   ├── FeesTab.jsx  StakingTab.jsx  DenyListAdmin.jsx  CallsignRegistryAdmin.jsx
+│   │   ├── ProtocolConfigTab.jsx  OracleAdaptersTab.jsx  MaintenanceTab.jsx
+│   │   └── ServiceHealthCard.jsx  PaymasterOpsCard.jsx
+│   └── ui/
+│       └── PremiumPurchaseModal.jsx   # purchase routed to the reference chain (US5)
+└── test/
+    ├── chainResolutionGuard.test.js   # doc-comment amended to state the actual rule (R5)
+    └── admin/                         # per-view suites, modelled on the two existing ones
+```
+
+**Structure Decision**: Existing web-application layout; frontend only. The one new directory is
+`frontend/src/lib/chains/`, which follows the established `lib/<domain>/` convention already used by
+`lib/custody/`, `lib/relay/`, `lib/network/`, `lib/recovery/`. The shared helper lands in `lib/`
+rather than staying under `components/admin/` because non-component callers (role sync in
+`contexts/`, purchase preflight) consume it.
+
+## Phase 1 Design Summary
+
+**Entities** — see [data-model.md](./data-model.md). Five: environment cohort, membership reference
+chain, chain read result, scoped chain, per-chain authority.
+
+**Module contracts** — see [contracts/](./contracts/). Three, each stating a rule that must hold at a
+seam rather than describing an implementation:
+
+- [`estate-read.md`](./contracts/estate-read.md) — every estate read returns a three-state result;
+  aggregation refuses cross-unit sums and labels partial totals.
+- [`membership-chain.md`](./contracts/membership-chain.md) — one resolver, cohort-derived, not
+  runtime-configurable.
+- [`view-scope.md`](./contracts/view-scope.md) — the contract each converted view honours: scope
+  independent of wallet, writes gated on wallet chain *and* per-contract authority, unreadable never
+  rendered as zero.
+
+**Validation** — see [quickstart.md](./quickstart.md).
+
+## Rollout
+
+Sequenced per research R8 so each step ships independently and the incident-response paths convert
+last, on a pattern already proven by eight earlier views:
+
+1. Foundation (`lib/chains/`, `membershipChainId()`) — no user-visible change.
+2. Console entry + permissions card (US2).
+3. Membership resolution + purchase routing (US1, US5).
+4. Overview and fee reporting (US3).
+5. Read-mostly views, then write-heavy views (US4).
+6. Emergency and Account Moderation last.
+
+## Complexity Tracking
+
+> No constitution violations. This section is intentionally empty.
+
+Two simplifications are worth recording, since both remove code rather than add it:
+
+- The estate helper is **moved**, not written. `liquidityAdminCommon.js` keeps re-exporting it, so
+  the two converted tabs and their 55 existing tests are untouched.
+- Membership resolution changes in **two resolver functions**, not at six call sites, because the
+  callers already funnel through them (research R3).

--- a/specs/071-multi-chain-admin-console/quickstart.md
+++ b/specs/071-multi-chain-admin-console/quickstart.md
@@ -1,0 +1,144 @@
+# Quickstart: validating spec 071
+
+**Feature**: `specs/071-multi-chain-admin-console/` | **Date**: 2026-07-27
+
+How to prove the feature works. Read [`contracts/`](./contracts/) for the rules being validated and
+[`data-model.md`](./data-model.md) for the shapes; this file is the run guide.
+
+## Prerequisites
+
+```bash
+cd frontend
+npm ci
+```
+
+An account is needed for the manual scenarios:
+
+- **For membership (US1, US5)**: an account holding an active `WAGER_PARTICIPANT` membership on the
+  reference chain (Polygon on a mainnet build).
+- **For operator scenarios (US2, US3, US4)**: an account holding an operator role on **exactly one**
+  chain — the interesting case is proving it works from a *different* chain.
+
+## Automated checks
+
+```bash
+# Whole frontend suite
+npm run test:frontend
+
+# The suites this feature adds to or depends on
+npx vitest run src/test/admin/                    # per-view conversions
+npx vitest run src/test/chainResolutionGuard.test.js
+npx vitest run src/test/lib/chains/               # estate helper + read-result unit tests
+
+# Must stay green untouched — the two already-converted views prove the
+# re-export did not disturb the reference implementation
+npx vitest run src/test/admin/AdminBridgeTab.test.jsx src/test/admin/AdminSupplyTab.test.jsx
+
+npm run lint
+```
+
+**Expected**: all green. The Bridge and Supply suites (27 + 28 tests) must pass **without
+modification** — if they needed changing, the helper was rewritten rather than moved.
+
+## Manual validation
+
+```bash
+npm run frontend
+```
+
+### US1 — membership follows the member across networks
+
+1. Connect the membership-holding account. Switch the wallet to **Base**, then **Arbitrum**, then
+   **Ethereum**.
+2. On each, open a membership-gated surface.
+
+**Expect**: the same tier and expiry every time.
+**Fail condition**: any network reports no membership. That is the pre-fix behaviour.
+
+3. Point the reference chain's endpoint at an unreachable host (My Account → Network) and reload.
+
+**Expect**: "membership could not be read" plus a retry.
+**Fail condition**: the words "no membership" appear anywhere. `unknown` must never render as
+`none` (FR-004).
+
+### US2 — reach the console from the wrong chain
+
+1. With the single-chain operator account, switch the wallet to a chain where it holds **nothing**.
+2. Open `/admin`.
+
+**Expect**: the console opens; only that role's views are listed; the permissions card names the
+network each role was found on.
+**Fail condition**: "Access Restricted".
+
+3. Break one non-reference chain's endpoint and reload.
+
+**Expect**: that chain reported as unread; entry still granted from roles found elsewhere (FR-011).
+
+### US3 — accrued fees across the estate
+
+1. Open **Overview**.
+
+**Expect**: every cohort chain listed as read / not deployed / unreadable. Accrued (undrawn) and
+treasury (received) are separate lines — research R6 — never added together.
+
+2. Break one chain's endpoint and reload.
+
+**Expect**: that chain flagged, excluded from totals, and the total labelled **partial** naming what
+is missing.
+**Fail condition**: the total silently shrinks, or an unreadable chain shows `0`.
+
+### US4 — every view spans the estate
+
+For each converted view, with the wallet on chain **A**:
+
+1. Scope the view to chain **B**.
+
+**Expect**: B's control state. Write controls disabled, saying the write happens on B and the wallet
+must switch there — *before* any signature attempt (SC-005).
+
+2. Switch the wallet to B.
+
+**Expect**: the scope **stays on B** (FR-016 — it must not follow the wallet), and write controls
+become available only if authority on B's contract is confirmed.
+
+3. Scope to a chain where the contract is not deployed.
+
+**Expect**: an explicit "not deployed on <chain>" — not an empty panel, not zeros.
+
+### US5 — purchases route to the reference chain
+
+1. With the wallet on a non-reference chain, start a membership purchase.
+
+**Expect**: the flow states the purchase settles on the reference chain and offers the switch.
+
+2. Decline the switch.
+
+**Expect**: no purchase on any chain.
+
+3. Complete the purchase, then connect from another network.
+
+**Expect**: the new membership resolves (closes the loop with US1).
+
+## Success criteria mapping
+
+| SC | Validated by |
+|---|---|
+| SC-001 | US1 steps 1–2 |
+| SC-002 | US2 steps 1–2 |
+| SC-003 | US3 step 1 |
+| SC-004 | US3 step 2; `aggregate` unit tests |
+| SC-005 | US4 step 1 |
+| SC-006 | US5 steps 1–2 |
+| SC-007 | US1 step 3, US3 step 2, US4 step 3 |
+| SC-008 | `membershipChainId()` cohort tests; source-level guard |
+
+## The three failure modes to watch for
+
+Everything else is detail. If a reviewer checks only three things:
+
+1. **An unreachable chain rendering as `0` or as nothing.** The whole feature exists to stop unread
+   state being read as fact.
+2. **A single figure summing balances across chains.** Different chains hold different tokens; one
+   number across them is invented.
+3. **A write control offered on the strength of an app-wide role flag** rather than the contract on
+   the scoped chain. That shows an operator an enabled control that reverts.

--- a/specs/071-multi-chain-admin-console/research.md
+++ b/specs/071-multi-chain-admin-console/research.md
@@ -61,7 +61,7 @@ export function readProviderFor(chainId, walletChainId, walletProvider) {
 `getRpcUrlForChain(chainId)`."* The consequence is real, not stylistic — this path bypasses
 `resolveRpcEndpoints`, so a member's configured endpoint override and its failover are ignored for
 every read the Bridge and Supply tabs make. Today that affects two tabs. Generalizing this helper
-to all fifteen views without fixing it would propagate the bug across the whole console.
+to the fifteen remaining views without fixing it would propagate the bug across the whole console.
 
 The shared helper therefore calls `getReadProvider(chainId)` and keeps only the
 "reuse the wallet's provider when the scope is the connected chain" optimization.
@@ -196,7 +196,10 @@ This is a gate the plan's Constitution Check treats as **passing**, not as a jus
 
 ---
 
-## R8 — Conversion order for the fifteen operator views
+## R8 — Conversion order for the fifteen remaining operator views
+
+The console has **17** views (`components/admin/adminNav.js` tab ids). Bridge and Supply are already
+converted, leaving **15**.
 
 **Decision**: convert in this order, so each step is independently shippable and the highest-risk
 surface is not first:
@@ -234,7 +237,7 @@ throughout, so every later step has a worked example to match rather than a desi
 
 **Rationale**: constitution principle II requires tests alongside behaviour. The existing
 `AdminBridgeTab` / `AdminSupplyTab` suites (27 and 28 tests) already cover exactly these cases for
-the two converted tabs and are the template for the other thirteen.
+the two converted tabs and are the template for the fifteen remaining.
 
 ---
 

--- a/specs/071-multi-chain-admin-console/research.md
+++ b/specs/071-multi-chain-admin-console/research.md
@@ -1,0 +1,255 @@
+# Phase 0 Research: Polygon membership reference chain + all-chains admin reads
+
+**Feature**: `specs/071-multi-chain-admin-console/` | **Date**: 2026-07-27
+
+Everything below was resolved against the codebase rather than assumed. Two findings changed the
+shape of the plan and are called out as such (R2, R6).
+
+---
+
+## R1 — Where the membership reference chain is declared
+
+**Decision**: Add `MEMBERSHIP_REFERENCE_CHAIN_ID` to `frontend/src/config/networks.js`, derived from
+the build's environment cohort, and export a `membershipChainId()` accessor. Mainnet cohort →
+`MAINNET_CHAIN_ID` (137, Polygon). Testnet cohort → `TESTNET_CHAIN_ID` (80002, Polygon Amoy).
+
+**Rationale**: `networks.js` already declares exactly this pair for the user-facing testnet/mainnet
+toggle:
+
+```js
+const MAINNET_CHAIN_ID = 137
+const TESTNET_CHAIN_ID = 80002
+export const TESTNET_MAINNET_PAIR = { testnet: TESTNET_CHAIN_ID, mainnet: MAINNET_CHAIN_ID }
+```
+
+The reference chain is the same fact under a different name, so it is derived from the existing
+constants rather than declared a second time. A second literal `137` in the codebase is a
+divergence waiting to happen.
+
+The cohort is read from the build's primary network — `NETWORKS[PRIMARY_CHAIN_ID].isTestnet` —
+which is the mechanism the app already uses to keep testnet and mainnet apart. `isTestnet` is
+present on all 11 network entries, so the cohort split is total, with no unclassified network.
+
+**Alternatives rejected**:
+- *Hardcode 137 at each membership call site* — six call sites, each free to drift, and no single
+  place to change for a testnet build. Also silently reads mainnet membership in a testnet build,
+  violating constitution III.
+- *Make it operator-configurable at runtime* — membership is a payment destination. A wrong value
+  sends a member's USDC to a chain where their membership will never be read. Nothing about this
+  wants a runtime switch (spec FR-001, Assumptions).
+
+---
+
+## R2 — The per-chain read helper (and a spec-069 violation to fix while generalizing) ⚠️
+
+**Decision**: Promote `readProviderFor` and the network-roster helper out of
+`frontend/src/components/admin/liquidityAdminCommon.js` into a shared module
+(`frontend/src/lib/chains/estate.js`), **and fix how it obtains a provider on the way**.
+
+**Finding**: the existing helper hand-builds a provider from the raw network config:
+
+```js
+export function readProviderFor(chainId, walletChainId, walletProvider) {
+  if (walletProvider && Number(chainId) === Number(walletChainId)) return walletProvider
+  const rpcUrl = NETWORKS[chainId]?.rpcUrl          // ← spec 069 forbids exactly this
+  return rpcUrl ? makeReadProvider(rpcUrl, chainId) : null
+}
+```
+
+`CLAUDE.md` (spec 069) states plainly: *"**Never hand-build a provider from
+`NETWORKS[chainId].rpcUrl`**: go through `makeReadProvider` / `getReadProvider(chainId)`, or
+`getRpcUrlForChain(chainId)`."* The consequence is real, not stylistic — this path bypasses
+`resolveRpcEndpoints`, so a member's configured endpoint override and its failover are ignored for
+every read the Bridge and Supply tabs make. Today that affects two tabs. Generalizing this helper
+to all fifteen views without fixing it would propagate the bug across the whole console.
+
+The shared helper therefore calls `getReadProvider(chainId)` and keeps only the
+"reuse the wallet's provider when the scope is the connected chain" optimization.
+
+**Rationale for promoting rather than reimplementing**: `liquidityAdminCommon.js` already documents
+the exact rules this feature generalizes — scope is a network not the wallet's network; an
+unreadable read is never a zero; authority is read from the contract in scope. Those doc-comments
+are the design; moving the code keeps one copy of it.
+
+**Alternatives rejected**:
+- *Leave the helper where it is and import it from `components/admin/`* — a `lib/` concern living
+  under one feature's component folder; every non-admin consumer would import through it.
+- *A React hook only* — some consumers (role sync in `contexts/`, purchase preflight) are not
+  components. The primitive is a plain async function; a hook wraps it.
+
+---
+
+## R3 — Which reads must move to the reference chain
+
+**Decision**: Membership resolution moves to the reference chain at the two resolver functions in
+`frontend/src/utils/blockchainService.js`, which every membership call site already funnels through:
+
+| Function | Current chain input | Consumers |
+|---|---|---|
+| `hasRoleOnChain(user, role, chainId)` | wallet chain | `contexts/RoleContext.jsx`, `contexts/WalletContext.jsx` |
+| `getUserTierOnChain(user, role, chainId)` | wallet chain | `components/ui/PremiumPurchaseModal.jsx` |
+
+The **membership** branch of each (the `WAGER_PARTICIPANT` / `MembershipManager` path) resolves
+against `membershipChainId()`. The **admin-role** branch keeps taking an explicit chain, because
+admin roles genuinely are per-chain (R4).
+
+**Rationale**: splitting at the resolver rather than at each caller means the rule is enforced in
+one place and cannot be forgotten by a future caller. The two branches already exist inside these
+functions as separate code paths — `hasRoleOnChain` branches on the role name before choosing a
+contract — so the split follows a seam that is already there.
+
+**Alternatives rejected**:
+- *Change every call site* — six sites now, unbounded later, and each is an opportunity to pass the
+  wallet chain by habit.
+- *Ignore the chain argument entirely* — would silently break the admin-role reads that legitimately
+  need a chain.
+
+---
+
+## R4 — Estate-wide console entry vs. per-chain authority
+
+**Decision**: Two distinct resolutions, never conflated.
+
+- **Entry** (`hasAnyRole(ADMIN_ROLES)`): resolved across every chain in the cohort. `RoleContext`
+  syncs roles per chain and records *which* chains answered yes, which said no, and which could not
+  be read.
+- **Authority to write**: resolved per (contract, chain, account) at the point of the control, via
+  the existing `readRouterAuthority` shape generalized to any AccessControl contract.
+
+**Rationale**: `liquidityAdminCommon.js` already documents why these cannot be one value, from a
+real defect: `isGuardian` means "guardian on the WagerRegistry", and treating it as authority showed
+operators an enabled killswitch that reverts. The same doc records the converse failure — an
+unreadable authority read must **not** withdraw a control, because an operator who does hold it
+concludes there isn't one. Both rules carry forward unchanged; this feature only widens the entry
+question.
+
+**Current entry behaviour to preserve**: role state is cached in local storage keyed by
+`(address, chainId)` and synced from chain. The sync loop gains a chain dimension; the cache key
+already has one, so no storage migration is required — a per-chain entry simply exists for more
+chains than before.
+
+---
+
+## R5 — The spec-008 chain-resolution guard still passes, but its stated intent must be amended
+
+**Finding**: `frontend/src/test/chainResolutionGuard.test.js` enforces spec 008 FR-011: user-facing
+code must resolve addresses and providers *chain-aware* rather than build-time-bound. It fails a
+file that adds a new `getContractAddress(name)` or argless `getProvider()`.
+
+Reference-chain resolution uses `getContractAddressForChain(name, membershipChainId())` — chain-aware,
+just with an explicit chain instead of the wallet's — so **the guard passes unmodified**.
+
+**Decision**: the guard's doc-comment says the requirement is the *"wallet's CONNECTED chain"*. That
+sentence becomes untrue for the membership path, so it is amended to state the rule the code
+actually follows: resolve against an **explicit** chain — the wallet's for wallet-scoped state, the
+reference chain for membership, the scoped chain for operator views — never the build-time default.
+The mechanical check is unchanged; only the reason it exists is restated correctly.
+
+**Rationale**: a guard whose comment describes a rule the code deliberately breaks trains the next
+reader to distrust the guard.
+
+---
+
+## R6 — What "accrued fees" actually means per chain ⚠️
+
+**Finding**: there is exactly **one** undrawn fee balance in the system, and it is not where the
+phrase "all chains for accrued fees" first suggests.
+
+- `MembershipManager.accruedFees()` — undrawn membership tier fees, withdrawable via
+  `withdrawFees(amount, to)`. **This is the only accruing balance.** Deployed on Polygon (137),
+  Amoy (80002), Mordor (63), Hardhat (1337) — and on **no other mainnet**.
+- `FeeRouter` (spec 060) — deployed on many more chains, but it **holds nothing**. `FeeRouter.sol`
+  forwards the fee to the treasury inside the same transaction (`depositToVaultWithFee`: fee →
+  treasury, net → vault, atomic). There is no accrual to read, by design.
+
+**Decision**: the fee overview reports two clearly distinguished things per chain:
+
+1. **Accrued (undrawn)** — `MembershipManager.accruedFees()`, only where a MembershipManager is
+   deployed; elsewhere the chain reads *not deployed*, not zero.
+2. **Treasury balance** — the configured treasury's payment-token balance on each chain carrying a
+   `FeeRouter`, labelled as *received*, not *accrued*.
+
+They are never added together: one is a liability the platform still owes itself, the other is money
+already delivered.
+
+**Rationale**: on the mainnet cohort, "accrued fees across all chains" would otherwise be a
+single-chain figure dressed up as an estate-wide one — the exact dishonesty FR-023 exists to
+prevent. Naming the second source is what makes the sentence true.
+
+**Units**: the payment token differs per chain (Polygon USDC `0x3c49…`, Mordor Classic USD
+`0xDE09…`). Cross-chain summing is refused by FR-022. Within the mainnet cohort the accrued figure
+is single-chain anyway, so the per-unit rule costs nothing today and prevents a wrong number the
+day a second mainnet deployment lands.
+
+---
+
+## R7 — Constitution III: "never leak across testnet/mainnet boundaries"
+
+**Decision**: every estate roster is filtered to the build's cohort before any read.
+
+**Rationale**: constitution principle III requires network-scoped data to stay scoped and never
+cross the testnet/mainnet boundary. Read literally against "read from all chains", these conflict.
+Cohort filtering dissolves the conflict: "all chains" means all chains *this build may read*. A
+mainnet build never reads Amoy; a testnet build never reads Polygon.
+
+This is a gate the plan's Constitution Check treats as **passing**, not as a justified violation.
+
+---
+
+## R8 — Conversion order for the fifteen operator views
+
+**Decision**: convert in this order, so each step is independently shippable and the highest-risk
+surface is not first:
+
+1. **Foundation** — `lib/chains/estate.js`, `membershipChainId()`, the per-chain read-result type.
+2. **Entry + permissions card** — US2. Nothing else can be reached from the wrong chain until this
+   lands.
+3. **Membership resolution + purchase routing** — US1, US5. Member-facing, and independent of the
+   operator views.
+4. **Overview / fee reporting** — US3, the first view to consume the estate helper end-to-end.
+5. **Read-mostly views** — Maintenance, Services, Oracle Adapters, Wiring & Tokens.
+6. **Write-heavy views** — Tiers, Members, Treasury, Fees, Staking, Deny-list, Callsigns, Admin
+   Roles. Each gains a scope selector plus a per-chain authority check.
+7. **Emergency + Account Moderation last.** These are the incident-response paths; converting them
+   after the pattern is proven on eight other views means the killswitch is the least-experimental
+   conversion, not the most.
+
+**Rationale**: Bridge and Supply are already converted and act as the reference implementation
+throughout, so every later step has a worked example to match rather than a design to invent.
+
+---
+
+## R9 — Testing approach
+
+**Decision**:
+- **Unit** — the estate helper's three-state read result (read / not deployed / unreadable) and its
+  refusal to sum across units, tested directly.
+- **Resolver** — `membershipChainId()` under both cohorts, proving a testnet build never returns 137.
+- **Component** — each converted view: scope to a chain the wallet is not on and assert read state
+  renders and write controls are withheld *with a stated reason*; make a chain unreadable and assert
+  it renders as unreadable rather than as zero.
+- **Guard** — a source-level test, in the spirit of the existing `chainResolutionGuard`, asserting
+  that membership resolution does not read the wallet chain and that no view sums balances across
+  chains.
+
+**Rationale**: constitution principle II requires tests alongside behaviour. The existing
+`AdminBridgeTab` / `AdminSupplyTab` suites (27 and 28 tests) already cover exactly these cases for
+the two converted tabs and are the template for the other thirteen.
+
+---
+
+## Resolved unknowns
+
+| Unknown | Resolution |
+|---|---|
+| Where the reference chain constant lives | R1 — derived in `config/networks.js` from the existing mainnet/testnet pair |
+| How reads reach a non-connected chain | R2 — shared estate helper via `getReadProvider`, fixing the current spec-069 bypass |
+| Whether every membership call site must change | R3 — no; the two resolvers funnel them all |
+| Whether entry and write authority are one question | R4 — no; deliberately separate, per an existing documented defect |
+| Whether the spec-008 guard blocks this | R5 — no; it passes, but its stated intent is amended |
+| What accrues, and where | R6 — only `MembershipManager.accruedFees`; the FeeRouter holds nothing |
+| Constitution III vs. "all chains" | R7 — cohort filtering; gate passes |
+| Conversion order | R8 — foundation → entry → membership → overview → read-mostly → write-heavy → incident paths |
+| Test strategy | R9 — mirror the existing Bridge/Supply admin suites |
+
+**No NEEDS CLARIFICATION items remain.**

--- a/specs/071-multi-chain-admin-console/research.md
+++ b/specs/071-multi-chain-admin-console/research.md
@@ -222,6 +222,41 @@ throughout, so every later step has a worked example to match rather than a desi
 
 ---
 
+## R10 — The spec-067 tabs span cohorts, and this feature must not "fix" that silently ⚠️
+
+**Found during implementation of Phase 2**, not during planning — recording it here because it
+qualifies FR-002 and the claim that Bridge/Supply "already comply".
+
+`adminNetworks(capability)` in `liquidityAdminCommon.js` builds its roster from
+`listSupportedChainIds()` — **both cohorts** — and the two spec-067 routers exist on mainnets only
+(Uniswap on 1/10/137/8453/42161, Across LP on Ethereum). The test build runs
+`VITE_NETWORK_ID=63` (Mordor), so it is a *testnet* build whose Bridge and Supply tabs list five
+**mainnets**. Under a strict reading of FR-002 that is precisely the cross-cohort read
+constitution III forbids.
+
+**Decision for this feature: leave it exactly as it is, and say so.** Cohort-bounding that roster
+would return an empty list in a testnet build and blank both tabs — replacing a debatable
+disclosure with a definite regression, in the two views this feature holds up as its reference
+implementation. So:
+
+- `estateNetworks()` (new, cohort-bounded) is used by every **new** estate read.
+- `adminNetworks()` (existing, cross-cohort) keeps its behaviour, with the reason written at the
+  call site, and `readProviderFor` takes an explicit `{ requireCohort: false }` opt-out that only
+  those two tabs pass.
+
+**Open question this leaves**, deliberately not settled here: whether a testnet build should show
+mainnet router state at all. Both answers are defensible — it is an operator surface, and the
+routers genuinely have no testnet deployment — but it is a spec-067 question about what those tabs
+are *for*, not a spec-071 question about how reads are scoped. It needs its own decision rather
+than being resolved as a side effect of this change.
+
+**Consequence for the spec**: FR-002 governs the reads this feature introduces. It does not
+retroactively bind the two pre-existing spec-067 rosters, and `contracts/view-scope.md`'s "Bridge
+and Supply already comply" should be read as "with the scope contract", which is how it is now
+worded.
+
+---
+
 ## R9 — Testing approach
 
 **Decision**:

--- a/specs/071-multi-chain-admin-console/spec.md
+++ b/specs/071-multi-chain-admin-console/spec.md
@@ -191,7 +191,7 @@ exists to complete a purchase on any other network.
 **All-chains reads across operator views**
 
 - **FR-013**: Every operator view MUST be able to present the control state of every chain in the cohort where the contract it manages can exist, independent of the connected chain.
-- **FR-014**: Each view MUST distinguish, per chain, at least these states: *read successfully*, *contract not deployed on this chain*, and *chain could not be read*. A chain that could not be read MUST NOT render as zero, empty, or absent.
+- **FR-014**: Each view MUST distinguish, per chain, exactly these three states: *read successfully*, *contract not deployed on this chain*, and *chain could not be read*. There is no fourth state, and the latter two carry no value — so no consumer has anywhere to put a default. A chain that could not be read MUST NOT render as zero, empty, or absent.
 - **FR-015**: A view MUST NOT block on the slowest chain; each chain's state MUST render as it resolves.
 - **FR-016**: A view's scoped chain MUST NOT change implicitly when the wallet changes network.
 

--- a/specs/071-multi-chain-admin-console/spec.md
+++ b/specs/071-multi-chain-admin-console/spec.md
@@ -1,4 +1,4 @@
-# Feature Specification: Polygon as the membership reference chain, and all-chains reads across the operations console
+# Feature Specification: Polygon as the membership reference chain, and all-chains reads across the operations control plane
 
 **Feature Branch**: `071-multi-chain-admin-console`
 
@@ -59,7 +59,7 @@ retry, and never as *none*.
 
 ### User Story 2 - An operator reaches the console from wherever they are (Priority: P1)
 
-An operator holds an operator role somewhere in the estate. They open the operations console and
+An operator holds an operator role somewhere in the estate. They open the operations control plane and
 get in, and the console tells them where their authority actually lives — rather than refusing
 them because their wallet happened to be pointed at a network where they hold nothing.
 
@@ -183,7 +183,7 @@ exists to complete a purchase on any other network.
 
 **Console entry**
 
-- **FR-009**: Entry to the operations console MUST be granted when the account holds any operator role on any chain in the cohort, regardless of the connected chain.
+- **FR-009**: Entry to the operations control plane MUST be granted when the account holds any operator role on any chain in the cohort, regardless of the connected chain.
 - **FR-010**: The console MUST show, for each operator role, the network(s) on which the account holds it.
 - **FR-011**: A chain that could not be read during the entry check MUST be reported as unread and MUST NOT be counted as evidence that a role is not held.
 - **FR-012**: Entry MUST be refused when no chain reports any operator role; when no chain could be read at all, the refusal MUST say so rather than asserting the account holds nothing.
@@ -212,6 +212,7 @@ exists to complete a purchase on any other network.
 
 - **Membership reference chain**: The single chain, per environment cohort, that is the authority for membership state. One per build; not operator-configurable at runtime.
 - **Environment cohort**: The set of chains a build may read — mainnets for a mainnet build, testnets for a testnet build. Reads never cross cohorts.
+- **Estate**: The platform's deployed state across the whole cohort — every contract on every chain the build may read. Distinct from the cohort, which is the *list of chains*: the estate is *what is deployed on them and what it says*. "Reading the estate" means asking every cohort chain and reporting all of them, including the ones that answered *not deployed* and the ones that could not be asked at all. A view that reads one chain is not reading the estate; a view that reads five and silently drops a sixth is not either.
 - **Chain read result**: The outcome of reading one contract on one chain. Carries one of *read*, *not deployed*, or *unreadable*, plus the value when read and the reason when not.
 - **Scoped chain**: The chain an operator view is currently showing. Chosen by the operator, independent of the wallet's network, and unchanged by wallet network changes.
 - **Per-chain authority**: Whether an account holds a given role on a given contract on a given chain. Distinct from console entry, which is an estate-wide question.

--- a/specs/071-multi-chain-admin-console/spec.md
+++ b/specs/071-multi-chain-admin-console/spec.md
@@ -1,0 +1,249 @@
+# Feature Specification: Polygon as the membership reference chain, and all-chains reads across the operations console
+
+**Feature Branch**: `071-multi-chain-admin-console`
+
+**Created**: 2026-07-27
+
+**Status**: Draft
+
+**Input**: User description: "when a user is attempting to access the admin console the platform needs to check polygon for membership and all chains for accrued fees. all admin views must read from all chains. polygon should be the reference chain for membership activities and be the place membership purchases are routed to"
+
+## Overview
+
+Today the platform answers two different questions with the same wrong input: *the chain the
+wallet happens to be connected to*.
+
+- **Membership** is read wherever the wallet sits. On mainnet, membership exists in exactly one
+  place — Polygon — so a member connected to Ethereum, Optimism, Base, Arbitrum or Ethereum
+  Classic is told they have no membership. They have one; the platform looked somewhere it was
+  never kept.
+- **Operator control state** is read wherever the wallet sits. That state is spread across every
+  network the platform is deployed on, so an operator is shown one network's worth of an estate
+  that spans many — and the rest reads as *absent* rather than as *not looked at*.
+
+This feature separates *where a fact lives* from *where the wallet is*. Membership gets a single
+declared home — the **membership reference chain** — and every membership question is asked
+there, including where purchases settle. Operator views stop being wallet-scoped and read the
+whole estate, saying honestly which chains answered and which did not.
+
+Two things deliberately do **not** change: a write is still a transaction on exactly one chain and
+still requires the wallet to be there, and authority for that write is still verified against the
+specific contract on that specific network.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A member's membership follows them across networks (Priority: P1)
+
+A member bought a membership. They connect from whichever network they are using that day — Base
+to move USDC, Arbitrum to trade, Ethereum to bridge — and the platform recognises the membership
+every time, because it always asks the reference chain. If the reference chain cannot be reached,
+the platform says so rather than reporting the member as having nothing.
+
+**Why this priority**: This is the live defect. Membership exists on exactly one mainnet, so every
+member on any other network is currently mis-read as unentitled — losing them access they paid
+for, on surfaces they reached correctly.
+
+**Independent Test**: Connect an account holding a reference-chain membership to each supported
+network in turn and confirm the tier and expiry resolve identically every time. Then make the
+reference chain unreachable and confirm the platform reports membership as *unknown*, with a
+retry, and never as *none*.
+
+**Acceptance Scenarios**:
+
+1. **Given** an account with an active membership on the reference chain, **When** it connects on any other supported network and opens a membership-gated surface, **Then** the membership resolves with the same tier and expiry as on the reference chain.
+2. **Given** an account with no membership anywhere, **When** it connects on any supported network, **Then** the platform reports no membership and offers the purchase path.
+3. **Given** the reference chain's endpoint is unreachable, **When** an account opens a membership-gated surface, **Then** the platform states that membership could not be read and offers a retry, and does not state that the account has no membership.
+4. **Given** a build configured for a testnet environment, **When** membership is resolved, **Then** it is read from that environment's reference chain and never from a mainnet.
+
+---
+
+### User Story 2 - An operator reaches the console from wherever they are (Priority: P1)
+
+An operator holds an operator role somewhere in the estate. They open the operations console and
+get in, and the console tells them where their authority actually lives — rather than refusing
+them because their wallet happened to be pointed at a network where they hold nothing.
+
+**Why this priority**: The console is the incident-response surface. An operator refused entry
+because of their wallet's current network is an operator who cannot act during an incident. Entry
+is a read, and reads should span the estate.
+
+**Independent Test**: With an account holding a role on exactly one network, connect on a
+different network and confirm the console opens, lists only the views that account can use, and
+names the network each role was found on.
+
+**Acceptance Scenarios**:
+
+1. **Given** an account holding an operator role on any single supported network, **When** it opens the console while connected to a different network, **Then** the console opens and offers the views that role gates.
+2. **Given** an account holding no operator role on any network, **When** it opens the console, **Then** access is refused with the existing restricted-access explanation.
+3. **Given** an account whose roles are held on more than one network, **When** it views its own permissions, **Then** each role is listed with the network(s) it is held on.
+4. **Given** one network's endpoint is unreachable during the entry check, **When** the console resolves entry, **Then** the unreadable network is reported as unread rather than counted as "role not held", and roles found elsewhere still grant entry.
+
+---
+
+### User Story 3 - Accrued fees are visible for the whole estate (Priority: P2)
+
+An operator opens the console and sees what has accrued everywhere fees accrue — per network, in
+the unit each network actually holds — instead of one network's balance presented as if it were
+the whole picture.
+
+**Why this priority**: A fee balance read on one network and shown without qualification is a
+number an operator will act on as if it were the total. Under-reporting the treasury is a
+financial-reporting error, not a display bug.
+
+**Independent Test**: With balances seeded on more than one network, open the console and confirm
+every network with a fee-bearing deployment is listed with its own balance and unit. Then make one
+network unreachable and confirm it is flagged and excluded from any total, and that the total does
+not silently shrink.
+
+**Acceptance Scenarios**:
+
+1. **Given** fee-bearing deployments on several networks, **When** the operator opens the fee overview, **Then** each network is listed with its own accrued balance and the unit that balance is denominated in.
+2. **Given** two networks whose balances are denominated in different units, **When** a total is displayed, **Then** it is shown per unit and never as a single cross-unit sum.
+3. **Given** one network's balance cannot be read, **When** the overview renders, **Then** that network is marked unreadable, is excluded from every total, and the total is labelled partial.
+4. **Given** a network has no fee-bearing deployment, **When** the overview renders, **Then** it is shown as not deployed there — distinct from a zero balance and from an unreadable one.
+
+---
+
+### User Story 4 - Every operator view spans the estate (Priority: P2)
+
+An operator picks the network they want to inspect from within any view and sees that network's
+control state, whatever their wallet is connected to. When they want to *change* something, the
+view tells them plainly that the write happens on that network and that their wallet must be
+there, and confirms their authority on that network's contract before offering the control.
+
+**Why this priority**: This generalizes the behaviour the bridge and liquidity surfaces already
+have. Until every view works this way, the console is an inconsistent mix — some views showing the
+estate, others showing one network — and an operator cannot tell which they are looking at.
+
+**Independent Test**: For each view, connect on network A, scope the view to network B, and confirm
+the state shown is B's. Confirm write controls are withheld with an explicit reason while the
+wallet is on A, and appear once the wallet is on B and authority on B is confirmed.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator connected to network A, **When** they scope any view to network B, **Then** the view shows network B's control state.
+2. **Given** a view scoped to a network the wallet is not connected to, **When** the operator looks for a write control, **Then** the control is unavailable and the view states that the write happens on that network and the wallet must be switched to it.
+3. **Given** an operator whose wallet is on the scoped network but who does not hold the gating role on that network's contract, **When** the view renders, **Then** no write control is offered and the view says the role is not held there.
+4. **Given** a view scoped to a network where its contract is not deployed, **When** the view renders, **Then** it says so explicitly rather than rendering empty or zeroed state.
+5. **Given** any view, **When** the operator performs a write, **Then** exactly one network is affected and the network is named in the confirmation.
+
+---
+
+### User Story 5 - Membership purchases go to the reference chain (Priority: P2)
+
+A member buys or renews a membership. The purchase is made on the reference chain, wherever they
+started from, and the platform says which network the payment will settle on before they sign.
+
+**Why this priority**: Membership must be readable from one place (US1), which is only true if it
+is also *written* in one place. A purchase that lands elsewhere creates a membership the
+reference-chain read will never see.
+
+**Independent Test**: Start a purchase while connected to a non-reference network and confirm the
+flow discloses the reference chain, requires the switch, and completes there — and that no path
+exists to complete a purchase on any other network.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member connected to a non-reference network, **When** they begin a membership purchase, **Then** the flow states the purchase settles on the reference chain and offers to switch the wallet there.
+2. **Given** a member who declines the switch, **When** the flow ends, **Then** no purchase has been made on any network.
+3. **Given** a member on the reference chain without sufficient payment balance there, **When** they begin a purchase, **Then** the shortfall is stated in terms of the reference chain's payment token, rather than counted from balances held elsewhere.
+4. **Given** a completed purchase, **When** the member connects on any other supported network, **Then** the new membership resolves (US1).
+
+---
+
+### Edge Cases
+
+- **Reference chain unreachable.** Membership resolves to *unknown*, never to *none*. Surfaces that gate on membership refuse the gated action but must attribute the refusal to the failed read, and offer a retry.
+- **Every chain unreachable during console entry.** Entry is refused, and the refusal states that no network could be read — distinct from "you hold no role".
+- **Partial estate readability.** Any aggregate is labelled partial and names the networks missing from it. A partial total is never presented as complete.
+- **Cross-unit aggregation.** Networks whose balances are denominated in different tokens are never summed. Only per-unit subtotals exist.
+- **Role held on one network, not another.** Entry is granted (US2) but no write control is offered on a network where the role is not held (US4) — the two questions are answered separately.
+- **Wallet switches network mid-session.** A view's scoped network does not change; read state does not silently re-target. Only the availability of write controls changes.
+- **Environment cohorts.** A build never reads across the testnet/mainnet boundary: a testnet build's reference chain and estate are testnet-only, a mainnet build's are mainnet-only.
+- **A network with no deployment of the contract a view manages.** Reported as not deployed — a distinct state from a zero value and from an unreadable one.
+- **Slow networks.** One slow endpoint does not block the rest of a view; each network resolves independently and renders as it arrives.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Membership reference chain**
+
+- **FR-001**: The platform MUST define exactly one **membership reference chain** for the build's environment cohort, and MUST NOT resolve membership on any other chain.
+- **FR-002**: The reference chain MUST be Polygon for mainnet builds, and the corresponding Polygon testnet for testnet builds; a build MUST NOT resolve membership across the testnet/mainnet boundary.
+- **FR-003**: Every membership question — console entry, tier gating, tier and expiry display, and any membership-derived entitlement — MUST be answered from the reference chain, regardless of the chain the wallet is connected to.
+- **FR-004**: When the reference chain cannot be read, membership MUST resolve to a distinct *unknown* state that is never presented as *no membership*, and the surface MUST offer a retry.
+- **FR-005**: A membership-gated action MUST be refused while membership is *unknown*, and the refusal MUST attribute itself to the failed read.
+
+**Membership purchases**
+
+- **FR-006**: Membership purchases MUST be routed to the reference chain, and the platform MUST NOT offer or complete a purchase on any other chain.
+- **FR-007**: Before a member signs, the purchase flow MUST disclose which network the purchase settles on, and MUST require the wallet to be on that network.
+- **FR-008**: Payment-balance sufficiency for a purchase MUST be evaluated against the member's balance on the reference chain only, and any shortfall MUST be stated in the reference chain's payment token.
+
+**Console entry**
+
+- **FR-009**: Entry to the operations console MUST be granted when the account holds any operator role on any chain in the cohort, regardless of the connected chain.
+- **FR-010**: The console MUST show, for each operator role, the network(s) on which the account holds it.
+- **FR-011**: A chain that could not be read during the entry check MUST be reported as unread and MUST NOT be counted as evidence that a role is not held.
+- **FR-012**: Entry MUST be refused when no chain reports any operator role; when no chain could be read at all, the refusal MUST say so rather than asserting the account holds nothing.
+
+**All-chains reads across operator views**
+
+- **FR-013**: Every operator view MUST be able to present the control state of every chain in the cohort where the contract it manages can exist, independent of the connected chain.
+- **FR-014**: Each view MUST distinguish, per chain, at least these states: *read successfully*, *contract not deployed on this chain*, and *chain could not be read*. A chain that could not be read MUST NOT render as zero, empty, or absent.
+- **FR-015**: A view MUST NOT block on the slowest chain; each chain's state MUST render as it resolves.
+- **FR-016**: A view's scoped chain MUST NOT change implicitly when the wallet changes network.
+
+**Writes stay single-chain**
+
+- **FR-017**: A write MUST target exactly one chain, and the confirmation MUST name that chain.
+- **FR-018**: A write control MUST be withheld unless the wallet is connected to the scoped chain, and the view MUST state that requirement rather than failing at signature time.
+- **FR-019**: A write control MUST be withheld unless the account's authority has been verified against the specific contract on the scoped chain; app-wide or entry-level role signals MUST NOT be treated as authority to write.
+- **FR-020**: The platform MUST NOT offer any control that performs one action across multiple chains implicitly.
+
+**Accrued fees**
+
+- **FR-021**: Accrued fees MUST be presented for every chain in the cohort carrying a fee-bearing deployment, each with its own balance and the unit that balance is denominated in.
+- **FR-022**: Balances denominated in different units MUST NOT be summed; totals MUST be per unit.
+- **FR-023**: A chain whose balance could not be read MUST be excluded from every total, MUST be flagged, and any total computed without it MUST be labelled partial and name what is missing.
+
+### Key Entities
+
+- **Membership reference chain**: The single chain, per environment cohort, that is the authority for membership state. One per build; not operator-configurable at runtime.
+- **Environment cohort**: The set of chains a build may read — mainnets for a mainnet build, testnets for a testnet build. Reads never cross cohorts.
+- **Chain read result**: The outcome of reading one contract on one chain. Carries one of *read*, *not deployed*, or *unreadable*, plus the value when read and the reason when not.
+- **Scoped chain**: The chain an operator view is currently showing. Chosen by the operator, independent of the wallet's network, and unchanged by wallet network changes.
+- **Per-chain authority**: Whether an account holds a given role on a given contract on a given chain. Distinct from console entry, which is an estate-wide question.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member holding a membership resolves that membership identically from 100% of supported networks in the cohort, with no network reporting them as unentitled.
+- **SC-002**: An operator holding a role on any one network can open the console and see that role's views from 100% of supported networks in the cohort.
+- **SC-003**: The fee overview accounts for 100% of the cohort's fee-bearing deployments; every network is shown as read, not deployed, or unreadable, with no network silently omitted.
+- **SC-004**: Zero displayed aggregates combine balances of different units, and zero aggregates computed from an incomplete set of networks are presented without a partial label.
+- **SC-005**: In every operator view, a wallet on the wrong network is told so before signing rather than at signature time — no write attempt fails because the wallet was on the wrong chain.
+- **SC-006**: 100% of membership purchases settle on the reference chain; no path exists that completes a purchase elsewhere.
+- **SC-007**: An unreachable network never renders as a zero or an absence anywhere in the console — every such case is attributable to a read failure in the interface.
+- **SC-008**: No build reads membership or control state across the testnet/mainnet boundary.
+
+## Assumptions
+
+- **Polygon is already the only mainnet home of membership.** Membership is deployed on Polygon and on testnet/local networks only; no other mainnet carries it. Anchoring membership to Polygon therefore strands no existing member — it corrects a lookup that was pointed at chains where membership was never kept.
+- **The reference chain is build configuration, not a runtime choice.** Operators and members do not select it; it follows the build's environment cohort, which is how the platform already avoids testnet/mainnet leakage.
+- **Reads use each chain's own endpoint.** Reading a chain the wallet is not connected to uses that chain's configured endpoint, with the member's own endpoint override honoured where one is set. No new custody, signing, or key material is involved in any read.
+- **Bridging is out of scope.** A member whose funds are on another network is told to switch and fund on the reference chain. Moving those funds is the existing transfer/bridge surface's job, not this feature's.
+- **The existing per-network pattern is the model.** The bridge and liquidity operator surfaces already read every capable network with per-network endpoints and gate writes on the wallet's chain; this feature generalizes that behaviour rather than inventing a second approach.
+- **No contract changes.** This is a resolution and presentation change. No on-chain interface, storage layout, or deployment is altered.
+- **Console entry stays a coarse signal.** Entry means "you hold something somewhere". It is not authority to act, and every write path re-checks authority against the contract on the scoped chain — the separation the existing least-privilege behaviour already relies on.
+- **Aggregate freshness is best-effort.** Chains resolve independently, so an aggregate may briefly reflect different read times per chain; where that matters, the interface shows per-chain freshness rather than implying a single instant.
+
+## Out of Scope
+
+- Moving membership to more than one chain, or replicating membership state across chains.
+- Bridging funds to the reference chain as part of the purchase flow.
+- Any control that executes one operator action across several chains in a single step.
+- Changes to which roles gate which views, or to the on-chain role model.
+- Contract deployments to networks that do not currently carry a given contract.

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -44,7 +44,7 @@ depends on this phase.** No user-visible change lands here.
 
 ### Cohort and reference chain
 
-- [ ] T003 Add `MEMBERSHIP_REFERENCE_CHAIN_ID`, `membershipChainId()`, `cohortChainIds()`, and `isInCohort(chainId)` to `frontend/src/config/networks.js`, deriving the reference chain from the existing `MAINNET_CHAIN_ID`/`TESTNET_CHAIN_ID` pair selected by `NETWORKS[PRIMARY_CHAIN_ID].isTestnet` — no second literal `137` (research R1, contracts/membership-chain.md)
+- [ ] T003 Add `MEMBERSHIP_REFERENCE_CHAIN_ID`, `membershipChainId()`, `cohortChainIds()`, and `isInCohort(chainId)` to `frontend/src/config/networks.js`, deriving the reference chain from the existing `MAINNET_CHAIN_ID`/`TESTNET_CHAIN_ID` pair selected by `NETWORKS[PRIMARY_CHAIN_ID].isTestnet` — no second literal `137` (FR-001, FR-002; research R1, contracts/membership-chain.md)
 - [ ] T004 Make a reference chain outside the current cohort fail loudly at module load rather than resolve, in `frontend/src/config/networks.js` (contracts/membership-chain.md rule 3)
 - [ ] T005 [P] Test the resolver in `frontend/src/test/membershipChain.test.js`: returns 137 under a mainnet build, 80002 under a testnet build, and never a mainnet id under a testnet build (SC-008)
 
@@ -58,11 +58,11 @@ depends on this phase.** No user-visible change lands here.
 
 - [ ] T009 Create `frontend/src/lib/chains/estate.js` by moving `readProviderFor`, the network-roster helper, and `readRouterAuthority` out of `frontend/src/components/admin/liquidityAdminCommon.js`, preserving their doc-comments — they are the design (research R2)
 - [ ] T010 **Fix the spec-069 violation while moving**: `readProviderFor` in `frontend/src/lib/chains/estate.js` obtains its provider from `getReadProvider(chainId)` instead of hand-building from `NETWORKS[chainId].rpcUrl`, keeping only the reuse-the-wallet-provider-for-the-connected-chain shortcut (research R2)
-- [ ] T011 Bound the roster to the cohort: `estateNetworks(capability)` in `frontend/src/lib/chains/estate.js` filters through `cohortChainIds()`, and still lists chains that could carry the capability but have no FairWins deployment (contracts/estate-read.md rule 7)
+- [ ] T011 Bound the roster to the cohort: `estateNetworks(capability)` in `frontend/src/lib/chains/estate.js` filters through `cohortChainIds()`, and still lists chains that could carry the capability but have no FairWins deployment (FR-002, FR-013; contracts/estate-read.md rule 7)
 - [ ] T012 Add `readAcrossEstate({chainIds, addressFor, read, walletChainId, walletProvider})` to `frontend/src/lib/chains/estate.js` — concurrent, never rejects, one dead endpoint becomes `unreadable` without failing the batch (FR-015)
 - [ ] T013 Generalize `readRouterAuthority` to `readAuthority({provider, address, account, roles})` in `frontend/src/lib/chains/estate.js` for any AccessControl contract, keeping `readable: false` ⇒ unknown-not-denied and `deployed: false` ⇒ definite denial (research R4)
 - [ ] T014 Turn `frontend/src/components/admin/liquidityAdminCommon.js` into a re-export of the promoted helpers so `BridgeTab`/`SupplyTab` are untouched
-- [ ] T015 [P] Test the helper in `frontend/src/test/lib/chains/estate.test.js`: a rejected read yields `unreadable` with a reason while siblings resolve; the roster never contains an out-of-cohort chain
+- [ ] T015 [P] Test the helper in `frontend/src/test/lib/chains/estate.test.js`: a rejected read yields `unreadable` with a reason while siblings resolve; a slow chain does not delay its siblings' results, which are observable before it settles (FR-015); the roster never contains an out-of-cohort chain
 - [ ] T016 [P] Source-level test in `frontend/src/test/lib/chains/estateProvider.test.js` asserting `estate.js` reaches providers via `getReadProvider` and contains no `NETWORKS[...].rpcUrl` access, so the spec-069 bypass cannot return
 - [ ] T017 **Checkpoint**: run `npx vitest run src/test/admin/AdminBridgeTab.test.jsx src/test/admin/AdminSupplyTab.test.jsx` — both suites MUST pass **unmodified**. If either needed changing, the helper was rewritten rather than moved; revert and redo T009–T014.
 
@@ -128,7 +128,7 @@ declining buys nothing, and that no path completes a purchase elsewhere.
 - [ ] T038 [US5] Offer a wallet network switch to the reference chain, and ensure declining leaves no purchase attempted on any chain (FR-007, acceptance 2)
 - [ ] T039 [US5] Evaluate payment-token sufficiency against the reference chain's balance only, stating any shortfall in that chain's payment token, in `frontend/src/components/ui/PremiumPurchaseModal.jsx` (FR-008)
 - [ ] T040 [US5] Audit `frontend/src/hooks/useTierPrices.js` and `frontend/src/hooks/useVouchers.js` for connected-chain assumptions in the purchase path and route them to the reference chain
-- [ ] T041 [P] [US5] Test in `frontend/src/test/membershipPurchaseRouting.test.jsx`: purchase from a non-reference chain discloses the settlement network; declining the switch sends no transaction; the built calls target the reference chain's MembershipManager
+- [ ] T041 [P] [US5] Test in `frontend/src/test/membershipPurchaseRouting.test.jsx`: purchase from a non-reference chain discloses the settlement network; declining the switch sends no transaction; the built calls target the reference chain's MembershipManager; **and the absence SC-006 claims** — drive the flow on *each* non-reference cohort chain and assert every built call still targets the reference chain's address, so "no path completes a purchase elsewhere" is verified rather than asserted in prose (mirrors the absence assertion T067 makes for FR-020)
 
 **Checkpoint**: US1 + US5 together close the read/write loop — a purchase is now readable from
 everywhere.
@@ -158,44 +158,46 @@ pattern for Phase 7.
 
 ## Phase 7: User Story 4 — Every operator view spans the estate (P2)
 
-**Goal**: The remaining thirteen views honour [contracts/view-scope.md](./contracts/view-scope.md).
+**Goal**: Thirteen of the fifteen remaining views honour
+[contracts/view-scope.md](./contracts/view-scope.md). The other two — Overview and Treasury —
+converted in Phase 6, so "thirteen" here is this phase's share, not the whole remainder.
 
 **Independent test**: Per view — connect on chain A, scope to B, confirm B's state renders, writes
 are withheld with a stated reason, and the scope does **not** follow the wallet when it switches.
 
 ### Shared scope control
 
-- [ ] T050 [US4] Extract the network scope selector used by `BridgeTab`/`SupplyTab` into a shared component under `frontend/src/components/admin/`, defaulting to the wallet chain when in the roster and never re-targeting when the wallet switches (FR-016)
+- [ ] T050 [US4] Extract the network scope selector used by `BridgeTab`/`SupplyTab` into a shared component under `frontend/src/components/admin/`, defaulting to the wallet chain when in the roster and never re-targeting when the wallet switches (FR-013, FR-016)
 - [ ] T051 [US4] Add a shared per-chain state renderer (read / not deployed / unreadable + reason + retry) so no view invents its own rendering of the three states (FR-014)
 - [ ] T052 [US4] Add a shared write-gate presenter that states "switch to <chain> to act" before signature and "role not held here" when authority is read and denied, leaving controls offered with authority unconfirmed when the read failed (FR-018, FR-019, research R4)
 - [ ] T053 [P] [US4] Test the three shared pieces in `frontend/src/test/admin/adminScopeControls.test.jsx`, including axe-clean rendering and per-chain status conveyed by text not colour alone (constitution V)
 
 ### Read-mostly views
 
-- [ ] T054 [P] [US4] Convert `frontend/src/components/admin/MaintenanceTab.jsx` to the scope contract; each permissionless call still targets one named chain
+- [ ] T054 [P] [US4] Convert `frontend/src/components/admin/MaintenanceTab.jsx` to the scope contract; each permissionless call still targets one named chain (FR-017)
 - [ ] T055 [P] [US4] Convert `frontend/src/components/admin/ServiceHealthCard.jsx` and `frontend/src/components/admin/PaymasterOpsCard.jsx`; the paymaster deposit is per chain
 - [ ] T056 [P] [US4] Convert `frontend/src/components/admin/OracleAdaptersTab.jsx`; chains without adapters read *not deployed*, which is the honest answer for most of the cohort
 - [ ] T057 [P] [US4] Convert `frontend/src/components/admin/ProtocolConfigTab.jsx` (Wiring & Tokens) across its three contracts
 
 ### Write-heavy views
 
-- [ ] T058 [P] [US4] Convert the Tiers view in `frontend/src/components/AdminPanel.jsx` — only the reference chain carries a MembershipManager on the mainnet cohort, so the rest must show *not deployed*, not an empty form
-- [ ] T059 [P] [US4] Convert the Members view in `frontend/src/components/AdminPanel.jsx`
+- [ ] T058 [US4] Convert the Tiers view in `frontend/src/components/AdminPanel.jsx` — only the reference chain carries a MembershipManager on the mainnet cohort, so the rest must show *not deployed*, not an empty form (**not** `[P]`: shares `AdminPanel.jsx` with T059/T064/T066/T068)
+- [ ] T059 [US4] Convert the Members view in `frontend/src/components/AdminPanel.jsx` (**not** `[P]`: same file as T058/T064/T066/T068)
 - [ ] T060 [P] [US4] Convert `frontend/src/components/admin/FeesTab.jsx`; fee rates are genuinely per chain and must not be shown as one global rate
 - [ ] T061 [P] [US4] Convert `frontend/src/components/admin/StakingTab.jsx`
 - [ ] T062 [P] [US4] Convert `frontend/src/components/admin/DenyListAdmin.jsx`
 - [ ] T063 [P] [US4] Convert `frontend/src/components/admin/CallsignRegistryAdmin.jsx`
 - [ ] T064 [US4] Convert the Admin Roles view in `frontend/src/components/AdminPanel.jsx` so a grant names the chain it lands on — grants are already per contract **per chain** on-chain, and the view currently implies otherwise
-- [ ] T065 [P] [US4] Per-view tests under `frontend/src/test/admin/` for T054–T064, each covering: scope-off-wallet renders read state; write withheld with a stated reason; unreadable ≠ zero; not-deployed stated explicitly
+- [ ] T065 [P] [US4] Per-view tests under `frontend/src/test/admin/` for T054–T064, each covering: scope-off-wallet renders read state; write withheld with a stated reason; unreadable ≠ zero; not-deployed stated explicitly; **the write confirmation names the chain it targets** (FR-017 — the only write requirement with no other test); and the view is **axe-clean** in every per-chain state, matching the `is axe-clean fully loaded` case the existing `AdminBridgeTab`/`AdminSupplyTab` suites already carry (constitution V)
 
 ### Incident-response views (converted last, on a proven pattern — research R8)
 
-- [ ] T066 [US4] Convert the Emergency view in `frontend/src/components/AdminPanel.jsx`; pause is per chain and the confirmation names it
+- [ ] T066 [US4] Convert the Emergency view in `frontend/src/components/AdminPanel.jsx`; pause is per chain and the confirmation names it (FR-017)
 - [ ] T067 [US4] Assert there is **no** cross-chain "pause everywhere" control (FR-020) — an implicit multi-chain killswitch is exactly what this feature must not create
-- [ ] T068 [US4] Convert the Account Moderation view in `frontend/src/components/AdminPanel.jsx`; freeze is per chain and the confirmation names it
+- [ ] T068 [US4] Convert the Account Moderation view in `frontend/src/components/AdminPanel.jsx`; freeze is per chain and the confirmation names it (FR-017)
 - [ ] T069 [P] [US4] Test the incident paths in `frontend/src/test/admin/adminIncidentEstate.test.jsx`, including the absence of any multi-chain action
 
-**Checkpoint**: all fifteen views honour one contract; the console no longer mixes estate-wide and
+**Checkpoint**: all seventeen views honour one contract; the console no longer mixes estate-wide and
 wallet-scoped views.
 
 ---

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -30,8 +30,8 @@ is reachable from the wrong chain until it does, and the incident-response views
 
 **Purpose**: Directory scaffolding. No new dependencies — this feature adds none.
 
-- [ ] T001 Create `frontend/src/lib/chains/` following the existing `lib/<domain>/` convention used by `lib/custody/`, `lib/network/`, `lib/relay/`
-- [ ] T002 [P] Create `frontend/src/test/lib/chains/` for the estate-helper unit suites
+- [X] T001 Create `frontend/src/lib/chains/` following the existing `lib/<domain>/` convention used by `lib/custody/`, `lib/network/`, `lib/relay/`
+- [X] T002 [P] Create `frontend/src/test/lib/chains/` for the estate-helper unit suites
 
 ---
 
@@ -44,27 +44,27 @@ depends on this phase.** No user-visible change lands here.
 
 ### Cohort and reference chain
 
-- [ ] T003 Add `MEMBERSHIP_REFERENCE_CHAIN_ID`, `membershipChainId()`, `cohortChainIds()`, and `isInCohort(chainId)` to `frontend/src/config/networks.js`, deriving the reference chain from the existing `MAINNET_CHAIN_ID`/`TESTNET_CHAIN_ID` pair selected by `NETWORKS[PRIMARY_CHAIN_ID].isTestnet` — no second literal `137` (FR-001, FR-002; research R1, contracts/membership-chain.md)
-- [ ] T004 Make a reference chain outside the current cohort fail loudly at module load rather than resolve, in `frontend/src/config/networks.js` (contracts/membership-chain.md rule 3)
-- [ ] T005 [P] Test the resolver in `frontend/src/test/membershipChain.test.js`: returns 137 under a mainnet build, 80002 under a testnet build, and never a mainnet id under a testnet build (SC-008)
+- [X] T003 Add `MEMBERSHIP_REFERENCE_CHAIN_ID`, `membershipChainId()`, `cohortChainIds()`, and `isInCohort(chainId)` to `frontend/src/config/networks.js`, deriving the reference chain from the existing `MAINNET_CHAIN_ID`/`TESTNET_CHAIN_ID` pair selected by `NETWORKS[PRIMARY_CHAIN_ID].isTestnet` — no second literal `137` (FR-001, FR-002; research R1, contracts/membership-chain.md)
+- [X] T004 Make a reference chain outside the current cohort fail loudly at module load rather than resolve, in `frontend/src/config/networks.js` (contracts/membership-chain.md rule 3)
+- [X] T005 [P] Test the resolver in `frontend/src/test/lib/chains/membershipChain.test.js`: returns 137 under a mainnet build, 80002 under a testnet build, and never a mainnet id under a testnet build (SC-008)
 
 ### Chain read result
 
-- [ ] T006 Create `frontend/src/lib/chains/chainReadResult.js` with `readOk`, `notDeployed`, `unreadable`, and `aggregate` per contracts/estate-read.md — no value field on the non-`read` states, so a default has nowhere to live
-- [ ] T007 Implement `aggregate` in `frontend/src/lib/chains/chainReadResult.js` as per-unit subtotals with `partial` + `missing`; expose no API that returns one figure across units (FR-022, FR-023)
-- [ ] T008 [P] Test the three states and aggregation in `frontend/src/test/lib/chains/chainReadResult.test.js`: mixed units yield separate subtotals; an `unreadable` contributor sets `partial` and is named; a `not-deployed` contributor does **not** set `partial`
+- [X] T006 Create `frontend/src/lib/chains/chainReadResult.js` with `readOk`, `notDeployed`, `unreadable`, and `aggregate` per contracts/estate-read.md — no value field on the non-`read` states, so a default has nowhere to live
+- [X] T007 Implement `aggregate` in `frontend/src/lib/chains/chainReadResult.js` as per-unit subtotals with `partial` + `missing`; expose no API that returns one figure across units (FR-022, FR-023)
+- [X] T008 [P] Test the three states and aggregation in `frontend/src/test/lib/chains/chainReadResult.test.js`: mixed units yield separate subtotals; an `unreadable` contributor sets `partial` and is named; a `not-deployed` contributor does **not** set `partial`
 
 ### Estate read helper
 
-- [ ] T009 Create `frontend/src/lib/chains/estate.js` by moving `readProviderFor`, the network-roster helper, and `readRouterAuthority` out of `frontend/src/components/admin/liquidityAdminCommon.js`, preserving their doc-comments — they are the design (research R2)
-- [ ] T010 **Fix the spec-069 violation while moving**: `readProviderFor` in `frontend/src/lib/chains/estate.js` obtains its provider from `getReadProvider(chainId)` instead of hand-building from `NETWORKS[chainId].rpcUrl`, keeping only the reuse-the-wallet-provider-for-the-connected-chain shortcut (research R2)
-- [ ] T011 Bound the roster to the cohort: `estateNetworks(capability)` in `frontend/src/lib/chains/estate.js` filters through `cohortChainIds()`, and still lists chains that could carry the capability but have no FairWins deployment (FR-002, FR-013; contracts/estate-read.md rule 7)
-- [ ] T012 Add `readAcrossEstate({chainIds, addressFor, read, walletChainId, walletProvider})` to `frontend/src/lib/chains/estate.js` — concurrent, never rejects, one dead endpoint becomes `unreadable` without failing the batch (FR-015)
-- [ ] T013 Generalize `readRouterAuthority` to `readAuthority({provider, address, account, roles})` in `frontend/src/lib/chains/estate.js` for any AccessControl contract, keeping `readable: false` ⇒ unknown-not-denied and `deployed: false` ⇒ definite denial (research R4)
-- [ ] T014 Turn `frontend/src/components/admin/liquidityAdminCommon.js` into a re-export of the promoted helpers so `BridgeTab`/`SupplyTab` are untouched
-- [ ] T015 [P] Test the helper in `frontend/src/test/lib/chains/estate.test.js`: a rejected read yields `unreadable` with a reason while siblings resolve; a slow chain does not delay its siblings' results, which are observable before it settles (FR-015); the roster never contains an out-of-cohort chain
-- [ ] T016 [P] Source-level test in `frontend/src/test/lib/chains/estateProvider.test.js` asserting `estate.js` reaches providers via `getReadProvider` and contains no `NETWORKS[...].rpcUrl` access, so the spec-069 bypass cannot return
-- [ ] T017 **Checkpoint**: run `npx vitest run src/test/admin/AdminBridgeTab.test.jsx src/test/admin/AdminSupplyTab.test.jsx` — both suites MUST pass **unmodified**. If either needed changing, the helper was rewritten rather than moved; revert and redo T009–T014.
+- [X] T009 Create `frontend/src/lib/chains/estate.js` by moving `readProviderFor`, the network-roster helper, and `readRouterAuthority` out of `frontend/src/components/admin/liquidityAdminCommon.js`, preserving their doc-comments — they are the design (research R2)
+- [X] T010 **Fix the spec-069 violation while moving**: `readProviderFor` in `frontend/src/lib/chains/estate.js` obtains its provider from `getReadProvider(chainId)` instead of hand-building from `NETWORKS[chainId].rpcUrl`, keeping only the reuse-the-wallet-provider-for-the-connected-chain shortcut (research R2)
+- [X] T011 Bound the roster to the cohort: `estateNetworks(capability)` in `frontend/src/lib/chains/estate.js` filters through `cohortChainIds()`, and still lists chains that could carry the capability but have no FairWins deployment (FR-002, FR-013; contracts/estate-read.md rule 7)
+- [X] T012 Add `readAcrossEstate({chainIds, addressFor, read, walletChainId, walletProvider})` to `frontend/src/lib/chains/estate.js` — concurrent, never rejects, one dead endpoint becomes `unreadable` without failing the batch (FR-015)
+- [X] T013 Generalize `readRouterAuthority` to `readAuthority({provider, address, account, roles})` in `frontend/src/lib/chains/estate.js` for any AccessControl contract, keeping `readable: false` ⇒ unknown-not-denied and `deployed: false` ⇒ definite denial (research R4)
+- [X] T014 Turn `frontend/src/components/admin/liquidityAdminCommon.js` into a re-export of the promoted helpers so `BridgeTab`/`SupplyTab` are untouched
+- [X] T015 [P] Test the helper in `frontend/src/test/lib/chains/estate.test.js`: a rejected read yields `unreadable` with a reason while siblings resolve; a slow chain does not delay its siblings' results, which are observable before it settles (FR-015); the roster never contains an out-of-cohort chain
+- [X] T016 [P] Source-level test (in `frontend/src/test/lib/chains/estate.test.js`, alongside the behavioural cases) asserting `estate.js` reaches providers via `getReadProvider` and contains no `NETWORKS[...].rpcUrl` access, so the spec-069 bypass cannot return
+- [X] T017 **Checkpoint**: run `npx vitest run src/test/admin/AdminBridgeTab.test.jsx src/test/admin/AdminSupplyTab.test.jsx` — both suites MUST pass **unmodified**. If either needed changing, the helper was rewritten rather than moved; revert and redo T009–T014.
 
 ---
 

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -1,0 +1,273 @@
+---
+
+description: "Task list for spec 071 — Polygon membership reference chain + all-chains admin reads"
+---
+
+# Tasks: Polygon membership reference chain + all-chains admin reads
+
+**Input**: Design documents from `/specs/071-multi-chain-admin-console/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md),
+[data-model.md](./data-model.md), [contracts/](./contracts/)
+
+**Tests**: **INCLUDED and non-optional.** Constitution principle II is NON-NEGOTIABLE — behaviour is
+not done until tests prove it — and research R9 defines the strategy. The existing
+`AdminBridgeTab`/`AdminSupplyTab` suites (27 + 28 tests) are the template throughout.
+
+**Organization**: Grouped by user story. Phase order follows the rollout in research R8, which is
+*not* strict priority order: console entry (US2) lands before membership (US1) because nothing else
+is reachable from the wrong chain until it does, and the incident-response views convert last.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on incomplete work)
+- **[Story]**: Which user story the task serves
+- Paths are repository-relative; this feature is frontend-only
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Directory scaffolding. No new dependencies — this feature adds none.
+
+- [ ] T001 Create `frontend/src/lib/chains/` following the existing `lib/<domain>/` convention used by `lib/custody/`, `lib/network/`, `lib/relay/`
+- [ ] T002 [P] Create `frontend/src/test/lib/chains/` for the estate-helper unit suites
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The cohort, the reference chain, and the estate read primitive. **Every user story
+depends on this phase.** No user-visible change lands here.
+
+**⚠️ Nothing in Phase 3+ may start until Phase 2 is complete.**
+
+### Cohort and reference chain
+
+- [ ] T003 Add `MEMBERSHIP_REFERENCE_CHAIN_ID`, `membershipChainId()`, `cohortChainIds()`, and `isInCohort(chainId)` to `frontend/src/config/networks.js`, deriving the reference chain from the existing `MAINNET_CHAIN_ID`/`TESTNET_CHAIN_ID` pair selected by `NETWORKS[PRIMARY_CHAIN_ID].isTestnet` — no second literal `137` (research R1, contracts/membership-chain.md)
+- [ ] T004 Make a reference chain outside the current cohort fail loudly at module load rather than resolve, in `frontend/src/config/networks.js` (contracts/membership-chain.md rule 3)
+- [ ] T005 [P] Test the resolver in `frontend/src/test/membershipChain.test.js`: returns 137 under a mainnet build, 80002 under a testnet build, and never a mainnet id under a testnet build (SC-008)
+
+### Chain read result
+
+- [ ] T006 Create `frontend/src/lib/chains/chainReadResult.js` with `readOk`, `notDeployed`, `unreadable`, and `aggregate` per contracts/estate-read.md — no value field on the non-`read` states, so a default has nowhere to live
+- [ ] T007 Implement `aggregate` in `frontend/src/lib/chains/chainReadResult.js` as per-unit subtotals with `partial` + `missing`; expose no API that returns one figure across units (FR-022, FR-023)
+- [ ] T008 [P] Test the three states and aggregation in `frontend/src/test/lib/chains/chainReadResult.test.js`: mixed units yield separate subtotals; an `unreadable` contributor sets `partial` and is named; a `not-deployed` contributor does **not** set `partial`
+
+### Estate read helper
+
+- [ ] T009 Create `frontend/src/lib/chains/estate.js` by moving `readProviderFor`, the network-roster helper, and `readRouterAuthority` out of `frontend/src/components/admin/liquidityAdminCommon.js`, preserving their doc-comments — they are the design (research R2)
+- [ ] T010 **Fix the spec-069 violation while moving**: `readProviderFor` in `frontend/src/lib/chains/estate.js` obtains its provider from `getReadProvider(chainId)` instead of hand-building from `NETWORKS[chainId].rpcUrl`, keeping only the reuse-the-wallet-provider-for-the-connected-chain shortcut (research R2)
+- [ ] T011 Bound the roster to the cohort: `estateNetworks(capability)` in `frontend/src/lib/chains/estate.js` filters through `cohortChainIds()`, and still lists chains that could carry the capability but have no FairWins deployment (contracts/estate-read.md rule 7)
+- [ ] T012 Add `readAcrossEstate({chainIds, addressFor, read, walletChainId, walletProvider})` to `frontend/src/lib/chains/estate.js` — concurrent, never rejects, one dead endpoint becomes `unreadable` without failing the batch (FR-015)
+- [ ] T013 Generalize `readRouterAuthority` to `readAuthority({provider, address, account, roles})` in `frontend/src/lib/chains/estate.js` for any AccessControl contract, keeping `readable: false` ⇒ unknown-not-denied and `deployed: false` ⇒ definite denial (research R4)
+- [ ] T014 Turn `frontend/src/components/admin/liquidityAdminCommon.js` into a re-export of the promoted helpers so `BridgeTab`/`SupplyTab` are untouched
+- [ ] T015 [P] Test the helper in `frontend/src/test/lib/chains/estate.test.js`: a rejected read yields `unreadable` with a reason while siblings resolve; the roster never contains an out-of-cohort chain
+- [ ] T016 [P] Source-level test in `frontend/src/test/lib/chains/estateProvider.test.js` asserting `estate.js` reaches providers via `getReadProvider` and contains no `NETWORKS[...].rpcUrl` access, so the spec-069 bypass cannot return
+- [ ] T017 **Checkpoint**: run `npx vitest run src/test/admin/AdminBridgeTab.test.jsx src/test/admin/AdminSupplyTab.test.jsx` — both suites MUST pass **unmodified**. If either needed changing, the helper was rewritten rather than moved; revert and redo T009–T014.
+
+---
+
+## Phase 3: User Story 2 — An operator reaches the console from wherever they are (P1)
+
+**Goal**: Console entry becomes an estate-wide question. An operator holding a role on any one chain
+gets in from any chain, and is told where their authority lives.
+
+**Independent test**: With an account holding a role on exactly one network, connect on a different
+network, open `/admin`, and confirm it opens with only that role's views and names the network each
+role was found on.
+
+- [ ] T018 [US2] Extend the role sync in `frontend/src/contexts/RoleContext.jsx` to resolve each admin role across `cohortChainIds()` instead of the wallet chain only, recording per chain whether the role was held, not held, or unreadable (FR-009, FR-011)
+- [ ] T019 [US2] Apply the same estate-wide sync in `frontend/src/contexts/WalletContext.jsx`, which carries a parallel copy of the sync loop
+- [ ] T020 [US2] Keep the existing `(address, chainId)` local-storage cache key in `frontend/src/utils/roleStorage.js` — the chain dimension already exists, so entries simply exist for more chains and **no migration is needed**; confirm no schema change is introduced
+- [ ] T021 [US2] Expose an estate-wide `hasAnyRole`/`hasRole` plus a per-chain query from `frontend/src/contexts/RoleContext.jsx`, so entry and authority stay separable (FR-009 vs FR-019)
+- [ ] T022 [US2] Make the entry gate in `frontend/src/components/AdminPanel.jsx` use the estate-wide answer
+- [ ] T023 [US2] Distinguish the two refusals in `frontend/src/components/AdminPanel.jsx`: "you hold no operator role" vs "no network could be read" (FR-012) — the second must never be phrased as the first
+- [ ] T024 [US2] Extend the "Your Permissions" card in `frontend/src/components/AdminPanel.jsx` to name the network(s) each role is held on, and mark unread networks as unread rather than as ✗ (FR-010, FR-011)
+- [ ] T025 [P] [US2] Test in `frontend/src/test/admin/adminEstateEntry.test.jsx`: role on one chain + wallet on another ⇒ console opens with that role's views; no role anywhere ⇒ refused; one chain unreadable ⇒ still granted from roles found elsewhere; all chains unreadable ⇒ the distinct refusal message
+- [ ] T026 [P] [US2] Test that the permissions card names the network per role and never renders an unread network as a denial
+
+**Checkpoint**: US2 is independently shippable — the console is reachable from any chain, with every
+view still gated exactly as before.
+
+---
+
+## Phase 4: User Story 1 — A member's membership follows them across networks (P1)
+
+**Goal**: Every membership read resolves on the reference chain, and an unreadable reference chain
+yields *unknown*, never *none*.
+
+**Independent test**: Connect a membership-holding account on each supported network in turn and
+confirm identical tier and expiry; then break the reference chain's endpoint and confirm *unknown*
+with a retry.
+
+- [ ] T027 [US1] Resolve the membership branch of `hasRoleOnChain` in `frontend/src/utils/blockchainService.js` against `membershipChainId()`, ignoring the caller's chain; leave the admin-role branch honouring its explicit chain (research R3, FR-003)
+- [ ] T028 [US1] Do the same for the MembershipManager path of `getUserTierOnChain` in `frontend/src/utils/blockchainService.js`
+- [ ] T029 [US1] Introduce a distinct *unknown* membership state in `frontend/src/utils/blockchainService.js` so a failed reference-chain read is no longer swallowed into `{tier: 0}` / `false` (FR-004) — this is the load-bearing change; today both functions return the same value for "no membership" and "could not ask"
+- [ ] T030 [US1] Propagate *unknown* through `frontend/src/contexts/RoleContext.jsx` and `frontend/src/hooks/useRoleDetails.js` without collapsing it to "no membership"
+- [ ] T031 [US1] Render *unknown* honestly wherever membership gates a surface: state that membership could not be read, offer a retry, and refuse the gated action attributing the refusal to the failed read (FR-005)
+- [ ] T032 [P] [US1] Test in `frontend/src/test/membershipReferenceChain.test.js` that `hasRoleOnChain(account, 'WAGER_PARTICIPANT', <any chain>)` constructs against the reference chain's MembershipManager — asserted by the constructed-address technique `adminLeastPrivilege.test.jsx` already uses
+- [ ] T033 [P] [US1] Test that `hasRoleOnChain(account, 'GUARDIAN', 8453)` still reads chain 8453 — the admin branch is unaffected
+- [ ] T034 [P] [US1] Test that a failed reference-chain read yields *unknown* and that no surface renders the words "no membership" in that state (FR-004)
+- [ ] T035 [P] [US1] Amend the doc-comment in `frontend/src/test/chainResolutionGuard.test.js` to state the rule the code actually follows — resolve against an **explicit** chain (wallet's, reference, or scoped), never the build-time default — and confirm the mechanical check still passes unmodified (research R5)
+
+**Checkpoint**: US1 is independently shippable and closes the live defect.
+
+---
+
+## Phase 5: User Story 5 — Membership purchases go to the reference chain (P2)
+
+**Goal**: Purchases settle on the reference chain, disclosed before signature. Depends on Phase 4's
+resolver.
+
+**Independent test**: Start a purchase from a non-reference chain; confirm disclosure + switch, that
+declining buys nothing, and that no path completes a purchase elsewhere.
+
+- [ ] T036 [US5] Route the purchase calls built in `frontend/src/components/ui/PremiumPurchaseModal.jsx` to `membershipChainId()` rather than the connected chain (FR-006)
+- [ ] T037 [US5] Disclose the settlement network in the confirm step of `frontend/src/components/ui/PremiumPurchaseModal.jsx` before signature, and require the wallet to be there (FR-007)
+- [ ] T038 [US5] Offer a wallet network switch to the reference chain, and ensure declining leaves no purchase attempted on any chain (FR-007, acceptance 2)
+- [ ] T039 [US5] Evaluate payment-token sufficiency against the reference chain's balance only, stating any shortfall in that chain's payment token, in `frontend/src/components/ui/PremiumPurchaseModal.jsx` (FR-008)
+- [ ] T040 [US5] Audit `frontend/src/hooks/useTierPrices.js` and `frontend/src/hooks/useVouchers.js` for connected-chain assumptions in the purchase path and route them to the reference chain
+- [ ] T041 [P] [US5] Test in `frontend/src/test/membershipPurchaseRouting.test.jsx`: purchase from a non-reference chain discloses the settlement network; declining the switch sends no transaction; the built calls target the reference chain's MembershipManager
+
+**Checkpoint**: US1 + US5 together close the read/write loop — a purchase is now readable from
+everywhere.
+
+---
+
+## Phase 6: User Story 3 — Accrued fees are visible for the whole estate (P2)
+
+**Goal**: The Overview accounts for every fee-bearing chain, per unit, with partial totals labelled.
+
+**Independent test**: With balances on more than one network, confirm each is listed with its own
+balance and unit; break one and confirm it is flagged, excluded, and the total labelled partial.
+
+- [ ] T042 [US3] Replace the single-chain `accruedFees` read in `frontend/src/components/AdminPanel.jsx` with a `readAcrossEstate` call over every cohort chain carrying a MembershipManager (FR-021)
+- [ ] T043 [US3] Add the second fee source per research R6 — the treasury's payment-token balance on each cohort chain carrying a `FeeRouter` — labelled **received**, and never added to **accrued (undrawn)**; the FeeRouter itself holds nothing, so it is not read for a balance
+- [ ] T044 [US3] Render the per-chain fee table in `frontend/src/components/AdminPanel.jsx` with each chain as read / not deployed / unreadable, each with its unit (FR-014, FR-021)
+- [ ] T045 [US3] Use `aggregate` for any total, showing per-unit subtotals and a partial label naming missing chains (FR-022, FR-023)
+- [ ] T046 [US3] Update `frontend/src/components/admin/MembershipTreasuryOverview.jsx` to accept per-chain results instead of a single `accruedFees` string
+- [ ] T047 [US3] Scope the Treasury withdrawal form in `frontend/src/components/AdminPanel.jsx` to a chain, defaulting its Max to that chain's accrued balance rather than a global figure
+- [ ] T048 [P] [US3] Test in `frontend/src/test/admin/adminFeeEstate.test.jsx`: every cohort chain appears in one of the three states; an unreadable chain is excluded, flagged, and the total labelled partial; accrued and received are never summed
+- [ ] T049 [P] [US3] Update `frontend/src/test/MembershipTreasuryOverview.test.jsx` for the new per-chain props
+
+**Checkpoint**: US3 is the first view consuming the estate helper end-to-end and validates the
+pattern for Phase 7.
+
+---
+
+## Phase 7: User Story 4 — Every operator view spans the estate (P2)
+
+**Goal**: The remaining thirteen views honour [contracts/view-scope.md](./contracts/view-scope.md).
+
+**Independent test**: Per view — connect on chain A, scope to B, confirm B's state renders, writes
+are withheld with a stated reason, and the scope does **not** follow the wallet when it switches.
+
+### Shared scope control
+
+- [ ] T050 [US4] Extract the network scope selector used by `BridgeTab`/`SupplyTab` into a shared component under `frontend/src/components/admin/`, defaulting to the wallet chain when in the roster and never re-targeting when the wallet switches (FR-016)
+- [ ] T051 [US4] Add a shared per-chain state renderer (read / not deployed / unreadable + reason + retry) so no view invents its own rendering of the three states (FR-014)
+- [ ] T052 [US4] Add a shared write-gate presenter that states "switch to <chain> to act" before signature and "role not held here" when authority is read and denied, leaving controls offered with authority unconfirmed when the read failed (FR-018, FR-019, research R4)
+- [ ] T053 [P] [US4] Test the three shared pieces in `frontend/src/test/admin/adminScopeControls.test.jsx`, including axe-clean rendering and per-chain status conveyed by text not colour alone (constitution V)
+
+### Read-mostly views
+
+- [ ] T054 [P] [US4] Convert `frontend/src/components/admin/MaintenanceTab.jsx` to the scope contract; each permissionless call still targets one named chain
+- [ ] T055 [P] [US4] Convert `frontend/src/components/admin/ServiceHealthCard.jsx` and `frontend/src/components/admin/PaymasterOpsCard.jsx`; the paymaster deposit is per chain
+- [ ] T056 [P] [US4] Convert `frontend/src/components/admin/OracleAdaptersTab.jsx`; chains without adapters read *not deployed*, which is the honest answer for most of the cohort
+- [ ] T057 [P] [US4] Convert `frontend/src/components/admin/ProtocolConfigTab.jsx` (Wiring & Tokens) across its three contracts
+
+### Write-heavy views
+
+- [ ] T058 [P] [US4] Convert the Tiers view in `frontend/src/components/AdminPanel.jsx` — only the reference chain carries a MembershipManager on the mainnet cohort, so the rest must show *not deployed*, not an empty form
+- [ ] T059 [P] [US4] Convert the Members view in `frontend/src/components/AdminPanel.jsx`
+- [ ] T060 [P] [US4] Convert `frontend/src/components/admin/FeesTab.jsx`; fee rates are genuinely per chain and must not be shown as one global rate
+- [ ] T061 [P] [US4] Convert `frontend/src/components/admin/StakingTab.jsx`
+- [ ] T062 [P] [US4] Convert `frontend/src/components/admin/DenyListAdmin.jsx`
+- [ ] T063 [P] [US4] Convert `frontend/src/components/admin/CallsignRegistryAdmin.jsx`
+- [ ] T064 [US4] Convert the Admin Roles view in `frontend/src/components/AdminPanel.jsx` so a grant names the chain it lands on — grants are already per contract **per chain** on-chain, and the view currently implies otherwise
+- [ ] T065 [P] [US4] Per-view tests under `frontend/src/test/admin/` for T054–T064, each covering: scope-off-wallet renders read state; write withheld with a stated reason; unreadable ≠ zero; not-deployed stated explicitly
+
+### Incident-response views (converted last, on a proven pattern — research R8)
+
+- [ ] T066 [US4] Convert the Emergency view in `frontend/src/components/AdminPanel.jsx`; pause is per chain and the confirmation names it
+- [ ] T067 [US4] Assert there is **no** cross-chain "pause everywhere" control (FR-020) — an implicit multi-chain killswitch is exactly what this feature must not create
+- [ ] T068 [US4] Convert the Account Moderation view in `frontend/src/components/AdminPanel.jsx`; freeze is per chain and the confirmation names it
+- [ ] T069 [P] [US4] Test the incident paths in `frontend/src/test/admin/adminIncidentEstate.test.jsx`, including the absence of any multi-chain action
+
+**Checkpoint**: all fifteen views honour one contract; the console no longer mixes estate-wide and
+wallet-scoped views.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+- [ ] T070 [P] Add a source-level guard in `frontend/src/test/admin/adminEstateGuard.test.js` asserting no admin view reads the wallet chain implicitly and none sums balances across chains (research R9)
+- [ ] T071 [P] Update `docs/runbooks/operations-control-plane.md`: scope selectors, the three per-chain states, partial totals, and that a write is always one named chain
+- [ ] T072 [P] Add `docs/developer-guide/chain-estate-reads.md` covering `membershipChainId()`, the estate helper, and the rule that unreadable is never zero
+- [ ] T073 [P] Update `CLAUDE.md` guardrails with the reference-chain rule and the "never hand-build a provider" reminder now that it applies console-wide
+- [ ] T074 Run the full `npm run test:frontend` and `npm run lint`; confirm the axe and Lighthouse CI jobs stay green
+- [ ] T075 Walk [quickstart.md](./quickstart.md) end to end, including the three failure modes it names
+
+---
+
+## Dependencies
+
+```text
+Phase 1 (Setup)
+    ↓
+Phase 2 (Foundational) ──────── blocks everything below
+    ↓
+Phase 3 (US2 — entry)          ← independently shippable
+    ↓
+Phase 4 (US1 — membership)     ← independently shippable
+    ↓
+Phase 5 (US5 — purchases)      ← depends on Phase 4's resolver
+    ↓
+Phase 6 (US3 — fees)           ← first end-to-end use of the estate helper
+    ↓
+Phase 7 (US4 — all views)      ← per-view tasks largely parallel
+    ↓
+Phase 8 (Polish)
+```
+
+**Story independence**: US2, US1, and US3 each ship alone. US5 depends only on US1's resolver. US4's
+per-view tasks depend on the shared scope controls (T050–T052) but not on each other.
+
+## Parallel execution examples
+
+**Phase 2** — T005, T008, T015, T016 are independent test files; T006/T007 (read result) and
+T009–T013 (estate helper) are different modules.
+
+**Phase 7** — after T050–T052 land, T054–T063 touch different files and run in parallel. T058, T059,
+T064, T066, T068 all edit `AdminPanel.jsx` and must be **serialized** with each other.
+
+**Phase 8** — T070–T073 are independent.
+
+## Implementation strategy
+
+**MVP**: Phase 1 + Phase 2 + Phase 3 (US2). That alone makes the console reachable from any chain
+with no other behaviour changed — the smallest useful increment.
+
+**Highest-value increment**: add Phase 4 (US1). Together, MVP + US1 close both live defects: an
+operator locked out by their wallet's network, and a member reported as unentitled.
+
+**Then**: US5, US3, US4 in order, each shippable on its own.
+
+**Riskiest work last, deliberately**: Emergency and Account Moderation (T066–T068) convert after
+eight other views have proven the pattern. The killswitch should be the least-experimental
+conversion in the feature, not the first.
+
+## Task summary
+
+| Phase | Story | Tasks | Count |
+|---|---|---|---|
+| 1 — Setup | — | T001–T002 | 2 |
+| 2 — Foundational | — | T003–T017 | 15 |
+| 3 — Console entry | US2 (P1) | T018–T026 | 9 |
+| 4 — Membership resolution | US1 (P1) | T027–T035 | 9 |
+| 5 — Purchase routing | US5 (P2) | T036–T041 | 6 |
+| 6 — Fee estate | US3 (P2) | T042–T049 | 8 |
+| 7 — All views | US4 (P2) | T050–T069 | 20 |
+| 8 — Polish | — | T070–T075 | 6 |
+| **Total** | | | **75** |


### PR DESCRIPTION
## What

`specs/071-multi-chain-admin-console/` — the full Spec Kit chain (specify → plan → tasks) for two connected changes. **Planning artifacts only; no implementation code in this PR.**

1. **Membership gets one declared home** — the *membership reference chain* — and every membership read, and every membership purchase, goes there regardless of the wallet's network.
2. **Every operator view reads the whole estate** instead of the connected chain, with accrued fees accounted for on every fee-bearing network.

## Why

Both halves are the same bug: the platform answers "where does this fact live?" with "wherever the wallet is pointed."

Checking the deployment record surfaced the sharp version — **Polygon is the only *mainnet* carrying a `MembershipManager`** (Mordor and Amoy are testnets, Hardhat is local). So today a member connected to Ethereum, Optimism, Base, Arbitrum or ETC is read as having *no membership*. They have one; the lookup was pointed somewhere it was never kept. That also settles the one question with real scope impact — anchoring to Polygon strands nobody — which is why no `[NEEDS CLARIFICATION]` markers remain.

## Research findings that changed the plan

Two things turned up in Phase 0 that were not visible from the request:

- **R2 — the helper this feature generalizes carries a live spec-069 violation.** The Bridge/Supply admin code hand-builds providers from `NETWORKS[chainId].rpcUrl`, bypassing `resolveRpcEndpoints`, so a member's configured endpoint override and its failover are **ignored for every read those two tabs make**. Generalizing it to fifteen views without fixing it would spread the bug across the console, so the promoted helper goes through `getReadProvider(chainId)` (task T010 — fixed *during* the move, not after).
- **R6 — "all chains for accrued fees" needed a real answer about what accrues.** Only `MembershipManager.accruedFees()` does. The `FeeRouter` forwards to the treasury inside the same transaction and **holds nothing**. On the mainnet cohort that makes a naive "accrued fees everywhere" figure a single-chain number dressed up as an estate-wide one, so the overview reports *accrued (undrawn)* and *treasury (received)* as separate lines, never added together.

## Design decisions worth a reviewer's attention

- **The reference chain is derived**, not declared again, from the `MAINNET_CHAIN_ID`/`TESTNET_CHAIN_ID` pair `networks.js` already holds. A second literal `137` is a divergence waiting to happen — and a hardcoded one silently reads *mainnet* membership in a testnet build.
- **Membership resolution changes in two resolver functions**, not at six call sites, because the callers already funnel through them. The membership branch takes the reference chain; the admin-role branch keeps its explicit chain, since admin roles genuinely are per-chain.
- **Entry and authority stay separate questions.** Entry is estate-wide — "you hold something somewhere" (FR-009). The power to write is still verified against the specific contract on the specific network (FR-019). Collapsing them would let a role held on one network imply the power to write on another — a defect `liquidityAdminCommon.js` already documents from experience.
- **The estate helper is moved, not rewritten.** `liquidityAdminCommon.js` re-exports it, and **T017 is a hard checkpoint**: the existing `AdminBridgeTab`/`AdminSupplyTab` suites (55 tests) must pass *unmodified*. If either needed changing, the helper was rewritten rather than moved — revert and redo.
- **Emergency and Account Moderation convert last**, after eight other views have proven the pattern. The killswitch should be the least-experimental conversion in the feature, not the first.
- **T067 asserts an absence**: no cross-chain "pause everywhere" control. A feature that makes every view span the estate is exactly where an implicit multi-chain killswitch would seem like a natural convenience.

## Constitution check

Passes on all five principles; **Complexity Tracking is empty**.

Principle III's *"never leak across testnet/mainnet boundaries"* appeared to collide with "read from all chains". The two are reconciled rather than traded off: **"all chains" means all chains this build may read** (the *environment cohort*). A mainnet build reads six mainnets and no testnet; a testnet build reads five testnets and no mainnet. FR-002 and SC-008 make it verifiable.

The spec-008 chain-resolution guard still passes unmodified — reference-chain reads are chain-aware, just explicit rather than wallet-derived. Its doc-comment claims the rule is "the wallet's CONNECTED chain", which the membership path deliberately no longer follows, so T035 amends the stated intent to match the code.

## Contents

| File | What it holds |
|---|---|
| `spec.md` | 5 prioritized user stories, 23 functional requirements, 8 success criteria, edge cases |
| `research.md` | R1–R9, every unknown resolved against the codebase rather than assumed |
| `plan.md` | Technical context, constitution check, structure, rollout |
| `data-model.md` | 5 entities + state transitions for membership, entry, and write availability |
| `contracts/` | 3 module contracts: estate reads, reference-chain resolver, per-view scope |
| `quickstart.md` | Validation guide, incl. the three failure modes to watch for |
| `tasks.md` | 75 tasks across 8 phases, organized by user story |
| `checklists/requirements.md` | Spec quality checklist, all passing |

## MVP and sequencing

Phase 1 + 2 + 3 (console entry) is the MVP — the console reachable from any chain with nothing else changed. Adding Phase 4 closes both live defects: an operator locked out by their wallet's network, and a member reported as unentitled. US5, US3 and US4 each ship independently after that.

No contract changes: no ABI, storage layout, or deployment is altered.