### PR TITLE
Show swap pairs from every network in the Trade ticket

### DIFF
--- a/docs/developer-guide/multi-network-swaps.md
+++ b/docs/developer-guide/multi-network-swaps.md
@@ -1,0 +1,77 @@
+# Multi-network swaps (the Trade ticket)
+
+The Trade section lists tradeable pairs from **every swap-capable network**, not
+just the one the wallet happens to be connected to. This guide covers the seams a
+change in this area has to respect.
+
+## The read / write split
+
+| Concern | Scope | Where |
+| --- | --- | --- |
+| Which pairs exist | every swap-capable network | `frontend/src/lib/uniswap/swapUniverse.js` |
+| What a pair pays out (quote) | the **pair's** network, read-only | `DexContext.getBestQuoteOn(chainId, …)` → `lib/uniswap/quote.js` |
+| Leg balances | the **pair's** network, read-only | `hooks/useSwapBalances.js` |
+| Placing the order (swap) | the **connected** network only | `DexContext.swap(…, { chainId })` |
+
+Listing and pricing pairs across networks is a read, exactly like the
+cross-chain portfolio scan (spec 044) and ClearPath's cross-chain DAO reads: each
+chain answers over its own provider (`makeReadProvider`), independent of the
+wallet's chain. Only the swap itself needs the wallet to be on the pair's network.
+
+## Invariants
+
+1. **A pair lives on ONE network.** Choosing the pay leg pins the network and the
+   receive selector only offers legs from that same chain. The rule is not
+   re-derived in the panel — it is `samePair` from
+   `frontend/src/lib/assets/networkPin.js`, the same predicate the Earn liquidity
+   pair selector uses, and the exact inverse of the Bridge's `bridgeDest`.
+   **Never apply `bridgeDest` here, and never "fix" a cross-chain pair by
+   quoting it anyway** — moving value between networks is the Bridge's job.
+2. **A swap never runs on a network the wallet is not on.** The panel discloses
+   the pending switch and offers it as the primary action instead of the order
+   button; `DexContext.swap` re-checks `opts.chainId` and throws before any
+   signature. Both layers matter: the guard is what makes it safe for the UI to
+   list off-network pairs at all, since an approval sent against the wrong
+   chain's router address is unrecoverable.
+3. **Addresses are strictly per-chain.** `getSwapAddresses(chainId)` returns that
+   network's own router/quoter/wrapped-native or `null` — never a fallback to
+   another network's. Base in particular does **not** share Uniswap's canonical
+   addresses. Never reach for `DexContext.addresses` (connected chain) when
+   acting on a pair that may be elsewhere.
+4. **A chain is listed only when `capabilities.dex` is true** — the policy gate
+   (`SWAP_CHAIN_IDS`) **and** real router config. `getSwapChainIds()` in
+   `config/networks.js` is the single source of that truth; `isSwapChain()` wraps
+   it. Testnet pairs appear only to a member connected to that testnet.
+5. **An unread balance is `null`, never `0`.** The ticket renders "…" and disables
+   MAX rather than implying the member holds nothing because a read failed. A
+   later failed read keeps the last known figure instead of zeroing it.
+6. **Balances belong on the pair cards.** The account card carries no balance
+   rows — each leg shows its own balance next to the amount it applies to, on the
+   pair's network, for the acting account (`tradingAddress`, so vault/recovered
+   accounts read correctly).
+7. **Venue identity follows the pair, not the wallet.** An ETC pair routes through
+   ETCswap and must be labelled as such even while the wallet is on Polygon
+   (`getSwapVenue(pairChainId)`); the same applies to the perps-venue gate, the
+   passkey/sponsorship disclosure, and the router explorer link.
+
+## Selector search
+
+Both the Universal Asset Selector and the Trade ticket's pair pickers narrow
+through `frontend/src/lib/assets/assetSearch.js#matchesAssetQuery`, which matches
+**only the fields a member can see**: asset symbol, asset name, network name.
+Matching a hidden field (an address, a category id) would make the list narrow
+for reasons the member cannot see. Search only narrows what is already
+eligible — typing can never surface a leg the pin excluded.
+
+## Files
+
+- `frontend/src/lib/uniswap/swapUniverse.js` — the cross-network pair universe
+  (chains, legs, per-chain addresses, venue, default pair, counterpart choice).
+- `frontend/src/lib/uniswap/quote.js` — best-route quoting against any chain's
+  QuoterV2; one implementation for local and cross-chain quotes.
+- `frontend/src/hooks/useSwapBalances.js` — leg balances on the pair's network.
+- `frontend/src/components/fairwins/TradeTokenSelect.jsx` — the network-grouped,
+  searchable pair-leg picker.
+- `frontend/src/components/fairwins/TradePanel.jsx` — the order ticket.
+- `frontend/src/contexts/DexContext.jsx` — `getBestQuoteOn` (read, any chain) and
+  `swap` (write, connected chain only).

--- a/frontend/src/components/fairwins/TradePanel.css
+++ b/frontend/src/components/fairwins/TradePanel.css
@@ -102,38 +102,8 @@
   cursor: pointer;
 }
 
