### PR TITLE
Clean up Transfer → Bridge: fix duplicated intro, de-narrate routine notes

### DIFF
--- a/frontend/src/components/wallet/Bridge.css
+++ b/frontend/src/components/wallet/Bridge.css
@@ -56,10 +56,19 @@
   margin: 0;
 }
 
-/* Honest unavailable / explanatory blocks — same shape as .earn-unavailable so the two
+/* A routine, non-blocking disclosure (a withheld network, a screening unknown, a
+   partial route read) — stated plainly inline, like .bridge-hint, never boxed.
+   Boxing every fact on the screen is what read as narrative clutter; a card is
+   reserved for a state that actually blocks the member (below). */
+.bridge-note {
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.82rem;
+  margin: 0;
+}
+
+/* Honest unavailable / blocking blocks — same shape as .earn-unavailable so the two
    sections read as one app. */
 .bridge-unavailable,
-.bridge-note,
 .bridge-switch-note,
 .bridge-gas-warning,
 .bridge-submitted {
@@ -75,7 +84,6 @@
 }
 
 .bridge-unavailable p,
-.bridge-note p,
 .bridge-submitted p {
   margin: 0;
 }

--- a/frontend/src/components/wallet/BridgeView.jsx
+++ b/frontend/src/components/wallet/BridgeView.jsx
@@ -70,7 +70,6 @@ import {
 } from '../../lib/bridge/bridgeRouter'
 import { SPOKE_POOL_IFACE } from '../../lib/bridge/bridgeStatus'
 import {
-  BRIDGE_AREA_DESC,
   BRIDGE_DISCLOSURE,
   BRIDGE_TIPS,
   BRIDGE_UNAVAILABLE,
@@ -667,13 +666,6 @@ export default function BridgeView({ onRecorded } = {}) {
 
   return (
     <div className="bridge-root">
-      <p className="bridge-intro">
-        {BRIDGE_AREA_DESC}
-        <InfoTip label="What is bridging?" className="earn-info">
-          {BRIDGE_TIPS.bridge}
-        </InfoTip>
-      </p>
-
       {/* FR-066/FR-006c — assets this surface cannot use are named and explained wherever they
           exist, including when they are ALL a member holds. These sit outside the branch below
           because the empty case is exactly when the explanation matters most. */}

--- a/frontend/src/components/wallet/PayTransferPanel.jsx
+++ b/frontend/src/components/wallet/PayTransferPanel.jsx
@@ -5,9 +5,10 @@ import TransferActivityList from './TransferActivityList'
 import BridgeView from './BridgeView'
 import BridgeStatusList from './BridgeStatusList'
 import BridgeUnavailableNotice from './BridgeUnavailableNotice'
+import InfoTip from '../ui/InfoTip'
 import { BRIDGE_UNAVAILABLE_REASON } from '../../hooks/useBridgeAvailability'
 import { bridgeGatewayUrl } from '../../lib/bridge/acrossQuotes'
-import { BRIDGE_AREA_DESC } from '../../lib/bridge/bridgeCopy'
+import { BRIDGE_AREA_DESC, BRIDGE_TIPS } from '../../lib/bridge/bridgeCopy'
 import './PayTransfer.css'
 
 const TABS = [
@@ -44,10 +45,16 @@ export default function PayTransferPanel() {
 
   return (
     <div className="pt-root">
-      <p className="pt-intro">
-        Send stablecoins and native tokens to any wallet or ENS name. Stablecoin transfers are gasless where
-        the rails are available.
-      </p>
+      {/* Each tab states only what applies to it — a same-chain send and a
+          cross-network bridge are different operations with different costs,
+          and folding them into one blurb either overstates or understates
+          each (mirrors TradePanel's per-context subtitle). */}
+      {tab === 'transfer' && (
+        <p className="pt-intro">
+          Send stablecoins and native tokens to any wallet or ENS name. Stablecoin transfers are gasless where
+          the rails are available.
+        </p>
+      )}
 
       <div className="pt-tabs" role="tablist" aria-label="Transfer sections">
         {TABS.map((t) => (
@@ -111,7 +118,12 @@ function BridgeTab() {
 
   return (
     <div className="bridge-tab">
-      <p className="pt-intro">{BRIDGE_AREA_DESC}</p>
+      <p className="pt-intro">
+        {BRIDGE_AREA_DESC}
+        <InfoTip label="What is bridging?" className="earn-info">
+          {BRIDGE_TIPS.bridge}
+        </InfoTip>
+      </p>
       {gatewayReady ? (
         <BridgeView onRecorded={() => setRecordedAt(Date.now())} />
       ) : (


### PR DESCRIPTION
## Summary
- Fixed a duplicated-text bug: the Bridge tab was rendering the same "Move an asset you already hold to another network…" sentence twice — once (plain) in `PayTransferPanel`'s Bridge tab wrapper, and again (with its InfoTip) inside `BridgeView`. Consolidated to a single line with the InfoTip attached.
- The generic "Send stablecoins and native tokens…" intro above the tabs now only shows on the Transfer tab, since it describes same-chain sending and doesn't apply to Bridge or Activity — mirrors the per-context subtitle approach from the recent Trade order-ticket cleanup (#987).
- Routine, non-blocking disclosures (a withheld network like Ethereum Classic, an unscreenable wallet, a partial route read) no longer render as bordered "warning card" style — that boxed treatment is now reserved for states that actually block the member (paused route, unreachable router, etc.), matching how Trade renders its own account notes as plain text.

No behavioral/functional changes: the cross-network asset picking (assets from every bridgeable network, not just the connected one) and the signing-time network switch were already implemented for Bridge and are untouched by this PR.

## Test plan
- [x] `npx vitest run src/test/bridge src/test/TransferForm.test.jsx src/test/TransferForm.bitcoin.test.jsx src/test/PortalNav.test.jsx src/test/TradePanel.test.jsx` — 161/161 passing
- [x] `npx eslint` on the changed JS files — no errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01We9ctNWh2jtMhouipSKvE9)_