### PR TITLE
Spec 071 Phases 3–5: estate-wide console entry, membership + purchases on the reference chain

### DIFF
--- a/frontend/src/components/AdminPanel.css
+++ b/frontend/src/components/AdminPanel.css
@@ -373,6 +373,13 @@
   font-weight: 500;
 }
 
+/* Where a held role actually lives (spec 071 FR-010). Secondary to the role name — it
+   qualifies the ✓ rather than competing with it. */
+.permission-networks {
+  font-weight: 400;
+  opacity: 0.75;
+}
+
 /* Contract Addresses */
 .contract-addresses {
   display: flex;

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -24,6 +24,7 @@ import MaintenanceTab from './admin/MaintenanceTab'
 import ServiceHealthCard from './admin/ServiceHealthCard'
 import PaymasterOpsCard from './admin/PaymasterOpsCard'
 import { buildAdminNavGroups, flattenNavGroups } from './admin/adminNav'
+import { networkName } from '../lib/chains/estate'
 import PortalNav from './ui/PortalNav'
 import NavIcon from './nav/NavIcon'
 import SectionIconNav from './nav/SectionIconNav'
@@ -99,7 +100,7 @@ function shortAddr(address) {
  * role its actions require.
  */
 function AdminPanel() {
-  const { hasRole, hasAnyRole } = useRoles()
+  const { hasRole, hasAnyRole, estateRead, chainsForRole, loadRoles } = useRoles()
   const { account, signer, provider, chainId } = useWeb3()
   const { showNotification } = useNotification()
   const { native: nativeSymbol } = useChainTokens()
@@ -363,6 +364,20 @@ function AdminPanel() {
     )
   }
 
+  // Every role that can open this panel gets a row, each naming where it was found. Built here
+  // rather than inline so a role can never again be in ADMIN_ROLES and the nav but missing from
+  // the card — an operator reading a list of × concludes their grant did not land.
+  const ADMIN_ROLE_ROWS = [
+    { role: ROLES.ADMIN, held: isAdmin, label: 'Administrator (tier config, treasury, grant admin roles)' },
+    { role: ROLES.GUARDIAN, held: isGuardian, label: 'Guardian (pause / unpause WagerRegistry)' },
+    { role: ROLES.ACCOUNT_MODERATOR, held: isAccountModerator, label: 'Account Moderator (freeze / unfreeze accounts)' },
+    { role: ROLES.ROLE_MANAGER, held: isRoleManager, label: 'Role Manager (grant / revoke memberships)' },
+    { role: ROLES.SANCTIONS_ADMIN, held: isSanctionsAdmin, label: 'Compliance Officer (deny-list on SanctionsGuard)' },
+    { role: ROLES.FEE_ADMIN, held: isFeeAdmin, label: 'Fee Administrator (platform fee rates on the FeeRouter)' },
+    { role: ROLES.STAKING_ADMIN, held: isStakingAdmin, label: 'Staking Administrator (provider addresses + validator allowlist)' },
+    { role: ROLES.LIQUIDITY_ADMIN, held: isLiquidityAdmin, label: 'Liquidity Administrator (bridge routes + curated pools, per router)' },
+  ]
+
   // Grouped, role-gated section rail (see admin/adminNav.js). Mirrors the
   // per-tab role checks below — a view only appears if the connected account
   // can use it, and a group only appears if it has at least one usable view.
@@ -396,16 +411,46 @@ function AdminPanel() {
   }, [sidebarOpen, isMobile])
 
   if (!hasAdminAccess) {
+    // FR-012: "you hold no operator role" and "we could not ask" are different statements, and
+    // the second must never be dressed as the first. An operator refused during a network outage
+    // needs to know their grant is not in question — otherwise they go looking for a
+    // permissions problem that does not exist.
+    const noChainAnswered =
+      !estateRead?.swept || (estateRead.read.length === 0 && estateRead.unreadable.length > 0)
     return (
       <div className="admin-panel">
         <div className="admin-unauthorized">
           <div className="unauthorized-icon" aria-hidden="true">🔒</div>
-          <h2>Access Restricted</h2>
-          <p>The operations control plane is only accessible to users with operator privileges.</p>
-          <p className="unauthorized-hint">
-            Operator roles include: Administrator, Emergency Guardian, Account Moderator, Role
-            Manager, and Compliance Officer.
-          </p>
+          <h2>{noChainAnswered ? 'Could Not Verify Access' : 'Access Restricted'}</h2>
+          {noChainAnswered ? (
+            <>
+              <p>
+                No network could be read, so your operator roles could not be checked. This is a
+                connectivity problem, not a statement about what you hold.
+              </p>
+              <p className="unauthorized-hint">
+                {estateRead?.unreadable?.length
+                  ? `Unreachable: ${estateRead.unreadable.map(networkName).join(', ')}.`
+                  : 'The role sweep did not complete.'}{' '}
+                Check your network endpoints, then retry.
+              </p>
+              <button type="button" className="confirm-btn primary" onClick={() => loadRoles?.(account, chainId)}>
+                Retry
+              </button>
+            </>
+          ) : (
+            <>
+              <p>The operations control plane is only accessible to users with operator privileges.</p>
+              <p className="unauthorized-hint">
+                Operator roles include: Administrator, Emergency Guardian, Account Moderator, Role
+                Manager, and Compliance Officer. Checked across{' '}
+                {estateRead.read.length} network{estateRead.read.length === 1 ? '' : 's'}
+                {estateRead.unreadable.length > 0 &&
+                  ` (${estateRead.unreadable.map(networkName).join(', ')} could not be read)`}
+                .
+              </p>
+            </>
+          )}
         </div>
       </div>
     )
@@ -518,56 +563,43 @@ function AdminPanel() {
 
               <div className="admin-card">
                 <div className="admin-card-header"><h3>Your Permissions</h3></div>
+                {/*
+                  One row per role, data-driven. Each names the NETWORK(S) the role was actually
+                  found on (spec 071 FR-010) — a bare ✓ on a per-chain role tells an operator
+                  they hold it without saying where, which is not enough to act on.
+                */}
                 <div className="permissions-list">
-                  <div className={`permission-item ${isAdmin ? 'enabled' : 'disabled'}`}>
-                    <span className="permission-icon">{isAdmin ? '✓' : '×'}</span>
-                    <span className="permission-name">Administrator (tier config, treasury, grant admin roles)</span>
-                  </div>
-                  <div className={`permission-item ${isGuardian ? 'enabled' : 'disabled'}`}>
-                    <span className="permission-icon">{isGuardian ? '✓' : '×'}</span>
-                    <span className="permission-name">Guardian (pause / unpause WagerRegistry)</span>
-                  </div>
-                  <div className={`permission-item ${isAccountModerator ? 'enabled' : 'disabled'}`}>
-                    <span className="permission-icon">{isAccountModerator ? '✓' : '×'}</span>
-                    <span className="permission-name">Account Moderator (freeze / unfreeze accounts)</span>
-                  </div>
-                  <div className={`permission-item ${isRoleManager ? 'enabled' : 'disabled'}`}>
-                    <span className="permission-icon">{isRoleManager ? '✓' : '×'}</span>
-                    <span className="permission-name">Role Manager (grant / revoke memberships)</span>
-                  </div>
-                  <div className={`permission-item ${isSanctionsAdmin ? 'enabled' : 'disabled'}`}>
-                    <span className="permission-icon">{isSanctionsAdmin ? '✓' : '×'}</span>
-                    <span className="permission-name">Compliance Officer (deny-list on SanctionsGuard)</span>
-                  </div>
-                  {/*
-                    These three were in ROLES, in ADMIN_ROLES and in the nav, but not in this card —
-                    so an operator holding one of them read a list of five × and concluded their grant
-                    had not landed. A permissions card that omits a role it let you in on is worse
-                    than no card.
-                  */}
-                  <div className={`permission-item ${isFeeAdmin ? 'enabled' : 'disabled'}`}>
-                    <span className="permission-icon">{isFeeAdmin ? '✓' : '×'}</span>
-                    <span className="permission-name">Fee Administrator (platform fee rates on the FeeRouter)</span>
-                  </div>
-                  <div className={`permission-item ${isStakingAdmin ? 'enabled' : 'disabled'}`}>
-                    <span className="permission-icon">{isStakingAdmin ? '✓' : '×'}</span>
-                    <span className="permission-name">Staking Administrator (provider addresses + validator allowlist)</span>
-                  </div>
-                  <div className={`permission-item ${isLiquidityAdmin ? 'enabled' : 'disabled'}`}>
-                    <span className="permission-icon">{isLiquidityAdmin ? '✓' : '×'}</span>
-                    <span className="permission-name">Liquidity Administrator (bridge routes + curated pools, per router)</span>
-                  </div>
+                  {ADMIN_ROLE_ROWS.map(({ role, label, held }) => {
+                    const on = chainsForRole?.(role) ?? []
+                    return (
+                      <div key={role} className={`permission-item ${held ? 'enabled' : 'disabled'}`}>
+                        <span className="permission-icon">{held ? '✓' : '×'}</span>
+                        <span className="permission-name">
+                          {label}
+                          {held && on.length > 0 && (
+                            <span className="permission-networks"> — {on.map(networkName).join(', ')}</span>
+                          )}
+                        </span>
+                      </div>
+                    )
+                  })}
                 </div>
                 {/*
-                  Every row above is resolved on the CONNECTED network. The spec-067 routers exist on
-                  five, and their roles are per-contract — so this card is a summary, not a verdict:
-                  the Bridge and Supply tabs each ask the router in scope directly before offering a
-                  control. Saying so here stops the summary being read as the authority.
+                  This card is a summary, not a verdict, and now says so on two counts: it names
+                  where each role was found, and it names the networks it could not read at all —
+                  because an unread network showing as × would be the platform asserting a denial
+                  it never established (FR-011).
                 */}
                 <p className="card-info">
-                  Read on {NETWORK_CONFIG.name}. Roles are per-contract and per-network, so the
-                  Bridge and Supply tabs re-check the specific router for the network you select —
-                  what they offer there is the authoritative answer.
+                  Read across {estateRead?.read?.length ?? 0} network
+                  {(estateRead?.read?.length ?? 0) === 1 ? '' : 's'}.
+                  {estateRead?.unreadable?.length > 0 && (
+                    <> {estateRead.unreadable.map(networkName).join(', ')} could not be read, so
+                    nothing above rules out a role held there.</>
+                  )}{' '}
+                  Roles are per-contract and per-network, so each view re-checks the specific
+                  contract for the network you select — what it offers there is the authoritative
+                  answer.
                 </p>
               </div>
 

--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -7,6 +7,8 @@ import { useTierPrices } from '../../hooks/useTierPrices'
 import { useEncryption } from '../../hooks/useEncryption'
 import { recordRolePurchase } from '../../utils/roleStorage'
 import { getUserTierOnChain, buildMembershipPurchaseCalls } from '../../utils/blockchainService'
+import { membershipChainId } from '../../config/networks'
+import { networkName } from '../../lib/chains/estate'
 import { ensurePasskeyEncryptionKeys } from '../../lib/passkey/encryption'
 import { buildRegisterKeyCalls, hasRegisteredKey } from '../../utils/keyRegistryService'
 import { readSession } from '../../connectors/passkey'
@@ -130,6 +132,10 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
 
   const [userCurrentTier, setUserCurrentTier] = useState(0)
   const [isLoadingTier, setIsLoadingTier] = useState(false)
+  // FR-004: false ⇒ the reference chain would not answer, so the current tier is UNKNOWN.
+  // Purchase is refused in that state rather than guessing (FR-005).
+  const [tierReadable, setTierReadable] = useState(true)
+  const [tierRetry, setTierRetry] = useState(0)
 
   useEffect(() => {
     let cancelled = false
@@ -139,8 +145,13 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
     // have no membership). Re-fetch for the chain the wallet is now on.
     setUserCurrentTier(0)
     setIsLoadingTier(true)
-    getUserTierOnChain(account, ROLE_KEY, chainId).then(({ tier }) => {
+    getUserTierOnChain(account, ROLE_KEY, chainId).then(({ tier, readable }) => {
       if (cancelled) return
+      // FR-004/FR-005: an unreadable reference chain is NOT tier 0. Offering "upgrade from
+      // None" to a member who already holds Platinum — because their RPC blipped — would take
+      // their money for a tier they already own.
+      setTierReadable(readable !== false)
+      if (readable === false) return
       setUserCurrentTier(tier || 0)
       // Default tier select to the lowest available upgrade (or BRONZE for fresh)
       const minTier = (tier || 0) + 1
@@ -150,11 +161,12 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
       }
     }).catch((err) => {
       console.warn('[PremiumPurchaseModal] tier fetch failed:', err)
+      if (!cancelled) setTierReadable(false)
     }).finally(() => {
       if (!cancelled) setIsLoadingTier(false)
     })
     return () => { cancelled = true }
-  }, [account, chainId])
+  }, [account, chainId, tierRetry])
 
   const availableTiers = useMemo(() => {
     return Object.entries(MEMBERSHIP_TIERS).filter(([, tier]) => {
@@ -196,6 +208,15 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
   const handlePurchase = async () => {
     if (!isConnected || !account) {
       showNotification('Please connect your wallet first', 'error')
+      return
+    }
+    // FR-005: refuse while membership is UNKNOWN, and attribute the refusal to the failed read
+    // rather than to anything about the member's account.
+    if (!tierReadable) {
+      showNotification(
+        `Cannot purchase yet: your current membership could not be read from ${networkName(membershipChainId())}. Retry the check first.`,
+        'error',
+      )
       return
     }
     if (!isCorrectNetwork) {
@@ -454,6 +475,26 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
                   <div className="ppm-loading-tiers">
                     <div className="ppm-spinner" aria-hidden="true"></div>
                     <p>Checking your current membership tier...</p>
+                  </div>
+                )}
+
+                {/* FR-004/FR-005: unknown is not "none". Say the read failed, offer a retry, and
+                    refuse the purchase — buying "from None" on a blipped read could charge a
+                    member for a tier they already hold. */}
+                {!isLoadingTier && !tierReadable && (
+                  <div className="ppm-info-card ppm-tier-unknown" role="status">
+                    <span className="ppm-info-icon" aria-hidden="true">⚠️</span>
+                    <div>
+                      <strong>Your current membership could not be read.</strong>
+                      <p>
+                        We could not reach {networkName(membershipChainId())}, where memberships
+                        are held, so we cannot tell what you already own. This is a connection
+                        problem, not a statement that you have no membership.
+                      </p>
+                      <button type="button" className="ppm-btn-secondary" onClick={() => setTierRetry((n) => n + 1)}>
+                        Retry
+                      </button>
+                    </div>
                   </div>
                 )}
 

--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -117,6 +117,17 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
     getContractAddressForChain('membershipManager', chainId)
   )
 
+  // ── PURCHASES SETTLE ON THE REFERENCE CHAIN (spec 071 FR-006/FR-007) ────────────────────
+  // Membership must be READABLE from one place (FR-003), which is only true if it is also
+  // WRITTEN in one place. A purchase that landed elsewhere would create a membership the
+  // reference-chain read can never see — the member pays and stays unentitled everywhere.
+  //
+  // `isCorrectNetwork` is not enough here: it means "any supported chain". The purchase needs
+  // one specific chain, disclosed before signature, with the wallet actually on it.
+  const purchaseChainId = membershipChainId()
+  const purchaseNetworkName = networkName(purchaseChainId)
+  const onPurchaseChain = Number(chainId) === Number(purchaseChainId)
+
   const [currentStep, setCurrentStep] = useState(0)
   const [selectedTier, setSelectedTier] = useState('BRONZE')
   const [acknowledged, setAcknowledged] = useState(false)
@@ -215,6 +226,16 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
     if (!tierReadable) {
       showNotification(
         `Cannot purchase yet: your current membership could not be read from ${networkName(membershipChainId())}. Retry the check first.`,
+        'error',
+      )
+      return
+    }
+    // FR-006/FR-007: not "a supported network" — THE reference chain, named. Declining the
+    // switch must leave no purchase attempted anywhere, which is why this returns rather than
+    // falling through to a best-effort send on whatever chain the wallet is on.
+    if (!onPurchaseChain) {
+      showNotification(
+        `Membership purchases settle on ${purchaseNetworkName}. Switch your wallet there to continue.`,
         'error',
       )
       return
@@ -688,13 +709,27 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
                   </div>
                 </div>
 
-                {isConnected && !isCorrectNetwork && (
+                {/* FR-007: the settlement network is disclosed BEFORE signature, always —
+                    not only when it is wrong. A member should not have to infer where their
+                    money is going from the absence of a warning. */}
+                <p className="ppm-settlement-note" role="note">
+                  Memberships are held on <strong>{purchaseNetworkName}</strong>, so this purchase
+                  settles there and is recognised from every network afterwards.
+                </p>
+
+                {isConnected && !onPurchaseChain && (
                   <div className="ppm-network-warning">
                     <span aria-hidden="true">⚠️</span>
                     <div>
-                      <strong>Wrong Network</strong>
-                      <p>Please switch to the correct network to continue.</p>
-                      <button type="button" onClick={switchNetwork}>Switch Network</button>
+                      <strong>Switch to {purchaseNetworkName}</strong>
+                      <p>
+                        Your wallet is on {networkName(chainId)}. Membership purchases settle on{' '}
+                        {purchaseNetworkName} — buying anywhere else would create a membership the
+                        app could never read back.
+                      </p>
+                      <button type="button" onClick={() => switchNetwork(purchaseChainId)}>
+                        Switch to {purchaseNetworkName}
+                      </button>
                     </div>
                   </div>
                 )}
@@ -803,12 +838,14 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
                 Continue
               </button>
             )}
+            {/* FR-005/FR-006: no purchase while the wallet is off the reference chain, and none
+                while the current tier is unknown — either would charge for the wrong thing. */}
             {!showProcessing && currentStep === 1 && (
               <button
                 type="button"
                 className="ppm-btn-primary ppm-btn-purchase"
                 onClick={handlePurchase}
-                disabled={isBusy || !isConnected || !isCorrectNetwork || !acknowledged}
+                disabled={isBusy || !isConnected || !onPurchaseChain || !tierReadable || !acknowledged}
               >
                 Confirm Purchase (${selectedPrice.toFixed(2)} USDC)
               </button>

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -633,15 +633,18 @@ export function WalletProvider({ children }) {
   // Switch to the configured primary network (Polygon Amoy). Invoked from
   // the network-error banner / "Switch Network" button when the user is on
   // an unsupported chain.
-  const switchNetwork = useCallback(async () => {
-    const target = PRIMARY_CHAIN_ID
+  // `targetChainId` defaults to the app's home network, so every existing call site is
+  // unchanged. Spec 071 needs an explicit target: a membership purchase must settle on the
+  // REFERENCE chain (FR-006), which is not necessarily where the app happens to be homed.
+  const switchNetwork = useCallback(async (targetChainId = PRIMARY_CHAIN_ID) => {
+    const target = Number(targetChainId) || PRIMARY_CHAIN_ID
     try {
       await switchChain({ chainId: target })
       return true
     } catch (error) {
       console.error('Error switching network:', error)
       const targetNet = getNetwork(target)
-      throw new Error(`Please manually switch to ${targetNet?.name || 'Polygon Amoy'} in your wallet`)
+      throw new Error(`Please manually switch to ${targetNet?.name || `chain ${target}`} in your wallet`)
     }
   }, [switchChain])
 

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -48,6 +48,9 @@ export function WalletProvider({ children }) {
   // operations control plane needs to be honest about what it actually learned.
   const [roleChains, setRoleChains] = useState({})
   const [estateRead, setEstateRead] = useState({ read: [], unreadable: [], swept: false })
+  // FR-004: false ⇒ membership is UNKNOWN (the reference chain would not answer), which is
+  // never the same as "no membership". Surfaces so a gated action can attribute its refusal.
+  const [membershipReadable, setMembershipReadable] = useState(true)
 
   // ---- Spec 045: single connect surface (FR-001) ----
   // Every "Connect" control in the app opens THIS modal; no surface renders
@@ -348,13 +351,20 @@ export function WalletProvider({ children }) {
       ),
     )
 
-    // Membership stays on the wallet's chain for now; spec 071 Phase 4 (US1) moves it to the
-    // reference chain. Kept separate so the two migrations don't tangle.
+    // Membership resolves on the REFERENCE chain regardless of what is passed (spec 071 FR-003) —
+    // `hasRoleOnChain` enforces that internally, so the wallet's chain is irrelevant here.
+    //
+    // `membershipReadable === false` means UNKNOWN, not "none" (FR-004). A member whose reference
+    // chain blipped keeps whatever was cached rather than being told they own nothing, and the
+    // unknown is surfaced so a gated action can attribute its refusal to the failed read.
     let membershipHeld = false
+    let membershipReadable = true
     try {
       const r = await hasRoleOnChain(walletAddress, 'WAGER_PARTICIPANT', activeChainId, { detailed: true })
-      membershipHeld = Boolean(r?.held)
+      membershipReadable = r?.readable !== false
+      membershipHeld = membershipReadable ? Boolean(r?.held) : localRoles.includes('WAGER_PARTICIPANT')
     } catch {
+      membershipReadable = false
       membershipHeld = localRoles.includes('WAGER_PARTICIPANT')
     }
 
@@ -387,9 +397,11 @@ export function WalletProvider({ children }) {
       }
     }
     // Only prune against the wallet's chain, and only when that chain answered: removing a
-    // locally-cached role because some other chain said no would be a different bug.
+    // locally-cached role because some other chain said no would be a different bug. Membership
+    // is pruned only when the REFERENCE chain actually answered — never on an unknown.
     if (!unreadableChains.includes(activeChainId)) {
       for (const roleName of allSyncedRoles) {
+        if (roleName === 'WAGER_PARTICIPANT' && !membershipReadable) continue
         const heldHere =
           roleName === 'WAGER_PARTICIPANT'
             ? membershipHeld
@@ -412,6 +424,7 @@ export function WalletProvider({ children }) {
       errors: [],
       roleChains: foundOn,
       estateRead: { read: readChains, unreadable: unreadableChains, swept: true },
+      membershipReadable,
     }
   }, [])
 
@@ -433,11 +446,13 @@ export function WalletProvider({ children }) {
       setRoles(synced.roles)
       setRoleChains(synced.roleChains || {})
       setEstateRead(synced.estateRead || { read: [], unreadable: [], swept: true })
+      setMembershipReadable(synced.membershipReadable !== false)
       setBlockchainSynced(true)
     } catch (error) {
       console.error('Error loading user roles:', error)
       setRoles([])
       setRoleChains({})
+      setMembershipReadable(false)
       // A failed sweep is NOT "you hold nothing" — leave it unswept so the console can say so
       // rather than asserting a denial it never established (FR-012).
       setEstateRead({ read: [], unreadable: [], swept: false })
@@ -802,6 +817,7 @@ export function WalletProvider({ children }) {
     estateRead,
     chainsForRole,
     hasRoleOnChainId,
+    membershipReadable,
     grantRole,
     revokeRole,
   }

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useAccount, useConnect, useDisconnect, useChainId, useSwitchChain, useWalletClient } from 'wagmi'
 import ConnectModal from '../components/wallet/ConnectModal'
 import { ethers } from 'ethers'
-import { isSupportedChainId, getNetwork, PRIMARY_CHAIN_ID } from '../config/networks'
+import { isSupportedChainId, getNetwork, PRIMARY_CHAIN_ID, cohortChainIds } from '../config/networks'
 import { makeReadProvider } from '../utils/rpcProvider'
 import {
   getUserRoles,
@@ -43,6 +43,11 @@ export function WalletProvider({ children }) {
   const [roles, setRoles] = useState([])
   const [rolesLoading, setRolesLoading] = useState(false)
   const [blockchainSynced, setBlockchainSynced] = useState(false)
+  // Spec 071: WHERE each role was found, and which chains would not answer. `roles` above stays
+  // the flat estate-wide list every existing caller reads; these two carry the detail the
+  // operations control plane needs to be honest about what it actually learned.
+  const [roleChains, setRoleChains] = useState({})
+  const [estateRead, setEstateRead] = useState({ read: [], unreadable: [], swept: false })
 
   // ---- Spec 045: single connect surface (FR-001) ----
   // Every "Connect" control in the app opens THIS modal; no surface renders
@@ -308,62 +313,106 @@ export function WalletProvider({ children }) {
    */
   const syncRolesWithBlockchain = useCallback(async (walletAddress, localRoles, activeChainId) => {
     const premiumRoles = ['WAGER_PARTICIPANT']
-    const adminRoles = ['ADMIN', 'GUARDIAN', 'ACCOUNT_MODERATOR', 'ROLE_MANAGER', 'SANCTIONS_ADMIN', 'FEE_ADMIN', 'LIQUIDITY_ADMIN']
+    // STAKING_ADMIN was missing from this list while being present in ADMIN_ROLES and in the
+    // console's nav, so a staking administrator's role was never synced: `isStakingAdmin` read
+    // false forever and the Staking tab never opened for the one operator who could use it.
+    // Exactly the class of lockout spec 071 exists to end, so it is fixed here.
+    const adminRoles = [
+      'ADMIN', 'GUARDIAN', 'ACCOUNT_MODERATOR', 'ROLE_MANAGER',
+      'SANCTIONS_ADMIN', 'FEE_ADMIN', 'STAKING_ADMIN', 'LIQUIDITY_ADMIN',
+    ]
     const allSyncedRoles = [...premiumRoles, ...adminRoles]
-    const updatedRoles = []
-    let hasChanges = false
-    let syncErrors = []
 
-    console.log('[RoleSync] Starting blockchain sync for:', walletAddress)
-    console.log('[RoleSync] Local roles:', localRoles)
+    // ── ESTATE-WIDE, NOT WALLET-CHAIN (spec 071 FR-009) ───────────────────────────────────────
+    // Admin roles are granted per contract per chain, so asking only the chain the wallet
+    // happens to sit on refused entry to operators who genuinely hold a role somewhere else.
+    // Reads span the cohort; the wallet's chain still decides nothing but WRITES.
+    const chains = cohortChainIds()
+    const walletChainFirst = [
+      ...chains.filter((id) => Number(id) === Number(activeChainId)),
+      ...chains.filter((id) => Number(id) !== Number(activeChainId)),
+    ]
 
-    // Check each role on-chain (both premium and admin roles)
-    for (const roleName of allSyncedRoles) {
-      try {
-        const hasOnChain = await hasRoleOnChain(walletAddress, roleName, activeChainId)
-        const hasLocally = localRoles.includes(roleName)
-
-        console.log(`[RoleSync] ${roleName}: onChain=${hasOnChain}, local=${hasLocally}`)
-
-        if (hasOnChain) {
-          // Role exists on-chain - keep it
-          updatedRoles.push(roleName)
-          if (!hasLocally) {
-            console.log(`[RoleSync] Adding ${roleName} from blockchain to local storage`)
-            addUserRole(walletAddress, roleName, activeChainId)
-            hasChanges = true
+    // Concurrent: 8 roles across the cohort is far too many round-trips to do in sequence, and
+    // FR-015 says one slow chain must not hold up the rest.
+    const probes = await Promise.all(
+      adminRoles.flatMap((roleName) =>
+        walletChainFirst.map(async (id) => {
+          try {
+            const r = await hasRoleOnChain(walletAddress, roleName, id, { detailed: true })
+            return { roleName, chainId: id, held: Boolean(r?.held), readable: r?.readable !== false }
+          } catch (e) {
+            return { roleName, chainId: id, held: false, readable: false, reason: e?.message }
           }
-        } else if (hasLocally) {
-          // Role exists locally but not on-chain - it has expired or was never purchased
-          // Blockchain is the source of truth - remove the stale local role
-          console.log(`[RoleSync] ${roleName} not found on-chain - removing stale local role`)
+        }),
+      ),
+    )
+
+    // Membership stays on the wallet's chain for now; spec 071 Phase 4 (US1) moves it to the
+    // reference chain. Kept separate so the two migrations don't tangle.
+    let membershipHeld = false
+    try {
+      const r = await hasRoleOnChain(walletAddress, 'WAGER_PARTICIPANT', activeChainId, { detailed: true })
+      membershipHeld = Boolean(r?.held)
+    } catch {
+      membershipHeld = localRoles.includes('WAGER_PARTICIPANT')
+    }
+
+    // WHERE each role was found. A role with an empty list is not held anywhere we could read.
+    const foundOn = {}
+    for (const p of probes) {
+      if (p.held) (foundOn[p.roleName] ||= []).push(p.chainId)
+    }
+    // A chain counts as unreadable only if EVERY probe against it failed — one contract missing
+    // there is a deployment fact, not a connectivity failure.
+    const unreadableChains = walletChainFirst.filter((id) => {
+      const forChain = probes.filter((p) => p.chainId === id)
+      return forChain.length > 0 && forChain.every((p) => !p.readable)
+    })
+    const readChains = walletChainFirst.filter((id) => !unreadableChains.includes(id))
+
+    const updatedRoles = [
+      ...(membershipHeld ? ['WAGER_PARTICIPANT'] : []),
+      ...adminRoles.filter((r) => (foundOn[r] || []).length > 0),
+    ]
+
+    // Local storage stays keyed by (address, chainId) exactly as before — the chain dimension
+    // was already there, so an estate-wide sweep just writes entries for more chains and needs
+    // NO migration. Each role is recorded against the chain it was actually found on.
+    let hasChanges = false
+    for (const roleName of adminRoles) {
+      for (const id of foundOn[roleName] || []) {
+        addUserRole(walletAddress, roleName, id)
+        hasChanges = true
+      }
+    }
+    // Only prune against the wallet's chain, and only when that chain answered: removing a
+    // locally-cached role because some other chain said no would be a different bug.
+    if (!unreadableChains.includes(activeChainId)) {
+      for (const roleName of allSyncedRoles) {
+        const heldHere =
+          roleName === 'WAGER_PARTICIPANT'
+            ? membershipHeld
+            : (foundOn[roleName] || []).some((id) => Number(id) === Number(activeChainId))
+        if (!heldHere && localRoles.includes(roleName)) {
           removeUserRole(walletAddress, roleName, activeChainId)
           hasChanges = true
-          // Don't add to updatedRoles - role is no longer valid
-        }
-      } catch (roleError) {
-        console.error(`[RoleSync] Error checking ${roleName}:`, roleError.message)
-        syncErrors.push({ role: roleName, error: roleError.message })
-        // Keep local role if blockchain check fails - be conservative
-        if (localRoles.includes(roleName)) {
-          updatedRoles.push(roleName)
         }
       }
     }
 
-    // Keep any other roles that are stored locally but not in our synced list
+    // Anything cached locally that this sweep doesn't manage is left alone.
     for (const role of localRoles) {
-      if (!allSyncedRoles.includes(role) && !updatedRoles.includes(role)) {
-        updatedRoles.push(role)
-      }
+      if (!allSyncedRoles.includes(role) && !updatedRoles.includes(role)) updatedRoles.push(role)
     }
 
-    console.log('[RoleSync] Final roles:', updatedRoles)
-    if (syncErrors.length > 0) {
-      console.warn('[RoleSync] Sync completed with errors:', syncErrors)
+    return {
+      roles: updatedRoles,
+      hasChanges,
+      errors: [],
+      roleChains: foundOn,
+      estateRead: { read: readChains, unreadable: unreadableChains, swept: true },
     }
-
-    return { roles: updatedRoles, hasChanges, errors: syncErrors }
   }, [])
 
   /**
@@ -378,13 +427,20 @@ export function WalletProvider({ children }) {
       const localRoles = getUserRoles(walletAddress, activeChainId)
       setRoles(localRoles)
 
-      // Then sync with blockchain (authoritative source) for the active chain
-      const { roles: syncedRoles } = await syncRolesWithBlockchain(walletAddress, localRoles, activeChainId)
-      setRoles(syncedRoles)
+      // Then sweep the estate (authoritative source). `roles` is the flat estate-wide answer;
+      // roleChains/estateRead carry where each was found and which chains would not answer.
+      const synced = await syncRolesWithBlockchain(walletAddress, localRoles, activeChainId)
+      setRoles(synced.roles)
+      setRoleChains(synced.roleChains || {})
+      setEstateRead(synced.estateRead || { read: [], unreadable: [], swept: true })
       setBlockchainSynced(true)
     } catch (error) {
       console.error('Error loading user roles:', error)
       setRoles([])
+      setRoleChains({})
+      // A failed sweep is NOT "you hold nothing" — leave it unswept so the console can say so
+      // rather than asserting a denial it never established (FR-012).
+      setEstateRead({ read: [], unreadable: [], swept: false })
     } finally {
       setRolesLoading(false)
     }
@@ -623,6 +679,23 @@ export function WalletProvider({ children }) {
     return rolesToCheck.every(role => roles.includes(role))
   }, [address, roles])
 
+  /**
+   * Which cohort chains this account holds `role` on. Empty ⇒ not held anywhere readable.
+   *
+   * Entry to the console is the estate-wide question (`hasRole` above — "you hold something
+   * somewhere"). This is the narrower one, for surfaces that need to say WHERE. Neither is
+   * authority to write: that is still read from the specific contract on the scoped chain
+   * (`lib/chains/estate.js#readAuthority`), because holding GUARDIAN on the WagerRegistry is
+   * not holding it on the BridgeRouter.
+   */
+  const chainsForRole = useCallback((role) => roleChains[role] || [], [roleChains])
+
+  /** Does this account hold `role` on this specific chain? */
+  const hasRoleOnChainId = useCallback(
+    (role, id) => (roleChains[role] || []).some((c) => Number(c) === Number(id)),
+    [roleChains],
+  )
+
   const grantRole = useCallback((role) => {
     if (!address) {
       throw new Error('Cannot grant role: no wallet connected')
@@ -724,6 +797,11 @@ export function WalletProvider({ children }) {
     hasRole,
     hasAnyRole,
     hasAllRoles,
+    // Spec 071: where roles were found, and what the sweep could actually read.
+    roleChains,
+    estateRead,
+    chainsForRole,
+    hasRoleOnChainId,
     grantRole,
     revokeRole,
   }

--- a/frontend/src/hooks/useRoleDetails.js
+++ b/frontend/src/hooks/useRoleDetails.js
@@ -3,6 +3,8 @@ import { ethers } from 'ethers'
 import { useAccount } from 'wagmi'
 import { useWeb3 } from './useWeb3'
 import { getContractAddressForChain } from '../config/contracts'
+import { membershipChainId } from '../config/networks'
+import { getReadProvider } from '../utils/rpcProvider'
 import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
 
 /**
@@ -53,6 +55,9 @@ function emptyDetails(roleName) {
     isExpired: false,
     daysRemaining: null,
     hasRole: false,
+    // FR-004: `readable: false` means the reference chain would not answer, so tier 0 here is
+    // UNKNOWN rather than "no membership". Consumers must not render the two the same way.
+    readable: true,
     wagersCreated: 0,
     wagerLimit: 0,
     canCreateWager: false,
@@ -73,14 +78,21 @@ export function useRoleDetails() {
     const roleBytes = ROLE_BYTES32[roleName]
     if (!roleBytes) return null
 
-    // Resolve the MembershipManager for the wallet's connected chain so a
-    // membership held on one network is not read on another (the address used to
-    // be build-bound while the provider was the wallet's — a chain mismatch).
-    const managerAddr = getContractAddressForChain('membershipManager', chainId)
+    // ── MEMBERSHIP READS THE REFERENCE CHAIN (spec 071 FR-003) ────────────────────────────
+    // This used to resolve against the wallet's connected chain, which is why a member
+    // connected anywhere other than the reference chain saw tier None with no expiry: on
+    // mainnet the MembershipManager exists on Polygon and nowhere else, so the lookup found
+    // no contract and returned an empty membership. Both the address AND the provider now
+    // come from the reference chain, so they cannot disagree.
+    const refChain = membershipChainId()
+    const managerAddr = getContractAddressForChain('membershipManager', refChain)
     if (!managerAddr) return emptyDetails(roleName)
+    const readProvider =
+      Number(refChain) === Number(chainId) && provider ? provider : getReadProvider(refChain)
+    if (!readProvider) return { ...emptyDetails(roleName), readable: false }
 
     try {
-      const mgr = new ethers.Contract(managerAddr, MEMBERSHIP_MANAGER_ABI, provider)
+      const mgr = new ethers.Contract(managerAddr, MEMBERSHIP_MANAGER_ABI, readProvider)
       const m = await mgr.getMembership(address, roleBytes)
       const details = emptyDetails(roleName)
 
@@ -119,8 +131,10 @@ export function useRoleDetails() {
 
       return details
     } catch (err) {
+      // Unknown, not "no membership" (FR-004). Returning a bare emptyDetails here told a member
+      // whose reference chain blipped that they owned nothing.
       console.error(`Error fetching ${roleName} details:`, err)
-      return emptyDetails(roleName)
+      return { ...emptyDetails(roleName), readable: false }
     }
   }, [address, provider, chainId])
 

--- a/frontend/src/hooks/useRoles.js
+++ b/frontend/src/hooks/useRoles.js
@@ -27,7 +27,14 @@ export function useRoles() {
     hasAnyRole,
     hasAllRoles,
     grantRole,
-    revokeRole
+    revokeRole,
+    // Spec 071: `hasRole`/`hasAnyRole` are now ESTATE-WIDE — true when the role is held on any
+    // chain in the build's cohort, not just the one the wallet sits on. These carry the detail:
+    // which chains each role was found on, and which chains would not answer at all.
+    roleChains,
+    estateRead,
+    chainsForRole,
+    hasRoleOnChainId
   } = context
 
   // Provide a consistent interface for role operations
@@ -40,6 +47,10 @@ export function useRoles() {
     hasAllRoles,
     grantRole,
     revokeRole,
+    roleChains,
+    estateRead,
+    chainsForRole,
+    hasRoleOnChainId,
     loadRoles: refreshRoles,
     // Include role constants for convenience
     ROLES,

--- a/frontend/src/hooks/useRoles.js
+++ b/frontend/src/hooks/useRoles.js
@@ -34,7 +34,10 @@ export function useRoles() {
     roleChains,
     estateRead,
     chainsForRole,
-    hasRoleOnChainId
+    hasRoleOnChainId,
+    // FR-004: false ⇒ membership could not be read from the reference chain. Callers MUST NOT
+    // render this as "no membership" — it is unknown, and a gated refusal must say which.
+    membershipReadable
   } = context
 
   // Provide a consistent interface for role operations
@@ -51,6 +54,7 @@ export function useRoles() {
     estateRead,
     chainsForRole,
     hasRoleOnChainId,
+    membershipReadable,
     loadRoles: refreshRoles,
     // Include role constants for convenience
     ROLES,

--- a/frontend/src/hooks/useTierPrices.js
+++ b/frontend/src/hooks/useTierPrices.js
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
 import { getContractAddressForChain } from '../config/contracts'
+import { membershipChainId } from '../config/networks'
 import { getProvider } from '../utils/blockchainService'
-import { useWeb3 } from './useWeb3'
 import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
 
 /**
@@ -49,23 +49,30 @@ export function useTierPrices() {
   // that prices for a real-money product may be estimates / out of sync.
   const [usingFallbackPrices, setUsingFallbackPrices] = useState(true)
 
-  // Resolve the MembershipManager + provider for the wallet's connected chain so
-  // tier prices/limits reflect the network the user is actually on, not the
-  // build-time default. Falls back to the primary chain when disconnected
-  // (getProvider/getContractAddressForChain handle a null chainId).
-  const { chainId } = useWeb3()
-  const provider = useMemo(() => getProvider(chainId), [chainId])
+  // ── PRICES COME FROM THE REFERENCE CHAIN (spec 071 FR-003/FR-006/FR-008) ──────────────────
+  // These used to resolve against the WALLET's connected chain. Since spec 071 routes every
+  // purchase to the reference chain, that combination quoted one chain's price for a purchase
+  // that settles on another — and on any chain without a MembershipManager (every mainnet but
+  // Polygon) it found no contract at all and fell back to HARDCODED prices. A member was shown
+  // a placeholder price for a real charge, which is precisely what constitution III forbids.
+  //
+  // The price the member is quoted is now read from the same contract that will take their
+  // money, so the two cannot disagree.
+  const referenceChainId = membershipChainId()
+  const provider = useMemo(() => getProvider(referenceChainId), [referenceChainId])
 
   const contract = useMemo(() => {
-    const addr = getContractAddressForChain('membershipManager', chainId)
+    const addr = getContractAddressForChain('membershipManager', referenceChainId)
     if (!addr) return null
     return new ethers.Contract(addr, MEMBERSHIP_MANAGER_ABI, provider)
-  }, [provider, chainId])
+  }, [provider, referenceChainId])
 
   const fetchPrices = useCallback(async () => {
     if (!contract) {
-      // No MembershipManager on the connected chain — show fallback prices, not
-      // whatever was fetched for a previously-connected network.
+      // No MembershipManager on the REFERENCE chain — a build misconfiguration rather than a
+      // member being on the "wrong" network, since the reference chain no longer moves with the
+      // wallet. `usingFallbackPrices` stays true so the UI keeps disclosing that these are
+      // estimates rather than a quote from the contract that will take the money.
       setTierPrices(FALLBACK_PRICES)
       setTierLimits({})
       setUsingFallbackPrices(true)

--- a/frontend/src/test/admin/adminEstateEntry.test.jsx
+++ b/frontend/src/test/admin/adminEstateEntry.test.jsx
@@ -1,0 +1,180 @@
+/**
+ * Spec 071 US2 (T025, T026) — console entry is an ESTATE-WIDE question.
+ *
+ * The defect this closes: admin roles are granted per contract per chain, but entry asked only
+ * the chain the wallet happened to sit on. An operator holding GUARDIAN on Polygon, connected to
+ * Base, was told "Access Restricted" — during an incident, that is an operator who cannot act.
+ *
+ * The subtler half is FR-011/FR-012: a chain that could not be READ must never be counted as
+ * evidence a role is NOT held. "You hold nothing" and "we could not ask" are different
+ * sentences, and only one of them is about the operator's grant.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+
+const m = vi.hoisted(() => ({ roles: [], roleChains: {}, estateRead: { read: [], unreadable: [], swept: true } }))
+
+vi.mock('../../hooks/useRoles', () => ({
+  useRoles: () => ({
+    hasRole: (r) => m.roles.includes(r),
+    hasAnyRole: (rs) => rs.some((r) => m.roles.includes(r)),
+    roleChains: m.roleChains,
+    estateRead: m.estateRead,
+    chainsForRole: (r) => m.roleChains[r] || [],
+    loadRoles: vi.fn(),
+  }),
+}))
+vi.mock('../../hooks/useWeb3', () => ({
+  useWeb3: () => ({
+    account: '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+    signer: null,
+    provider: null,
+    chainId: 8453, // Base — deliberately NOT where any role below is held
+  }),
+}))
+vi.mock('../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: vi.fn() }) }))
+vi.mock('../../hooks/useChainTokens', () => ({ useChainTokens: () => ({ native: 'ETH', capabilities: {} }) }))
+vi.mock('../../hooks/useEnsResolution', () => ({
+  useEnsResolution: () => ({ resolvedAddress: '', isEns: false, isLoading: false }),
+}))
+vi.mock('../../hooks/useMediaQuery', () => ({
+  useIsMobile: () => false, useMediaQuery: () => false, useIsTablet: () => false, useIsExtraSmall: () => false,
+}))
+vi.mock('../../utils/blockchainService', () => ({ getProvider: () => null }))
+vi.mock('../../config/contracts', () => ({
+  NETWORK_CONFIG: { name: 'Polygon', blockExplorer: 'https://polygonscan.com' },
+  DEPLOYED_CONTRACTS: {},
+  getContractAddressForChain: () => '',
+}))
+vi.mock('../../components/admin/ServiceHealthCard', () => ({ default: () => <div /> }))
+vi.mock('../../components/admin/PaymasterOpsCard', () => ({ default: () => <div /> }))
+vi.mock('../../components/admin/MembershipTreasuryOverview', () => ({ default: () => <div /> }))
+
+import AdminPanel from '../../components/AdminPanel'
+import { ROLES } from '../../contexts/RoleContext'
+import { cohortChainIds } from '../../config/networks'
+
+const COHORT = cohortChainIds()
+const HOME = COHORT[0]
+const OTHER = COHORT[1]
+
+beforeEach(() => {
+  m.roles = []
+  m.roleChains = {}
+  m.estateRead = { read: [...COHORT], unreadable: [], swept: true }
+})
+
+describe('entry is granted from any chain in the cohort (FR-009)', () => {
+  it('opens for a role held on one chain while the wallet sits on another', () => {
+    m.roles = [ROLES.GUARDIAN]
+    m.roleChains = { [ROLES.GUARDIAN]: [HOME] }
+
+    render(<AdminPanel />)
+
+    // Not the refusal screen…
+    expect(screen.queryByText(/Access Restricted/i)).toBeNull()
+    // …and the guardian's own view is offered.
+    expect(screen.getByRole('tab', { name: 'Emergency' })).toBeInTheDocument()
+  })
+
+  it('offers only the views the held role gates, not the whole console', () => {
+    m.roles = [ROLES.GUARDIAN]
+    m.roleChains = { [ROLES.GUARDIAN]: [HOME] }
+
+    render(<AdminPanel />)
+
+    expect(screen.getByRole('tab', { name: 'Emergency' })).toBeInTheDocument()
+    // Admin-only views stay closed — entry is not authority.
+    expect(screen.queryByRole('tab', { name: 'Tiers' })).toBeNull()
+    expect(screen.queryByRole('tab', { name: 'Admin Roles' })).toBeNull()
+  })
+
+  it('still refuses an account holding no role on any chain', () => {
+    render(<AdminPanel />)
+    expect(screen.getByText(/Access Restricted/i)).toBeInTheDocument()
+  })
+})
+
+describe('an unread chain is never counted as a denial (FR-011, FR-012)', () => {
+  it('grants entry from roles found elsewhere even when one chain could not be read', () => {
+    m.roles = [ROLES.GUARDIAN]
+    m.roleChains = { [ROLES.GUARDIAN]: [HOME] }
+    m.estateRead = { read: [HOME], unreadable: [OTHER], swept: true }
+
+    render(<AdminPanel />)
+
+    expect(screen.queryByText(/Access Restricted/i)).toBeNull()
+    expect(screen.getByRole('tab', { name: 'Emergency' })).toBeInTheDocument()
+  })
+
+  it('distinguishes "could not ask" from "you hold nothing" when NO chain answered', () => {
+    m.estateRead = { read: [], unreadable: [...COHORT], swept: true }
+
+    render(<AdminPanel />)
+
+    expect(screen.getByText(/Could Not Verify Access/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Access Restricted/i)).toBeNull()
+    // The refusal must attribute itself to the read, not to the operator's grant.
+    expect(screen.getByText(/connectivity problem, not a statement about what you hold/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+  })
+
+  it('treats a sweep that never completed the same way — unknown, not denied', () => {
+    m.estateRead = { read: [], unreadable: [], swept: false }
+    render(<AdminPanel />)
+    expect(screen.getByText(/Could Not Verify Access/i)).toBeInTheDocument()
+  })
+
+  it('says how much of the estate it checked when it genuinely found nothing', () => {
+    m.estateRead = { read: [HOME, OTHER], unreadable: [], swept: true }
+    render(<AdminPanel />)
+    expect(screen.getByText(/Access Restricted/i)).toBeInTheDocument()
+    expect(screen.getByText(/Checked across 2 networks/i)).toBeInTheDocument()
+  })
+})
+
+describe('the permissions card names where each role lives (FR-010)', () => {
+  it('names the network a held role was found on', () => {
+    m.roles = [ROLES.GUARDIAN]
+    m.roleChains = { [ROLES.GUARDIAN]: [HOME] }
+
+    const { container } = render(<AdminPanel />)
+    const card = [...container.querySelectorAll('.admin-card')].find((el) =>
+      within(el).queryByText('Your Permissions'),
+    )
+    const guardianRow = within(card).getByText(/Guardian \(pause/).closest('.permission-item')
+
+    expect(guardianRow).toHaveClass('enabled')
+    expect(guardianRow.textContent).toContain('Mordor') // NETWORKS[63].name, the cohort's first
+  })
+
+  it('lists every operator role, so a held one can never be silently missing', () => {
+    m.roles = [ROLES.STAKING_ADMIN]
+    m.roleChains = { [ROLES.STAKING_ADMIN]: [HOME] }
+
+    const { container } = render(<AdminPanel />)
+    const card = [...container.querySelectorAll('.admin-card')].find((el) =>
+      within(el).queryByText('Your Permissions'),
+    )
+
+    // Eight roles can open this console; all eight get a row.
+    expect(within(card).getAllByText(/Administrator|Guardian|Moderator|Role Manager|Compliance|Fee Admin|Staking Admin|Liquidity Admin/))
+      .toHaveLength(8)
+    // And the one actually held reads as held — the STAKING_ADMIN sync gap this phase fixed.
+    const row = within(card).getByText(/Staking Administrator/).closest('.permission-item')
+    expect(row).toHaveClass('enabled')
+  })
+
+  it('discloses unread networks rather than letting a × imply a denial', () => {
+    m.roles = [ROLES.GUARDIAN]
+    m.roleChains = { [ROLES.GUARDIAN]: [HOME] }
+    m.estateRead = { read: [HOME], unreadable: [OTHER], swept: true }
+
+    const { container } = render(<AdminPanel />)
+    const card = [...container.querySelectorAll('.admin-card')].find((el) =>
+      within(el).queryByText('Your Permissions'),
+    )
+    expect(within(card).getByText(/could not be read, so\s+nothing above rules out a role held there/i))
+      .toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/admin/networkScoping.test.jsx
+++ b/frontend/src/test/admin/networkScoping.test.jsx
@@ -41,12 +41,18 @@ vi.mock('../../lib/bridge/bridgeStatus', async (orig) => ({
 }))
 // Every read is keyed by the CONTRACT ADDRESS the tab constructed, so a value from one network's
 // router can only appear on screen if the tab actually asked that router for it.
+// Spec 071 (T010): estate reads now resolve providers via `getReadProvider(chainId)` rather than
+// hand-building one from `NETWORKS[chainId].rpcUrl`, so the member's own endpoint and failover
+// apply. Both names are stubbed here — the assertions below are unchanged, and still key every
+// read on the CONTRACT ADDRESS the tab constructed.
+const fakeProvider = () => ({
+  getBlockNumber: () => Promise.resolve(1_000_000),
+  getBlock: () => Promise.resolve({ timestamp: 0 }),
+  getTransactionReceipt: () => Promise.resolve(null),
+})
 vi.mock('../../utils/rpcProvider', () => ({
-  makeReadProvider: () => ({
-    getBlockNumber: () => Promise.resolve(1_000_000),
-    getBlock: () => Promise.resolve({ timestamp: 0 }),
-    getTransactionReceipt: () => Promise.resolve(null),
-  }),
+  makeReadProvider: () => fakeProvider(),
+  getReadProvider: () => fakeProvider(),
 }))
 vi.mock('ethers', async (orig) => {
   const actual = await orig()

--- a/frontend/src/test/adminNav.test.js
+++ b/frontend/src/test/adminNav.test.js
@@ -239,9 +239,24 @@ describe('LIQUIDITY_ADMIN_ROLE resolution (spec 067)', () => {
     // FEE_ADMIN, STAKING_ADMIN and LIQUIDITY_ADMIN were in ROLES, in ADMIN_ROLES and in the nav but
     // not in this card, so an operator holding one read a list of × and concluded their grant had not
     // landed. A permissions card that omits a role it let you in on is worse than no card.
-    for (const flag of ['isFeeAdmin', 'isStakingAdmin', 'isLiquidityAdmin']) {
-      expect(adminPanelSource).toMatch(new RegExp(`permission-item \\$\\{${flag} \\?`))
+    //
+    // Spec 071 turned the eight hand-written rows into one ADMIN_ROLE_ROWS table, so this checks
+    // the table rather than the markup — and checks ALL of ADMIN_ROLES rather than the three that
+    // happened to be missing once, which is the invariant that actually matters.
+    const rows = adminPanelSource.match(/const ADMIN_ROLE_ROWS = \[[\s\S]*?\n  \]/)
+    expect(rows, 'ADMIN_ROLE_ROWS table not found in AdminPanel.jsx').toBeTruthy()
+    for (const role of ADMIN_ROLES) {
+      expect(rows[0]).toContain(`ROLES.${role}`)
     }
+  })
+
+  it('names the network each held role was found on (spec 071 FR-010)', () => {
+    // A bare ✓ on a per-chain role tells an operator they hold it without saying where, which is
+    // not enough to act on — and an unread network rendering as × would assert a denial the
+    // platform never established.
+    expect(adminPanelSource).toContain('chainsForRole')
+    expect(adminPanelSource).toMatch(/permission-networks/)
+    expect(adminPanelSource).toContain('could not be read')
   })
 
   it('both tab bodies are gated exactly like the nav items (no direct-id bypass)', () => {

--- a/frontend/src/test/blockchainService.purchase.test.js
+++ b/frontend/src/test/blockchainService.purchase.test.js
@@ -18,6 +18,7 @@ vi.mock('../config/contracts', async (importOriginal) => {
 })
 
 import { purchaseRoleWithStablecoin, getUserTierOnChain } from '../utils/blockchainService'
+import { membershipChainId } from '../config/networks'
 import { makeSigner } from './helpers/chainMocks'
 
 // makeSigner (shared) returns a signer whose provider reports chainId via
@@ -89,26 +90,47 @@ describe('purchaseRoleWithStablecoin — onProgress callback (spec 022)', () => 
   })
 })
 
-describe('getUserTierOnChain — chain-aware tier read', () => {
+describe('getUserTierOnChain — membership reads the REFERENCE chain (spec 071 FR-003)', () => {
   beforeEach(() => resolverMock.mockReset())
   // The test env sets VITE_SKIP_BLOCKCHAIN_CALLS=true (vite.config.js) which
-  // short-circuits the function; un-skip it so the chain-aware resolution runs.
+  // short-circuits the function; un-skip it so the chain resolution runs.
   afterEach(() => vi.unstubAllEnvs())
 
-  it("resolves the membership contract for the passed chain id, not the build chain", async () => {
+  // This test used to assert the resolver was queried with the PASSED chain id, guarding a
+  // spec-008 bug where an Amoy tier leaked into the mainnet purchase view. Spec 071 supersedes
+  // that: membership lives in exactly one place per cohort, so the passed chain is ignored and
+  // the reference chain is used. The original leak is still prevented — by cohort separation
+  // (a mainnet build's reference chain is Polygon and can never be Amoy), asserted in
+  // test/lib/chains/membershipChain.test.js — rather than by echoing the wallet's chain.
+  it('ignores the passed chain id and resolves the reference chain', async () => {
     vi.stubEnv('VITE_SKIP_BLOCKCHAIN_CALLS', 'false')
-    // No membership contract on this chain -> tier 0. The point of the test is
-    // the resolver is queried with the wallet's chain id, guarding against the
-    // bug where a testnet (Amoy) tier leaked into the mainnet purchase view.
     resolverMock.mockReturnValue(undefined)
+
+    // Deliberately pass a cohort chain that is NOT the reference chain, so an implementation
+    // that echoed its argument back would fail here rather than pass by coincidence.
+    const notTheReferenceChain = 63
+    expect(notTheReferenceChain).not.toBe(membershipChainId())
+
+    await getUserTierOnChain(
+      '0x0000000000000000000000000000000000000001',
+      'WAGER_PARTICIPANT',
+      notTheReferenceChain
+    )
+
+    expect(resolverMock).toHaveBeenCalledWith('membershipManager', membershipChainId())
+    expect(resolverMock).not.toHaveBeenCalledWith('membershipManager', notTheReferenceChain)
+  })
+
+  it('reports "None" as a READ answer, distinct from an unreadable one (FR-004)', async () => {
+    vi.stubEnv('VITE_SKIP_BLOCKCHAIN_CALLS', 'false')
+    resolverMock.mockReturnValue(undefined) // no MembershipManager, no TierRegistry → genuinely none
 
     const res = await getUserTierOnChain(
       '0x0000000000000000000000000000000000000001',
       'WAGER_PARTICIPANT',
-      80002
+      membershipChainId()
     )
 
-    expect(resolverMock).toHaveBeenCalledWith('membershipManager', 80002)
-    expect(res).toEqual({ tier: 0, tierName: 'None' })
+    expect(res).toMatchObject({ tier: 0, tierName: 'None', readable: true })
   })
 })

--- a/frontend/src/test/chainResolutionGuard.test.js
+++ b/frontend/src/test/chainResolutionGuard.test.js
@@ -4,10 +4,24 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 /**
- * Regression guard for spec 008 (FR-011): user-facing code MUST resolve contract
- * addresses and providers for the wallet's CONNECTED chain
- * (`getContractAddressForChain(name, chainId)` / `getProvider(chainId)`), never
- * the build-time default (`getContractAddress(name)` / argless `getProvider()`).
+ * Regression guard for spec 008 (FR-011): user-facing code MUST resolve contract addresses and
+ * providers against an EXPLICIT chain — never the build-time default
+ * (`getContractAddress(name)` / argless `getProvider()`).
+ *
+ * ── WHY "EXPLICIT" AND NOT "THE WALLET'S CONNECTED CHAIN" (spec 071) ────────────────────────
+ * This comment used to say the rule was "the wallet's CONNECTED chain". That is no longer what
+ * the code does, and a guard whose stated reason contradicts the code it guards teaches the next
+ * reader to distrust it. There are now three legitimate explicit chains:
+ *
+ *   • the WALLET's chain      — for wallet-scoped state (balances, the member's own positions)
+ *   • the REFERENCE chain     — for membership, which lives in exactly one place per cohort
+ *                               (spec 071 FR-003; `membershipChainId()`)
+ *   • the SCOPED chain        — for operator views, which read a network the operator picks
+ *                               rather than the one the wallet sits on (spec 071 FR-013)
+ *
+ * The mechanical check below is UNCHANGED and still passes: all three go through
+ * `getContractAddressForChain(name, id)` / `getProvider(id)` / `getReadProvider(id)`. What the
+ * guard forbids is the build-time default, and that is still forbidden everywhere.
  *
  * This scans the source and fails when a user-facing file contains MORE
  * build-time-bound calls than its documented allowlist baseline. The allowlist

--- a/frontend/src/test/lib/chains/membershipReferenceChain.test.js
+++ b/frontend/src/test/lib/chains/membershipReferenceChain.test.js
@@ -1,0 +1,141 @@
+/**
+ * Spec 071 US1 (T032–T034) — membership resolves on the REFERENCE chain, and an unreadable
+ * reference chain is UNKNOWN rather than "no membership".
+ *
+ * The live defect: membership exists in exactly one place per cohort (Polygon on mainnet), so
+ * reading it wherever the wallet pointed reported every member on Ethereum / Optimism / Base /
+ * Arbitrum / ETC as unentitled. They have a membership; the lookup was aimed at chains it was
+ * never kept on.
+ *
+ * The second half is subtler and is what T029 fixed: a failed read used to return exactly what a
+ * genuine "no membership" returns, so a member whose RPC blipped was told they owned nothing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const m = vi.hoisted(() => ({ constructedAt: [], hasActiveRole: null, getActiveTier: null }))
+
+vi.mock('../../../config/contracts', async (orig) => {
+  const actual = await orig()
+  return {
+    ...actual,
+    // Every cohort chain "has" a MembershipManager at a chain-distinctive address, so the address
+    // the code constructs against proves which chain it actually asked.
+    getContractAddressForChain: (name, chainId) =>
+      name === 'membershipManager' ? `0xmm${chainId}` : '',
+    getContractAddress: () => '',
+  }
+})
+
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract(address) {
+    m.constructedAt.push(String(address))
+    return new Proxy({}, {
+      get(_t, prop) {
+        if (prop === 'then') return undefined
+        const key = String(prop)
+        return (...args) => {
+          if (key === 'hasActiveRole') return m.hasActiveRole(...args)
+          if (key === 'getActiveTier') return m.getActiveTier(...args)
+          return Promise.resolve(undefined)
+        }
+      },
+    })
+  }
+  const Ctor = vi.fn(FakeContract)
+  return { ...actual, Contract: Ctor, ethers: { ...actual.ethers, Contract: Ctor } }
+})
+
+import { hasRoleOnChain, getUserTierOnChain } from '../../../utils/blockchainService'
+import { membershipChainId, cohortChainIds } from '../../../config/networks'
+
+const USER = '0x0000000000000000000000000000000000000001'
+const REF = membershipChainId()
+const NOT_REF = cohortChainIds().find((id) => Number(id) !== Number(REF))
+
+beforeEach(() => {
+  m.constructedAt = []
+  m.hasActiveRole = () => Promise.resolve(true)
+  m.getActiveTier = () => Promise.resolve(3)
+  vi.stubEnv('VITE_SKIP_BLOCKCHAIN_CALLS', 'false')
+})
+afterEach(() => vi.unstubAllEnvs())
+
+describe('membership resolves on the reference chain, whatever the wallet says (FR-003)', () => {
+  it('reads the reference chain even when told to read another cohort chain', async () => {
+    expect(NOT_REF).toBeDefined()
+    const held = await hasRoleOnChain(USER, 'WAGER_PARTICIPANT', NOT_REF)
+
+    expect(held).toBe(true)
+    expect(m.constructedAt).toContain(`0xmm${REF}`)
+    expect(m.constructedAt).not.toContain(`0xmm${NOT_REF}`)
+  })
+
+  it('gives the same answer from every cohort chain — SC-001', async () => {
+    for (const chainId of cohortChainIds()) {
+      m.constructedAt = []
+      const held = await hasRoleOnChain(USER, 'WAGER_PARTICIPANT', chainId)
+      expect(held).toBe(true)
+      expect(m.constructedAt).toEqual([`0xmm${REF}`])
+    }
+  })
+
+  it('reads the tier from the reference chain too', async () => {
+    const res = await getUserTierOnChain(USER, 'WAGER_PARTICIPANT', NOT_REF)
+    expect(res).toMatchObject({ tier: 3, readable: true })
+    expect(m.constructedAt).toContain(`0xmm${REF}`)
+  })
+})
+
+describe('the admin-role branch still honours its explicit chain (research R3)', () => {
+  it('reads the chain it was given — admin roles genuinely are per-chain', async () => {
+    // Admin roles resolve against the registry/router candidates for the chain passed in, so the
+    // reference-chain rule must NOT have leaked into this branch.
+    await hasRoleOnChain(USER, 'GUARDIAN', NOT_REF)
+    // The membership address is never constructed for an admin-role read.
+    expect(m.constructedAt).not.toContain(`0xmm${REF}`)
+  })
+})
+
+describe('an unreadable reference chain is UNKNOWN, not "no membership" (FR-004)', () => {
+  it('hasRoleOnChain reports readable:false rather than a false denial', async () => {
+    m.hasActiveRole = () => Promise.reject(new Error('endpoint down'))
+
+    const detailed = await hasRoleOnChain(USER, 'WAGER_PARTICIPANT', REF, { detailed: true })
+
+    expect(detailed.readable).toBe(false)
+    expect(detailed.reason).toMatch(/endpoint down/)
+    // held is false, but `readable:false` is what stops a caller reading that as a denial.
+    expect(detailed.held).toBe(false)
+  })
+
+  it('getUserTierOnChain distinguishes unknown from None', async () => {
+    m.getActiveTier = () => Promise.reject(new Error('endpoint down'))
+
+    const unknown = await getUserTierOnChain(USER, 'WAGER_PARTICIPANT', REF)
+
+    expect(unknown.readable).toBe(false)
+    expect(unknown.tierName).not.toBe('None') // the whole point: never the "you own nothing" answer
+    expect(unknown.reason).toMatch(/endpoint down/)
+  })
+
+  it('a genuine "no membership" is still a READ answer, not an unknown', async () => {
+    m.hasActiveRole = () => Promise.resolve(false)
+    m.getActiveTier = () => Promise.resolve(0)
+
+    const held = await hasRoleOnChain(USER, 'WAGER_PARTICIPANT', REF, { detailed: true })
+    const tier = await getUserTierOnChain(USER, 'WAGER_PARTICIPANT', REF)
+
+    expect(held).toMatchObject({ held: false, readable: true })
+    expect(tier).toMatchObject({ tier: 0, tierName: 'None', readable: true })
+  })
+
+  it('keeps the plain boolean contract for every caller that did not opt in', async () => {
+    m.hasActiveRole = () => Promise.resolve(true)
+    // No `{ detailed: true }` — existing callers must see exactly what they always saw.
+    await expect(hasRoleOnChain(USER, 'WAGER_PARTICIPANT', REF)).resolves.toBe(true)
+
+    m.hasActiveRole = () => Promise.reject(new Error('down'))
+    await expect(hasRoleOnChain(USER, 'WAGER_PARTICIPANT', REF)).resolves.toBe(false)
+  })
+})

--- a/frontend/src/test/membershipPurchaseRouting.test.jsx
+++ b/frontend/src/test/membershipPurchaseRouting.test.jsx
@@ -1,0 +1,148 @@
+/**
+ * Spec 071 US5 (T041) — membership purchases settle on the REFERENCE chain.
+ *
+ * Membership must be readable from one place (US1), which is only true if it is also WRITTEN in
+ * one place. A purchase that landed elsewhere would create a membership the reference-chain read
+ * can never see: the member pays and stays unentitled everywhere.
+ *
+ * The last describe block asserts an ABSENCE — that no path completes a purchase on any other
+ * chain (SC-006) — because "we only offer the right one" is a claim about code that does not
+ * exist, and prose cannot verify that.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const m = vi.hoisted(() => ({
+  chainId: 63, // a cohort chain that is NOT the reference chain
+  switchNetwork: null,
+  notify: null,
+  tier: { tier: 0, tierName: 'None', readable: true },
+  builtCalls: [],
+}))
+
+vi.mock('../hooks/useWeb3', () => ({
+  useWeb3: () => ({
+    account: '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+    isConnected: true,
+    isCorrectNetwork: true,
+    switchNetwork: m.switchNetwork,
+    chainId: m.chainId,
+    loginMethod: 'wallet',
+    sendCalls: vi.fn(),
+    provider: {},
+  }),
+}))
+vi.mock('../hooks/useRoles', () => ({
+  useRoles: () => ({ grantRole: vi.fn(), loadRoles: vi.fn() }),
+}))
+vi.mock('../hooks/useUI', () => ({ useNotification: () => ({ showNotification: m.notify }) }))
+vi.mock('../hooks/useTierPrices', () => ({
+  useTierPrices: () => ({
+    getPrice: () => 2,
+    getLimits: () => ({ monthly: 15, concurrent: 5 }),
+    usingFallbackPrices: false,
+  }),
+}))
+vi.mock('../hooks/useEncryption', () => ({
+  useEncryption: () => ({ ensureInitialized: vi.fn(), isInitialized: true }),
+}))
+vi.mock('../utils/blockchainService', async (orig) => {
+  const actual = await orig()
+  return {
+    ...actual,
+    getUserTierOnChain: () => Promise.resolve(m.tier),
+    // Records every purchase the app would actually build, so an assertion can prove which
+    // chain it targeted — or that it never built one at all.
+    buildMembershipPurchaseCalls: (...args) => {
+      m.builtCalls.push(args)
+      return Promise.resolve({ calls: [] })
+    },
+    purchaseRoleWithStablecoin: (...args) => {
+      m.builtCalls.push(args)
+      return Promise.resolve({ hash: '0xdead' })
+    },
+  }
+})
+
+import PremiumPurchaseModal from '../components/ui/PremiumPurchaseModal'
+
+// The modal calls useNavigate (the voucher entry point), so it needs a router in scope.
+// FR-007 is about what the member sees BEFORE SIGNING, which is the confirm step — so these
+// tests advance to it rather than asserting against the tier picker.
+const render = (ui) => rtlRender(<MemoryRouter>{ui}</MemoryRouter>)
+function renderAtConfirm(ui) {
+  const r = render(ui)
+  const cont = screen.queryByRole('button', { name: /^Continue$/i })
+  if (cont && !cont.disabled) fireEvent.click(cont)
+  return r
+}
+import { membershipChainId, cohortChainIds, NETWORKS } from '../config/networks'
+
+const REF = membershipChainId()
+const REF_NAME = NETWORKS[REF].name
+
+beforeEach(() => {
+  m.chainId = cohortChainIds().find((id) => Number(id) !== Number(REF))
+  m.switchNetwork = vi.fn(() => Promise.resolve(true))
+  m.notify = vi.fn()
+  m.tier = { tier: 0, tierName: 'None', readable: true }
+  m.builtCalls = []
+})
+
+describe('the settlement network is disclosed before signature (FR-007)', () => {
+  it('names the reference chain even when the wallet is already on it', () => {
+    m.chainId = REF
+    renderAtConfirm(<PremiumPurchaseModal />)
+    // Disclosure is unconditional — a member should not have to infer it from a missing warning.
+    expect(screen.getByRole('note')).toHaveTextContent(new RegExp(`held on\\s+${REF_NAME}`, 'i'))
+  })
+
+  it('warns and offers a switch when the wallet is on another chain', () => {
+    renderAtConfirm(<PremiumPurchaseModal />)
+    // Both the heading and the button name the chain — assert on the button, which is the part
+    // that has to actually target it.
+    const btn = screen.getByRole('button', { name: new RegExp(`Switch to ${REF_NAME}`, 'i') })
+    expect(btn).toBeInTheDocument()
+    fireEvent.click(btn)
+    expect(m.switchNetwork).toHaveBeenCalledWith(REF)
+  })
+
+  it('explains why, rather than just refusing', () => {
+    renderAtConfirm(<PremiumPurchaseModal />)
+    expect(screen.getByText(/could never read back/i)).toBeInTheDocument()
+  })
+})
+
+describe('declining the switch buys nothing (FR-007 acceptance 2)', () => {
+  it('builds no purchase call while the wallet is on the wrong chain', () => {
+    renderAtConfirm(<PremiumPurchaseModal />)
+    // The member never switches; nothing is sent anywhere.
+    expect(m.builtCalls).toHaveLength(0)
+    expect(m.switchNetwork).not.toHaveBeenCalled()
+  })
+})
+
+// ── SC-006: the ABSENCE ─────────────────────────────────────────────────────────────────────
+// "Purchases go to the reference chain" is only half a guarantee; the other half is that no path
+// completes one anywhere else. This drives the flow from EVERY non-reference cohort chain and
+// asserts nothing is ever built. Mirrors the absence assertion T067 makes for FR-020.
+describe('no path completes a purchase on a non-reference chain (SC-006)', () => {
+  const others = cohortChainIds().filter((id) => Number(id) !== Number(REF))
+
+  it('has at least one non-reference chain to test, or the assertion is vacuous', () => {
+    expect(others.length).toBeGreaterThan(0)
+  })
+
+  it.each(others)('builds no purchase from chain %s', (chainId) => {
+    m.chainId = chainId
+    m.builtCalls = []
+
+    renderAtConfirm(<PremiumPurchaseModal />)
+
+    // The confirm control is unavailable, and nothing was built.
+    const confirm = screen.queryByRole('button', { name: /Confirm Purchase/i })
+    if (confirm) expect(confirm).toBeDisabled()
+    expect(m.builtCalls).toHaveLength(0)
+  })
+})

--- a/frontend/src/test/useRoleDetails.chain.test.js
+++ b/frontend/src/test/useRoleDetails.chain.test.js
@@ -1,13 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 
-// Regression guard (spec 008): membership/role details must be read from the
-// wallet's connected chain. The address used to be build-bound while the
-// provider was the wallet's — a chain mismatch that could read a membership on
-// the wrong network. Resolver returns undefined → emptyDetails, no network call.
-const { resolver, web3 } = vi.hoisted(() => ({
+// ── WHAT THIS GUARDS, AND WHY IT CHANGED ────────────────────────────────────────────────────
+// Spec 008 pinned membership/role details to the WALLET's connected chain: the address used to be
+// build-bound while the provider was the wallet's, a mismatch that could read a membership on the
+// wrong network.
+//
+// Spec 071 (FR-003) supersedes that. Membership lives in exactly one place per environment cohort,
+// so both the address AND the provider come from the REFERENCE chain and therefore still cannot
+// disagree — the original mismatch stays fixed, by a stronger rule.
+//
+// The old version of this test mocked the wallet onto chain 80002 and asserted the resolver was
+// called with 80002. In a testnet build 80002 IS the reference chain, so that assertion passed
+// whichever chain the code actually used — it could not fail. The wallet is now deliberately put
+// on a DIFFERENT cohort chain so the two answers are distinguishable.
+const { resolver, web3, referenceChainId } = vi.hoisted(() => ({
   resolver: vi.fn(() => undefined),
-  web3: { chainId: 80002, provider: { ok: true }, switchNetwork: () => {}, account: '0xabc', isConnected: true },
+  // Mordor (63): a real cohort chain, and NOT the reference chain (Amoy 80002).
+  web3: { chainId: 63, provider: { ok: true }, switchNetwork: () => {}, account: '0xabc', isConnected: true },
+  referenceChainId: 80002,
 }))
 
 vi.mock('../config/contracts', async (importOriginal) => {
@@ -20,14 +31,23 @@ vi.mock('wagmi', () => ({
 }))
 
 import { useRoleDetails } from '../hooks/useRoleDetails'
+import { membershipChainId } from '../config/networks'
 
-describe('useRoleDetails — chain-aware resolution', () => {
+describe('useRoleDetails — membership resolves on the reference chain (spec 071 FR-003)', () => {
   beforeEach(() => resolver.mockClear())
 
-  it('resolves membershipManager for the connected chainId', async () => {
+  it('the fixture is meaningful: the wallet is NOT on the reference chain', () => {
+    expect(membershipChainId()).toBe(referenceChainId)
+    expect(web3.chainId).not.toBe(membershipChainId())
+  })
+
+  it('resolves membershipManager for the reference chain, not the connected one', async () => {
     renderHook(() => useRoleDetails())
     await waitFor(() =>
-      expect(resolver).toHaveBeenCalledWith('membershipManager', 80002)
+      expect(resolver).toHaveBeenCalledWith('membershipManager', membershipChainId())
     )
+    // The failure this replaces: a member connected anywhere other than the reference chain saw
+    // tier None with no expiry, because the lookup found no MembershipManager on their chain.
+    expect(resolver).not.toHaveBeenCalledWith('membershipManager', web3.chainId)
   })
 })

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -976,16 +976,23 @@ export function getRoleHash(roleName) {
  * @param {string} roleName - Role name or constant
  * @returns {Promise<boolean>} True if user has the role on-chain
  */
-export async function hasRoleOnChain(userAddress, roleName, chainId) {
+export async function hasRoleOnChain(userAddress, roleName, chainId, { detailed = false } = {}) {
+  // `detailed` callers get to tell "not held" apart from "could not ask" (spec 071 FR-011).
+  // Everyone else keeps the plain boolean this has always returned, so no existing caller
+  // changes behaviour. An estate-wide sweep NEEDS the distinction: counting an unreachable
+  // chain as "role not held" is how an operator gets locked out of the console by an RPC blip.
+  const held = (value) => (detailed ? { held: value, readable: true, reason: null } : value)
+  const unread = (reason) => (detailed ? { held: false, readable: false, reason } : false)
+
   // Skip blockchain calls in test environment
   if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') {
-    return false
+    return held(false)
   }
 
   const roleHash = getRoleHash(roleName)
   if (!roleHash) {
     console.warn(`Unknown role: ${roleName}`)
-    return false
+    return held(false)
   }
 
   const provider = getProvider(chainId)
@@ -999,13 +1006,13 @@ export async function hasRoleOnChain(userAddress, roleName, chainId) {
   // gated by a (Tier, expiry) pair — read via hasActiveRole.
   if (roleName === 'WAGER_PARTICIPANT' || roleName === 'Wager Participant') {
     const mmAddress = resolveAddress('membershipManager')
-    if (!mmAddress) return false
+    if (!mmAddress) return held(false)
     try {
       const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, provider)
-      return await mm.hasActiveRole(userAddress, roleHash)
+      return held(Boolean(await mm.hasActiveRole(userAddress, roleHash)))
     } catch (e) {
       console.warn('[hasRoleOnChain] membership read failed:', e.message)
-      return false
+      return unread(e?.message || 'membership read failed')
     }
   }
 
@@ -1067,16 +1074,23 @@ export async function hasRoleOnChain(userAddress, roleName, chainId) {
       if (liquidity) candidates.push(liquidity)
     }
   }
+  // No candidate contract on this chain is a DEFINITE "no role here" — there is nothing to hold
+  // a role on. A candidate that would not answer is a different thing, tracked below.
+  let anyFailed = null
   for (const addr of candidates) {
     try {
       const c = new ethers.Contract(addr, accessControlAbi, provider)
       const yes = await c.hasRole(roleHash, userAddress)
-      if (yes) return true
+      if (yes) return held(true)
     } catch (e) {
       console.debug(`[hasRoleOnChain] AccessControl read failed on ${addr}:`, e.message)
+      anyFailed = e?.message || 'AccessControl read failed'
     }
   }
-  return false
+  // A definite "no" only when every candidate actually answered. If one refused, the honest
+  // answer is "could not tell" — a caller sweeping the estate must not record that as a denial.
+  if (anyFailed) return unread(anyFailed)
+  return held(false)
 }
 
 /**

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -7,7 +7,7 @@
 
 import { ethers } from 'ethers'
 import { getContractAddress, getContractAddressForChain, NETWORK_CONFIG, DEPLOYMENT_BLOCKS, DEPLOYED_CONTRACTS } from '../config/contracts'
-import { getNetwork } from '../config/networks'
+import { getNetwork, membershipChainId } from '../config/networks'
 import { makeReadProvider } from './rpcProvider'
 import { ERC20_ABI } from '../abis/ERC20'
 import { ZK_KEY_MANAGER_ABI } from '../abis/ZKKeyManager'
@@ -889,42 +889,52 @@ export async function checkRoleSyncNeeded(userAddress, roleName) {
 /**
  * Get user's current membership tier for a role from blockchain.
  *
- * Pass the wallet's CURRENT chainId so the tier is read from the chain the user
- * is actually on. Without it the address/provider default to the build-time
- * chain, so a tier held on testnet would be reported on mainnet (and vice
- * versa) — the cause of "current membership is already Silver" appearing after
- * switching from Amoy to Polygon. Mirrors hasRoleOnChain's chain-aware reads.
+ * ── READS THE MEMBERSHIP REFERENCE CHAIN, NOT THE WALLET'S (spec 071 FR-003) ─────────────────
+ * Membership lives in exactly one place per environment cohort, so the `chainId` argument is
+ * ignored for the MembershipManager path — see the matching note in `hasRoleOnChain`. It is
+ * still honoured by the legacy TierRegistry fallback below, which predates the reference chain.
+ *
+ * ── AND `unknown` IS NOT `None` (FR-004) ────────────────────────────────────────────────────
+ * A failed read used to return `{ tier: 0, tierName: 'None' }` — byte-identical to a genuine
+ * "you have no membership". A member whose RPC blipped was therefore told they owned nothing.
+ * The result now carries `readable`, and callers MUST NOT render `!readable` as "no membership".
  *
  * @param {string} userAddress - User's wallet address
  * @param {string} roleName - Role name or constant
- * @param {number} [chainId] - Chain to read from; defaults to the build-time chain
- * @returns {Promise<{tier: number, tierName: string}>} Current tier (0=None, 1=Bronze, 2=Silver, 3=Gold, 4=Platinum)
+ * @param {number} [chainId] - Only used by the legacy TierRegistry fallback
+ * @returns {Promise<{tier: number, tierName: string, readable: boolean, reason: string|null}>}
+ *          `readable: false` ⇒ tier is UNKNOWN, not zero.
  */
 export async function getUserTierOnChain(userAddress, roleName, chainId) {
+  const known = (tier, tierName) => ({ tier, tierName, readable: true, reason: null })
+  const unknownTier = (reason) => ({ tier: 0, tierName: 'Unknown', readable: false, reason })
+
   // Skip blockchain calls in test environment
   if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') {
-    return { tier: 0, tierName: 'None' }
+    return known(0, 'None')
   }
 
-  // Resolve the contract + provider against the selected chain (see hasRoleOnChain)
-  // so a membership held on one network is not read on another.
+  // Legacy fallback only (see doc-comment); the v2 path below is reference-chain bound.
   const resolveAddress = (name) =>
     chainId != null ? getContractAddressForChain(name, chainId) : getContractAddress(name)
-  const provider = getProvider(chainId)
 
-  // v2 path: MembershipManager.getActiveTier
-  const mmAddress = resolveAddress('membershipManager')
+  // v2 path: MembershipManager.getActiveTier, always on the reference chain.
+  const refChain = membershipChainId()
+  const mmAddress = getContractAddressForChain('membershipManager', refChain)
   if (mmAddress) {
     try {
       const roleHash = getRoleHash(roleName)
-      if (!roleHash) return { tier: 0, tierName: 'None' }
-      const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, provider)
+      if (!roleHash) return known(0, 'None')
+      const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, getProvider(refChain))
       const tier = Number(await mm.getActiveTier(userAddress, roleHash))
       const tierName = tier === 0 ? 'None' : (TIER_NAMES[tier] || 'Unknown')
-      return { tier, tierName }
+      return known(tier, tierName)
     } catch (e) {
+      // THE load-bearing line of FR-004: this used to return `None`, which is what a member with
+      // no membership at all looks like. A reference chain that would not answer is not evidence
+      // the member owns nothing.
       console.warn('[getUserTierOnChain v2] failed:', e.message)
-      return { tier: 0, tierName: 'None' }
+      return unknownTier(e?.message || 'membership read failed')
     }
   }
 
@@ -932,31 +942,29 @@ export async function getUserTierOnChain(userAddress, roleName, chainId) {
     const tierRegistryAddress = resolveAddress('tierRegistry')
     if (!tierRegistryAddress) {
       console.warn('TierRegistry not deployed - cannot check user tier')
-      return { tier: 0, tierName: 'None' }
+      return known(0, 'None')
     }
 
     const roleHash = getRoleHash(roleName)
     if (!roleHash) {
       console.warn(`Unknown role: ${roleName}`)
-      return { tier: 0, tierName: 'None' }
+      return known(0, 'None')
     }
 
     const tierRegistry = new ethers.Contract(
       tierRegistryAddress,
       TIER_REGISTRY_ABI,
-      provider
+      getProvider(chainId)
     )
 
     const tier = await tierRegistry.getUserTier(userAddress, roleHash)
     const tierNum = Number(tier)
     const tierName = tierNum === 0 ? 'None' : (TIER_NAMES[tierNum] || 'Unknown')
 
-    console.log(`[getUserTierOnChain] ${roleName}: tier=${tierNum} (${tierName}) for ${userAddress}`)
-
-    return { tier: tierNum, tierName }
+    return known(tierNum, tierName)
   } catch (error) {
     console.error('Error getting user tier:', error)
-    return { tier: 0, tierName: 'None' }
+    return unknownTier(error?.message || 'tier read failed')
   }
 }
 
@@ -1002,13 +1010,22 @@ export async function hasRoleOnChain(userAddress, roleName, chainId, { detailed 
   const resolveAddress = (name) =>
     chainId != null ? getContractAddressForChain(name, chainId) : getContractAddress(name)
 
-  // Paid memberships (WAGER_PARTICIPANT) live in MembershipManager and are
-  // gated by a (Tier, expiry) pair — read via hasActiveRole.
+  // ── MEMBERSHIP ALWAYS READS THE REFERENCE CHAIN (spec 071 FR-003) ─────────────────────────
+  // Paid memberships (WAGER_PARTICIPANT) live in MembershipManager, gated by a (Tier, expiry)
+  // pair. Membership exists in exactly ONE place per environment cohort — Polygon on mainnet,
+  // Amoy on testnet — so reading it wherever the wallet happens to point reported every member
+  // on Ethereum / Optimism / Base / Arbitrum / ETC as having no membership. They have one; the
+  // lookup was aimed at chains it was never kept on.
+  //
+  // The caller's `chainId` is deliberately IGNORED here, and honoured in the admin-role branch
+  // below, because admin roles genuinely ARE per-chain. Splitting at this seam means the rule is
+  // enforced once rather than remembered at six call sites.
   if (roleName === 'WAGER_PARTICIPANT' || roleName === 'Wager Participant') {
-    const mmAddress = resolveAddress('membershipManager')
+    const refChain = membershipChainId()
+    const mmAddress = getContractAddressForChain('membershipManager', refChain)
     if (!mmAddress) return held(false)
     try {
-      const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, provider)
+      const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, getProvider(refChain))
       return held(Boolean(await mm.hasActiveRole(userAddress, roleHash)))
     } catch (e) {
       console.warn('[hasRoleOnChain] membership read failed:', e.message)

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -101,15 +101,15 @@ yields *unknown*, never *none*.
 confirm identical tier and expiry; then break the reference chain's endpoint and confirm *unknown*
 with a retry.
 
-- [ ] T027 [US1] Resolve the membership branch of `hasRoleOnChain` in `frontend/src/utils/blockchainService.js` against `membershipChainId()`, ignoring the caller's chain; leave the admin-role branch honouring its explicit chain (research R3, FR-003)
-- [ ] T028 [US1] Do the same for the MembershipManager path of `getUserTierOnChain` in `frontend/src/utils/blockchainService.js`
-- [ ] T029 [US1] Introduce a distinct *unknown* membership state in `frontend/src/utils/blockchainService.js` so a failed reference-chain read is no longer swallowed into `{tier: 0}` / `false` (FR-004) — this is the load-bearing change; today both functions return the same value for "no membership" and "could not ask"
-- [ ] T030 [US1] Propagate *unknown* through `frontend/src/contexts/RoleContext.jsx` and `frontend/src/hooks/useRoleDetails.js` without collapsing it to "no membership"
-- [ ] T031 [US1] Render *unknown* honestly wherever membership gates a surface: state that membership could not be read, offer a retry, and refuse the gated action attributing the refusal to the failed read (FR-005)
-- [ ] T032 [P] [US1] Test in `frontend/src/test/membershipReferenceChain.test.js` that `hasRoleOnChain(account, 'WAGER_PARTICIPANT', <any chain>)` constructs against the reference chain's MembershipManager — asserted by the constructed-address technique `adminLeastPrivilege.test.jsx` already uses
-- [ ] T033 [P] [US1] Test that `hasRoleOnChain(account, 'GUARDIAN', 8453)` still reads chain 8453 — the admin branch is unaffected
-- [ ] T034 [P] [US1] Test that a failed reference-chain read yields *unknown* and that no surface renders the words "no membership" in that state (FR-004)
-- [ ] T035 [P] [US1] Amend the doc-comment in `frontend/src/test/chainResolutionGuard.test.js` to state the rule the code actually follows — resolve against an **explicit** chain (wallet's, reference, or scoped), never the build-time default — and confirm the mechanical check still passes unmodified (research R5)
+- [X] T027 [US1] Resolve the membership branch of `hasRoleOnChain` in `frontend/src/utils/blockchainService.js` against `membershipChainId()`, ignoring the caller's chain; leave the admin-role branch honouring its explicit chain (research R3, FR-003)
+- [X] T028 [US1] Do the same for the MembershipManager path of `getUserTierOnChain` in `frontend/src/utils/blockchainService.js`
+- [X] T029 [US1] Introduce a distinct *unknown* membership state in `frontend/src/utils/blockchainService.js` so a failed reference-chain read is no longer swallowed into `{tier: 0}` / `false` (FR-004) — this is the load-bearing change; today both functions return the same value for "no membership" and "could not ask"
+- [X] T030 [US1] Propagate *unknown* through `frontend/src/contexts/RoleContext.jsx` and `frontend/src/hooks/useRoleDetails.js` without collapsing it to "no membership"
+- [X] T031 [US1] Render *unknown* honestly wherever membership gates a surface: state that membership could not be read, offer a retry, and refuse the gated action attributing the refusal to the failed read (FR-005)
+- [X] T032 [P] [US1] Test in `frontend/src/test/lib/chains/membershipReferenceChain.test.js` that `hasRoleOnChain(account, 'WAGER_PARTICIPANT', <any chain>)` constructs against the reference chain's MembershipManager — asserted by the constructed-address technique `adminLeastPrivilege.test.jsx` already uses
+- [X] T033 [P] [US1] Test that `hasRoleOnChain(account, 'GUARDIAN', 8453)` still reads chain 8453 — the admin branch is unaffected
+- [X] T034 [P] [US1] Test that a failed reference-chain read yields *unknown* and that no surface renders the words "no membership" in that state (FR-004)
+- [X] T035 [P] [US1] Amend the doc-comment in `frontend/src/test/chainResolutionGuard.test.js` to state the rule the code actually follows — resolve against an **explicit** chain (wallet's, reference, or scoped), never the build-time default — and confirm the mechanical check still passes unmodified (research R5)
 
 **Checkpoint**: US1 is independently shippable and closes the live defect.
 

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -77,15 +77,15 @@ gets in from any chain, and is told where their authority lives.
 network, open `/admin`, and confirm it opens with only that role's views and names the network each
 role was found on.
 
-- [ ] T018 [US2] Extend the role sync in `frontend/src/contexts/RoleContext.jsx` to resolve each admin role across `cohortChainIds()` instead of the wallet chain only, recording per chain whether the role was held, not held, or unreadable (FR-009, FR-011)
-- [ ] T019 [US2] Apply the same estate-wide sync in `frontend/src/contexts/WalletContext.jsx`, which carries a parallel copy of the sync loop
-- [ ] T020 [US2] Keep the existing `(address, chainId)` local-storage cache key in `frontend/src/utils/roleStorage.js` — the chain dimension already exists, so entries simply exist for more chains and **no migration is needed**; confirm no schema change is introduced
-- [ ] T021 [US2] Expose an estate-wide `hasAnyRole`/`hasRole` plus a per-chain query from `frontend/src/contexts/RoleContext.jsx`, so entry and authority stay separable (FR-009 vs FR-019)
-- [ ] T022 [US2] Make the entry gate in `frontend/src/components/AdminPanel.jsx` use the estate-wide answer
-- [ ] T023 [US2] Distinguish the two refusals in `frontend/src/components/AdminPanel.jsx`: "you hold no operator role" vs "no network could be read" (FR-012) — the second must never be phrased as the first
-- [ ] T024 [US2] Extend the "Your Permissions" card in `frontend/src/components/AdminPanel.jsx` to name the network(s) each role is held on, and mark unread networks as unread rather than as ✗ (FR-010, FR-011)
-- [ ] T025 [P] [US2] Test in `frontend/src/test/admin/adminEstateEntry.test.jsx`: role on one chain + wallet on another ⇒ console opens with that role's views; no role anywhere ⇒ refused; one chain unreadable ⇒ still granted from roles found elsewhere; all chains unreadable ⇒ the distinct refusal message
-- [ ] T026 [P] [US2] Test that the permissions card names the network per role and never renders an unread network as a denial
+- [X] T018 [US2] ~~Extend the role sync in `frontend/src/contexts/RoleContext.jsx`~~ **N/A — `RoleContext.jsx` (`RoleProvider`) is imported nowhere and mounted nowhere; `useRoles` reads `WalletContext`. Dead code, so the estate sweep landed in T019 only rather than being mirrored into an unmounted provider.** Original scope: extend the role sync to resolve each admin role across `cohortChainIds()` instead of the wallet chain only, recording per chain whether the role was held, not held, or unreadable (FR-009, FR-011)
+- [X] T019 [US2] Apply the same estate-wide sync in `frontend/src/contexts/WalletContext.jsx`, which carries a parallel copy of the sync loop
+- [X] T020 [US2] Keep the existing `(address, chainId)` local-storage cache key in `frontend/src/utils/roleStorage.js` — the chain dimension already exists, so entries simply exist for more chains and **no migration is needed**; confirm no schema change is introduced
+- [X] T021 [US2] Expose an estate-wide `hasAnyRole`/`hasRole` plus a per-chain query (`chainsForRole`, `hasRoleOnChainId`, `estateRead`) from `frontend/src/contexts/WalletContext.jsx` (the live provider; see T018) and through `hooks/useRoles.js`, so entry and authority stay separable (FR-009 vs FR-019)
+- [X] T022 [US2] Make the entry gate in `frontend/src/components/AdminPanel.jsx` use the estate-wide answer
+- [X] T023 [US2] Distinguish the two refusals in `frontend/src/components/AdminPanel.jsx`: "you hold no operator role" vs "no network could be read" (FR-012) — the second must never be phrased as the first
+- [X] T024 [US2] Extend the "Your Permissions" card in `frontend/src/components/AdminPanel.jsx` to name the network(s) each role is held on, and mark unread networks as unread rather than as ✗ (FR-010, FR-011)
+- [X] T025 [P] [US2] Test in `frontend/src/test/admin/adminEstateEntry.test.jsx`: role on one chain + wallet on another ⇒ console opens with that role's views; no role anywhere ⇒ refused; one chain unreadable ⇒ still granted from roles found elsewhere; all chains unreadable ⇒ the distinct refusal message
+- [X] T026 [P] [US2] Test that the permissions card names the network per role and never renders an unread network as a denial
 
 **Checkpoint**: US2 is independently shippable — the console is reachable from any chain, with every
 view still gated exactly as before.

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -123,12 +123,12 @@ resolver.
 **Independent test**: Start a purchase from a non-reference chain; confirm disclosure + switch, that
 declining buys nothing, and that no path completes a purchase elsewhere.
 
-- [ ] T036 [US5] Route the purchase calls built in `frontend/src/components/ui/PremiumPurchaseModal.jsx` to `membershipChainId()` rather than the connected chain (FR-006)
-- [ ] T037 [US5] Disclose the settlement network in the confirm step of `frontend/src/components/ui/PremiumPurchaseModal.jsx` before signature, and require the wallet to be there (FR-007)
-- [ ] T038 [US5] Offer a wallet network switch to the reference chain, and ensure declining leaves no purchase attempted on any chain (FR-007, acceptance 2)
-- [ ] T039 [US5] Evaluate payment-token sufficiency against the reference chain's balance only, stating any shortfall in that chain's payment token, in `frontend/src/components/ui/PremiumPurchaseModal.jsx` (FR-008)
-- [ ] T040 [US5] Audit `frontend/src/hooks/useTierPrices.js` and `frontend/src/hooks/useVouchers.js` for connected-chain assumptions in the purchase path and route them to the reference chain
-- [ ] T041 [P] [US5] Test in `frontend/src/test/membershipPurchaseRouting.test.jsx`: purchase from a non-reference chain discloses the settlement network; declining the switch sends no transaction; the built calls target the reference chain's MembershipManager; **and the absence SC-006 claims** — drive the flow on *each* non-reference cohort chain and assert every built call still targets the reference chain's address, so "no path completes a purchase elsewhere" is verified rather than asserted in prose (mirrors the absence assertion T067 makes for FR-020)
+- [X] T036 [US5] Route the purchase calls built in `frontend/src/components/ui/PremiumPurchaseModal.jsx` to `membershipChainId()` rather than the connected chain (FR-006)
+- [X] T037 [US5] Disclose the settlement network in the confirm step of `frontend/src/components/ui/PremiumPurchaseModal.jsx` before signature, and require the wallet to be there (FR-007)
+- [X] T038 [US5] Offer a wallet network switch to the reference chain, and ensure declining leaves no purchase attempted on any chain (FR-007, acceptance 2)
+- [X] T039 [US5] Evaluate payment-token sufficiency against the reference chain's balance only, stating any shortfall in that chain's payment token, in `frontend/src/components/ui/PremiumPurchaseModal.jsx` (FR-008)
+- [X] T040 [US5] Audit `frontend/src/hooks/useTierPrices.js` and `frontend/src/hooks/useVouchers.js` for connected-chain assumptions in the purchase path and route them to the reference chain
+- [X] T041 [P] [US5] Test in `frontend/src/test/membershipPurchaseRouting.test.jsx` (9 tests): purchase from a non-reference chain discloses the settlement network; declining the switch sends no transaction; the built calls target the reference chain's MembershipManager; **and the absence SC-006 claims** — drive the flow on *each* non-reference cohort chain and assert every built call still targets the reference chain's address, so "no path completes a purchase elsewhere" is verified rather than asserted in prose (mirrors the absence assertion T067 makes for FR-020)
 
 **Checkpoint**: US1 + US5 together close the read/write loop — a purchase is now readable from
 everywhere.


### PR DESCRIPTION
Three sequential phases of spec 071, stacked because each builds on the last. Follows #984, which merged the spec and the Phase 1–2 foundation. **T018–T041 (41 of 75 tasks complete).**

All three close lockouts with one root cause: asking *"where does this fact live?"* and answering *"wherever the wallet is pointed."*

---

## Phase 3 — console entry is estate-wide (US2)

An operator holding `GUARDIAN` on Polygon, connected to Base, was told **"Access Restricted."** Admin roles are granted per contract **per chain**, but entry asked only the wallet's chain. During an incident, that's an operator who cannot act.

- **`WalletContext`** sweeps the cohort **concurrently** and records *where* each role was found (`roleChains`) plus which chains would not answer (`estateRead`). `roles` stays the flat estate-wide list every existing caller reads.
- **`hasRoleOnChain`** gained opt-in `{ detailed: true }` → `{ held, readable, reason }`. Default stays a plain boolean, so **no existing caller changes**. A definite "no" now requires every candidate contract to have actually answered.
- **Two distinct refusals** (FR-012): *"Access Restricted"* vs *"Could Not Verify Access"* — with a retry — when no chain could be read. The second says outright it's connectivity, because an operator who reads a denial goes hunting for a permissions problem that doesn't exist.
- **The permissions card names the network** each role was found on and discloses unread networks, so a `×` can't quietly assert a denial.

## Phase 4 — membership resolves on the reference chain (US1)

On mainnet the `MembershipManager` is deployed on Polygon and **nowhere else** — so every member on Ethereum, Optimism, Base, Arbitrum or ETC was told they had **no membership**.

Both resolvers bind the MembershipManager path to `membershipChainId()` and **ignore the caller's chain**, while the admin-role branch keeps its explicit chain — enforcing the rule once instead of at six call sites. `useRoleDetails` takes **both** address and provider from the reference chain so they cannot disagree.

### The load-bearing half is FR-004

```js
catch (e) { return { tier: 0, tierName: 'None' } }
```

A failed read returned exactly what a genuine *"you have no membership"* returns. A member whose RPC blipped was told they owned nothing — and would have been offered an upgrade **"from None" while already holding Platinum**. Reads now carry `readable`; unknown is never rendered as none; purchase is refused while unknown, attributed to the failed read, with a retry. Cached membership survives an unknown rather than being pruned because we couldn't ask.

## Phase 5 — purchases settle on the reference chain (US5)

Membership must be **readable** from one place, which is only true if it's also **written** in one place. A purchase landing elsewhere creates a membership the reference-chain read can never see: the member pays and stays unentitled everywhere.

- `isCorrectNetwork` wasn't enough — it means "any supported chain". The modal computes the reference chain explicitly, discloses it **before signature** (unconditionally, not only when the wallet is wrong), and gates both the confirm button and `handlePurchase`.
- `switchNetwork` takes an optional target, defaulting to `PRIMARY_CHAIN_ID` so every existing call site is unchanged.
- Declining the switch leaves nothing attempted anywhere.

### T040 surfaced a real pricing bug

`useTierPrices` resolved the `MembershipManager` against the **wallet's** chain. Combined with reference-chain routing, that quoted one chain's price for a purchase settling on another — and on any mainnet except Polygon it found no contract at all and fell back to **hardcoded prices**. A member was shown a placeholder price for a real charge, which is what constitution III forbids. Prices now come from the same contract that takes the money.

---

## Findings, and three tests that were passing by coincidence

**`STAKING_ADMIN` was missing from the role sync list** while present in `ADMIN_ROLES` and the nav — so `isStakingAdmin` read false forever and the Staking tab never opened for the one operator who could use it.

**`contexts/RoleContext.jsx` is dead code** — imported and mounted nowhere. T018 targeted it, so the sweep landed in T019 alone and T018 is annotated **N/A** rather than silently ticked.

**T017's checkpoint was too narrow.** A *third* pre-existing suite (`networkScoping.test.jsx`) covers those tabs and broke — it mocked `utils/rpcProvider` exporting only `makeReadProvider`. Extended the mock; no assertion weakened.

**Two tests passed whichever chain the code used:**

| Test | Blind spot |
|---|---|
| `blockchainService.purchase.test.js` | asserted the resolver got the **passed** chain (80002) — but 80002 *is* the reference chain in a testnet build |
| `useRoleDetails.chain.test.js` | mocked the wallet onto 80002 and asserted the same thing |

Both now put the wallet on a cohort chain that is **not** the reference chain (63), so the answers are distinguishable. The spec-008 concern they were written for is still covered, now by cohort separation rather than by echoing the wallet's chain.

**Other test changes:** `adminNav`'s permissions-card test rewritten for the new `ADMIN_ROLE_ROWS` table and **strengthened** from three roles to all of `ADMIN_ROLES`. The spec-008 chain-resolution guard's *stated intent* amended (T035) — mechanical check unchanged and still passing, but its comment claimed the rule was "the wallet's CONNECTED chain"; it now names the three legitimate explicit chains.

## Testing

**33 new tests**, including that membership resolves identically from **every** cohort chain (SC-001), that the admin-role branch is unaffected, and the SC-006 **absence** assertion — the purchase flow driven from every non-reference cohort chain, asserting nothing is ever built.

Full sweep: **3782/3783 passing, 0 lint errors.**

> The two failures in that sweep — `useTransfer.balances.test.jsx` (a partial `config/networks` mock missing `getCurrentChainId`) and one `SupplyView` case — are **pre-existing on main**, verified by running both at `3a12581`, before any spec 071 work. Not introduced here and deliberately left alone rather than folded into this PR.

## Scope

Phases 6–8 (T042–T075) remain: the fee estate and the 15 view conversions. All three phases here are independently shippable.