### PR TITLE
Spec 071 Phase 6: fees across the estate (US3)

### DIFF
--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -25,6 +25,7 @@ import ServiceHealthCard from './admin/ServiceHealthCard'
 import PaymasterOpsCard from './admin/PaymasterOpsCard'
 import { buildAdminNavGroups, flattenNavGroups } from './admin/adminNav'
 import { networkName } from '../lib/chains/estate'
+import { isRead, isNotDeployed, formatUnitAmount } from '../lib/chains/chainReadResult'
 import { useFeeEstate } from '../hooks/useFeeEstate'
 import ChainStateTable from './admin/ChainStateTable'
 import PortalNav from './ui/PortalNav'
@@ -130,6 +131,18 @@ function AdminPanel() {
 
   // Fees across every cohort chain (US3), independent of where the wallet is connected.
   const feeEstate = useFeeEstate({ walletChainId: chainId, walletProvider: provider })
+
+  // A withdrawal targets ONE chain. It defaults to the wallet's chain when that chain carries a
+  // MembershipManager, otherwise to the first chain that does — the same rule the spec-067 tabs
+  // use — and it does NOT follow the wallet afterwards (FR-016).
+  const [withdrawChainId, setWithdrawChainId] = useState(null)
+  const withdrawScope = feeEstate.accrued.find((r) => Number(r.chainId) === Number(withdrawChainId))
+  useEffect(() => {
+    if (withdrawChainId != null || feeEstate.accrued.length === 0) return
+    const onWallet = feeEstate.accrued.find((r) => Number(r.chainId) === Number(chainId) && isRead(r))
+    const anyRead = feeEstate.accrued.find(isRead)
+    setWithdrawChainId((onWallet || anyRead || feeEstate.accrued[0]).chainId)
+  }, [feeEstate.accrued, chainId, withdrawChainId])
 
   const [activeTab, setActiveTab] = useState('overview')
   // The section rail collapses to an icon-only strip rather than disappearing.
@@ -361,12 +374,24 @@ function AdminPanel() {
   const handleWithdraw = () => {
     const target = withdrawEns.resolvedAddress || withdrawForm.to
     if (!isValidEthereumAddress(target)) return showNotification('Invalid address', 'error')
-    const amount = ethers.parseUnits(String(withdrawForm.amount || '0'), USDC_DECIMALS)
+    // FR-017/FR-018: one named chain, wallet required to be there. Checked here as well as in
+    // the disabled button so a stale render can never send to the wrong network.
+    if (Number(chainId) !== Number(withdrawChainId)) {
+      return showNotification(
+        `This withdrawal happens on ${networkName(withdrawChainId)}. Switch your wallet there first.`,
+        'error',
+      )
+    }
+    const addr = getContractAddressForChain('membershipManager', withdrawChainId)
+    if (!addr) return showNotification(`No MembershipManager on ${networkName(withdrawChainId)}`, 'error')
+    const decimals = withdrawScope?.unit?.decimals ?? USDC_DECIMALS
+    const symbol = withdrawScope?.unit?.symbol ?? 'USDC'
+    const amount = ethers.parseUnits(String(withdrawForm.amount || '0'), decimals)
     if (amount === 0n) return showNotification('Amount must be greater than 0', 'error')
     return runTx(
-      () => new ethers.Contract(membershipManagerAddr, MEMBERSHIP_ADMIN_ABI, signer).withdrawFees(amount, target),
-      `Withdrew ${withdrawForm.amount} USDC to ${shortAddr(target)}`
-    )
+      () => new ethers.Contract(addr, MEMBERSHIP_ADMIN_ABI, signer).withdrawFees(amount, target),
+      `Withdrew ${withdrawForm.amount} ${symbol} to ${shortAddr(target)} on ${networkName(withdrawChainId)}`
+    ).then((ok) => { if (ok) feeEstate.refresh(); return ok })
   }
 
   // Every role that can open this panel gets a row, each naming where it was found. Built here
@@ -898,11 +923,48 @@ function AdminPanel() {
           <div className="admin-tab-content" role="tabpanel">
             <div className="admin-card">
               <h3>Treasury Withdrawal</h3>
-              <p>
-                Withdraws accrued tier fees from MembershipManager in USDC. Current balance:{' '}
-                <strong>{contractState.accruedFees} USDC</strong>.
-              </p>
+              {/*
+                A withdrawal is a WRITE, so it targets exactly one chain and says which
+                (FR-017), and it is withheld unless the wallet is there rather than failing at
+                signature time (FR-018). The balance shown is that chain's — never an estate
+                total, which is not a thing any single `withdrawFees` call could move.
+              */}
               <div className="admin-form">
+                <label>
+                  Network to withdraw on
+                  <select
+                    value={String(withdrawChainId)}
+                    onChange={(e) => setWithdrawChainId(Number(e.target.value))}
+                  >
+                    {feeEstate.accrued.map((r) => (
+                      <option key={r.chainId} value={String(r.chainId)}>
+                        {networkName(r.chainId)}
+                        {isRead(r) ? ` — ${formatUnitAmount(r, ethers.formatUnits)} available` : ''}
+                        {isNotDeployed(r) ? ' — not deployed' : ''}
+                        {!isRead(r) && !isNotDeployed(r) ? ' — could not be read' : ''}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <p className="card-info">
+                  {withdrawScope && isRead(withdrawScope) ? (
+                    <>
+                      Withdrawing <strong>{formatUnitAmount(withdrawScope, ethers.formatUnits)}</strong>{' '}
+                      of accrued tier fees on <strong>{networkName(withdrawChainId)}</strong>.
+                    </>
+                  ) : withdrawScope && isNotDeployed(withdrawScope) ? (
+                    <>No MembershipManager on {networkName(withdrawChainId)} — nothing to withdraw there.</>
+                  ) : (
+                    <>
+                      The balance on {networkName(withdrawChainId)} could not be read, so the
+                      available amount is unknown.
+                    </>
+                  )}
+                  {Number(chainId) !== Number(withdrawChainId) && (
+                    <> Your wallet is on {networkName(chainId)} — switch it to{' '}
+                    {networkName(withdrawChainId)} to sign this withdrawal.</>
+                  )}
+                </p>
                 <label>
                   Recipient (address or ENS)
                   <input type="text" value={withdrawForm.to}
@@ -917,16 +979,30 @@ function AdminPanel() {
                   )}
                 </label>
                 <label>
-                  Amount (USDC)
+                  Amount ({withdrawScope?.unit?.symbol || 'tokens'})
                   <input type="number" min="0" step="0.01" value={withdrawForm.amount}
                     onChange={(e) => setWithdrawForm({ ...withdrawForm, amount: e.target.value })} />
+                  {/* Max is the SCOPED chain's balance, and is offered only when that balance
+                      was actually read — filling it from an unknown would be a guess. */}
                   <button type="button" className="hint-btn"
-                    onClick={() => setWithdrawForm({ ...withdrawForm, amount: contractState.accruedFees })}>
+                    disabled={!withdrawScope || !isRead(withdrawScope)}
+                    onClick={() => setWithdrawForm({
+                      ...withdrawForm,
+                      amount: ethers.formatUnits(withdrawScope.value, withdrawScope.unit?.decimals ?? 6),
+                    })}>
                     Max
                   </button>
                 </label>
-                <button className="confirm-btn primary" onClick={handleWithdraw} disabled={pendingTx}>
-                  {pendingTx ? 'Withdrawing...' : 'Withdraw Fees'}
+                <button
+                  className="confirm-btn primary"
+                  onClick={handleWithdraw}
+                  disabled={pendingTx || Number(chainId) !== Number(withdrawChainId)}
+                >
+                  {pendingTx
+                    ? 'Withdrawing...'
+                    : Number(chainId) !== Number(withdrawChainId)
+                      ? `Switch to ${networkName(withdrawChainId)} to withdraw`
+                      : `Withdraw on ${networkName(withdrawChainId)}`}
                 </button>
               </div>
             </div>

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -25,6 +25,8 @@ import ServiceHealthCard from './admin/ServiceHealthCard'
 import PaymasterOpsCard from './admin/PaymasterOpsCard'
 import { buildAdminNavGroups, flattenNavGroups } from './admin/adminNav'
 import { networkName } from '../lib/chains/estate'
+import { useFeeEstate } from '../hooks/useFeeEstate'
+import ChainStateTable from './admin/ChainStateTable'
 import PortalNav from './ui/PortalNav'
 import NavIcon from './nav/NavIcon'
 import SectionIconNav from './nav/SectionIconNav'
@@ -125,6 +127,9 @@ function AdminPanel() {
   // an operator who can open that tab. Offering the link to someone the Fees tab is closed to
   // would send them to a blank panel, so they get the same sentence without a dead control.
   const canOpenFees = isAdmin || isFeeAdmin
+
+  // Fees across every cohort chain (US3), independent of where the wallet is connected.
+  const feeEstate = useFeeEstate({ walletChainId: chainId, walletProvider: provider })
 
   const [activeTab, setActiveTab] = useState('overview')
   // The section rail collapses to an icon-only strip rather than disappearing.
@@ -546,10 +551,9 @@ function AdminPanel() {
                       {contractState.isPaused ? 'Paused' : 'Active'}
                     </span>
                   </div>
-                  <div className="status-row">
-                    <span className="status-label">Accrued tier fees</span>
-                    <span className="status-value">{contractState.accruedFees} USDC</span>
-                  </div>
+                  {/* The single-chain figure that used to sit here read one network's balance
+                      and presented it without qualification — a number an operator would act on
+                      as if it were the total. The estate breakdown is its own card below. */}
                   <div className="status-row">
                     <span className="status-label">Network</span>
                     <span className="status-value">{NETWORK_CONFIG.name}</span>
@@ -611,6 +615,36 @@ function AdminPanel() {
                 address={membershipManagerAddr}
                 accruedFees={contractState.accruedFees}
               />
+
+              {/*
+                Fees across the whole estate (US3). Two SEPARATE figures, deliberately:
+                  • accrued (undrawn) — MembershipManager.accruedFees, the only accruing balance
+                  • treasury (received) — already delivered; the FeeRouter forwards and holds nothing
+                They are never added together — one is money the platform still owes itself, the
+                other is money already paid out. And neither is summed across units, because the
+                payment token differs per chain (research R6, FR-021…FR-023).
+              */}
+              <div className="admin-card full-width">
+                <div className="admin-card-header"><h3>Fees across the estate</h3></div>
+                <ChainStateTable
+                  caption="Accrued (undrawn) — withdrawable from MembershipManager"
+                  results={feeEstate.accrued}
+                  totals={feeEstate.accruedTotals}
+                  onRetry={feeEstate.refresh}
+                />
+                <ChainStateTable
+                  caption="Treasury balance (received) — already delivered by the FeeRouter"
+                  results={feeEstate.received}
+                  totals={feeEstate.receivedTotals}
+                  onRetry={feeEstate.refresh}
+                />
+                <p className="card-info">
+                  These two are never combined: the first is undrawn and still withdrawable, the
+                  second has already been paid to the treasury. Totals are shown per token because
+                  networks hold different payment tokens, and any total computed while a network
+                  was unreadable says so and names it.
+                </p>
+              </div>
 
               <div className="admin-card full-width">
                 <div className="admin-card-header"><h3>Contract Addresses</h3></div>

--- a/frontend/src/components/admin/ChainStateTable.css
+++ b/frontend/src/components/admin/ChainStateTable.css
@@ -1,0 +1,105 @@
+/* Per-chain state table (spec 071 FR-014). The three states are distinguished by TEXT first;
+   colour only reinforces, so the distinction survives for a colour-blind operator and in a
+   high-contrast theme (constitution V). */
+
+.chain-state {
+  margin: 0.75rem 0;
+}
+
+.chain-state-caption {
+  margin: 0 0 0.5rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.chain-state-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.chain-state-table th,
+.chain-state-table td {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-color, var(--color-border, #e5e7eb));
+  vertical-align: top;
+}
+
+.chain-state-table thead th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary, var(--color-text-secondary, #8895A1));
+}
+
+.chain-state-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+/* A definite answer: there is no contract here. Muted, but never absent. */
+.chain-state-absent {
+  color: var(--text-secondary, var(--color-text-secondary, #5A6772));
+  font-style: italic;
+}
+
+/* NOT an answer. Must never be mistaken for a zero, so it is the one state that gets a
+   warning colour AND its own wording AND the failure reason. */
+.chain-state-unreadable {
+  color: var(--color-warning, #B45309);
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.chain-state-retry {
+  border: 1px solid currentColor;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 0.8125rem;
+  padding: 0.125rem 0.5rem;
+  cursor: pointer;
+}
+
+.chain-state-retry:focus-visible {
+  outline: 2px solid var(--brand-primary, var(--color-primary, #36B37E));
+  outline-offset: 2px;
+}
+
+.chain-state-totals {
+  margin-top: 0.5rem;
+}
+
+.chain-state-total {
+  margin: 0.25rem 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.chain-state-total-scope {
+  color: var(--text-secondary, var(--color-text-secondary, #5A6772));
+  font-size: 0.8125rem;
+}
+
+/* A total computed while a chain was unreadable says so, and names what is missing. */
+.chain-state-partial {
+  margin: 0.25rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--color-warning, #B45309);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/src/components/admin/ChainStateTable.jsx
+++ b/frontend/src/components/admin/ChainStateTable.jsx
@@ -1,0 +1,89 @@
+/**
+ * One row per chain, in one of the three states a chain read can be in (spec 071 FR-014).
+ *
+ * Shared so no view invents its own rendering of the three, because the whole point is that
+ * they stay distinguishable everywhere:
+ *
+ *   read          → the value, in its own unit
+ *   not deployed  → said explicitly. A FACT, not a gap — there is nothing here to have a value
+ *   unreadable    → said explicitly, WITH the reason, plus a retry. Never a zero, never blank
+ *
+ * The last one is the reason this component exists. An operator auditing a control surface reads
+ * a silent `0` as a fact, so an unreachable chain must never be able to look like an answer.
+ *
+ * Status is carried by TEXT, not colour alone (constitution V).
+ */
+import { ethers } from 'ethers'
+import { networkName } from '../../lib/chains/estate'
+import { isRead, isNotDeployed, partialLabel, formatUnitAmount } from '../../lib/chains/chainReadResult'
+import './ChainStateTable.css'
+
+export default function ChainStateTable({ results = [], caption, totals = null, onRetry = null }) {
+  return (
+    <div className="chain-state">
+      {caption && <h4 className="chain-state-caption">{caption}</h4>}
+      <table className="chain-state-table">
+        <caption className="sr-only">{caption || 'Per-network state'}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Network</th>
+            <th scope="col">State</th>
+          </tr>
+        </thead>
+        <tbody>
+          {results.map((r) => (
+            <tr key={r.chainId} className={`chain-state-row is-${r.status}`}>
+              <th scope="row">{networkName(r.chainId)}</th>
+              <td>
+                {isRead(r) && <span className="chain-state-value">{formatUnitAmount(r, ethers.formatUnits)}</span>}
+                {isNotDeployed(r) && (
+                  <span className="chain-state-absent">Not deployed on this network</span>
+                )}
+                {!isRead(r) && !isNotDeployed(r) && (
+                  <span className="chain-state-unreadable">
+                    Could not be read — {r.reason}
+                    {onRetry && (
+                      <button type="button" className="chain-state-retry" onClick={onRetry}>
+                        Retry
+                      </button>
+                    )}
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+          {results.length === 0 && (
+            <tr>
+              <td colSpan={2}>No networks in this build&rsquo;s cohort carry this contract.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+
+      {totals && (
+        <div className="chain-state-totals">
+          {Object.entries(totals.subtotals).length === 0 && (
+            <p className="chain-state-total">No balances to total.</p>
+          )}
+          {/* Per unit. There is deliberately no single figure across units — different chains
+              hold different tokens, and one number across them would be invented. */}
+          {Object.entries(totals.subtotals).map(([symbol, amount]) => {
+            const decimals =
+              results.find((r) => r.unit?.symbol === symbol)?.unit?.decimals ?? 0
+            return (
+              <p key={symbol} className="chain-state-total">
+                <strong>{ethers.formatUnits(amount, decimals)} {symbol}</strong>
+                <span className="chain-state-total-scope"> across {symbol} networks</span>
+              </p>
+            )
+          })}
+          {totals.partial && (
+            <p className="chain-state-partial" role="status">
+              {partialLabel(totals, networkName)}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useFeeEstate.js
+++ b/frontend/src/hooks/useFeeEstate.js
@@ -1,0 +1,100 @@
+/**
+ * Fee state across the whole estate (spec 071 US3, FR-021…FR-023).
+ *
+ * ── WHAT ACTUALLY ACCRUES, AND WHERE (research R6) ──────────────────────────────────────────
+ * "All chains for accrued fees" needed a real answer about what accrues, and there is exactly
+ * ONE accruing balance in the system:
+ *
+ *   ACCRUED (undrawn) — `MembershipManager.accruedFees()`, withdrawable via `withdrawFees`.
+ *                       Deployed on the reference chain and the testnet/local networks only.
+ *   RECEIVED          — the treasury's payment-token balance on each chain carrying a
+ *                       `FeeRouter`. The FeeRouter itself holds NOTHING: it forwards the fee to
+ *                       the treasury inside the same transaction (spec 060), by design.
+ *
+ * These are never added together. One is money the platform still owes itself; the other is
+ * money already delivered. Summing them would invent a third number that is neither.
+ *
+ * ── AND WHY THERE IS NO GRAND TOTAL ─────────────────────────────────────────────────────────
+ * Payment tokens differ per chain — Polygon holds USDC, Mordor holds Classic USD. `aggregate`
+ * returns per-unit subtotals and refuses to cross them (FR-022), and any total computed while a
+ * chain was unreadable is flagged `partial` and names what is missing (FR-023). A chain that
+ * simply has no deployment reads `not-deployed`, which is a fact rather than a gap.
+ */
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { ethers } from 'ethers'
+import { NETWORKS, cohortChainIds } from '../config/networks'
+import { getContractAddressForChain } from '../config/contracts'
+import { readAcrossEstate } from '../lib/chains/estate'
+import { aggregate } from '../lib/chains/chainReadResult'
+
+const MEMBERSHIP_FEE_ABI = [
+  'function accruedFees() view returns (uint128)',
+  'function treasury() view returns (address)',
+]
+const FEE_ROUTER_ABI = ['function treasury() view returns (address)']
+const ERC20_BALANCE_ABI = ['function balanceOf(address) view returns (uint256)']
+
+/** The unit a chain's fee balances are denominated in. Never guessed — config or nothing. */
+export function feeUnitFor(chainId) {
+  const s = NETWORKS[chainId]?.stablecoin
+  return s?.symbol ? { symbol: s.symbol, decimals: s.decimals ?? 6, address: s.address } : null
+}
+
+export function useFeeEstate({ walletChainId, walletProvider } = {}) {
+  const [accrued, setAccrued] = useState([])
+  const [received, setReceived] = useState([])
+  const [loading, setLoading] = useState(true)
+  const chains = useMemo(() => cohortChainIds(), [])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    // The two reads are independent and run together; neither can fail the other, and a chain
+    // that answers for one but not the other is reported honestly in each.
+    const [accruedResults, receivedResults] = await Promise.all([
+      readAcrossEstate({
+        chainIds: chains,
+        addressFor: (id) => getContractAddressForChain('membershipManager', id),
+        read: ({ provider, address }) =>
+          new ethers.Contract(address, MEMBERSHIP_FEE_ABI, provider).accruedFees(),
+        walletChainId,
+        walletProvider,
+        unitFor: feeUnitFor,
+      }),
+      readAcrossEstate({
+        chainIds: chains,
+        addressFor: (id) => getContractAddressForChain('feeRouter', id),
+        read: async ({ chainId, provider, address }) => {
+          // The FeeRouter holds nothing, so the meaningful figure is what its treasury RECEIVED.
+          const treasury = await new ethers.Contract(address, FEE_ROUTER_ABI, provider).treasury()
+          if (!treasury || treasury === ethers.ZeroAddress) {
+            throw new Error('no treasury configured on this router')
+          }
+          const token = NETWORKS[chainId]?.stablecoin?.address
+          if (!token) throw new Error('no payment token configured for this network')
+          return new ethers.Contract(token, ERC20_BALANCE_ABI, provider).balanceOf(treasury)
+        },
+        walletChainId,
+        walletProvider,
+        unitFor: feeUnitFor,
+      }),
+    ])
+    setAccrued(accruedResults)
+    setReceived(receivedResults)
+    setLoading(false)
+  }, [chains, walletChainId, walletProvider])
+
+  useEffect(() => {
+    refresh()
+    const interval = setInterval(refresh, 60_000)
+    return () => clearInterval(interval)
+  }, [refresh])
+
+  // Two separate aggregates, deliberately. There is no API here that returns one figure across
+  // both, because the two things are not the same kind of money.
+  const accruedTotals = useMemo(() => aggregate(accrued), [accrued])
+  const receivedTotals = useMemo(() => aggregate(received), [received])
+
+  return { accrued, received, accruedTotals, receivedTotals, loading, refresh, chains }
+}
+
+export default useFeeEstate

--- a/frontend/src/lib/chains/chainReadResult.js
+++ b/frontend/src/lib/chains/chainReadResult.js
@@ -126,3 +126,19 @@ export function partialLabel(aggregated, nameForChain = (id) => `chain ${id}`) {
   const names = aggregated.missing.map((m) => nameForChain(m.chainId))
   return `Partial — excludes ${names.join(', ')} (could not be read)`
 }
+
+/**
+ * A read value rendered in its own declared unit, or null when there is no value to render.
+ *
+ * Falls back to RAW UNITS with that fact stated rather than guessing a scale: a mis-scaled
+ * balance is a silent, wrong number, and an admitted "raw units" is not.
+ */
+export function formatUnitAmount(result, formatUnits) {
+  if (!isRead(result)) return null
+  const decimals = result.unit?.decimals ?? 0
+  try {
+    return `${formatUnits(result.value ?? 0n, decimals)} ${result.unit?.symbol ?? ''}`.trim()
+  } catch {
+    return `${String(result.value)} (raw units)`
+  }
+}

--- a/frontend/src/test/admin/adminFeeEstate.test.jsx
+++ b/frontend/src/test/admin/adminFeeEstate.test.jsx
@@ -1,0 +1,167 @@
+/**
+ * Spec 071 US3 (T048) — fees across the whole estate, honestly.
+ *
+ * The defect: one network's `accruedFees` was shown without qualification, as "Accrued tier
+ * fees: N USDC". An operator acts on that as if it were the total. Under-reporting the treasury
+ * is a financial-reporting error, not a display bug.
+ *
+ * Three things this pins, all of which are ways to state a number that is not true:
+ *   1. an unreadable network rendering as a zero, or vanishing from a total without a trace
+ *   2. balances in different tokens summed into one invented figure
+ *   3. accrued (still owed to us) added to received (already delivered)
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { ethers } from 'ethers'
+import ChainStateTable from '../../components/admin/ChainStateTable'
+import { readOk, notDeployed, unreadable, aggregate } from '../../lib/chains/chainReadResult'
+import { feeUnitFor } from '../../hooks/useFeeEstate'
+import { cohortChainIds, NETWORKS } from '../../config/networks'
+
+const USDC = { symbol: 'USDC', decimals: 6 }
+const USC = { symbol: 'USC', decimals: 6 }
+
+const rowFor = (container, name) =>
+  [...container.querySelectorAll('.chain-state-row')].find((tr) =>
+    within(tr).queryByText(name, { selector: 'th' }),
+  )
+
+describe('every network appears, in exactly one of the three states (FR-014, FR-021)', () => {
+  const results = [readOk(80002, 1_500_000n, USDC), notDeployed(63), unreadable(1337, 'endpoint down')]
+
+  it('shows a read balance with its own unit', () => {
+    const { container } = render(<ChainStateTable results={results} caption="Accrued" />)
+    const row = rowFor(container, NETWORKS[80002].name)
+    expect(within(row).getByText('1.5 USDC')).toBeInTheDocument()
+  })
+
+  it('says "not deployed" explicitly rather than rendering a zero or a blank', () => {
+    const { container } = render(<ChainStateTable results={results} caption="Accrued" />)
+    const row = rowFor(container, NETWORKS[63].name)
+    expect(within(row).getByText(/Not deployed on this network/i)).toBeInTheDocument()
+    expect(row.textContent).not.toMatch(/\b0(\.0+)?\s*(USDC|USC)\b/)
+  })
+
+  it('says an unreadable network could not be read, WITH the reason — never as a zero', () => {
+    const { container } = render(<ChainStateTable results={results} caption="Accrued" />)
+    const row = rowFor(container, NETWORKS[1337].name)
+    expect(within(row).getByText(/Could not be read/i)).toBeInTheDocument()
+    expect(row.textContent).toContain('endpoint down')
+    expect(row.textContent).not.toMatch(/\b0(\.0+)?\s*(USDC|USC)\b/)
+  })
+
+  it('offers a retry on an unreadable network', () => {
+    const onRetry = vi.fn()
+    const { container } = render(<ChainStateTable results={results} caption="Accrued" onRetry={onRetry} />)
+    const row = rowFor(container, NETWORKS[1337].name)
+    within(row).getByRole('button', { name: /retry/i }).click()
+    expect(onRetry).toHaveBeenCalled()
+  })
+
+  it('accounts for every network it was given — none silently omitted (SC-003)', () => {
+    const { container } = render(<ChainStateTable results={results} caption="Accrued" />)
+    expect(container.querySelectorAll('.chain-state-row')).toHaveLength(results.length)
+  })
+})
+
+describe('totals are per unit and never cross tokens (FR-022, SC-004)', () => {
+  // The test cohort genuinely spans two tokens: Amoy holds USDC, Mordor holds Classic USD.
+  it('the fixture is real: two cohort chains declare different payment tokens', () => {
+    const symbols = new Set(
+      cohortChainIds().map((id) => feeUnitFor(id)?.symbol).filter(Boolean),
+    )
+    expect(symbols.size).toBeGreaterThan(1)
+  })
+
+  it('renders one subtotal per token, never one combined figure', () => {
+    const results = [readOk(80002, 1_000_000n, USDC), readOk(63, 2_000_000n, USC)]
+    const { container } = render(
+      <ChainStateTable results={results} caption="Accrued" totals={aggregate(results)} />,
+    )
+
+    // Scope to the totals block: the per-row values also read "1.0 USDC", and it is the
+    // TOTALS that must not cross units.
+    const totalsEl = container.querySelector('.chain-state-totals')
+    expect(totalsEl.textContent).toMatch(/1\.0 USDC/)
+    expect(totalsEl.textContent).toMatch(/2\.0 USC/)
+    // 3.0 of anything would be the invented cross-unit sum.
+    expect(totalsEl.textContent).not.toMatch(/3\.0/)
+  })
+})
+
+describe('a partial total says so and names what is missing (FR-023, SC-007)', () => {
+  it('flags partial and names the excluded network', () => {
+    const results = [readOk(80002, 1_000_000n, USDC), unreadable(63, 'timeout')]
+    render(<ChainStateTable results={results} caption="Accrued" totals={aggregate(results)} />)
+
+    const note = screen.getByRole('status')
+    expect(note).toHaveTextContent(/Partial/i)
+    expect(note).toHaveTextContent(NETWORKS[63].name)
+  })
+
+  it('does NOT flag partial when a network is merely not deployed', () => {
+    const results = [readOk(80002, 1_000_000n, USDC), notDeployed(63)]
+    render(<ChainStateTable results={results} caption="Accrued" totals={aggregate(results)} />)
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('the total does not silently shrink — the same figure, but labelled incomplete', () => {
+    const complete = aggregate([readOk(80002, 1_000_000n, USDC)])
+    const withGap = aggregate([readOk(80002, 1_000_000n, USDC), unreadable(63, 'timeout')])
+
+    expect(withGap.subtotals.USDC).toBe(complete.subtotals.USDC)
+    expect(withGap.partial).toBe(true)
+    expect(complete.partial).toBe(false)
+  })
+})
+
+describe('accrued and received are never combined (research R6)', () => {
+  it('are rendered as two separate tables with distinct captions', () => {
+    const accrued = [readOk(80002, 1_000_000n, USDC)]
+    const received = [readOk(80002, 5_000_000n, USDC)]
+    const { container } = render(
+      <>
+        <ChainStateTable results={accrued} caption="Accrued (undrawn)" totals={aggregate(accrued)} />
+        <ChainStateTable results={received} caption="Treasury balance (received)" totals={aggregate(received)} />
+      </>,
+    )
+
+    // Each caption renders twice (visible heading + the table's screen-reader caption).
+    expect(screen.getAllByText(/Accrued \(undrawn\)/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Treasury balance \(received\)/).length).toBeGreaterThan(0)
+    // 6.0 USDC would be the two summed — money still owed added to money already paid.
+    expect(container.textContent).not.toMatch(/6\.0 USDC/)
+  })
+})
+
+describe('feeUnitFor — a unit is config or nothing, never guessed', () => {
+  it('returns the configured stablecoin for a chain that has one', () => {
+    const unit = feeUnitFor(80002)
+    expect(unit).toMatchObject({ symbol: NETWORKS[80002].stablecoin.symbol })
+  })
+
+  it('returns null for a chain with no configured payment token', () => {
+    expect(feeUnitFor(999999)).toBeNull()
+  })
+
+  it('a value with no unit is excluded from totals rather than bucketed by guess', () => {
+    const agg = aggregate([readOk(80002, 1_000_000n, USDC), readOk(63, 5n, null)])
+    expect(Object.keys(agg.subtotals)).toEqual(['USDC'])
+    expect(agg.partial).toBe(true)
+  })
+})
+
+describe('formatting refuses to guess a scale', () => {
+  it('renders raw units, and says so, rather than mis-scaling an unformattable value', () => {
+    const results = [readOk(80002, 'not-a-number', USDC)]
+    const { container } = render(<ChainStateTable results={results} caption="Accrued" />)
+    expect(container.textContent).toMatch(/raw units/)
+  })
+
+  it('formats a genuine zero as a zero — a read answer, not a gap', () => {
+    const results = [readOk(80002, 0n, USDC)]
+    const { container } = render(<ChainStateTable results={results} caption="Accrued" />)
+    expect(container.textContent).toContain(`${ethers.formatUnits(0n, 6)} USDC`)
+    expect(container.textContent).not.toMatch(/Could not be read|Not deployed/)
+  })
+})

--- a/frontend/src/test/admin/adminFeeEstate.test.jsx
+++ b/frontend/src/test/admin/adminFeeEstate.test.jsx
@@ -17,6 +17,7 @@ import ChainStateTable from '../../components/admin/ChainStateTable'
 import { readOk, notDeployed, unreadable, aggregate } from '../../lib/chains/chainReadResult'
 import { feeUnitFor } from '../../hooks/useFeeEstate'
 import { cohortChainIds, NETWORKS } from '../../config/networks'
+import adminPanelSource from '../../components/AdminPanel.jsx?raw'
 
 const USDC = { symbol: 'USDC', decimals: 6 }
 const USC = { symbol: 'USC', decimals: 6 }
@@ -163,5 +164,39 @@ describe('formatting refuses to guess a scale', () => {
     const { container } = render(<ChainStateTable results={results} caption="Accrued" />)
     expect(container.textContent).toContain(`${ethers.formatUnits(0n, 6)} USDC`)
     expect(container.textContent).not.toMatch(/Could not be read|Not deployed/)
+  })
+})
+
+// ── T047: a withdrawal is a WRITE, so it targets one named chain ────────────────────────────
+// `withdrawFees` moves money on exactly one MembershipManager. An estate total is not something
+// any single call could move, and a Max button filled from an unread balance would be a guess.
+describe('the Treasury withdrawal is scoped to one named chain (FR-017, FR-018)', () => {
+  const source = adminPanelSource
+
+  it('sends to the SCOPED chain\'s MembershipManager, not the wallet chain\'s', () => {
+    expect(source).toMatch(/getContractAddressForChain\('membershipManager', withdrawChainId\)/)
+  })
+
+  it('refuses to sign while the wallet is on a different chain, before the transaction', () => {
+    expect(source).toMatch(/Number\(chainId\) !== Number\(withdrawChainId\)/)
+    expect(source).toContain('Switch your wallet there first')
+  })
+
+  it('names the chain in the confirmation', () => {
+    expect(source).toMatch(/Withdrew \$\{withdrawForm\.amount\} \$\{symbol\} to \$\{shortAddr\(target\)\} on \$\{networkName\(withdrawChainId\)\}/)
+  })
+
+  it('offers Max only when that chain\'s balance was actually read', () => {
+    expect(source).toMatch(/disabled=\{!withdrawScope \|\| !isRead\(withdrawScope\)\}/)
+  })
+
+  it('uses the scoped chain\'s own decimals and symbol, not a hardcoded USDC', () => {
+    expect(source).toMatch(/withdrawScope\?\.unit\?\.decimals \?\? USDC_DECIMALS/)
+    expect(source).toMatch(/withdrawScope\?\.unit\?\.symbol \?\? 'USDC'/)
+  })
+
+  it('does not let the scope follow the wallet once chosen (FR-016)', () => {
+    // The effect seeds the scope only while it is null; it never re-assigns on a chainId change.
+    expect(source).toMatch(/if \(withdrawChainId != null \|\| feeEstate\.accrued\.length === 0\) return/)
   })
 })

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -142,13 +142,13 @@ everywhere.
 **Independent test**: With balances on more than one network, confirm each is listed with its own
 balance and unit; break one and confirm it is flagged, excluded, and the total labelled partial.
 
-- [ ] T042 [US3] Replace the single-chain `accruedFees` read in `frontend/src/components/AdminPanel.jsx` with a `readAcrossEstate` call over every cohort chain carrying a MembershipManager (FR-021)
-- [ ] T043 [US3] Add the second fee source per research R6 — the treasury's payment-token balance on each cohort chain carrying a `FeeRouter` — labelled **received**, and never added to **accrued (undrawn)**; the FeeRouter itself holds nothing, so it is not read for a balance
-- [ ] T044 [US3] Render the per-chain fee table in `frontend/src/components/AdminPanel.jsx` with each chain as read / not deployed / unreadable, each with its unit (FR-014, FR-021)
-- [ ] T045 [US3] Use `aggregate` for any total, showing per-unit subtotals and a partial label naming missing chains (FR-022, FR-023)
+- [X] T042 [US3] Replace the single-chain `accruedFees` read in `frontend/src/components/AdminPanel.jsx` with a `readAcrossEstate` call over every cohort chain carrying a MembershipManager (FR-021)
+- [X] T043 [US3] Add the second fee source per research R6 — the treasury's payment-token balance on each cohort chain carrying a `FeeRouter` — labelled **received**, and never added to **accrued (undrawn)**; the FeeRouter itself holds nothing, so it is not read for a balance
+- [X] T044 [US3] Render the per-chain fee table in `frontend/src/components/AdminPanel.jsx` with each chain as read / not deployed / unreadable, each with its unit (FR-014, FR-021)
+- [X] T045 [US3] Use `aggregate` for any total, showing per-unit subtotals and a partial label naming missing chains (FR-022, FR-023)
 - [ ] T046 [US3] Update `frontend/src/components/admin/MembershipTreasuryOverview.jsx` to accept per-chain results instead of a single `accruedFees` string
 - [ ] T047 [US3] Scope the Treasury withdrawal form in `frontend/src/components/AdminPanel.jsx` to a chain, defaulting its Max to that chain's accrued balance rather than a global figure
-- [ ] T048 [P] [US3] Test in `frontend/src/test/admin/adminFeeEstate.test.jsx`: every cohort chain appears in one of the three states; an unreadable chain is excluded, flagged, and the total labelled partial; accrued and received are never summed
+- [X] T048 [P] [US3] Test in `frontend/src/test/admin/adminFeeEstate.test.jsx`: every cohort chain appears in one of the three states; an unreadable chain is excluded, flagged, and the total labelled partial; accrued and received are never summed
 - [ ] T049 [P] [US3] Update `frontend/src/test/MembershipTreasuryOverview.test.jsx` for the new per-chain props
 
 **Checkpoint**: US3 is the first view consuming the estate helper end-to-end and validates the

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -146,10 +146,10 @@ balance and unit; break one and confirm it is flagged, excluded, and the total l
 - [X] T043 [US3] Add the second fee source per research R6 — the treasury's payment-token balance on each cohort chain carrying a `FeeRouter` — labelled **received**, and never added to **accrued (undrawn)**; the FeeRouter itself holds nothing, so it is not read for a balance
 - [X] T044 [US3] Render the per-chain fee table in `frontend/src/components/AdminPanel.jsx` with each chain as read / not deployed / unreadable, each with its unit (FR-014, FR-021)
 - [X] T045 [US3] Use `aggregate` for any total, showing per-unit subtotals and a partial label naming missing chains (FR-022, FR-023)
-- [ ] T046 [US3] Update `frontend/src/components/admin/MembershipTreasuryOverview.jsx` to accept per-chain results instead of a single `accruedFees` string
-- [ ] T047 [US3] Scope the Treasury withdrawal form in `frontend/src/components/AdminPanel.jsx` to a chain, defaulting its Max to that chain's accrued balance rather than a global figure
+- [ ] T046 [US3] *(deferred — the estate card supersedes this card’s single-chain figure; see PR notes)* Update `frontend/src/components/admin/MembershipTreasuryOverview.jsx` to accept per-chain results instead of a single `accruedFees` string
+- [X] T047 [US3] Scope the Treasury withdrawal form in `frontend/src/components/AdminPanel.jsx` to a chain, defaulting its Max to that chain's accrued balance rather than a global figure
 - [X] T048 [P] [US3] Test in `frontend/src/test/admin/adminFeeEstate.test.jsx`: every cohort chain appears in one of the three states; an unreadable chain is excluded, flagged, and the total labelled partial; accrued and received are never summed
-- [ ] T049 [P] [US3] Update `frontend/src/test/MembershipTreasuryOverview.test.jsx` for the new per-chain props
+- [ ] T049 [P] [US3] *(deferred with T046)* Update `frontend/src/test/MembershipTreasuryOverview.test.jsx` for the new per-chain props
 
 **Checkpoint**: US3 is the first view consuming the estate helper end-to-end and validates the
 pattern for Phase 7.


### PR DESCRIPTION
Follows #986 (Phases 3–5, merged). **T042–T045 and T048.**

The Overview showed one network's `accruedFees` as **"Accrued tier fees: N USDC"** — a number an operator reads as the total. Under-reporting the treasury is a financial-reporting error, not a display bug.

## Research R6 is what shapes this

*"All chains for accrued fees"* needed a real answer about what accrues, and only **one** thing does: `MembershipManager.accruedFees()`. The `FeeRouter` forwards to the treasury inside the same transaction and **holds nothing** (spec 060, by design).

So the new card reports two figures that are **never added**:

| | meaning |
|---|---|
| **accrued (undrawn)** | still owed to us, withdrawable via `withdrawFees` |
| **treasury (received)** | already delivered |

Adding them would invent a third number that is neither.

They're also never summed **across networks**: the test cohort alone spans **USDC** (Amoy) and **Classic USD** (Mordor), so the per-unit rule is exercised rather than theoretical.

## The three states, everywhere

- **read** → the value, in its own unit
- **not deployed** → said explicitly. A *fact*, not a gap — and it does **not** make a total partial
- **unreadable** → `"Could not be read — <reason>"` with a retry. **Never a zero**, excluded from totals, and the total is labelled partial and names it

`formatUnitAmount` falls back to **raw units and says so** rather than guessing a scale — a mis-scaled balance is a silent wrong number; an admitted "raw units" is not.

## New files

- `hooks/useFeeEstate.js` — reads both fee sources across every cohort chain, concurrently, via `readAcrossEstate`.
- `components/admin/ChainStateTable.jsx` — the shared three-state renderer with per-unit subtotals and partial labelling. **This also lands T051 for Phase 7**, since every view needs exactly this. Status is carried by text, not colour alone (constitution V).

`formatUnitAmount` lives in `chainReadResult.js` rather than the component — it's a property of the read result, and it keeps the component file to a single export (`react-refresh`).

## Testing

**16 new tests**, including that the two-token fixture is real (asserted from config, not hardcoded), that a partial total doesn't silently shrink, and that accrued + received never appear combined. **187 passing** across the admin and chains suites; **0 lint errors**.

## Deliberately still open in this phase

- **T046** — `MembershipTreasuryOverview` taking per-chain results rather than one string
- **T047** — scoping the Treasury withdrawal form to a chain and naming it at the write
- **T049** — that card's test

I stopped rather than rush these. The new estate card is **additive**, so the existing single-chain treasury card still renders correctly meanwhile — it's *narrower* than the new card, not wrong.

Phases 7–8 (T050–T075) remain: the 15 view conversions and docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1FMyMAhgkDcbYVVTvGj1W)_