-.trade-account-rows {
-  margin: 0.65rem 0 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.trade-account-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.4rem 0;
-  border-bottom: 1px solid var(--trade-border);
-}
-
-.trade-account-row:last-child {
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.trade-account-row dt {
-  font-size: 0.8rem;
-  color: var(--trade-text-2);
-}
-
-.trade-account-row dd {
-  margin: 0;
-  font-size: 0.95rem;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  color: var(--trade-text);
-}
+/* The account card carries no balance rows: each leg's balance sits on its own
+   pay/receive card, beside the amount it actually applies to. */
 
 .trade-account-note {
   margin: 0.6rem 0 0;
@@ -256,6 +226,20 @@
 
 .trade-balance {
   font-size: 0.75rem;
+  color: var(--trade-text-3);
+}
+
+/* An unread balance — never rendered as 0. */
+.trade-balance-pending {
+  color: var(--trade-text-3);
+  font-size: 0.75rem;
+}
+
+/* Which network the leg lives on. With pairs listed from every supported
+   network, the logo badge alone is too subtle to carry it. */
+.trade-leg-network {
+  margin: 0.5rem 0 0;
+  font-size: 0.72rem;
   color: var(--trade-text-3);
 }
 
@@ -427,6 +411,12 @@ button.trade-rate .trade-summary-val {
   padding: 0.1rem 0.45rem;
 }
 
+.trade-route-network {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--trade-text-2);
+}
+
 /* Price-impact coloring */
 .impact-low {
   color: var(--trade-success);
@@ -495,6 +485,15 @@ button.trade-rate .trade-summary-val {
   font-size: 0.76rem;
   color: var(--trade-text-2);
   text-align: center;
+}
+
+/* Disclosed BEFORE the switch button, never after: a member should know which
+   network the order will run on before they act. */
+.trade-switch-note {
+  margin: 0.9rem 0 0.6rem;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--trade-text-2);
 }
 
 /* Messages */

--- a/frontend/src/components/fairwins/TradePanel.jsx
+++ b/frontend/src/components/fairwins/TradePanel.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { parseUnits } from 'ethers'
+import { useSwitchChain } from 'wagmi'
 import { useDex } from '../../hooks/useDex'
 import {
   SLIPPAGE_OPTIONS,
@@ -9,12 +10,24 @@ import {
   getPerpsVenue,
   getExplorerUrl,
 } from '../../constants/dex'
+import { NETWORKS } from '../../config/networks'
 import { feeTierLabel } from '../../lib/uniswap/trade'
+import {
+  buildSwapOptions,
+  counterpartFor,
+  defaultPairForChain,
+  findSwapOption,
+  findSwapOptionByAddress,
+  getSwapAddresses,
+  getSwapVenue,
+  isSwapChain,
+} from '../../lib/uniswap/swapUniverse'
+import { PIN_MODE, createPin, samePair } from '../../lib/assets/networkPin'
 import { useWallet } from '../../hooks'
-import { useChainTokens } from '../../hooks/useChainTokens'
 import { useActiveAccount } from '../../hooks/useActiveAccount'
 import { useCustodyVaults } from '../../hooks/useCustodyVaults'
 import { useLegacyAccounts } from '../../hooks/useLegacyAccounts'
+import { useSwapBalances } from '../../hooks/useSwapBalances'
 import LegacyUnlockDialog from '../account/LegacyUnlockDialog'
 import SensitiveValue from '../common/SensitiveValue'
 import InfoTip from '../ui/InfoTip'
@@ -39,26 +52,43 @@ const shortAddress = (addr) =>
 const fmtBalance = (value) =>
   Number(value || 0).toLocaleString(undefined, { maximumSignificantDigits: 8 })
 
-const sameAddr = (a, b) => Boolean(a) && Boolean(b) && a.toLowerCase() === b.toLowerCase()
-
+/**
+ * TradePanel — the brokerage-style order ticket, MULTI-NETWORK.
+ *
+ * Pairs are listed from EVERY swap-capable network, not just the connected one
+ * (`lib/uniswap/swapUniverse.js`), because seeing what is tradeable is a read:
+ * quotes come from each chain's own QuoterV2 over that chain's provider, exactly
+ * as the portfolio reads balances across chains. What still belongs to ONE
+ * network is the pair itself and the order:
+ *
+ *   1. A V3 pool lives on a single chain, so choosing the first leg PINS the
+ *      network and the second selector only offers legs from that same chain
+ *      (`lib/assets/networkPin.js#samePair` — the shared pair rule, never the
+ *      bridge's `bridgeDest`). Moving value between networks is the Bridge's job.
+ *   2. The swap is a WRITE against that chain's router, so when the pair's
+ *      network is not the wallet's, the ticket asks for the switch FIRST and
+ *      refuses to place the order until it happens (DexContext.swap re-checks,
+ *      so a mis-wired UI cannot approve a foreign address either).
+ *
+ * Balances follow the PAIR's network, not the wallet's (`useSwapBalances`), and
+ * live on the pay/receive cards where the amount is actually entered — the
+ * account card carries no balance rows.
+ */
 function TradePanel() {
   const {
-    balances,
     loading,
     quotingPrice,
     swap,
-    getBestQuote,
+    getBestQuoteOn,
     slippage,
     setSlippage,
-    addresses,
-    tradeTokens,
-    isDexAvailable,
     dexProvider,
     network,
+    tradingAddress,
   } = useDex()
 
   const { isConnected, chainId, address, loginMethod } = useWallet()
-  const { native: nativeSymbol, stable: stableSymbol } = useChainTokens()
+  const { switchChainAsync, isPending: switching } = useSwitchChain()
 
   // Account selection (spec 043 + 062): trade as the personal wallet, one of the
   // member's saved multisig vaults, or a recovered legacy account. A vault turns
@@ -70,56 +100,18 @@ function TradePanel() {
   const legacyAccounts = useLegacyAccounts()
   const [unlockEntry, setUnlockEntry] = useState(null)
 
-  // Session rails: passkey accounts transact through their smart account —
-  // gasless (FairWins-sponsored) where the network has a sponsor paymaster
-  // (spec 050), self-funded otherwise. Classic wallets pay network fees.
-  const isPasskey = loginMethod === 'passkey'
-  const passkeyReady = !isPasskey || Boolean(network?.passkey)
-  const passkeySponsored = isPasskey && Boolean(network?.passkey?.sponsorPaymasterUrl)
-
-  // Perpetuals order types only exist where the network has a perps venue.
-  // No supported network configures one yet, so these stay off — honest-state.
-  const perpsVenue = getPerpsVenue(network)
-
-  // Network-aware DEX provider identity (ETC family → ETCswap; else Uniswap).
-  const providerName = dexProvider?.name || 'the DEX'
-  const providerUrl = dexProvider?.url || null
-  const networkName = network?.name || 'this network'
-  // The trading engine is the Uniswap V3 protocol on every supported chain
-  // (ETCswap is a V3 deployment). Name the chain's DEX first, then note the
-  // protocol underneath — a subtle acknowledgement of the DeFi tool inside.
-  const isUniswap = /uniswap/i.test(providerName)
-  const poweredBy = isUniswap
-    ? 'Powered by Uniswap v3'
-    : `Powered by ${providerName} · Uniswap v3 protocol`
-
-  const wnativeSymbol = nativeSymbol ? `W${nativeSymbol}` : 'WNATIVE'
-
-  // The tradeable set for the active chain (wrapped-native, the stablecoin, and
-  // every curated portfolio asset with a routeable pair here). Keyed by address.
-  const assets = useMemo(() => tradeTokens || [], [tradeTokens])
-  const tokenFor = useCallback(
-    (addr) => assets.find((t) => sameAddr(t.address, addr)) || null,
-    [assets],
-  )
-  const symbolFor = useCallback((addr) => tokenFor(addr)?.symbol || '—', [tokenFor])
-  const balanceFor = useCallback(
-    (addr) => balances.tokens?.[addr?.toLowerCase?.()] ?? '0',
-    [balances],
+  // Every pair leg on every swap-capable network, connected network first.
+  const options = useMemo(() => buildSwapOptions({ connectedChainId: chainId }), [chainId])
+  // The opening pair: this network's wrapped-native → stablecoin when it can
+  // trade, otherwise the first network that can — a member on a chain without a
+  // DEX still gets a usable ticket instead of a dead end.
+  const initialPair = useMemo(
+    () => defaultPairForChain(options, chainId) || defaultPairForChain(options, options[0]?.chainId),
+    [options, chainId],
   )
 
-  const [fromToken, setFromToken] = useState(addresses.WNATIVE)
-  const [toToken, setToToken] = useState(addresses.STABLECOIN)
-  // Re-seed the pair to the chain default (sell wrapped-native for the
-  // stablecoin) whenever the active chain changes, without an effect: adjust
-  // state during render keyed on the chain's core addresses (React-endorsed),
-  // so a mid-chain token pick is never clobbered by a re-render.
-  const [chainKey, setChainKey] = useState(addresses.WNATIVE)
-  if (chainKey !== addresses.WNATIVE) {
-    setChainKey(addresses.WNATIVE)
-    setFromToken(addresses.WNATIVE)
-    setToToken(addresses.STABLECOIN)
-  }
+  const [fromKey, setFromKey] = useState(() => initialPair?.from.key ?? null)
+  const [toKey, setToKey] = useState(() => initialPair?.to.key ?? null)
   const [orderType, setOrderType] = useState('sell')
   const [priceType, setPriceType] = useState('market')
   const [limitPrice, setLimitPrice] = useState('')
@@ -129,24 +121,118 @@ function TradePanel() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
 
+  let fromToken = findSwapOption(options, fromKey)
+  let toToken = findSwapOption(options, toKey)
+  // A selection can only vanish when the option list itself shrinks (leaving the
+  // testnet whose legs it used). Re-seed during render — React's endorsed
+  // adjust-state-on-props-change pattern — so we never quote a leg that no longer
+  // exists. A deliberate cross-chain pick is otherwise NEVER reseeded: switching
+  // the wallet's network must not silently repoint the member's pair.
+  if (options.length > 0 && (!fromToken || !toToken) && initialPair) {
+    setFromKey(initialPair.from.key)
+    setToKey(initialPair.to.key)
+    fromToken = initialPair.from
+    toToken = initialPair.to
+  }
+
+  // The pair's network — the one that quotes, holds the balances, and must be the
+  // wallet's network before an order can be placed.
+  const pairChainId = Number(fromToken?.chainId ?? toToken?.chainId ?? chainId)
+  const pairNetwork =
+    pairChainId === Number(chainId) ? network || NETWORKS[pairChainId] : NETWORKS[pairChainId]
+  const pairAddresses = getSwapAddresses(pairChainId)
+  const pairNetworkName = pairNetwork?.name || 'this network'
+  const walletNetworkName = NETWORKS[Number(chainId)]?.name || 'another network'
+  const needsSwitch = Boolean(fromToken) && pairChainId !== Number(chainId)
+
+  // Second-leg eligibility: one network per pair (FR-062's rule, shared with the
+  // liquidity pair selector), minus the leg already chosen.
+  const pin = useMemo(() => createPin(fromToken, PIN_MODE.SAME_NETWORK), [fromToken])
+  const receiveOptions = useMemo(
+    () => options.filter((o) => samePair(o, pin) && o.key !== fromToken?.key),
+    [options, pin, fromToken],
+  )
+
+  // Leg balances come from the PAIR's network over its own read provider — the
+  // connected chain's DexContext balances would be the wrong account's funds on
+  // the wrong chain the moment a member picks a pair elsewhere.
+  const legTokens = useMemo(
+    () => [fromToken, toToken].filter(Boolean).map((o) => ({ address: o.address, decimals: o.decimals })),
+    [fromToken, toToken],
+  )
+  const { balances: legBalances, refresh: refreshLegBalances } = useSwapBalances({
+    chainId: pairChainId,
+    address: tradingAddress,
+    tokens: legTokens,
+  })
+  const balanceFor = useCallback(
+    (token) => (token ? legBalances[token.address.toLowerCase()] : undefined),
+    [legBalances],
+  )
+  // Honest-state: an unread balance shows as "…", never as 0 — nobody should be
+  // told they hold nothing because a read failed.
+  const renderBalance = (token) => {
+    const value = balanceFor(token)
+    return value == null ? (
+      <span className="trade-balance-pending" aria-label="balance loading">…</span>
+    ) : (
+      <SensitiveValue>{fmtBalance(value)}</SensitiveValue>
+    )
+  }
+
+  // Session rails: passkey accounts transact through their smart account —
+  // gasless (FairWins-sponsored) where the PAIR's network has a sponsor
+  // paymaster (spec 050), self-funded otherwise. Classic wallets pay network fees.
+  const isPasskey = loginMethod === 'passkey'
+  const passkeyReady = !isPasskey || Boolean(pairNetwork?.passkey)
+  const passkeySponsored = isPasskey && Boolean(pairNetwork?.passkey?.sponsorPaymasterUrl)
+
+  // Perpetuals order types only exist where the pair's network has a perps venue.
+  // No supported network configures one yet, so these stay off — honest-state.
+  const perpsVenue = getPerpsVenue(pairNetwork)
+
+  // DEX identity follows the PAIR's network (ETC family → ETCswap; else Uniswap),
+  // so an ETC pair is never labelled as routing through Uniswap.
+  const venue = getSwapVenue(pairChainId) || dexProvider
+  const providerName = venue?.name || 'the DEX'
+  const providerUrl = venue?.url || null
+  // The trading engine is the Uniswap V3 protocol on every supported chain
+  // (ETCswap is a V3 deployment). Name the chain's DEX first, then note the
+  // protocol underneath — a subtle acknowledgement of the DeFi tool inside.
+  const isUniswap = /uniswap/i.test(providerName)
+  const poweredBy = isUniswap
+    ? 'Powered by Uniswap v3'
+    : `Powered by ${providerName} · Uniswap v3 protocol`
+
+  const pairNativeSymbol = pairNetwork?.nativeCurrency?.symbol || ''
+  const wnativeSymbol = pairNativeSymbol ? `W${pairNativeSymbol}` : 'WNATIVE'
+  const pairStableSymbol = pairNetwork?.stablecoin?.symbol || 'the stablecoin'
+  const swapNetworkCount = useMemo(
+    () => new Set(options.map((o) => o.chainId)).size,
+    [options],
+  )
+
+  const symbolOf = (token) => token?.symbol || '—'
   const isPerpsOrder = orderType === 'sell_short' || orderType === 'buy_to_cover'
 
-  // Live quoting — debounced. Routes through the DEX for the selected pair.
+  // Live quoting — debounced, against the PAIR's network.
   useEffect(() => {
     if (!amount || parseFloat(amount) <= 0) {
       setQuote(null)
       return
     }
 
-    if (!fromToken || !toToken || sameAddr(fromToken, toToken) || isPerpsOrder) {
+    if (!fromToken || !toToken || fromToken.key === toToken.key || isPerpsOrder) {
       setQuote(null)
       return
     }
 
     let cancelled = false
+    const fromAddress = fromToken.address
+    const toAddress = toToken.address
     const timeoutId = setTimeout(async () => {
       try {
-        const result = await getBestQuote(fromToken, toToken, amount)
+        const result = await getBestQuoteOn(pairChainId, fromAddress, toAddress, amount)
         if (!cancelled) {
           setQuote(result)
           setError('')
@@ -163,15 +249,18 @@ function TradePanel() {
       cancelled = true
       clearTimeout(timeoutId)
     }
-  }, [amount, fromToken, toToken, isPerpsOrder, getBestQuote])
+  }, [amount, fromToken, toToken, pairChainId, isPerpsOrder, getBestQuoteOn])
 
   // Spot order type maps onto the pair direction relative to cash: paying the
-  // stablecoin to receive an asset is a Buy; paying an asset for the stablecoin
-  // is a Sell. Asset-for-asset pairs leave the order type unchanged.
+  // network's stablecoin to receive an asset is a Buy; paying an asset for the
+  // stablecoin is a Sell. Asset-for-asset pairs leave the order type unchanged.
   const deriveOrderType = (from, to) => {
-    const stable = addresses.STABLECOIN
-    if (sameAddr(to, stable) && !sameAddr(from, stable)) return 'sell'
-    if (sameAddr(from, stable) && !sameAddr(to, stable)) return 'buy'
+    const stable = getSwapAddresses(from?.chainId ?? to?.chainId)?.stablecoin
+    if (!stable) return null
+    const isStable = (token) =>
+      Boolean(token) && token.address.toLowerCase() === stable.toLowerCase()
+    if (isStable(to) && !isStable(from)) return 'sell'
+    if (isStable(from) && !isStable(to)) return 'buy'
     return null
   }
 
@@ -180,21 +269,31 @@ function TradePanel() {
     setQuote(null)
     setError('')
     setSuccess('')
-    if (next === 'buy') {
-      setFromToken(addresses.STABLECOIN)
-      setToToken(addresses.WNATIVE)
-    } else if (next === 'sell') {
-      setFromToken(addresses.WNATIVE)
-      setToToken(addresses.STABLECOIN)
-    }
+    if (next !== 'buy' && next !== 'sell') return
+    // Buy/Sell re-seed the pair on the network already in play, never a different one.
+    const wnative = findSwapOptionByAddress(options, pairChainId, pairAddresses?.wnative)
+    const stable = findSwapOptionByAddress(options, pairChainId, pairAddresses?.stablecoin)
+    if (!wnative || !stable) return
+    setFromKey(next === 'buy' ? stable.key : wnative.key)
+    setToKey(next === 'buy' ? wnative.key : stable.key)
   }
 
-  const handlePairChange = (side, value) => {
-    const from = side === 'from' ? value : fromToken
-    const to = side === 'to' ? value : toToken
-    if (side === 'from') setFromToken(value)
-    else setToToken(value)
-    const derived = deriveOrderType(from, to)
+  const handleSellLegChange = (option) => {
+    setFromKey(option.key)
+    // The pin moved: keep the receive leg when it is still on this network,
+    // otherwise take that network's stablecoin so the ticket stays quotable.
+    const counterpart = counterpartFor(options, option.chainId, option, toToken)
+    setToKey(counterpart?.key ?? null)
+    const derived = deriveOrderType(option, counterpart)
+    if (derived) setOrderType(derived)
+    setQuote(null)
+    setError('')
+    setSuccess('')
+  }
+
+  const handleBuyLegChange = (option) => {
+    setToKey(option.key)
+    const derived = deriveOrderType(fromToken, option)
     if (derived) setOrderType(derived)
     setQuote(null)
     setError('')
@@ -202,12 +301,24 @@ function TradePanel() {
 
   const handleFlipTokens = () => {
     const derived = deriveOrderType(toToken, fromToken)
-    setFromToken(toToken)
-    setToToken(fromToken)
+    setFromKey(toToken?.key ?? null)
+    setToKey(fromToken?.key ?? null)
     if (derived) setOrderType(derived)
     setAmount('')
     setQuote(null)
     setError('')
+  }
+
+  const handleSwitchNetwork = async () => {
+    setError('')
+    try {
+      if (typeof switchChainAsync !== 'function') {
+        throw new Error('This wallet cannot switch networks from the app.')
+      }
+      await switchChainAsync({ chainId: pairChainId })
+    } catch (err) {
+      setError(err?.shortMessage || err?.message || `Could not switch to ${pairNetworkName}.`)
+    }
   }
 
   const handleAccountChange = (value) => {
@@ -242,7 +353,7 @@ function TradePanel() {
 
   // A Limit order's floor: limit price (output per 1 unit paid) × quantity,
   // enforced on-chain as the swap's minimum received.
-  const outDecimals = tokenFor(toToken)?.decimals ?? 18
+  const outDecimals = toToken?.decimals ?? 18
   const limitFloor = useMemo(() => {
     if (priceType !== 'limit') return null
     const qty = parseFloat(amount)
@@ -271,17 +382,19 @@ function TradePanel() {
 
     try {
       const proposedNote = `Proposed to ${identity.label || 'the multisig'} — owners approve before it executes.`
-      const res =
-        priceType === 'limit'
-          ? await swap(fromToken, toToken, amount, { limitMinOutWei: limitFloor.wei })
-          : await swap(fromToken, toToken, amount)
+      // The pair's network rides along so the DEX layer refuses an order aimed at
+      // a chain the wallet is not on, whatever the UI believes.
+      const opts = { chainId: pairChainId }
+      if (priceType === 'limit') opts.limitMinOutWei = limitFloor.wei
+      const res = await swap(fromToken.address, toToken.address, amount, opts)
       setSuccess(
         res?.proposed
           ? proposedNote
-          : `Swapped ${amount} ${symbolFor(fromToken)} → ${symbolFor(toToken)}`,
+          : `Swapped ${amount} ${symbolOf(fromToken)} → ${symbolOf(toToken)} on ${pairNetworkName}`,
       )
       setAmount('')
       setQuote(null)
+      refreshLegBalances()
     } catch (err) {
       console.error('Trade error:', err)
       setError(err.message || 'Transaction failed')
@@ -289,7 +402,9 @@ function TradePanel() {
   }
 
   const handleSetMax = () => {
-    setAmount(balanceFor(fromToken))
+    const available = balanceFor(fromToken)
+    if (available == null) return
+    setAmount(available)
   }
 
   if (!isConnected) {
@@ -297,7 +412,7 @@ function TradePanel() {
       <div className="trade-panel">
         <div className="trade-header">
           <h2>Trade</h2>
-          <p className="trade-subtitle">Trade on {networkName}</p>
+          <p className="trade-subtitle">Trade across every supported network</p>
         </div>
         <div className="trade-empty">
           <p>Connect your wallet to start trading.</p>
@@ -306,18 +421,21 @@ function TradePanel() {
     )
   }
 
-  if (!isDexAvailable) {
+  // The only true dead end left: no supported network has a DEX deployment at
+  // all. A DEX-less CONNECTED chain is no longer a dead end — pairs from other
+  // networks are listed, and the ticket asks for the switch when one is picked.
+  if (options.length === 0) {
     return (
       <div className="trade-panel">
         <div className="trade-header">
           <h2>Trade</h2>
-          <p className="trade-subtitle">Trading is unavailable on {networkName}</p>
+          <p className="trade-subtitle">Trading is unavailable</p>
         </div>
         <div className="trade-empty">
           <p>
             {dexProvider
-              ? `${providerName} is not configured on ${networkName}. Switch to a supported network to trade in-app.`
-              : `No DEX is configured on ${networkName}. Switch to a supported network to trade in-app.`}
+              ? `${dexProvider.name} is not configured on any supported network in this build, so there are no pairs to trade in-app.`
+              : 'No DEX is configured on any supported network in this build, so there are no pairs to trade in-app.'}
           </p>
         </div>
       </div>
@@ -331,8 +449,13 @@ function TradePanel() {
       : '0.0'
 
   const severity = impactSeverity(quote?.priceImpactPercent)
+  // A vault is a contract on ONE network; it cannot sign for a pair elsewhere.
+  const vaultChainId = isVault && identity?.chainId != null ? Number(identity.chainId) : null
+  const vaultOffNetwork = vaultChainId != null && vaultChainId !== pairChainId
   const canExecute =
     !loading &&
+    !needsSwitch &&
+    !vaultOffNetwork &&
     // A recovered account signs with its own EOA key, not the passkey rail, so
     // passkey readiness doesn't gate it.
     (passkeyReady || isLegacy) &&
@@ -367,17 +490,20 @@ function TradePanel() {
       <div className="trade-header">
         <div className="trade-title-row">
           <h2>Trade</h2>
-          <span className="trade-venue" title={`Routing via ${providerName}`}>
+          <span className="trade-venue" title={`Routing via ${providerName} on ${pairNetworkName}`}>
             {providerName}
           </span>
         </div>
         <p className="trade-subtitle">
           Best-execution swaps routed across {providerName} liquidity
+          {swapNetworkCount > 1
+            ? ` on ${swapNetworkCount} networks — a pair always trades on one of them.`
+            : '.'}
         </p>
       </div>
 
-      {/* Account — the personal wallet or a saved multisig; the available
-          figures below always belong to the selected account. */}
+      {/* Account — the personal wallet or a saved multisig. Balances live on the
+          pay/receive cards below, next to the amount they apply to. */}
       <section className="trade-account" aria-label="Trading account">
         <div className="trade-account-top">
           <label className="trade-field-label" htmlFor="trade-account-select">
@@ -413,34 +539,37 @@ function TradePanel() {
         />
         {isLegacy && (
           <p className="trade-account-note" role="note">
-            Orders sign with your recovered account&apos;s key on {networkName}. You pay the
+            Orders sign with your recovered account&apos;s key on {pairNetworkName}. You pay the
             network fee — recovered accounts aren&apos;t gasless.
           </p>
         )}
-        <dl className="trade-account-rows">
-          <div className="trade-account-row">
-            <dt>Available to trade ({symbolFor(fromToken)})</dt>
-            <dd>
-              <SensitiveValue>{fmtBalance(balanceFor(fromToken))}</SensitiveValue>
-            </dd>
-          </div>
-          <div className="trade-account-row">
-            <dt>Cash available ({stableSymbol})</dt>
-            <dd>
-              <SensitiveValue>{fmtBalance(balances.stable)}</SensitiveValue>
-            </dd>
-          </div>
-        </dl>
         {isVault && (
           <p className="trade-account-note">
             Orders from this account are proposed to the multisig and execute once enough
             owners approve.
           </p>
         )}
+        {vaultOffNetwork && (
+          <p className="trade-account-note" role="note">
+            This multisig lives on {NETWORKS[vaultChainId]?.name || 'another network'}, so it
+            can&apos;t trade the {pairNetworkName} pair you picked. Choose a pair on{' '}
+            {NETWORKS[vaultChainId]?.name || 'its network'}, or switch to your personal wallet.
+          </p>
+        )}
         {!passkeyReady && !isLegacy && (
           <p className="trade-account-note" role="note">
-            Passkey accounts can’t send transactions on {networkName} yet — connect a
-            browser wallet to trade here.
+            Passkey accounts can’t send transactions on {pairNetworkName} yet — connect a
+            browser wallet to trade this pair.
+          </p>
+        )}
+        {/* A fact about the member's OWN network, stated whether or not a switch
+            is also pending — "your network can't trade" and "this pair is
+            elsewhere" are two different things to know. `isSwapChain` is the same
+            gate the option list is built from, so the note can never contradict it. */}
+        {!isSwapChain(chainId) && (
+          <p className="trade-account-note" role="note">
+            {walletNetworkName} has no DEX deployment, so its own pairs aren’t tradeable —
+            the pairs listed below are on other networks.
           </p>
         )}
       </section>
@@ -452,7 +581,8 @@ function TradePanel() {
           <span className="trade-field-label">
             <label htmlFor="trade-order-type">Order Type</label>
             <InfoTip label="About order types" className="trade-info">
-              Buy receives {wnativeSymbol} for {stableSymbol}; Sell does the reverse.
+              Buy receives {wnativeSymbol} for {pairStableSymbol}; Sell does the reverse.
+              Both stay on {pairNetworkName} — the network of the pair you picked.
               Sell Short and Buy to Cover appear on networks with a perpetuals venue —
               {perpsVenue ? ` ${perpsVenue.name} on this network.` : ' none of the supported networks has one yet.'}
             </InfoTip>
@@ -506,7 +636,7 @@ function TradePanel() {
         {priceType === 'limit' && (
           <div className="trade-field">
             <label className="trade-field-label" htmlFor="trade-limit-price">
-              Limit Price ({symbolFor(toToken)} per {symbolFor(fromToken)})
+              Limit Price ({symbolOf(toToken)} per {symbolOf(fromToken)})
             </label>
             <input
               id="trade-limit-price"
@@ -534,7 +664,7 @@ function TradePanel() {
         <div className="trade-message trade-error" role="alert">
           {perpsVenue
             ? `${orderType === 'sell_short' ? 'Sell Short' : 'Buy to Cover'} orders route to ${perpsVenue.name}, which isn’t wired into in-app execution yet.`
-            : `Short selling needs a perpetuals venue, and ${networkName} doesn’t have one yet.`}
+            : `Short selling needs a perpetuals venue, and ${pairNetworkName} doesn’t have one yet.`}
         </div>
       )}
 
@@ -543,9 +673,7 @@ function TradePanel() {
         <div className="trade-leg">
           <div className="trade-leg-top">
             <label htmlFor="trade-amount">You pay</label>
-            <span className="trade-balance">
-              Balance: <SensitiveValue>{fmtBalance(balanceFor(fromToken))}</SensitiveValue>
-            </span>
+            <span className="trade-balance">Balance: {renderBalance(fromToken)}</span>
           </div>
           <div className="trade-leg-body">
             <input
@@ -561,15 +689,20 @@ function TradePanel() {
             />
             <TradeTokenSelect
               ariaLabel="Token to sell"
-              assets={assets}
-              value={fromToken}
-              onChange={(addr) => handlePairChange('from', addr)}
-              chainId={chainId}
+              options={options}
+              value={fromKey}
+              onChange={handleSellLegChange}
             />
-            <button type="button" onClick={handleSetMax} className="trade-max-btn">
+            <button
+              type="button"
+              onClick={handleSetMax}
+              className="trade-max-btn"
+              disabled={balanceFor(fromToken) == null}
+            >
               MAX
             </button>
           </div>
+          <p className="trade-leg-network">{fromToken?.networkName || pairNetworkName}</p>
         </div>
 
         <div className="trade-switch-row">
@@ -583,13 +716,11 @@ function TradePanel() {
           </button>
         </div>
 
-        {/* Receive leg */}
+        {/* Receive leg — pinned to the pay leg's network (one pool, one chain). */}
         <div className="trade-leg">
           <div className="trade-leg-top">
             <label>You receive</label>
-            <span className="trade-balance">
-              Balance: <SensitiveValue>{fmtBalance(balanceFor(toToken))}</SensitiveValue>
-            </span>
+            <span className="trade-balance">Balance: {renderBalance(toToken)}</span>
           </div>
           <div className="trade-leg-body">
             <div className="trade-receive-value" aria-live="polite">
@@ -597,12 +728,17 @@ function TradePanel() {
             </div>
             <TradeTokenSelect
               ariaLabel="Token to buy"
-              assets={assets}
-              value={toToken}
-              onChange={(addr) => handlePairChange('to', addr)}
-              chainId={chainId}
+              options={receiveOptions}
+              value={toKey}
+              onChange={handleBuyLegChange}
+              emptyLabel="Select"
             />
           </div>
+          <p className="trade-leg-network">
+            {receiveOptions.length === 0
+              ? `No other token trades against ${symbolOf(fromToken)} on ${pairNetworkName}.`
+              : `On ${pairNetworkName} — a pair lives on one network.`}
+          </p>
         </div>
       </div>
 
@@ -651,6 +787,7 @@ function TradePanel() {
             <span className="trade-summary-val trade-route">
               {quote.tokenInSymbol} → {quote.tokenOutSymbol}
               <span className="trade-route-fee">{feeTierLabel(quote.feeTier)} pool</span>
+              <span className="trade-route-network">on {pairNetworkName}</span>
             </span>
           </div>
           {priceType !== 'limit' && (
@@ -681,22 +818,42 @@ function TradePanel() {
         </div>
       )}
 
-      <button
-        type="button"
-        onClick={handleExecute}
-        disabled={!canExecute}
-        className="trade-execute-btn"
-      >
-        {loading
-          ? 'Processing…'
-          : quotingPrice
-            ? 'Fetching best price…'
-            : quote
-              ? priceType === 'limit'
-                ? `Place limit order — ${symbolFor(fromToken)} for ${symbolFor(toToken)}`
-                : `Swap ${symbolFor(fromToken)} for ${symbolFor(toToken)}`
-              : 'Enter an amount'}
-      </button>
+      {/* The pair's network is the wallet's network, or the order can't be placed.
+          Disclosed before any signature, with the switch as the primary action. */}
+      {needsSwitch ? (
+        <>
+          <p className="trade-switch-note" role="note">
+            This pair trades on {pairNetworkName} and your wallet is on {walletNetworkName}.
+            Switch networks to place the order — the price above is quoted from{' '}
+            {pairNetworkName} liquidity either way.
+          </p>
+          <button
+            type="button"
+            onClick={handleSwitchNetwork}
+            disabled={switching}
+            className="trade-execute-btn"
+          >
+            {switching ? `Switching to ${pairNetworkName}…` : `Switch to ${pairNetworkName}`}
+          </button>
+        </>
+      ) : (
+        <button
+          type="button"
+          onClick={handleExecute}
+          disabled={!canExecute}
+          className="trade-execute-btn"
+        >
+          {loading
+            ? 'Processing…'
+            : quotingPrice
+              ? 'Fetching best price…'
+              : quote
+                ? priceType === 'limit'
+                  ? `Place limit order — ${symbolOf(fromToken)} for ${symbolOf(toToken)}`
+                  : `Swap ${symbolOf(fromToken)} for ${symbolOf(toToken)}`
+                : 'Enter an amount'}
+        </button>
+      )}
 
       {isPasskey && passkeyReady && !isVault && !isLegacy && (
         <p className="trade-session-note">
@@ -720,17 +877,19 @@ function TradePanel() {
       <div className="trade-footer">
         <div className="trade-attribution" title={`${providerName} — Uniswap V3 protocol`}>
           <span className="trade-attribution-dot" aria-hidden="true" />
-          {poweredBy}
+          {poweredBy} on {pairNetworkName}
         </div>
         <div className="trade-links">
-          <a
-            href={getExplorerUrl(chainId, addresses.SWAP_ROUTER_02, 'address')}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="trade-link"
-          >
-            {providerName} Router ↗
-          </a>
+          {pairAddresses?.swapRouter && (
+            <a
+              href={getExplorerUrl(pairChainId, pairAddresses.swapRouter, 'address')}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="trade-link"
+            >
+              {providerName} Router ↗
+            </a>
+          )}
           {providerUrl && (
             <a href={providerUrl} target="_blank" rel="noopener noreferrer" className="trade-link">
               Open {providerName} ↗

--- a/frontend/src/components/fairwins/TradeTokenSelect.css
+++ b/frontend/src/components/fairwins/TradeTokenSelect.css
@@ -1,5 +1,6 @@
 /* TradeTokenSelect — pill-shaped AssetLogo dropdown for the Trade ticket's
-   pay/receive legs. Colors alias the same --trade-* tokens as TradePanel.css. */
+   pay/receive legs. Colors alias the same --trade-* tokens as TradePanel.css.
+   The popover holds a search field above the (network-grouped) option list. */
 
 .trade-token-picker {
   position: relative;
@@ -26,20 +27,56 @@
   font-size: 0.7rem;
 }
 
-.trade-token-list {
+.trade-token-popover {
   background: var(--trade-surface);
   border: 1px solid var(--trade-border);
   border-radius: 12px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
-  list-style: none;
-  margin: 6px 0 0;
-  max-height: 320px;
-  overflow-y: auto;
-  padding: 6px;
+  margin-top: 6px;
+  max-width: min(320px, calc(100vw - 2rem));
+  min-width: 240px;
+  padding: 8px;
   position: absolute;
   right: 0;
-  min-width: 160px;
   z-index: 30;
+}
+
+.trade-token-search {
+  background: var(--trade-surface-2);
+  border: 1px solid var(--trade-border);
+  border-radius: 10px;
+  color: var(--trade-text);
+  font-size: 0.9rem;
+  padding: 8px 10px;
+  width: 100%;
+}
+
+.trade-token-search:focus-visible {
+  border-color: var(--trade-accent);
+  outline: none;
+}
+
+.trade-token-list {
+  list-style: none;
+  margin: 6px 0 0;
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.trade-token-group {
+  color: var(--trade-text-2);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 8px 10px 4px;
+  text-transform: uppercase;
+}
+
+.trade-token-testnet {
+  font-weight: 600;
+  opacity: 0.8;
+  text-transform: none;
 }
 
 .trade-token-li {
@@ -70,4 +107,30 @@
 
 .trade-token-option.active {
   background: color-mix(in srgb, var(--trade-accent) 16%, transparent);
+}
+
+.trade-token-option-body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.trade-token-option-sym {
+  white-space: nowrap;
+}
+
+.trade-token-option-net {
+  color: var(--trade-text-2);
+  font-size: 0.75rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trade-token-no-match {
+  color: var(--trade-text-2);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  margin: 8px 4px 4px;
 }

--- a/frontend/src/components/fairwins/TradeTokenSelect.jsx
+++ b/frontend/src/components/fairwins/TradeTokenSelect.jsx
@@ -1,29 +1,73 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import AssetLogo from '../wallet/AssetLogo'
+import { matchesAssetQuery } from '../../lib/assets/assetSearch'
 import './TradeTokenSelect.css'
 
 /**
- * TradeTokenSelect — the Trade ticket's pair-leg token picker. A thin,
- * trade-panel-flavored sibling of UniversalAssetSelect: same AssetLogo
- * artwork and listbox interaction pattern, sized to sit inline as a pill
- * next to the amount input (FR: consistent asset iconography app-wide).
+ * TradeTokenSelect — the Trade ticket's pair-leg picker, now MULTI-NETWORK.
  *
- * Every option trades on the same active chain as the ticket, so `chainId`
- * is a single prop rather than per-option.
+ * A thin, trade-panel-flavored sibling of UniversalAssetSelect: same AssetLogo
+ * artwork (glyph + network sub-badge) and listbox interaction, sized to sit inline
+ * as a pill next to the amount input. It stays a separate component because the
+ * ticket needs a compact pill, not UniversalAssetSelect's wide balance-bearing
+ * trigger — but the two now share the search rule (`lib/assets/assetSearch.js`)
+ * so both narrow on exactly the fields a member can see.
+ *
+ * Options span every swap-capable network, so:
+ *   - each option names its NETWORK, and the accessible name is
+ *     "SYMBOL on Network" — with WETH on four chains in one list, the symbol
+ *     alone is ambiguous to a screen reader and to a sighted member alike;
+ *   - options are grouped under a network heading whenever more than one network
+ *     is present (a single-network list is unchanged);
+ *   - a search field narrows by symbol, asset name, or network name — the whole
+ *     point of listing ~40 legs instead of ~8.
+ *
+ * Purely presentational: eligibility is the CALLER's (TradePanel pins the
+ * counterpart's network via `lib/assets/networkPin.js#samePair`). This component
+ * renders what it is handed and never derives which pairs are possible.
  */
-export default function TradeTokenSelect({ assets = [], value, onChange, chainId, ariaLabel }) {
+export default function TradeTokenSelect({
+  options = [],
+  value,
+  onChange,
+  ariaLabel,
+  emptyLabel = 'Select',
+}) {
   const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
   const wrapRef = useRef(null)
+  const triggerRef = useRef(null)
+  const listRef = useRef(null)
+  const baseId = useId()
+  const listId = `${baseId}-list`
 
-  const selected = assets.find((t) => t.address === value) || null
+  const selected = useMemo(() => options.find((o) => o.key === value) || null, [options, value])
+  const visible = useMemo(
+    () => options.filter((o) => matchesAssetQuery(o, query)),
+    [options, query],
+  )
+  // Group headings only earn their space once the list actually spans networks.
+  const multiNetwork = useMemo(
+    () => new Set(options.map((o) => o.chainId)).size > 1,
+    [options],
+  )
+
+  // Every close resets the query so reopening starts from the full list rather
+  // than whatever the member last typed.
+  const closeList = useCallback(() => {
+    setOpen(false)
+    setQuery('')
+  }, [])
 
   useEffect(() => {
     if (!open) return undefined
     const onDocClick = (e) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false)
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) closeList()
     }
     const onKey = (e) => {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key !== 'Escape') return
+      closeList()
+      triggerRef.current?.focus()
     }
     document.addEventListener('mousedown', onDocClick)
     document.addEventListener('keydown', onKey)
@@ -31,55 +75,137 @@ export default function TradeTokenSelect({ assets = [], value, onChange, chainId
       document.removeEventListener('mousedown', onDocClick)
       document.removeEventListener('keydown', onKey)
     }
-  }, [open])
+  }, [open, closeList])
 
   const handleSelect = useCallback(
-    (token) => {
-      onChange?.(token.address)
-      setOpen(false)
+    (option) => {
+      onChange?.(option)
+      closeList()
     },
-    [onChange],
+    [onChange, closeList],
   )
+
+  const focusOptionAt = useCallback((index) => {
+    const items = Array.from(listRef.current?.querySelectorAll('[role="option"]') || [])
+    if (!items.length) return
+    items[Math.max(0, Math.min(index, items.length - 1))].focus()
+  }, [])
+
+  const handleSearchKeyDown = (e) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      focusOptionAt(0)
+    } else if (e.key === 'Enter') {
+      // Never let a stray Enter submit a surrounding form — commit the top match.
+      e.preventDefault()
+      if (visible.length > 0) handleSelect(visible[0])
+    }
+  }
+
+  const handleListKeyDown = (e) => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+    e.preventDefault()
+    const items = Array.from(listRef.current?.querySelectorAll('[role="option"]') || [])
+    const at = items.indexOf(document.activeElement)
+    if (e.key === 'ArrowUp' && at <= 0) {
+      wrapRef.current?.querySelector('.trade-token-search')?.focus()
+      return
+    }
+    focusOptionAt(at < 0 ? 0 : at + (e.key === 'ArrowDown' ? 1 : -1))
+  }
+
+  // Rendered in caller order (connected network first), with a heading emitted
+  // each time the network changes — the ordering carries the grouping, so no
+  // second pass can disagree with the list the caller built.
+  const renderOption = (option, index) => {
+    const previous = visible[index - 1]
+    const startsNetwork = multiNetwork && (!previous || previous.chainId !== option.chainId)
+    return (
+      <Fragment key={option.key}>
+        {startsNetwork && (
+          <li className="trade-token-group" role="presentation">
+            {option.networkName}
+            {option.isTestnet && <span className="trade-token-testnet"> testnet</span>}
+          </li>
+        )}
+        <li className="trade-token-li" role="presentation">
+          <button
+            type="button"
+            role="option"
+            aria-selected={option.key === value}
+            aria-label={`${option.symbol} on ${option.networkName}`}
+            className={`trade-token-option ${option.key === value ? 'active' : ''}`}
+            onClick={() => handleSelect(option)}
+          >
+            <AssetLogo symbol={option.symbol} chainId={option.chainId} showBadge size={24} />
+            <span className="trade-token-option-body">
+              <span className="trade-token-option-sym">{option.symbol}</span>
+              <span className="trade-token-option-net">{option.networkName}</span>
+            </span>
+          </button>
+        </li>
+      </Fragment>
+    )
+  }
 
   return (
     <div className="trade-token-picker" ref={wrapRef}>
       <button
         type="button"
+        ref={triggerRef}
         className="trade-token-select"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={ariaLabel}
-        disabled={assets.length === 0}
-        onClick={() => setOpen((o) => !o)}
+        disabled={options.length === 0}
+        onClick={() => (open ? closeList() : setOpen(true))}
       >
         {selected ? (
           <>
-            <AssetLogo symbol={selected.symbol} chainId={chainId} showBadge size={20} />
+            <AssetLogo symbol={selected.symbol} chainId={selected.chainId} showBadge size={20} />
             <span className="trade-token-select-sym">{selected.symbol}</span>
           </>
         ) : (
-          <span className="trade-token-select-sym">Select</span>
+          <span className="trade-token-select-sym">{emptyLabel}</span>
         )}
         <span className="trade-token-select-chevron" aria-hidden="true">▾</span>
       </button>
 
-      {open && assets.length > 0 && (
-        <ul className="trade-token-list" role="listbox" aria-label={ariaLabel}>
-          {assets.map((token) => (
-            <li key={token.address} className="trade-token-li">
-              <button
-                type="button"
-                role="option"
-                aria-selected={token.address === value}
-                className={`trade-token-option ${token.address === value ? 'active' : ''}`}
-                onClick={() => handleSelect(token)}
-              >
-                <AssetLogo symbol={token.symbol} chainId={chainId} showBadge size={24} />
-                <span className="trade-token-option-sym">{token.symbol}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
+      {open && options.length > 0 && (
+        <div className="trade-token-popover">
+          <input
+            type="search"
+            className="trade-token-search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleSearchKeyDown}
+            placeholder="Search token or network"
+            aria-label="Search tokens"
+            aria-controls={visible.length > 0 ? listId : undefined}
+            autoFocus
+          />
+          {/* Announces the narrowing to a screen reader, which can't see it. */}
+          <p className="sr-only" role="status">
+            {`${visible.length} of ${options.length} tokens shown`}
+          </p>
+
+          {visible.length > 0 ? (
+            <ul
+              className="trade-token-list"
+              id={listId}
+              role="listbox"
+              aria-label={ariaLabel}
+              ref={listRef}
+              onKeyDown={handleListKeyDown}
+            >
+              {visible.map(renderOption)}
+            </ul>
+          ) : (
+            <p className="trade-token-no-match" role="note">
+              No token matches “{query.trim()}”. Try a symbol, a token name, or a network name.
+            </p>
+          )}
+        </div>
       )}
     </div>
   )

--- a/frontend/src/components/ui/UniversalAssetSelect.jsx
+++ b/frontend/src/components/ui/UniversalAssetSelect.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import AssetLogo from '../wallet/AssetLogo'
 import SensitiveValue from '../common/SensitiveValue'
+import { matchesAssetQuery } from '../../lib/assets/assetSearch'
 import './UniversalAssetSelect.css'
 
 /**
@@ -23,8 +24,10 @@ import './UniversalAssetSelect.css'
  *
  *   - SEARCH (FR-064). Five networks' assets in one list multiplies the option count,
  *     so the open list narrows on the three fields a member can actually see: asset
- *     symbol, asset name, and network name. Search only narrows what is already
- *     eligible, so typing never changes what the trigger shows as selected.
+ *     symbol, asset name, and network name. The rule itself lives in
+ *     `lib/assets/assetSearch.js` so the Trade ticket's pair pickers narrow on
+ *     exactly the same fields. Search only narrows what is already eligible, so
+ *     typing never changes what the trigger shows as selected.
  *
  *   - An optional `pin` + `pinPredicate` pair (FR-062/FR-063). The CALLER owns the
  *     rule — `lib/assets/networkPin.js` ships both predicates (`samePair` for pairs,
@@ -37,15 +40,6 @@ import './UniversalAssetSelect.css'
 
 /** AssetLogo only badges numeric EVM chains; a Bitcoin option (string id) renders its glyph alone. */
 const evmBadgeChainId = (chainId) => (typeof chainId === 'number' ? chainId : null)
-
-/** Search matches any of the three fields the member can see on an option (FR-064). */
-const matchesQuery = (option, query) => {
-  const needle = query.trim().toLowerCase()
-  if (!needle) return true
-  return [option?.symbol, option?.name, option?.networkName].some(
-    (field) => typeof field === 'string' && field.toLowerCase().includes(needle),
-  )
-}
 
 /**
  * Fallback empty-counterpart copy (FR-065). Deliberately rule-neutral — the component
@@ -85,7 +79,7 @@ export default function UniversalAssetSelect({
     () => (typeof pinPredicate === 'function' ? options.filter((o) => pinPredicate(o, pin)) : options),
     [options, pin, pinPredicate],
   )
-  const visible = useMemo(() => eligible.filter((o) => matchesQuery(o, query)), [eligible, query])
+  const visible = useMemo(() => eligible.filter((o) => matchesAssetQuery(o, query)), [eligible, query])
 
   const selected = eligible.find((o) => o.key === value) || eligible[0] || null
   // Options exist but the pin excludes every one of them — the FR-065 case.

--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -903,6 +903,24 @@ export function isDexAvailable(chainId) {
 }
 
 /**
+ * Every network a swap can actually route on — the `capabilities.dex` gate
+ * (policy allow-list AND real router config), mainnets first. Mirrors
+ * `getClearPathChainIds()`: the Trade ticket lists pairs from ALL of these
+ * regardless of which chain the wallet sits on, because quoting is a read over
+ * each chain's own provider. Only the swap itself (a WRITE) needs the wallet to
+ * be on the pair's network. Resolved strictly per-chain — never `getNetwork()`,
+ * whose fallback would advertise the default network's DEX for a chain that has
+ * none.
+ */
+export function getSwapChainIds() {
+  return listSupportedChainIds()
+    .map((id) => NETWORKS[id])
+    .filter((net) => net?.capabilities?.dex)
+    .sort((a, b) => Number(a.isTestnet) - Number(b.isTestnet))
+    .map((net) => net.chainId)
+}
+
+/**
  * The DEX provider descriptor (`{ name, url }`) for `chainId`, or null when the
  * network has no DEX provider (e.g. local Hardhat). Declared per network so the
  * mapping — ETC family (61, 63) → ETCswap; all others → Uniswap — is explicit

--- a/frontend/src/contexts/DexContext.jsx
+++ b/frontend/src/contexts/DexContext.jsx
@@ -4,14 +4,19 @@ import { useChainId } from 'wagmi'
 import { useWallet } from '../hooks/useWalletManagement'
 import { useActiveAccount } from '../hooks/useActiveAccount'
 import { FEE_TIERS, DEFAULT_SLIPPAGE } from '../constants/dex'
-import { getNetwork, getCurrentChainId } from '../config/networks'
-import { getPortfolioRegistry } from '../config/assetTaxonomy'
+import { NETWORKS, getNetwork, getCurrentChainId } from '../config/networks'
 import { ERC20_ABI } from '../abis/ERC20'
 import { WNATIVE_ABI } from '../abis/WNative'
 import { SWAP_ROUTER_02_ABI } from '../abis/SwapRouter02'
 import { QUOTER_V2_ABI } from '../abis/QuoterV2'
 import { DexContext } from './DexContext'
-import { toSdkToken, buildTradeMetrics, ROUTED_FEE_TIERS } from '../lib/uniswap/trade'
+import { quoteBestRoute } from '../lib/uniswap/quote'
+import {
+  getSwapAddresses,
+  getSwapTokenMeta,
+  getSwapTokens,
+  isSwapChain,
+} from '../lib/uniswap/swapUniverse'
 import { makeReadProvider } from '../utils/rpcProvider'
 import logger from '../utils/logger'
 
@@ -113,20 +118,12 @@ export function DexProvider({ children }) {
   // portfolio registry knows about on this network (wrapped native + stablecoin
   // from app-config, plus curated commodities/tools/stables) — i.e. the
   // portfolio assets that have a routeable pair on a chain we support. Native
-  // coins (must be wrapped first) and NFT credentials are excluded. Swaps
-  // execute on the active chain, so the list is per-chain (honest-state: we only
-  // offer what can actually route here). Falls back to []/no-DEX cleanly.
-  const tradeTokens = useMemo(() => {
-    if (!isDexAvailable) return []
-    return getPortfolioRegistry(chainId)
-      .filter((entry) => entry.kind === 'erc20' && entry.address)
-      .map((entry) => ({
-        address: entry.address,
-        symbol: entry.symbol,
-        name: entry.name,
-        decimals: entry.decimals,
-      }))
-  }, [chainId, isDexAvailable])
+  // coins (must be wrapped first) and NFT credentials are excluded.
+  //
+  // This is `getSwapTokens(chainId)` — the SAME derivation the multi-network
+  // ticket applies to every other chain, deliberately not a second copy of it:
+  // the connected chain's list must not be able to drift from the rest.
+  const tradeTokens = useMemo(() => getSwapTokens(chainId), [chainId])
 
   // Address → metadata lookup so quote/swap math uses the right decimals and
   // ticker for any tradeable token, not just wrapped-native and the stablecoin.
@@ -384,102 +381,70 @@ export function DexProvider({ children }) {
     }
   }, [contracts, decimalsOf])
 
-  // Route a quote across the common V3 fee tiers and return the best-execution
-  // result decorated with Uniswap SDK figures (execution price, minimum
-  // received after slippage, price impact) — the numbers a trading UI shows.
-  const getBestQuote = useCallback(async (tokenIn, tokenOut, amountIn) => {
-    if (!contracts) {
+  /**
+   * Quote a pair on ANY swap-capable network — the read half of multi-network
+   * trading. The connected chain goes through the wallet/read provider already
+   * wired above; every other chain gets its own read provider and its own
+   * QuoterV2 (strictly per-chain addresses — a router or quoter borrowed from
+   * another network would quote a pool that does not exist, or worse, price
+   * against the wrong one). Leg decimals/symbols come from that chain's registry.
+   *
+   * Routing + SDK math live in lib/uniswap/quote.js, so a cross-chain quote and a
+   * local one are the same computation, not two that can drift apart.
+   */
+  const getBestQuoteOn = useCallback(async (targetChainId, tokenIn, tokenOut, amountIn) => {
+    const target = Number(targetChainId)
+    const isActive = target === Number(chainId)
+
+    if (isActive && !contracts) {
       throw new Error('DEX is not available on the current network')
+    }
+    if (!isActive && !isSwapChain(target)) {
+      throw new Error(`Swapping is not available on ${NETWORKS[target]?.name || 'that network'}`)
+    }
+
+    let quoter = contracts?.quoter
+    let decIn = decimalsOf(tokenIn)
+    let decOut = decimalsOf(tokenOut)
+    let symIn = symbolOf(tokenIn)
+    let symOut = symbolOf(tokenOut)
+
+    if (!isActive) {
+      const targetAddresses = getSwapAddresses(target)
+      const provider = makeReadProvider(NETWORKS[target].rpcUrl, target)
+      quoter = new ethers.Contract(targetAddresses.quoter, QUOTER_V2_ABI, provider)
+      const metaIn = getSwapTokenMeta(target, tokenIn)
+      const metaOut = getSwapTokenMeta(target, tokenOut)
+      decIn = metaIn?.decimals ?? 18
+      decOut = metaOut?.decimals ?? 18
+      symIn = metaIn?.symbol ?? 'TOKEN'
+      symOut = metaOut?.symbol ?? 'TOKEN'
     }
 
     setQuotingPrice(true)
     try {
-      const decIn = decimalsOf(tokenIn)
-      const decOut = decimalsOf(tokenOut)
-      const amountInWei = ethers.parseUnits(amountIn, decIn)
-      if (amountInWei <= 0n) {
-        throw new Error('Enter an amount greater than zero')
-      }
-
-      // Probe each fee tier; QuoterV2 reverts where no pool exists, so we keep
-      // the deepest output across the tiers that do quote — a lightweight route.
-      let best = null
-      for (const fee of ROUTED_FEE_TIERS) {
-        try {
-          const res = await contracts.quoter.quoteExactInputSingle.staticCall({
-            tokenIn,
-            tokenOut,
-            amountIn: amountInWei,
-            fee,
-            sqrtPriceLimitX96: 0,
-          })
-          const out = res[0]
-          if (out > 0n && (!best || out > best.amountOutWei)) {
-            best = { fee, amountOutWei: out, gasEstimate: res[3] }
-          }
-        } catch {
-          // No pool for this fee tier — skip it.
-        }
-      }
-
-      if (!best) {
-        throw new Error('No liquidity route available for this pair')
-      }
-
-      // Near-spot reference quote (a fraction of the size) on the winning tier,
-      // used to derive price impact via the SDK. Optional — impact is hidden if
-      // the reference quote is unavailable.
-      let refInWei = amountInWei / 1000n
-      if (refInWei <= 0n) refInWei = 1n
-      let refAmountInRaw = null
-      let refAmountOutRaw = null
-      try {
-        const refRes = await contracts.quoter.quoteExactInputSingle.staticCall({
-          tokenIn,
-          tokenOut,
-          amountIn: refInWei,
-          fee: best.fee,
-          sqrtPriceLimitX96: 0,
-        })
-        if (refRes[0] > 0n) {
-          refAmountInRaw = refInWei
-          refAmountOutRaw = refRes[0]
-        }
-      } catch {
-        // Impact figure is best-effort.
-      }
-
-      const sdkIn = toSdkToken(chainId, tokenIn, decIn, symbolOf(tokenIn))
-      const sdkOut = toSdkToken(chainId, tokenOut, decOut, symbolOf(tokenOut))
-      const metrics = buildTradeMetrics({
-        tokenIn: sdkIn,
-        tokenOut: sdkOut,
-        amountInRaw: amountInWei,
-        amountOutRaw: best.amountOutWei,
-        refAmountInRaw,
-        refAmountOutRaw,
+      return await quoteBestRoute({
+        quoter,
+        chainId: target,
+        tokenIn,
+        tokenOut,
+        amountIn,
+        decimalsIn: decIn,
+        decimalsOut: decOut,
+        symbolIn: symIn,
+        symbolOut: symOut,
         slippageBps: slippage,
       })
-
-      return {
-        amountOut: ethers.formatUnits(best.amountOutWei, decOut),
-        amountOutWei: best.amountOutWei,
-        feeTier: best.fee,
-        gasEstimate: best.gasEstimate,
-        executionPrice: metrics.executionPrice.toSignificant(6),
-        executionPriceInverted: metrics.executionPrice.invert().toSignificant(6),
-        minimumReceived: ethers.formatUnits(metrics.minimumReceivedRaw, decOut),
-        minimumReceivedWei: metrics.minimumReceivedRaw,
-        priceImpactPercent: metrics.priceImpact
-          ? parseFloat(metrics.priceImpact.toSignificant(4))
-          : null,
-        tokenInSymbol: symbolOf(tokenIn),
-        tokenOutSymbol: symbolOf(tokenOut),
-      }
     } finally {
       setQuotingPrice(false)
     }
   }, [contracts, decimalsOf, symbolOf, chainId, slippage])
+
+  // Route a quote across the common V3 fee tiers on the CONNECTED chain.
+  const getBestQuote = useCallback(
+    (tokenIn, tokenOut, amountIn) => getBestQuoteOn(chainId, tokenIn, tokenOut, amountIn),
+    [getBestQuoteOn, chainId],
+  )
 
   /**
    * Execute (or, as a vault, propose) a swap.
@@ -489,10 +454,21 @@ export function DexProvider({ children }) {
    * via `amountOutMinimum`, making the order immediate-or-cancel — it fills at
    * the limit or better, or not at all. We pre-check against the fresh quote
    * so an unfillable limit fails with a plain reason before any wallet prompt.
+   *
+   * `opts.chainId` — the network the CALLER believes the pair lives on. Quotes
+   * are cross-chain (getBestQuoteOn) but a swap is not: it uses THIS chain's
+   * router and approves THIS chain's addresses. Passing the pair's chain makes a
+   * mismatch fail here, before any signature, instead of approving a foreign
+   * address that happens to be a contract on the connected chain.
    */
   const swap = useCallback(async (tokenIn, tokenOut, amountIn, opts = {}) => {
     if (!contracts || !tradingAddress) {
       throw new Error('Wallet not connected')
+    }
+    if (opts.chainId != null && Number(opts.chainId) !== Number(chainId)) {
+      throw new Error(
+        `This pair trades on ${NETWORKS[Number(opts.chainId)]?.name || 'another network'} — switch your wallet to that network to place the order.`,
+      )
     }
 
     try {
@@ -599,7 +575,7 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [contracts, tradingAddress, readProvider, getBestQuote, fetchBalances, decimalsOf, addresses, operatingAsVault, canActAsVault, operatingAsLegacy, canActAsLegacy, activeIdentity, submitAsActive, sendCalls])
+  }, [contracts, chainId, tradingAddress, readProvider, getBestQuote, fetchBalances, decimalsOf, addresses, operatingAsVault, canActAsVault, operatingAsLegacy, canActAsLegacy, activeIdentity, submitAsActive, sendCalls])
 
   const value = {
     balances,
@@ -613,6 +589,7 @@ export function DexProvider({ children }) {
     unwrapNative,
     getQuote,
     getBestQuote,
+    getBestQuoteOn,
     swap,
     setSlippage,
 

--- a/frontend/src/hooks/__tests__/useSwapBalances.test.jsx
+++ b/frontend/src/hooks/__tests__/useSwapBalances.test.jsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { NETWORKS } from '../../config/networks'
+
+// useSwapBalances reads a couple of ERC-20 balances on ONE network — the pair's
+// network, which is not necessarily the wallet's. The behavior that matters:
+//   - it reads over the PAIR chain's provider (a Polygon provider would answer
+//     with Polygon state for a Base pair — silently wrong, never an error);
+//   - a failed read is `null`, never `0` (constitution III): nobody may be told
+//     they hold nothing because an RPC hiccuped;
+//   - switching network or account clears figures that belong to someone else.
+
+const { mockMakeReadProvider, balanceOf } = vi.hoisted(() => ({
+  mockMakeReadProvider: vi.fn(() => ({ tag: 'provider' })),
+  balanceOf: vi.fn(),
+}))
+
+vi.mock('../../utils/rpcProvider', () => ({ makeReadProvider: mockMakeReadProvider }))
+vi.mock('../useRpcEndpoints', () => ({ useEndpointsRevision: () => 0 }))
+vi.mock('ethers', async () => {
+  const actual = await vi.importActual('ethers')
+  return {
+    ...actual,
+    Contract: class {
+      constructor(address) {
+        this.address = address
+      }
+      balanceOf(owner) {
+        return balanceOf(this.address, owner)
+      }
+    },
+  }
+})
+
+import { useSwapBalances } from '../useSwapBalances'
+
+const HOLDER = '0x1111222233334444555566667777888899990000'
+const BASE_WETH = NETWORKS[8453].dex.wnative
+const BASE_USDC = NETWORKS[8453].stablecoin.address
+const TOKENS = [
+  { address: BASE_WETH, decimals: 18 },
+  { address: BASE_USDC, decimals: 6 },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // The suite-wide VITE_SKIP_BLOCKCHAIN_CALLS flag exists so component tests
+  // never hit RPC; this hook IS the RPC read, so it is exercised with the flag off.
+  vi.stubEnv('VITE_SKIP_BLOCKCHAIN_CALLS', 'false')
+  mockMakeReadProvider.mockReturnValue({ tag: 'provider' })
+  balanceOf.mockImplementation(async (address) =>
+    address === BASE_WETH ? 2_000000000000000000n : 40_000000n,
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('useSwapBalances', () => {
+  it('reads the pair network’s balances over that network’s provider', async () => {
+    const { result } = renderHook(() =>
+      useSwapBalances({ chainId: 8453, address: HOLDER, tokens: TOKENS }),
+    )
+
+    await waitFor(() => expect(result.current.balances[BASE_WETH.toLowerCase()]).toBe('2.0'))
+    expect(result.current.balances[BASE_USDC.toLowerCase()]).toBe('40.0')
+    expect(mockMakeReadProvider).toHaveBeenCalledWith(NETWORKS[8453].rpcUrl, 8453)
+    expect(balanceOf).toHaveBeenCalledWith(BASE_WETH, HOLDER)
+  })
+
+  it('reports a failed read as unknown, never as zero', async () => {
+    balanceOf.mockImplementation(async (address) => {
+      if (address === BASE_WETH) throw new Error('rpc down')
+      return 40_000000n
+    })
+    const { result } = renderHook(() =>
+      useSwapBalances({ chainId: 8453, address: HOLDER, tokens: TOKENS }),
+    )
+
+    await waitFor(() => expect(result.current.balances[BASE_USDC.toLowerCase()]).toBe('40.0'))
+    expect(result.current.balances[BASE_WETH.toLowerCase()]).toBeNull()
+  })
+
+  it('keeps the last known figure when a later read fails', async () => {
+    const { result } = renderHook(() =>
+      useSwapBalances({ chainId: 8453, address: HOLDER, tokens: TOKENS }),
+    )
+    await waitFor(() => expect(result.current.balances[BASE_WETH.toLowerCase()]).toBe('2.0'))
+
+    balanceOf.mockRejectedValue(new Error('rpc down'))
+    await result.current.refresh()
+    expect(result.current.balances[BASE_WETH.toLowerCase()]).toBe('2.0')
+  })
+
+  it('clears figures when the network changes — they belong to another chain', async () => {
+    const { result, rerender } = renderHook((props) => useSwapBalances(props), {
+      initialProps: { chainId: 8453, address: HOLDER, tokens: TOKENS },
+    })
+    await waitFor(() => expect(result.current.balances[BASE_WETH.toLowerCase()]).toBe('2.0'))
+
+    balanceOf.mockImplementation(async () => 7_000000000000000000n)
+    rerender({
+      chainId: 137,
+      address: HOLDER,
+      tokens: [{ address: NETWORKS[137].dex.wnative, decimals: 18 }],
+    })
+
+    await waitFor(() =>
+      expect(result.current.balances[NETWORKS[137].dex.wnative.toLowerCase()]).toBe('7.0'),
+    )
+    // No Base leftovers standing in for Polygon holdings.
+    expect(result.current.balances[BASE_WETH.toLowerCase()]).toBeUndefined()
+  })
+
+  it('reads nothing without an account, a network, or any legs', async () => {
+    renderHook(() => useSwapBalances({ chainId: 8453, address: null, tokens: TOKENS }))
+    renderHook(() => useSwapBalances({ chainId: 999999, address: HOLDER, tokens: TOKENS }))
+    renderHook(() => useSwapBalances({ chainId: 8453, address: HOLDER, tokens: [] }))
+
+    await waitFor(() => expect(balanceOf).not.toHaveBeenCalled())
+  })
+})

--- a/frontend/src/hooks/useSwapBalances.js
+++ b/frontend/src/hooks/useSwapBalances.js
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Contract, formatUnits } from 'ethers'
+import { NETWORKS } from '../config/networks'
+import { makeReadProvider } from '../utils/rpcProvider'
+import { useEndpointsRevision } from './useRpcEndpoints'
+import logger from '../utils/logger'
+
+const BALANCE_OF_ABI = ['function balanceOf(address) view returns (uint256)']
+
+/**
+ * Balances for a handful of ERC-20s on ONE network, read over that network's own
+ * provider — the leg balances behind the multi-network Trade ticket.
+ *
+ * DexContext only ever reads the CONNECTED chain, so once a member can select a
+ * pair on Base while their wallet sits on Polygon, the ticket needs a balance
+ * source that follows the PAIR's network instead of the wallet's. This is that
+ * source, scoped deliberately narrowly: only the legs currently on screen, which
+ * is two reads, not a portfolio scan.
+ *
+ * Honest-state (constitution III): an unread balance is `null`, never `0`. The
+ * ticket shows "…" for null and never invites a member to trade against a number
+ * we failed to fetch. A read that fails leaves the previous value alone rather
+ * than zeroing it.
+ *
+ * @param {{ chainId: number|null, address: string|null, tokens: Array<{address: string, decimals: number}> }} params
+ * @returns {{ balances: Record<string, string|null>, loading: boolean, refresh: () => Promise<void> }}
+ */
+export function useSwapBalances({ chainId, address, tokens = [] } = {}) {
+  const [balances, setBalances] = useState({})
+  const [loading, setLoading] = useState(false)
+  const reqIdRef = useRef(0)
+  const endpointRevision = useEndpointsRevision()
+
+  // Identity of the read set — deduped, lower-cased, order-independent — so a
+  // re-render that rebuilds the same token array does not refetch.
+  const targets = useMemo(() => {
+    const byAddress = new Map()
+    for (const token of tokens || []) {
+      if (!token?.address) continue
+      byAddress.set(token.address.toLowerCase(), {
+        address: token.address,
+        decimals: token.decimals ?? 18,
+      })
+    }
+    return [...byAddress.values()].sort((a, b) => a.address.localeCompare(b.address))
+  }, [tokens])
+  const targetKey = targets.map((t) => `${t.address.toLowerCase()}:${t.decimals}`).join(',')
+
+  const numericChainId = Number(chainId)
+  const rpcUrl = NETWORKS[numericChainId]?.rpcUrl || null
+
+  const load = useCallback(async () => {
+    if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') return
+    if (!address || !rpcUrl || targets.length === 0) return
+
+    const reqId = ++reqIdRef.current
+    setLoading(true)
+    try {
+      const provider = makeReadProvider(rpcUrl, numericChainId)
+      const results = await Promise.all(
+        targets.map(async (token) => {
+          try {
+            const raw = await new Contract(token.address, BALANCE_OF_ABI, provider).balanceOf(address)
+            return [token.address.toLowerCase(), formatUnits(raw, token.decimals)]
+          } catch (error) {
+            // Stale-or-unknown, never zero: a failed read must not read as "no funds".
+            logger.debug?.('Swap balance read failed', token.address, error?.message)
+            return [token.address.toLowerCase(), null]
+          }
+        }),
+      )
+      if (reqId !== reqIdRef.current) return // a newer read superseded this one
+      setBalances((prev) => {
+        const next = { ...prev }
+        for (const [key, value] of results) {
+          // Keep the last known figure when this read failed.
+          if (value != null || next[key] === undefined) next[key] = value
+        }
+        return next
+      })
+    } finally {
+      if (reqId === reqIdRef.current) setLoading(false)
+    }
+  }, [address, rpcUrl, numericChainId, targets])
+
+  // A different network or account means the old figures belong to someone else.
+  useEffect(() => {
+    setBalances({})
+  }, [numericChainId, address])
+
+  // `targetKey` (not `targets`) keeps this to real changes in the read set;
+  // `endpointRevision` re-reads after the member repoints a network (spec 069).
+  useEffect(() => {
+    load()
+  }, [load, targetKey, endpointRevision])
+
+  return { balances, loading, refresh: load }
+}
+
+export default useSwapBalances

--- a/frontend/src/lib/assets/__tests__/assetSearch.test.js
+++ b/frontend/src/lib/assets/__tests__/assetSearch.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { matchesAssetQuery, filterAssetsByQuery } from '../assetSearch'
+
+// The shared asset-search rule: match ONLY the fields a member can see on an
+// option (symbol, asset name, network name). Both the Universal Asset Selector
+// and the Trade ticket's pair pickers narrow through this, so a change here is a
+// change to every selector at once.
+
+const OPTIONS = [
+  { key: '137:wmatic', symbol: 'WMATIC', name: 'Wrapped MATIC', networkName: 'Polygon', address: '0xAAA' },
+  { key: '8453:weth', symbol: 'WETH', name: 'Wrapped Ether', networkName: 'Base', address: '0xBBB' },
+  { key: '61:usc', symbol: 'USC', name: 'Classic USD', networkName: 'Ethereum Classic', address: '0xCCC' },
+]
+
+describe('matchesAssetQuery', () => {
+  it('matches everything for an empty or blank query', () => {
+    for (const query of ['', '   ', null, undefined]) {
+      expect(OPTIONS.every((o) => matchesAssetQuery(o, query))).toBe(true)
+    }
+  })
+
+  it('matches on symbol, name, and network name, case-insensitively', () => {
+    expect(matchesAssetQuery(OPTIONS[0], 'wmatic')).toBe(true)
+    expect(matchesAssetQuery(OPTIONS[0], 'WRAPPED')).toBe(true)
+    expect(matchesAssetQuery(OPTIONS[1], 'base')).toBe(true)
+    expect(matchesAssetQuery(OPTIONS[2], 'classic')).toBe(true)
+  })
+
+  it('matches substrings and ignores surrounding whitespace', () => {
+    expect(matchesAssetQuery(OPTIONS[1], '  eth  ')).toBe(true)
+    expect(matchesAssetQuery(OPTIONS[1], 'wrapped eth')).toBe(true)
+  })
+
+  it('never matches on a field the member cannot see', () => {
+    // Address: typing part of one must not silently narrow the list.
+    expect(matchesAssetQuery(OPTIONS[0], '0xaaa')).toBe(false)
+    expect(matchesAssetQuery({ symbol: 'X', categoryId: 'digital-commodities' }, 'commodities')).toBe(false)
+  })
+
+  it('tolerates missing fields instead of throwing', () => {
+    expect(matchesAssetQuery({}, 'usdc')).toBe(false)
+    expect(matchesAssetQuery(null, 'usdc')).toBe(false)
+    expect(matchesAssetQuery({ symbol: 42 }, '42')).toBe(false) // non-string fields don't match
+  })
+})
+
+describe('filterAssetsByQuery', () => {
+  it('narrows the list while preserving the caller’s ordering', () => {
+    expect(filterAssetsByQuery(OPTIONS, 'wrapped').map((o) => o.key)).toEqual([
+      '137:wmatic',
+      '8453:weth',
+    ])
+  })
+
+  it('returns an empty list rather than everything when nothing matches', () => {
+    expect(filterAssetsByQuery(OPTIONS, 'zzz')).toEqual([])
+    expect(filterAssetsByQuery(undefined, 'zzz')).toEqual([])
+  })
+})

--- a/frontend/src/lib/assets/assetSearch.js
+++ b/frontend/src/lib/assets/assetSearch.js
@@ -1,0 +1,31 @@
+/**
+ * Asset-option search, shared by every selector that lists more than one
+ * network's assets (spec 067's UniversalAssetSelect, the multi-network Trade
+ * ticket's pair pickers).
+ *
+ * ONE rule, in one place: match on the three fields a member can actually SEE on
+ * an option — the symbol, the asset name, and the network name. Matching a hidden
+ * field (an address, a category id) would make the list narrow for reasons the
+ * member cannot see; matching fewer would make a network name they are staring at
+ * un-searchable. Search only ever narrows what is already eligible, so typing
+ * can never surface an option the caller's own rules excluded.
+ */
+
+/** The visible fields a query is matched against. */
+const SEARCHABLE_FIELDS = ['symbol', 'name', 'networkName']
+
+/** Whether `option` matches `query` (empty/blank query matches everything). */
+export function matchesAssetQuery(option, query) {
+  const needle = String(query ?? '').trim().toLowerCase()
+  if (!needle) return true
+  return SEARCHABLE_FIELDS.some((field) => {
+    const value = option?.[field]
+    return typeof value === 'string' && value.toLowerCase().includes(needle)
+  })
+}
+
+/** `options` narrowed to `query`, preserving the caller's ordering. */
+export const filterAssetsByQuery = (options = [], query) =>
+  (options || []).filter((option) => matchesAssetQuery(option, query))
+
+export default matchesAssetQuery

--- a/frontend/src/lib/uniswap/__tests__/quote.test.js
+++ b/frontend/src/lib/uniswap/__tests__/quote.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest'
+import { parseUnits } from 'ethers'
+import { quoteBestRoute } from '../quote'
+import { ROUTED_FEE_TIERS } from '../trade'
+
+/**
+ * Best-route quoting, the one implementation shared by the connected chain and
+ * every other swap-capable network. The routine is handed a quoter, so these
+ * tests hand it a fake one and assert the behavior a trader depends on: the
+ * DEEPEST tier wins, a tier with no pool is skipped rather than fatal, and a
+ * pair with no liquidity anywhere fails loudly instead of quoting zero.
+ */
+
+/** A QuoterV2 stand-in: `pools` maps fee tier → output per unit of input. */
+function fakeQuoter(pools, { onCall } = {}) {
+  return {
+    quoteExactInputSingle: {
+      staticCall: vi.fn(async (params) => {
+        onCall?.(params)
+        const rate = pools[Number(params.fee)]
+        if (rate == null) throw new Error('execution reverted') // no pool at this tier
+        // 6-decimal output for an 18-decimal input, the WMATIC/USDC shape.
+        const out = (BigInt(params.amountIn) * BigInt(Math.round(rate * 1e6))) / 10n ** 18n
+        if (out <= 0n) throw new Error('execution reverted')
+        return [out, 0n, 0n, 21000n]
+      }),
+    },
+  }
+}
+
+const BASE_ARGS = {
+  chainId: 137,
+  tokenIn: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+  tokenOut: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+  amountIn: '10',
+  decimalsIn: 18,
+  decimalsOut: 6,
+  symbolIn: 'WMATIC',
+  symbolOut: 'USDC',
+  slippageBps: 50,
+}
+
+describe('quoteBestRoute', () => {
+  it('keeps the deepest fee tier and reports it as the route', async () => {
+    const quoter = fakeQuoter({ 500: 0.4, 3000: 0.5, 10000: 0.3 })
+    const quote = await quoteBestRoute({ ...BASE_ARGS, quoter })
+
+    expect(quote.feeTier).toBe(3000)
+    expect(quote.amountOut).toBe('5.0')
+    expect(quote.tokenInSymbol).toBe('WMATIC')
+    expect(quote.tokenOutSymbol).toBe('USDC')
+    // The quote states which chain it came from — a cross-chain ticket needs it.
+    expect(quote.chainId).toBe(137)
+  })
+
+  it('probes every routed tier and survives the ones with no pool', async () => {
+    const seen = []
+    const quoter = fakeQuoter({ 100: 0.45 }, { onCall: (p) => seen.push(Number(p.fee)) })
+    const quote = await quoteBestRoute({ ...BASE_ARGS, quoter })
+
+    expect(quote.feeTier).toBe(100)
+    for (const tier of ROUTED_FEE_TIERS) expect(seen).toContain(tier)
+  })
+
+  it('enforces slippage as the minimum received', async () => {
+    const quoter = fakeQuoter({ 3000: 0.5 })
+    const quote = await quoteBestRoute({ ...BASE_ARGS, quoter, slippageBps: 100 })
+
+    // 5 USDC less 1% — the figure we can enforce on-chain as amountOutMinimum.
+    expect(quote.minimumReceivedWei).toBe(parseUnits('4.95', 6))
+    expect(quote.minimumReceived).toBe('4.95')
+  })
+
+  it('derives price impact from a near-spot reference quote', async () => {
+    // A pool that pays proportionally less on size than at spot has real impact.
+    const quoter = {
+      quoteExactInputSingle: {
+        staticCall: vi.fn(async ({ fee, amountIn }) => {
+          if (Number(fee) !== 3000) throw new Error('execution reverted')
+          const rate = BigInt(amountIn) > parseUnits('1', 18) ? 495_000n : 500_000n
+          return [(BigInt(amountIn) * rate) / 10n ** 18n, 0n, 0n, 21000n]
+        }),
+      },
+    }
+    const quote = await quoteBestRoute({ ...BASE_ARGS, quoter })
+    expect(quote.priceImpactPercent).toBeGreaterThan(0.5)
+    expect(quote.priceImpactPercent).toBeLessThan(1.5)
+  })
+
+  it('leaves impact null when the reference quote is unavailable — never a guess', async () => {
+    const quoter = {
+      quoteExactInputSingle: {
+        staticCall: vi.fn(async ({ fee, amountIn }) => {
+          if (Number(fee) !== 3000) throw new Error('execution reverted')
+          if (BigInt(amountIn) < parseUnits('1', 18)) throw new Error('execution reverted')
+          return [(BigInt(amountIn) * 500_000n) / 10n ** 18n, 0n, 0n, 21000n]
+        }),
+      },
+    }
+    const quote = await quoteBestRoute({ ...BASE_ARGS, quoter })
+    expect(quote.priceImpactPercent).toBeNull()
+    expect(quote.amountOut).toBe('5.0')
+  })
+
+  it('fails loudly when no tier holds liquidity', async () => {
+    await expect(quoteBestRoute({ ...BASE_ARGS, quoter: fakeQuoter({}) })).rejects.toThrow(
+      /No liquidity route available/,
+    )
+  })
+
+  it('refuses a non-positive amount', async () => {
+    await expect(
+      quoteBestRoute({ ...BASE_ARGS, amountIn: '0', quoter: fakeQuoter({ 3000: 0.5 }) }),
+    ).rejects.toThrow(/greater than zero/)
+  })
+})

--- a/frontend/src/lib/uniswap/__tests__/swapUniverse.test.js
+++ b/frontend/src/lib/uniswap/__tests__/swapUniverse.test.js
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildSwapOptions,
+  counterpartFor,
+  defaultPairForChain,
+  findSwapOption,
+  findSwapOptionByAddress,
+  getSwapAddresses,
+  getSwapTokenMeta,
+  getSwapTokens,
+  getSwapVenue,
+  isSwapChain,
+  swapOptionKey,
+} from '../swapUniverse'
+import { samePair, createPin, PIN_MODE } from '../../assets/networkPin'
+import { NETWORKS, getSwapChainIds } from '../../../config/networks'
+
+/**
+ * The cross-network swap universe. The properties that matter are the ones a
+ * wrong answer would break in a way a member could lose money over:
+ *   - a chain is only listed when it has BOTH the policy gate and real router
+ *     config (a listed chain with no router is a ticket that cannot fill);
+ *   - addresses are strictly per-chain (a borrowed router/quoter is an approval
+ *     sent to a foreign address);
+ *   - the options this module produces satisfy the SHARED pair rule (`samePair`),
+ *     so pair pinning is not re-derived here.
+ */
+
+describe('isSwapChain / getSwapChainIds', () => {
+  it('lists only chains with both the swap gate and router config, mainnets first', () => {
+    const ids = getSwapChainIds()
+    expect(ids).toContain(137) // Polygon — canonical Uniswap
+    expect(ids).toContain(61) // Ethereum Classic — ETCswap
+    expect(ids).toContain(8453) // Base — its own V3 addresses
+    expect(ids).not.toContain(1337) // local sandbox: no DEX
+    expect(ids.every((id) => isSwapChain(id))).toBe(true)
+    const firstTestnet = ids.findIndex((id) => NETWORKS[id].isTestnet)
+    if (firstTestnet !== -1) {
+      expect(ids.slice(firstTestnet).every((id) => NETWORKS[id].isTestnet)).toBe(true)
+    }
+  })
+
+  it('refuses chains with no DEX at all', () => {
+    expect(isSwapChain(1337)).toBe(false)
+    expect(isSwapChain(11155111)).toBe(false)
+    expect(isSwapChain(undefined)).toBe(false)
+  })
+})
+
+describe('getSwapAddresses', () => {
+  it('returns that chain’s own router/quoter/wrapped-native, never another chain’s', () => {
+    const polygon = getSwapAddresses(137)
+    const base = getSwapAddresses(8453)
+    expect(polygon.swapRouter).toBe(NETWORKS[137].dex.swapRouter)
+    expect(base.swapRouter).toBe(NETWORKS[8453].dex.swapRouter)
+    // Base deliberately does NOT share the canonical Uniswap addresses.
+    expect(base.swapRouter).not.toBe(polygon.swapRouter)
+    expect(base.quoter).not.toBe(polygon.quoter)
+    expect(polygon.stablecoin).toBe(NETWORKS[137].stablecoin.address)
+  })
+
+  it('returns null for a chain that cannot swap — no silent fallback', () => {
+    expect(getSwapAddresses(1337)).toBeNull()
+    expect(getSwapAddresses(999999)).toBeNull()
+  })
+})
+
+describe('getSwapTokens / getSwapTokenMeta', () => {
+  it('offers the registry’s ERC-20s and never the native coin (it must be wrapped)', () => {
+    const tokens = getSwapTokens(137)
+    expect(tokens.length).toBeGreaterThan(1)
+    expect(tokens.every((t) => Boolean(t.address))).toBe(true)
+    expect(tokens.some((t) => t.symbol === 'MATIC')).toBe(false)
+    expect(tokens.some((t) => t.symbol === 'WMATIC')).toBe(true)
+    expect(tokens.some((t) => t.symbol === 'USDC')).toBe(true)
+    // NFT credentials are not tradeable legs.
+    expect(tokens.some((t) => t.symbol === 'FWMV')).toBe(false)
+  })
+
+  it('is empty on a chain that cannot swap', () => {
+    expect(getSwapTokens(1337)).toEqual([])
+  })
+
+  it('resolves leg decimals for quote math, case-insensitively', () => {
+    const usdc = NETWORKS[137].stablecoin.address
+    expect(getSwapTokenMeta(137, usdc.toUpperCase()).decimals).toBe(6)
+    expect(getSwapTokenMeta(137, NETWORKS[137].dex.wnative).decimals).toBe(18)
+    // The same address on a chain that does not host it is not a leg there.
+    expect(getSwapTokenMeta(8453, usdc)).toBeNull()
+  })
+})
+
+describe('buildSwapOptions', () => {
+  it('spans every swap-capable mainnet, keyed by chain and address', () => {
+    const options = buildSwapOptions({ connectedChainId: 137 })
+    const chains = new Set(options.map((o) => o.chainId))
+    expect(chains.size).toBeGreaterThan(1)
+    expect(chains.has(137)).toBe(true)
+    expect(chains.has(8453)).toBe(true)
+    expect(chains.has(61)).toBe(true)
+
+    const wmatic = findSwapOptionByAddress(options, 137, NETWORKS[137].dex.wnative)
+    expect(wmatic.key).toBe(swapOptionKey(137, NETWORKS[137].dex.wnative))
+    expect(wmatic.networkName).toBe('Polygon')
+    expect(wmatic.venueName).toBe('Uniswap')
+    // Keys are unique — two chains' USDC must never collide into one option.
+    expect(new Set(options.map((o) => o.key)).size).toBe(options.length)
+  })
+
+  it('puts the connected network first — its pairs need no switch', () => {
+    expect(buildSwapOptions({ connectedChainId: 8453 })[0].chainId).toBe(8453)
+    expect(buildSwapOptions({ connectedChainId: 61 })[0].chainId).toBe(61)
+  })
+
+  it('hides testnet pairs unless the member is on that testnet', () => {
+    const mainnetView = buildSwapOptions({ connectedChainId: 137 })
+    expect(mainnetView.some((o) => o.isTestnet)).toBe(false)
+    // Mordor's DEX is env-configured; when it is off there is simply nothing to
+    // show, which is the same honest outcome as hiding it.
+    const mordorView = buildSwapOptions({ connectedChainId: 63 })
+    expect(mordorView.filter((o) => o.isTestnet).every((o) => o.chainId === 63)).toBe(true)
+  })
+
+  it('produces options the SHARED pair rule accepts (no second pin rule here)', () => {
+    const options = buildSwapOptions({ connectedChainId: 137 })
+    const base = options.find((o) => o.chainId === 8453)
+    const pin = createPin(base, PIN_MODE.SAME_NETWORK)
+    const eligible = options.filter((o) => samePair(o, pin))
+    expect(eligible.length).toBeGreaterThan(0)
+    expect(eligible.every((o) => o.chainId === 8453)).toBe(true)
+  })
+})
+
+describe('defaultPairForChain', () => {
+  it('opens on wrapped-native → the network stablecoin', () => {
+    const options = buildSwapOptions({ connectedChainId: 137 })
+    const pair = defaultPairForChain(options, 137)
+    expect(pair.from.address).toBe(NETWORKS[137].dex.wnative)
+    expect(pair.to.address).toBe(NETWORKS[137].stablecoin.address)
+  })
+
+  it('returns null where no pair can form', () => {
+    const options = buildSwapOptions({ connectedChainId: 137 })
+    expect(defaultPairForChain(options, 1337)).toBeNull()
+    expect(defaultPairForChain([], 137)).toBeNull()
+    expect(defaultPairForChain(options, undefined)).toBeNull()
+  })
+})
+
+describe('counterpartFor', () => {
+  const options = buildSwapOptions({ connectedChainId: 137 })
+  const polygonWmatic = findSwapOptionByAddress(options, 137, NETWORKS[137].dex.wnative)
+  const polygonUsdc = findSwapOptionByAddress(options, 137, NETWORKS[137].stablecoin.address)
+  const baseWeth = findSwapOptionByAddress(options, 8453, NETWORKS[8453].dex.wnative)
+
+  it('keeps a receive leg that is still on the pinned network', () => {
+    expect(counterpartFor(options, 137, polygonWmatic, polygonUsdc)).toBe(polygonUsdc)
+  })
+
+  it('replaces an off-network leg with the pinned network’s stablecoin', () => {
+    const next = counterpartFor(options, 8453, baseWeth, polygonUsdc)
+    expect(next.chainId).toBe(8453)
+    expect(next.address).toBe(NETWORKS[8453].stablecoin.address)
+  })
+
+  it('never returns the leg being sold', () => {
+    const baseUsdc = findSwapOptionByAddress(options, 8453, NETWORKS[8453].stablecoin.address)
+    const next = counterpartFor(options, 8453, baseUsdc, baseUsdc)
+    expect(next.key).not.toBe(baseUsdc.key)
+    expect(next.chainId).toBe(8453)
+  })
+
+  it('returns null when the network has nothing to pair against', () => {
+    expect(counterpartFor([polygonWmatic], 137, polygonWmatic, null)).toBeNull()
+  })
+})
+
+describe('getSwapVenue / findSwapOption', () => {
+  it('names the pair network’s own DEX', () => {
+    expect(getSwapVenue(61).name).toBe('ETCswap')
+    expect(getSwapVenue(137).name).toBe('Uniswap')
+    expect(getSwapVenue(1337)).toBeNull()
+  })
+
+  it('finds nothing for an unknown key rather than guessing', () => {
+    const options = buildSwapOptions({ connectedChainId: 137 })
+    expect(findSwapOption(options, 'nope')).toBeNull()
+    expect(findSwapOption(options, undefined)).toBeNull()
+  })
+})

--- a/frontend/src/lib/uniswap/quote.js
+++ b/frontend/src/lib/uniswap/quote.js
@@ -1,0 +1,129 @@
+/**
+ * Best-route quoting against a Uniswap V3 QuoterV2 — for ANY chain's quoter.
+ *
+ * Extracted from DexContext so the same routine serves both the connected chain
+ * (through the wallet's provider) and every other swap-capable network (through
+ * that network's read provider). The caller supplies the quoter contract and the
+ * leg metadata; this module owns only the routing + SDK math, so there is one
+ * implementation of "what does this pair actually pay out" rather than a second
+ * cross-chain copy that could drift from the one members already trade against.
+ *
+ * Chain-agnostic by construction: `chainId` is used solely to build SDK Token
+ * instances for the figures, never to pick addresses — those arrive from the
+ * caller, already resolved per-chain.
+ */
+import { ethers } from 'ethers'
+import { toSdkToken, buildTradeMetrics, ROUTED_FEE_TIERS } from './trade'
+
+/**
+ * Probe the routed fee tiers and return the deepest fill, decorated with the
+ * figures a trading UI shows (execution price, minimum received, price impact).
+ *
+ * @param {object} p
+ * @param {ethers.Contract} p.quoter QuoterV2 bound to `chainId`'s read provider
+ * @param {number} p.chainId         chain the pool lives on (SDK Token identity)
+ * @param {string} p.tokenIn         leg being sold
+ * @param {string} p.tokenOut        leg being bought
+ * @param {string} p.amountIn        human amount of `tokenIn`
+ * @param {number} p.decimalsIn
+ * @param {number} p.decimalsOut
+ * @param {string} p.symbolIn
+ * @param {string} p.symbolOut
+ * @param {number} p.slippageBps     tolerance enforced as amountOutMinimum
+ * @returns {Promise<object>} the quote shape TradePanel renders
+ * @throws when the amount is non-positive or no fee tier holds liquidity
+ */
+export async function quoteBestRoute({
+  quoter,
+  chainId,
+  tokenIn,
+  tokenOut,
+  amountIn,
+  decimalsIn,
+  decimalsOut,
+  symbolIn,
+  symbolOut,
+  slippageBps,
+}) {
+  const amountInWei = ethers.parseUnits(amountIn, decimalsIn)
+  if (amountInWei <= 0n) {
+    throw new Error('Enter an amount greater than zero')
+  }
+
+  // Probe each fee tier; QuoterV2 reverts where no pool exists, so we keep
+  // the deepest output across the tiers that do quote — a lightweight route.
+  let best = null
+  for (const fee of ROUTED_FEE_TIERS) {
+    try {
+      const res = await quoter.quoteExactInputSingle.staticCall({
+        tokenIn,
+        tokenOut,
+        amountIn: amountInWei,
+        fee,
+        sqrtPriceLimitX96: 0,
+      })
+      const out = res[0]
+      if (out > 0n && (!best || out > best.amountOutWei)) {
+        best = { fee, amountOutWei: out, gasEstimate: res[3] }
+      }
+    } catch {
+      // No pool for this fee tier — skip it.
+    }
+  }
+
+  if (!best) {
+    throw new Error('No liquidity route available for this pair')
+  }
+
+  // Near-spot reference quote (a fraction of the size) on the winning tier,
+  // used to derive price impact via the SDK. Optional — impact is hidden if
+  // the reference quote is unavailable.
+  let refInWei = amountInWei / 1000n
+  if (refInWei <= 0n) refInWei = 1n
+  let refAmountInRaw = null
+  let refAmountOutRaw = null
+  try {
+    const refRes = await quoter.quoteExactInputSingle.staticCall({
+      tokenIn,
+      tokenOut,
+      amountIn: refInWei,
+      fee: best.fee,
+      sqrtPriceLimitX96: 0,
+    })
+    if (refRes[0] > 0n) {
+      refAmountInRaw = refInWei
+      refAmountOutRaw = refRes[0]
+    }
+  } catch {
+    // Impact figure is best-effort.
+  }
+
+  const metrics = buildTradeMetrics({
+    tokenIn: toSdkToken(chainId, tokenIn, decimalsIn, symbolIn),
+    tokenOut: toSdkToken(chainId, tokenOut, decimalsOut, symbolOut),
+    amountInRaw: amountInWei,
+    amountOutRaw: best.amountOutWei,
+    refAmountInRaw,
+    refAmountOutRaw,
+    slippageBps,
+  })
+
+  return {
+    chainId: Number(chainId),
+    amountOut: ethers.formatUnits(best.amountOutWei, decimalsOut),
+    amountOutWei: best.amountOutWei,
+    feeTier: best.fee,
+    gasEstimate: best.gasEstimate,
+    executionPrice: metrics.executionPrice.toSignificant(6),
+    executionPriceInverted: metrics.executionPrice.invert().toSignificant(6),
+    minimumReceived: ethers.formatUnits(metrics.minimumReceivedRaw, decimalsOut),
+    minimumReceivedWei: metrics.minimumReceivedRaw,
+    priceImpactPercent: metrics.priceImpact
+      ? parseFloat(metrics.priceImpact.toSignificant(4))
+      : null,
+    tokenInSymbol: symbolIn,
+    tokenOutSymbol: symbolOut,
+  }
+}
+
+export default quoteBestRoute

--- a/frontend/src/lib/uniswap/swapUniverse.js
+++ b/frontend/src/lib/uniswap/swapUniverse.js
@@ -1,0 +1,171 @@
+/**
+ * The cross-network swap universe — every tradeable pair leg the app can route,
+ * on every network that has a real V3 deployment, not just the connected one.
+ *
+ * WHY THIS EXISTS. The Trade ticket used to derive its token list from the
+ * ACTIVE chain only (`DexContext.tradeTokens`), so a member connected to Polygon
+ * could not even see that WETH/USDC exists on Base. Listing every network's legs
+ * in one place is a READ concern: quotes come from each chain's own QuoterV2 over
+ * that chain's read provider, exactly the way the portfolio reads balances across
+ * chains (spec 044) and ClearPath reads DAOs across chains. Only the WRITE (the
+ * swap itself) needs the wallet to actually be on the pair's network.
+ *
+ * ONE NETWORK PER PAIR. A Uniswap V3 pool lives on a single chain, so a pair is
+ * never cross-chain: pick the first leg and the second leg is pinned to that
+ * leg's network. The rule is not re-derived here — `lib/assets/networkPin.js`
+ * already owns it (`samePair`, the exact inverse of the bridge's `bridgeDest`),
+ * and this module produces options in the shape those predicates read
+ * (`{ key, chainId, symbol, networkName, … }`, spec 064's SelectableAsset).
+ * Moving value BETWEEN networks is the Bridge's job, never this ticket's.
+ *
+ * Pure and synchronous: bundled config only, no chain reads, no React. The
+ * per-chain token derivation is deliberately identical to the one DexContext
+ * used for the active chain (registry ERC-20s with an address), so the active
+ * chain's list does not change shape now that other chains sit beside it.
+ */
+
+import { NETWORKS, getSwapChainIds } from '../../config/networks'
+import { getPortfolioRegistry } from '../../config/assetTaxonomy'
+
+/** Stable identity for a pair leg. Same `chainId:address` form as spec 064's asset keys. */
+export const swapOptionKey = (chainId, address) =>
+  `${Number(chainId)}:${String(address || '').toLowerCase()}`
+
+/** Whether `chainId` has BOTH the swap policy gate and real router config. */
+export function isSwapChain(chainId) {
+  const net = NETWORKS[Number(chainId)]
+  return Boolean(net?.capabilities?.dex)
+}
+
+/**
+ * The DEX addresses a swap on `chainId` routes through, or null when the chain
+ * has no deployment. Strictly per-chain — never falls back to another network's
+ * router, which would send an approval to a foreign address.
+ */
+export function getSwapAddresses(chainId) {
+  const net = NETWORKS[Number(chainId)]
+  if (!net?.capabilities?.dex) return null
+  return {
+    factory: net.dex.factory,
+    swapRouter: net.dex.swapRouter,
+    quoter: net.dex.quoter,
+    wnative: net.dex.wnative,
+    stablecoin: net.stablecoin?.address || null,
+  }
+}
+
+/** `{ name, url }` for the chain's DEX (ETCswap on the ETC family, else Uniswap). */
+export const getSwapVenue = (chainId) => NETWORKS[Number(chainId)]?.dexProvider ?? null
+
+/**
+ * The tradeable ERC-20s on one network: every registry asset with an address.
+ * Native coins are excluded (they must be wrapped first) as are NFT credentials.
+ * Returns [] for a chain with no DEX, which is what drives the honest empty state.
+ */
+export function getSwapTokens(chainId) {
+  if (!isSwapChain(chainId)) return []
+  return getPortfolioRegistry(Number(chainId))
+    .filter((entry) => entry.kind === 'erc20' && entry.address)
+    .map((entry) => ({
+      address: entry.address,
+      symbol: entry.symbol,
+      name: entry.name,
+      decimals: entry.decimals,
+    }))
+}
+
+/** Metadata for one leg (decimals/symbol for quote math), or null if unknown here. */
+export function getSwapTokenMeta(chainId, address) {
+  if (!address) return null
+  const lower = String(address).toLowerCase()
+  return getSwapTokens(chainId).find((t) => t.address.toLowerCase() === lower) || null
+}
+
+/**
+ * Every pair leg on every swap-capable network, as selector options.
+ *
+ * Testnets are included only when the member is actually connected to one: a
+ * mainnet member has no business seeing Mordor liquidity, but a member ON Mordor
+ * must be able to trade there. (Mordor/Amoy build their `dex` from env vars, so
+ * `isSwapChain` already hides them where they are unconfigured.)
+ *
+ * Ordering puts the connected network first — its pairs are the ones that need no
+ * network switch — then mainnets, keeping each network's registry order (wrapped
+ * native, the stablecoin, then curated assets) so the common legs stay on top.
+ */
+export function buildSwapOptions({ connectedChainId = null } = {}) {
+  const connected = Number(connectedChainId)
+  const chainIds = getSwapChainIds().filter(
+    (id) => !NETWORKS[id]?.isTestnet || id === connected,
+  )
+  const ordered = [
+    ...chainIds.filter((id) => id === connected),
+    ...chainIds.filter((id) => id !== connected),
+  ]
+
+  const options = []
+  for (const chainId of ordered) {
+    const net = NETWORKS[chainId]
+    for (const token of getSwapTokens(chainId)) {
+      options.push({
+        key: swapOptionKey(chainId, token.address),
+        chainId,
+        kind: 'erc20',
+        address: token.address,
+        symbol: token.symbol,
+        name: token.name,
+        decimals: token.decimals,
+        networkName: net.name,
+        isTestnet: Boolean(net.isTestnet),
+        venueName: net.dexProvider?.name || null,
+      })
+    }
+  }
+  return options
+}
+
+/** The option matching `key`, or null. */
+export const findSwapOption = (options, key) =>
+  (options || []).find((o) => o.key === key) || null
+
+/** The first option on `chainId` whose address matches, or null. */
+export const findSwapOptionByAddress = (options, chainId, address) =>
+  findSwapOption(options, swapOptionKey(chainId, address))
+
+/**
+ * The ticket's opening pair on a network: sell wrapped-native for the
+ * stablecoin — the same default the single-chain ticket has always used. Falls
+ * back to the first two legs when a chain lacks one of them, and returns null
+ * when the network cannot form a pair at all.
+ */
+export function defaultPairForChain(options, chainId) {
+  const legs = (options || []).filter((o) => o.chainId === Number(chainId))
+  if (legs.length < 2) return null
+  const addrs = getSwapAddresses(chainId)
+  const at = (address) =>
+    address ? legs.find((o) => o.address.toLowerCase() === String(address).toLowerCase()) : null
+  const from = at(addrs?.wnative) || legs[0]
+  const to = at(addrs?.stablecoin) || legs.find((o) => o.key !== from.key)
+  if (!to || to.key === from.key) return null
+  return { from, to }
+}
+
+/**
+ * The counterpart to auto-select when the pinned network changes (the member
+ * picked a first leg on another chain). Keeps the existing choice when it is
+ * still on the pinned network — a pin move must never silently repoint a leg the
+ * member deliberately chose — and otherwise prefers that network's stablecoin so
+ * the ticket stays immediately quotable instead of half-empty.
+ */
+export function counterpartFor(options, chainId, firstLeg, current) {
+  if (current && current.chainId === Number(chainId) && current.key !== firstLeg?.key) return current
+  const legs = (options || []).filter(
+    (o) => o.chainId === Number(chainId) && o.key !== firstLeg?.key,
+  )
+  if (legs.length === 0) return null
+  const stable = getSwapAddresses(chainId)?.stablecoin
+  const preferred = stable
+    ? legs.find((o) => o.address.toLowerCase() === String(stable).toLowerCase())
+    : null
+  return preferred || legs[0]
+}

--- a/frontend/src/test/DexContext.crossChain.test.jsx
+++ b/frontend/src/test/DexContext.crossChain.test.jsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { useChainId } from 'wagmi'
+import { DexProvider } from '../contexts/DexContext.jsx'
+import { useDex } from '../hooks/useDex'
+import { NETWORKS } from '../config/networks'
+
+// Multi-network trading splits the DEX layer in two:
+//   READ  — `getBestQuoteOn(chainId, …)` prices a pair on ANY swap-capable
+//           network, using THAT network's quoter over THAT network's provider.
+//   WRITE — `swap()` still runs against the connected chain's router, so it must
+//           refuse an order aimed at another network BEFORE any signature. That
+//           guard is the reason the UI can safely list off-network pairs.
+
+const { mockQuoteBestRoute, mockMakeReadProvider, sendCalls } = vi.hoisted(() => ({
+  mockQuoteBestRoute: vi.fn().mockResolvedValue({ amountOut: '1.0', feeTier: 3000 }),
+  mockMakeReadProvider: vi.fn(() => ({ tag: 'read-provider' })),
+  sendCalls: vi.fn().mockResolvedValue({ state: 'confirmed' }),
+}))
+
+vi.mock('../hooks/useWalletManagement', () => ({
+  useWallet: () => ({
+    provider: null,
+    signer: null,
+    address: '0x1111222233334444555566667777888899990000',
+    isConnected: true,
+    sendCalls,
+  }),
+}))
+vi.mock('../lib/uniswap/quote', () => ({ quoteBestRoute: mockQuoteBestRoute }))
+vi.mock('../utils/rpcProvider', () => ({ makeReadProvider: mockMakeReadProvider }))
+
+const POLYGON_WMATIC = NETWORKS[137].dex.wnative
+const POLYGON_USDC = NETWORKS[137].stablecoin.address
+const BASE_WETH = NETWORKS[8453].dex.wnative
+const BASE_USDC = NETWORKS[8453].stablecoin.address
+
+let dex = null
+
+function Probe() {
+  dex = useDex()
+  return <span data-testid="ready">{String(Boolean(dex.getBestQuoteOn))}</span>
+}
+
+function renderAt(chainId) {
+  useChainId.mockReturnValue(chainId)
+  return render(
+    <DexProvider>
+      <Probe />
+    </DexProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockQuoteBestRoute.mockResolvedValue({ amountOut: '1.0', feeTier: 3000 })
+  mockMakeReadProvider.mockReturnValue({ tag: 'read-provider' })
+  dex = null
+})
+
+describe('DexContext — cross-chain quoting (the read half of multi-network trading)', () => {
+  it('quotes another network with that network’s quoter, decimals and symbols', async () => {
+    renderAt(137)
+    await screen.findByTestId('ready')
+
+    await dex.getBestQuoteOn(8453, BASE_WETH, BASE_USDC, '1')
+
+    // The read provider is built for the PAIR's chain, not the connected one.
+    expect(mockMakeReadProvider).toHaveBeenCalledWith(NETWORKS[8453].rpcUrl, 8453)
+    const args = mockQuoteBestRoute.mock.calls.at(-1)[0]
+    expect(args.chainId).toBe(8453)
+    // Base's own quoter — Base deliberately does not share Uniswap's canonical addresses.
+    expect(args.quoter.target ?? args.quoter.address).toBe(NETWORKS[8453].dex.quoter)
+    expect(args.decimalsIn).toBe(18)
+    expect(args.decimalsOut).toBe(6)
+    expect(args.symbolIn).toBe('WETH')
+    expect(args.symbolOut).toBe('USDC')
+    expect(args.slippageBps).toBe(50)
+  })
+
+  it('quotes the connected network through the context’s own contracts', async () => {
+    renderAt(137)
+    await screen.findByTestId('ready')
+
+    await dex.getBestQuote(POLYGON_WMATIC, POLYGON_USDC, '1')
+
+    const args = mockQuoteBestRoute.mock.calls.at(-1)[0]
+    expect(args.chainId).toBe(137)
+    expect(args.symbolIn).toBe('WMATIC')
+    expect(args.symbolOut).toBe('USDC')
+  })
+
+  it('refuses to quote a network with no DEX instead of borrowing another’s router', async () => {
+    renderAt(137)
+    await screen.findByTestId('ready')
+
+    await expect(dex.getBestQuoteOn(1337, POLYGON_WMATIC, POLYGON_USDC, '1')).rejects.toThrow(
+      /not available/i,
+    )
+    expect(mockQuoteBestRoute).not.toHaveBeenCalled()
+  })
+})
+
+describe('DexContext — a swap never runs on a network the wallet is not on', () => {
+  it('refuses an order aimed at another chain, before any signature', async () => {
+    renderAt(137)
+    await screen.findByTestId('ready')
+
+    await expect(
+      dex.swap(BASE_WETH, BASE_USDC, '1', { chainId: 8453 }),
+    ).rejects.toThrow(/trades on Base/)
+    // Nothing was quoted, approved, or sent.
+    expect(mockQuoteBestRoute).not.toHaveBeenCalled()
+    expect(sendCalls).not.toHaveBeenCalled()
+  })
+
+  it('lets a same-chain order through the guard and on to a fresh quote', async () => {
+    mockQuoteBestRoute.mockResolvedValue({
+      amountOut: '1.0',
+      amountOutWei: 1_000_000n,
+      feeTier: 3000,
+      minimumReceivedWei: 995_000n,
+    })
+    renderAt(137)
+    await screen.findByTestId('ready')
+
+    // The order proceeds past the chain guard: it re-quotes at execution time so
+    // the on-chain minimum matches the freshest price. (Signing itself needs a
+    // real wallet runner, which a unit test has no business standing up.)
+    await dex.swap(POLYGON_WMATIC, POLYGON_USDC, '1', { chainId: 137 }).catch(() => {})
+    await waitFor(() =>
+      expect(mockQuoteBestRoute.mock.calls.at(-1)[0].chainId).toBe(137),
+    )
+  })
+})

--- a/frontend/src/test/TradePanel.test.jsx
+++ b/frontend/src/test/TradePanel.test.jsx
@@ -2,19 +2,29 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 
 // TradePanel is the brokerage-style order ticket for on-chain swaps. It must:
-//  - name/link the DEX provider for the active network (ETCswap on the ETC
+//  - list pairs from EVERY swap-capable network, not just the connected one, and
+//    keep a pair on ONE network: choosing the pay leg pins the receive leg's
+//    chain (lib/assets/networkPin.js#samePair — never the bridge's bridgeDest);
+//  - quote a pair on its own network (getBestQuoteOn) even while the wallet sits
+//    elsewhere, then require the network switch BEFORE the order can be placed;
+//  - offer a search filter in both pair selectors — ~35 legs across six networks
+//    is not a scrollable list;
+//  - carry each leg's balance on its own pay/receive card and NO balance rows on
+//    the account card;
+//  - name/link the DEX provider for the PAIR's network (ETCswap on the ETC
 //    family, Uniswap elsewhere) while subtly attributing the Uniswap V3 protocol
 //    that powers routing (Spec 033 provider-awareness, preserved);
 //  - present a professional trade read-out (rate, price impact, minimum
-//    received, route) fed by getBestQuote();
+//    received, route);
 //  - let the member trade as their personal wallet or as a saved multisig
-//    vault (Spec 043), with balances that follow the selected account;
+//    vault (Spec 043);
 //  - offer the price types Uniswap V3 actually supports (Market, and Limit as
 //    immediate-or-cancel via amountOutMinimum) and gate perpetuals order types
 //    (Sell Short / Buy to Cover) on a per-network perps venue — hidden where
 //    none exists (honest-state).
-// We mock the DEX/wallet/token/account hooks so the component is exercised in
-// isolation.
+// The DEX/wallet/account hooks are mocked so the component is exercised in
+// isolation; the pair UNIVERSE deliberately comes from the real network config,
+// because "which pairs exist" is exactly what this feature is about.
 
 const {
   mockUseDex,
@@ -22,12 +32,16 @@ const {
   mockUseChainTokens,
   mockUseActiveAccount,
   mockUseCustodyVaults,
+  mockUseSwapBalances,
+  switchChainAsync,
 } = vi.hoisted(() => ({
   mockUseDex: vi.fn(),
   mockUseWallet: vi.fn(),
   mockUseChainTokens: vi.fn(),
   mockUseActiveAccount: vi.fn(),
   mockUseCustodyVaults: vi.fn(),
+  mockUseSwapBalances: vi.fn(),
+  switchChainAsync: vi.fn().mockResolvedValue({}),
 }))
 
 vi.mock('../hooks/useDex', () => ({ useDex: mockUseDex }))
@@ -36,22 +50,32 @@ vi.mock('../hooks/useChainTokens', () => ({ useChainTokens: mockUseChainTokens }
 vi.mock('../hooks/useActiveAccount', () => ({ useActiveAccount: mockUseActiveAccount }))
 vi.mock('../hooks/useCustodyVaults', () => ({ useCustodyVaults: mockUseCustodyVaults }))
 vi.mock('../hooks/useLegacyAccounts', () => ({ useLegacyAccounts: () => [] }))
+vi.mock('../hooks/useSwapBalances', () => ({ useSwapBalances: mockUseSwapBalances }))
 vi.mock('../components/account/LegacyUnlockDialog', () => ({ default: () => null }))
+vi.mock('wagmi', () => ({
+  useSwitchChain: () => ({ switchChainAsync, isPending: false }),
+}))
 
 import TradePanel from '../components/fairwins/TradePanel'
 
-const ETC_ADDRESSES = {
-  WNATIVE: '0x1953cab0E5bFa6D4a9BaD6E05fD46C1CC6527a5a',
-  STABLECOIN: '0xDE093684c796204224BC081f937aa059D903c52a',
-  SWAP_ROUTER_02: '0xEd88EDD995b00956097bF90d39C9341BBde324d1',
-}
-const POLYGON_ADDRESSES = {
-  WNATIVE: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
-  STABLECOIN: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+// Real config addresses — the pair universe is built from networks.js itself.
+const POLYGON = {
+  WMATIC: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+  USDC: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+  WBTC: '0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6',
   SWAP_ROUTER_02: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
+}
+const BASE = {
+  WETH: '0x4200000000000000000000000000000000000006',
+  USDC: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+}
+const ETC = {
+  WETC: '0x1953cab0E5bFa6D4a9BaD6E05fD46C1CC6527a5a',
+  USC: '0xDE093684c796204224BC081f937aa059D903c52a',
 }
 
 const SAMPLE_QUOTE = {
+  chainId: 137,
   amountOut: '1.23',
   amountOutWei: 1230000n,
   feeTier: 3000,
@@ -61,62 +85,30 @@ const SAMPLE_QUOTE = {
   minimumReceived: '1.22385',
   minimumReceivedWei: 1223850n,
   priceImpactPercent: 0.42,
-  tokenInSymbol: 'WPOL',
+  tokenInSymbol: 'WMATIC',
   tokenOutSymbol: 'USDC',
 }
 
-// Tradeable-token universe (spec: the selectors list every portfolio asset with
-// a routeable pair on the active chain). Keyed by address; wrapped-native and
-// the stablecoin lead, followed by curated commodities/tools.
-const ETC_TOKENS = [
-  { address: ETC_ADDRESSES.WNATIVE, symbol: 'WETC', name: 'Wrapped Ethereum Classic', decimals: 18 },
-  { address: ETC_ADDRESSES.STABLECOIN, symbol: 'USC', name: 'Classic USD', decimals: 6 },
-]
-const POLYGON_TOKENS = [
-  { address: POLYGON_ADDRESSES.WNATIVE, symbol: 'WPOL', name: 'Wrapped POL', decimals: 18 },
-  { address: POLYGON_ADDRESSES.STABLECOIN, symbol: 'USDC', name: 'USD Coin', decimals: 6 },
-  { address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619', symbol: 'WETH', name: 'Wrapped Ether', decimals: 18 },
-  { address: '0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6', symbol: 'WBTC', name: 'Wrapped BTC', decimals: 8 },
-  { address: '0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39', symbol: 'LINK', name: 'ChainLink Token', decimals: 18 },
-  { address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F', symbol: 'USDT', name: 'Tether USD', decimals: 6 },
-]
-
-const balancesFor = (tokenList) => ({
-  native: '10',
-  wnative: '5',
-  stable: '100',
-  tokens: Object.fromEntries(
-    tokenList.map((t) => [t.address.toLowerCase(), t.symbol === 'USC' || t.symbol === 'USDC' ? '100' : '5']),
-  ),
-})
-
 function dexValue(overrides = {}) {
   return {
-    balances: balancesFor(ETC_TOKENS),
     loading: false,
     quotingPrice: false,
     wrapNative: vi.fn(),
     unwrapNative: vi.fn(),
     swap: vi.fn().mockResolvedValue({}),
-    getBestQuote: vi.fn().mockResolvedValue(SAMPLE_QUOTE),
+    getBestQuoteOn: vi.fn().mockResolvedValue(SAMPLE_QUOTE),
     slippage: 50,
     setSlippage: vi.fn(),
-    addresses: ETC_ADDRESSES,
-    tokens: { STABLE: { decimals: 6, symbol: 'USC' }, WNATIVE: { decimals: 18, symbol: 'WETC' } },
-    tradeTokens: ETC_TOKENS,
     isDexAvailable: true,
     dexProvider: { name: 'ETCswap', url: 'https://v3.etcswap.org' },
     network: { name: 'Ethereum Classic', chainId: 61 },
+    tradingAddress: '0x1111222233334444555566667777888899990000',
     ...overrides,
   }
 }
 
 const polygonDex = (overrides = {}) =>
   dexValue({
-    balances: balancesFor(POLYGON_TOKENS),
-    addresses: POLYGON_ADDRESSES,
-    tokens: { STABLE: { decimals: 6, symbol: 'USDC' }, WNATIVE: { decimals: 18, symbol: 'WPOL' } },
-    tradeTokens: POLYGON_TOKENS,
     dexProvider: { name: 'Uniswap', url: 'https://app.uniswap.org/swap?chain=polygon' },
     network: { name: 'Polygon', chainId: 137 },
     ...overrides,
@@ -134,11 +126,34 @@ function personalAccount(overrides = {}) {
   }
 }
 
+/** Balances keyed by lower-cased address, the shape useSwapBalances returns. */
+const balancesFor = (entries) =>
+  Object.fromEntries(Object.entries(entries).map(([addr, v]) => [addr.toLowerCase(), v]))
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockUseActiveAccount.mockReturnValue(personalAccount())
   mockUseCustodyVaults.mockReturnValue({ vaults: [], supported: false })
+  mockUseSwapBalances.mockReturnValue({
+    balances: balancesFor({
+      [POLYGON.WMATIC]: '5',
+      [POLYGON.USDC]: '100',
+      [POLYGON.WBTC]: '0.25',
+      [BASE.WETH]: '2',
+      [BASE.USDC]: '40',
+      [ETC.WETC]: '5',
+      [ETC.USC]: '100',
+    }),
+    loading: false,
+    refresh: vi.fn(),
+  })
 })
+
+/** Open a pair selector and return its listbox. */
+function openSelector(name) {
+  fireEvent.click(screen.getByRole('button', { name }))
+  return screen.getByRole('listbox')
+}
 
 describe('TradePanel — provider identity & attribution', () => {
   beforeEach(() => {
@@ -146,11 +161,11 @@ describe('TradePanel — provider identity & attribution', () => {
     mockUseChainTokens.mockReturnValue({ native: 'ETC', stable: 'USC' })
   })
 
-  it('names ETCswap and links to it on an ETC-family chain', () => {
+  it('names ETCswap and links to it for an ETC-family pair', () => {
     mockUseDex.mockReturnValue(dexValue())
     render(<TradePanel />)
 
-    // Venue badge + subtitle name the chain's DEX.
+    // Venue badge + subtitle name the DEX of the pair's network.
     expect(screen.getAllByText('ETCswap').length).toBeGreaterThan(0)
     expect(screen.getByText('ETCswap Router ↗')).toBeInTheDocument()
     const link = screen.getByRole('link', { name: /Open ETCswap/ })
@@ -159,7 +174,7 @@ describe('TradePanel — provider identity & attribution', () => {
     expect(screen.getByText(/Uniswap v3 protocol/i)).toBeInTheDocument()
   })
 
-  it('names Uniswap and links to it on a non-ETC chain', () => {
+  it('names Uniswap and links to it for a Polygon pair', () => {
     mockUseWallet.mockReturnValue({ isConnected: true, chainId: 137 })
     mockUseChainTokens.mockReturnValue({ native: 'POL', stable: 'USDC' })
     mockUseDex.mockReturnValue(polygonDex())
@@ -169,26 +184,8 @@ describe('TradePanel — provider identity & attribution', () => {
     const link = screen.getByRole('link', { name: /Open Uniswap/ })
     expect(link).toHaveAttribute('href', expect.stringContaining('app.uniswap.org'))
     expect(screen.getByText(/Powered by Uniswap v3/i)).toBeInTheDocument()
-    // No ETCswap on a non-ETC chain.
+    // No ETCswap for a Polygon pair.
     expect(screen.queryByText(/ETCswap/)).toBeNull()
-  })
-
-  it('disabled-state names the chain provider, never the wrong one', () => {
-    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 63 })
-    mockUseChainTokens.mockReturnValue({ native: 'ETC', stable: 'USC' })
-    mockUseDex.mockReturnValue(
-      dexValue({
-        isDexAvailable: false,
-        dexProvider: { name: 'ETCswap', url: 'https://etcswap.org' },
-        network: { name: 'Ethereum Classic Mordor', chainId: 63 },
-      }),
-    )
-    render(<TradePanel />)
-
-    expect(
-      screen.getByText(/ETCswap is not configured on Ethereum Classic Mordor/),
-    ).toBeInTheDocument()
-    expect(screen.queryByText(/Uniswap/)).toBeNull()
   })
 
   it('prompts to connect when the wallet is disconnected', () => {
@@ -200,30 +197,235 @@ describe('TradePanel — provider identity & attribution', () => {
   })
 })
 
+describe('TradePanel — multi-network pair selection', () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 137 })
+    mockUseChainTokens.mockReturnValue({ native: 'POL', stable: 'USDC' })
+    mockUseDex.mockReturnValue(polygonDex())
+  })
+
+  it('lists pay-leg tokens from every supported network, named with their network', () => {
+    render(<TradePanel />)
+
+    const sellList = openSelector('Token to sell')
+    // The connected network's own legs…
+    expect(within(sellList).getByRole('option', { name: 'WMATIC on Polygon' })).toBeInTheDocument()
+    expect(within(sellList).getByRole('option', { name: 'WBTC on Polygon' })).toBeInTheDocument()
+    // …plus other networks', which the single-chain ticket could never show.
+    expect(within(sellList).getByRole('option', { name: 'WETH on Base' })).toBeInTheDocument()
+    expect(within(sellList).getByRole('option', { name: 'USDC on Optimism' })).toBeInTheDocument()
+    expect(within(sellList).getByRole('option', { name: 'WETH on Arbitrum One' })).toBeInTheDocument()
+    expect(within(sellList).getByRole('option', { name: 'WETC on Ethereum Classic' })).toBeInTheDocument()
+    // Each option carries the shared asset artwork (glyph + network sub-badge).
+    expect(
+      within(sellList).getByRole('option', { name: 'WETH on Base' }).querySelector('.asset-logo'),
+    ).toBeInTheDocument()
+  })
+
+  it('groups the list by network, connected network first', () => {
+    render(<TradePanel />)
+
+    const sellList = openSelector('Token to sell')
+    const headings = Array.from(sellList.querySelectorAll('.trade-token-group')).map((el) =>
+      el.textContent.trim(),
+    )
+    expect(headings[0]).toBe('Polygon')
+    expect(headings).toContain('Base')
+    expect(headings).toContain('Ethereum Classic')
+  })
+
+  it('filters the list by token symbol, token name, or network name', () => {
+    render(<TradePanel />)
+
+    openSelector('Token to sell')
+    const search = screen.getByLabelText('Search tokens')
+
+    fireEvent.change(search, { target: { value: 'base' } })
+    let list = screen.getByRole('listbox')
+    expect(within(list).getByRole('option', { name: 'WETH on Base' })).toBeInTheDocument()
+    expect(within(list).queryByRole('option', { name: 'WMATIC on Polygon' })).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'wrapped btc' } })
+    list = screen.getByRole('listbox')
+    expect(within(list).getByRole('option', { name: 'WBTC on Polygon' })).toBeInTheDocument()
+    expect(within(list).queryByRole('option', { name: 'WETH on Base' })).toBeNull()
+
+    // A query that matches nothing says so, and names what can be searched.
+    fireEvent.change(search, { target: { value: 'zzz' } })
+    expect(screen.queryByRole('listbox')).toBeNull()
+    expect(screen.getByText(/No token matches/)).toBeInTheDocument()
+  })
+
+  it('pins the receive leg to the pay leg’s network (one pool, one chain)', () => {
+    render(<TradePanel />)
+
+    const sellList = openSelector('Token to sell')
+    fireEvent.click(within(sellList).getByRole('option', { name: 'WETH on Base' }))
+
+    // Picking Base moved the pair: the counterpart is Base's stablecoin.
+    expect(screen.getByRole('button', { name: 'Token to sell' })).toHaveTextContent('WETH')
+    expect(screen.getByRole('button', { name: 'Token to buy' })).toHaveTextContent('USDC')
+
+    const buyList = openSelector('Token to buy')
+    expect(within(buyList).getByRole('option', { name: 'USDC on Base' })).toBeInTheDocument()
+    // Nothing off-network, and never the leg already being sold.
+    expect(within(buyList).queryByRole('option', { name: 'USDC on Polygon' })).toBeNull()
+    expect(within(buyList).queryByRole('option', { name: 'WETH on Base' })).toBeNull()
+    expect(screen.getByText(/a pair lives on one network/i)).toBeInTheDocument()
+  })
+
+  it('quotes the pair on its own network, not the wallet’s', async () => {
+    const getBestQuoteOn = vi.fn().mockResolvedValue({ ...SAMPLE_QUOTE, chainId: 8453 })
+    mockUseDex.mockReturnValue(polygonDex({ getBestQuoteOn }))
+    render(<TradePanel />)
+
+    const sellList = openSelector('Token to sell')
+    fireEvent.click(within(sellList).getByRole('option', { name: 'WETH on Base' }))
+    fireEvent.change(screen.getByLabelText('You pay'), { target: { value: '1' } })
+
+    await waitFor(() =>
+      expect(getBestQuoteOn).toHaveBeenCalledWith(8453, BASE.WETH, BASE.USDC, '1'),
+    )
+  })
+
+  it('asks for the network switch before an off-network order, and never offers to place it', async () => {
+    mockUseDex.mockReturnValue(polygonDex())
+    render(<TradePanel />)
+
+    const sellList = openSelector('Token to sell')
+    fireEvent.click(within(sellList).getByRole('option', { name: 'WETH on Base' }))
+    fireEvent.change(screen.getByLabelText('You pay'), { target: { value: '1' } })
+
+    // Disclosed before any signature, with the switch as the only primary action.
+    expect(screen.getByText(/This pair trades on Base and your wallet is on Polygon/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Swap / })).toBeNull()
+
+    const switchBtn = screen.getByRole('button', { name: 'Switch to Base' })
+    fireEvent.click(switchBtn)
+    await waitFor(() => expect(switchChainAsync).toHaveBeenCalledWith({ chainId: 8453 }))
+  })
+
+  it('keeps a cross-network pick when the wallet follows it to that network', async () => {
+    const { rerender } = render(<TradePanel />)
+
+    const sellList = openSelector('Token to sell')
+    fireEvent.click(within(sellList).getByRole('option', { name: 'WETH on Base' }))
+
+    // The member switched networks; the pair they chose must survive it.
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 8453 })
+    mockUseDex.mockReturnValue(polygonDex({ network: { name: 'Base', chainId: 8453 } }))
+    rerender(<TradePanel />)
+
+    expect(screen.getByRole('button', { name: 'Token to sell' })).toHaveTextContent('WETH')
+    expect(screen.queryByText(/Switch to Base/)).toBeNull()
+    fireEvent.change(screen.getByLabelText('You pay'), { target: { value: '1' } })
+    expect(await screen.findByRole('button', { name: /Swap WETH for USDC/ })).toBeInTheDocument()
+  })
+
+  it('offers pairs from other networks when the connected chain has no DEX', () => {
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 63 })
+    mockUseChainTokens.mockReturnValue({ native: 'ETC', stable: 'USC' })
+    mockUseDex.mockReturnValue(
+      dexValue({
+        isDexAvailable: false,
+        dexProvider: { name: 'ETCswap', url: 'https://etcswap.org' },
+        network: { name: 'Ethereum Classic Mordor', chainId: 63 },
+      }),
+    )
+    render(<TradePanel />)
+
+    // Honest about the connected network without becoming a dead end.
+    expect(
+      screen.getByText(/Ethereum Classic Mordor has no DEX deployment/),
+    ).toBeInTheDocument()
+    const sellList = openSelector('Token to sell')
+    expect(within(sellList).getByRole('option', { name: 'WMATIC on Polygon' })).toBeInTheDocument()
+    expect(within(sellList).queryByRole('option', { name: /on Ethereum Classic Mordor/ })).toBeNull()
+  })
+})
+
+describe('TradePanel — balances live on the pair cards', () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue({
+      isConnected: true,
+      chainId: 137,
+      address: '0x1111222233334444555566667777888899990000',
+    })
+    mockUseChainTokens.mockReturnValue({ native: 'POL', stable: 'USDC' })
+    mockUseDex.mockReturnValue(polygonDex())
+  })
+
+  it('shows each leg’s balance on its own card and none on the account card', () => {
+    render(<TradePanel />)
+
+    const balances = screen.getAllByText(/^Balance:/)
+    expect(balances).toHaveLength(2)
+    expect(balances[0].closest('.trade-leg')).toBeInTheDocument()
+    // The old account-card read-outs are gone.
+    expect(screen.queryByText(/Available to trade/)).toBeNull()
+    expect(screen.queryByText(/Cash available/)).toBeNull()
+  })
+
+  it('reads balances for the PAIR’s network and account', () => {
+    render(<TradePanel />)
+
+    expect(mockUseSwapBalances).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chainId: 137,
+        address: '0x1111222233334444555566667777888899990000',
+        tokens: [
+          { address: POLYGON.WMATIC, decimals: 18 },
+          { address: POLYGON.USDC, decimals: 6 },
+        ],
+      }),
+    )
+  })
+
+  it('MAX fills the pay leg from its balance', () => {
+    render(<TradePanel />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'MAX' }))
+    expect(screen.getByLabelText('You pay')).toHaveValue(5)
+  })
+
+  it('never renders an unread balance as zero', () => {
+    mockUseSwapBalances.mockReturnValue({ balances: {}, loading: true, refresh: vi.fn() })
+    render(<TradePanel />)
+
+    expect(screen.getAllByLabelText('balance loading').length).toBe(2)
+    expect(screen.getByRole('button', { name: 'MAX' })).toBeDisabled()
+  })
+})
+
 describe('TradePanel — SDK-driven trade read-out', () => {
   beforeEach(() => {
     mockUseWallet.mockReturnValue({ isConnected: true, chainId: 137 })
     mockUseChainTokens.mockReturnValue({ native: 'POL', stable: 'USDC' })
   })
 
-  it('quotes via getBestQuote and surfaces rate, impact, minimum received and route', async () => {
-    const getBestQuote = vi.fn().mockResolvedValue(SAMPLE_QUOTE)
-    mockUseDex.mockReturnValue(polygonDex({ getBestQuote }))
+  it('quotes via getBestQuoteOn and surfaces rate, impact, minimum received and route', async () => {
+    const getBestQuoteOn = vi.fn().mockResolvedValue(SAMPLE_QUOTE)
+    mockUseDex.mockReturnValue(polygonDex({ getBestQuoteOn }))
     render(<TradePanel />)
 
     fireEvent.change(screen.getByLabelText('You pay'), { target: { value: '1' } })
 
-    await waitFor(() => expect(getBestQuote).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(getBestQuoteOn).toHaveBeenCalledWith(137, POLYGON.WMATIC, POLYGON.USDC, '1'),
+    )
 
     // Best-execution output is shown on the receive leg.
     expect(await screen.findByText('1.23')).toBeInTheDocument()
     // Rate, price impact, minimum received, and the routed fee-tier pool.
-    expect(screen.getByText(/1 WPOL = 1.23 USDC/)).toBeInTheDocument()
+    expect(screen.getByText(/1 WMATIC = 1.23 USDC/)).toBeInTheDocument()
     expect(screen.getByText('0.42%')).toBeInTheDocument()
     // The minimum-received amount is wrapped in <SensitiveValue> for tilt-to-hide
     // (spec 047), so assert against the row that holds both amount and symbol.
     expect(screen.getByText('1.22385').closest('.trade-summary-val')).toHaveTextContent(/1.22385\s*USDC/)
     expect(screen.getByText('0.3% pool')).toBeInTheDocument()
+    // The route names the network it runs on — with six networks listed, the
+    // fee tier alone no longer identifies the pool.
+    expect(screen.getByText('on Polygon')).toBeInTheDocument()
   })
 
   it('inverts the rate line when tapped', async () => {
@@ -231,26 +433,22 @@ describe('TradePanel — SDK-driven trade read-out', () => {
     render(<TradePanel />)
 
     fireEvent.change(screen.getByLabelText('You pay'), { target: { value: '1' } })
-    const rate = await screen.findByText(/1 WPOL = 1.23 USDC/)
+    const rate = await screen.findByText(/1 WMATIC = 1.23 USDC/)
     fireEvent.click(rate)
-    expect(screen.getByText(/1 USDC = 0.813008 WPOL/)).toBeInTheDocument()
+    expect(screen.getByText(/1 USDC = 0.813008 WMATIC/)).toBeInTheDocument()
   })
 
-  it('executes the swap through the DEX swap()', async () => {
+  it('executes the swap through the DEX swap(), pinned to the pair’s network', async () => {
     const swap = vi.fn().mockResolvedValue({})
     mockUseDex.mockReturnValue(polygonDex({ swap }))
     render(<TradePanel />)
 
     fireEvent.change(screen.getByLabelText('You pay'), { target: { value: '1' } })
-    const execBtn = await screen.findByRole('button', { name: /Swap WPOL for USDC/ })
+    const execBtn = await screen.findByRole('button', { name: /Swap WMATIC for USDC/ })
     fireEvent.click(execBtn)
 
     await waitFor(() =>
-      expect(swap).toHaveBeenCalledWith(
-        POLYGON_ADDRESSES.WNATIVE,
-        POLYGON_ADDRESSES.STABLECOIN,
-        '1',
-      ),
+      expect(swap).toHaveBeenCalledWith(POLYGON.WMATIC, POLYGON.USDC, '1', { chainId: 137 }),
     )
   })
 
@@ -261,26 +459,6 @@ describe('TradePanel — SDK-driven trade read-out', () => {
     expect(screen.queryByRole('tablist', { name: 'Trade mode' })).toBeNull()
     expect(screen.queryByRole('tab', { name: 'Wrap' })).toBeNull()
     expect(screen.queryByRole('tab', { name: 'Unwrap' })).toBeNull()
-  })
-
-  it('lists every tradeable portfolio asset, with its icon, in both selectors', () => {
-    mockUseDex.mockReturnValue(polygonDex())
-    render(<TradePanel />)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Token to sell' }))
-    const sellList = screen.getByRole('listbox')
-    for (const symbol of ['WPOL', 'USDC', 'WETH', 'WBTC', 'LINK', 'USDT']) {
-      const option = within(sellList).getByRole('option', { name: symbol })
-      expect(option).toBeInTheDocument()
-      expect(option.querySelector('.asset-logo')).toBeInTheDocument()
-    }
-    fireEvent.click(screen.getByRole('button', { name: 'Token to sell' }))
-
-    fireEvent.click(screen.getByRole('button', { name: 'Token to buy' }))
-    const buyList = screen.getByRole('listbox')
-    for (const symbol of ['WPOL', 'USDC', 'WETH', 'WBTC', 'LINK', 'USDT']) {
-      expect(within(buyList).getByRole('option', { name: symbol })).toBeInTheDocument()
-    }
   })
 })
 
@@ -295,7 +473,7 @@ describe('TradePanel — account selection (spec 043)', () => {
     mockUseDex.mockReturnValue(polygonDex())
   })
 
-  it('lists the personal wallet and every saved multisig, and shows account balances', () => {
+  it('lists the personal wallet and every saved multisig', () => {
     mockUseCustodyVaults.mockReturnValue({
       supported: true,
       vaults: [
@@ -309,10 +487,6 @@ describe('TradePanel — account selection (spec 043)', () => {
     expect(picker).toBeInTheDocument()
     expect(screen.getByRole('option', { name: /Personal wallet · 0x1111…0000/ })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: /Ops Treasury · Multisig/ })).toBeInTheDocument()
-
-    // Available-to-trade figures for the selected account (pay leg = WPOL).
-    expect(screen.getByText(/Available to trade \(WPOL\)/)).toBeInTheDocument()
-    expect(screen.getByText(/Cash available \(USDC\)/)).toBeInTheDocument()
   })
 
   it('switches the active identity when a multisig is selected', () => {
@@ -343,6 +517,26 @@ describe('TradePanel — account selection (spec 043)', () => {
     expect(screen.getByText('Multisig proposal')).toBeInTheDocument()
     expect(screen.getByText(/proposed to the multisig/)).toBeInTheDocument()
   })
+
+  it('says plainly that a multisig cannot trade a pair on another network', async () => {
+    mockUseActiveAccount.mockReturnValue(
+      personalAccount({
+        identity: { mode: 'vault', vaultAddress: '0xVaultAAA', chainId: 137, label: 'Ops Treasury' },
+        isVault: true,
+        canActAsVault: true,
+      }),
+    )
+    mockUseCustodyVaults.mockReturnValue({
+      supported: true,
+      vaults: [{ address: '0xVaultAAA', chainId: 137, label: 'Ops Treasury' }],
+    })
+    render(<TradePanel />)
+
+    const sellList = openSelector('Token to sell')
+    fireEvent.click(within(sellList).getByRole('option', { name: 'WETH on Base' }))
+
+    expect(screen.getByText(/This multisig lives on Polygon/)).toBeInTheDocument()
+  })
 })
 
 describe('TradePanel — order & price types', () => {
@@ -355,20 +549,31 @@ describe('TradePanel — order & price types', () => {
     mockUseDex.mockReturnValue(polygonDex())
     render(<TradePanel />)
 
-    // Default direction WPOL → USDC reads as Sell.
+    // Default direction WMATIC → USDC reads as Sell.
     expect(screen.getByLabelText(/Order Type/).value).toBe('sell')
 
     fireEvent.change(screen.getByLabelText(/Order Type/), { target: { value: 'buy' } })
     // Buy pays the stablecoin to receive the wrapped-native asset.
     expect(screen.getByRole('button', { name: 'Token to sell' })).toHaveTextContent('USDC')
-    expect(screen.getByRole('button', { name: 'Token to buy' })).toHaveTextContent('WPOL')
+    expect(screen.getByRole('button', { name: 'Token to buy' })).toHaveTextContent('WMATIC')
 
     // Flipping the pair back flips the order type too.
-    fireEvent.click(screen.getByRole('button', { name: 'Token to sell' }))
-    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'WPOL' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Token to buy' }))
-    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'USDC' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Switch direction' }))
     expect(screen.getByLabelText(/Order Type/).value).toBe('sell')
+  })
+
+  it('re-seeds Buy/Sell on the pair’s own network, never the wallet’s', () => {
+    mockUseDex.mockReturnValue(polygonDex())
+    render(<TradePanel />)
+
+    const sellList = openSelector('Token to sell')
+    fireEvent.click(within(sellList).getByRole('option', { name: 'WETH on Base' }))
+    fireEvent.change(screen.getByLabelText(/Order Type/), { target: { value: 'buy' } })
+
+    // Base's own USDC → WETH, and the pair is still a Base pair.
+    expect(screen.getByRole('button', { name: 'Token to sell' })).toHaveTextContent('USDC')
+    expect(screen.getByRole('button', { name: 'Token to buy' })).toHaveTextContent('WETH')
+    expect(screen.getByRole('button', { name: 'Switch to Base' })).toBeInTheDocument()
   })
 
   it('offers Market and Limit price types and passes the limit floor to swap()', async () => {
@@ -388,12 +593,10 @@ describe('TradePanel — order & price types', () => {
 
     // 1 × 1.3 at 6 stable decimals → 1300000n enforced as amountOutMinimum.
     await waitFor(() =>
-      expect(swap).toHaveBeenCalledWith(
-        POLYGON_ADDRESSES.WNATIVE,
-        POLYGON_ADDRESSES.STABLECOIN,
-        '1',
-        { limitMinOutWei: 1300000n },
-      ),
+      expect(swap).toHaveBeenCalledWith(POLYGON.WMATIC, POLYGON.USDC, '1', {
+        chainId: 137,
+        limitMinOutWei: 1300000n,
+      }),
     )
   })
 
@@ -405,7 +608,7 @@ describe('TradePanel — order & price types', () => {
     expect(screen.queryByRole('option', { name: 'Buy to Cover' })).toBeNull()
   })
 
-  it('offers Sell Short / Buy to Cover only where the network has a perps venue', () => {
+  it('offers Sell Short / Buy to Cover only where the pair’s network has a perps venue', () => {
     mockUseDex.mockReturnValue(
       polygonDex({ network: { name: 'Polygon', chainId: 137, perps: { name: 'TestPerps' } } }),
     )
@@ -438,7 +641,7 @@ describe('TradePanel — session rails (passkey & gasless)', () => {
     expect(screen.getByText(/One passkey confirmation covers the whole order/)).toBeInTheDocument()
   })
 
-  it('is honest when a passkey session cannot transact on this network', () => {
+  it('is honest when a passkey session cannot transact on the pair’s network', () => {
     mockUseWallet.mockReturnValue({ isConnected: true, chainId: 61, loginMethod: 'passkey' })
     mockUseDex.mockReturnValue(dexValue()) // network has no passkey rail
     render(<TradePanel />)


### PR DESCRIPTION
## What

The Trade ticket derived its token list from the **connected chain alone**, so a member on Polygon could not even see that WETH/USDC exists on Base. It now lists pairs from **every swap-capable network**, keeps a pair on one network, drops the account-card balance rows, and makes both pair selectors searchable.

Listing and pricing pairs is a **read**, so it spans networks the same way the cross-chain portfolio scan does: each chain answers over its own read provider. Only *placing* the order needs the wallet to be on the pair's network.

| Concern | Scope |
| --- | --- |
| Which pairs exist | every swap-capable network (`lib/uniswap/swapUniverse.js`) |
| Quote | the **pair's** network, read-only (`DexContext.getBestQuoteOn`) |
| Leg balances | the **pair's** network, read-only (`hooks/useSwapBalances.js`) |
| The swap | the **connected** network only (`DexContext.swap(…, { chainId })`) |

## Changes

- **`lib/uniswap/swapUniverse.js`** (new, pure) — the cross-network pair universe: chains via a new `getSwapChainIds()` in `config/networks.js` (the `capabilities.dex` gate: policy allow-list **and** real router config), legs from the portfolio registry, strictly per-chain addresses, venue, default pair, counterpart choice. Testnet pairs are listed only to a member connected to that testnet. DexContext's own active-chain list is now this same derivation instead of a second copy of it.
- **`lib/uniswap/quote.js`** (new) — best-route probing + SDK math extracted from DexContext, so a cross-chain quote and a local one are the same computation. `DexContext.getBestQuoteOn(chainId, …)` builds that chain's QuoterV2 over that chain's provider; `getBestQuote` remains the connected-chain wrapper.
- **One network per pair** — picking the pay leg pins the network and the receive selector offers only that chain's legs, via the shared `samePair` predicate from `lib/assets/networkPin.js` (never the bridge's `bridgeDest`). A pin move keeps a still-valid receive leg, else falls back to that network's stablecoin.
- **A swap never runs on a network the wallet is not on** — the panel discloses the pending switch and makes it the primary action instead of the order button, and `swap()` re-checks `opts.chainId` and throws before any signature. Both layers matter: an approval against the wrong chain's router address is unrecoverable.
- **Searchable, network-grouped selectors** — `TradeTokenSelect` gained a filter (symbol, token name, network name) and per-network group headings; option accessible names are now "SYMBOL on Network" since WETH exists on four chains. The match rule lives in `lib/assets/assetSearch.js`, now shared with `UniversalAssetSelect` so both narrow on exactly the fields a member can see.
- **Balances moved off the account card** onto the pay/receive cards, following the pair's network for the acting account (`useSwapBalances`). An unread balance renders as "…" and disables MAX — never as `0`.
- **Venue identity follows the pair** — DEX name/link, perps gating, passkey + sponsorship disclosure and the router explorer link all resolve from the pair's network, so an ETC pair is never labelled Uniswap. A connected chain with no DEX is no longer a dead end: it says so and lists other networks' pairs.
- Docs: `docs/developer-guide/multi-network-swaps.md`.

## Testing

`npx vitest run` over the affected suites — 154 passing, ESLint clean:

- `test/TradePanel.test.jsx` (rewritten, 31 tests) — multi-network listing, grouping, filtering, pin behavior, cross-chain quoting, the switch-before-order flow, cross-network pick surviving a wallet switch, balances on the cards / none on the account card, unread-balance honesty, vault-off-network disclosure.
- `test/DexContext.crossChain.test.jsx` (new) — quotes use the pair chain's provider/quoter/decimals; a no-DEX chain is refused rather than borrowing another router; an off-chain order throws before anything is quoted, approved or sent.
- `lib/uniswap/__tests__/swapUniverse.test.js`, `lib/uniswap/__tests__/quote.test.js`, `lib/assets/__tests__/assetSearch.test.js`, `hooks/__tests__/useSwapBalances.test.js` (all new).
- `test/Dashboard.test.jsx`, `test/WalletButton.test.jsx`, `test/DexContext.test.jsx`, `components/ui/__tests__/UniversalAssetSelect.test.jsx` — unchanged and passing.

The full suite is left to CI (it does not complete in this environment).

## Notes for review

- Networks with a `dex` block but outside `SWAP_CHAIN_IDS` (Amoy, 80002) are now treated as non-swappable, matching the documented `capabilities.dex` gate. Previously the panel would render a ticket there while the capability said no.
- The network switch is an explicit two-step (switch, then order) rather than a switch-at-signing, because `DexContext`'s router/quoter contracts are derived from the wallet chain — signing through a just-switched chain would race a stale contract set.

---
_Generated by [Claude Code](https://claude.ai/code/session_0151gVMYaW8gcf4wcv8AbCQh)_