### PR TITLE
Spec 071 Phases 7 + 8: the console spans the estate — all 75 tasks, plus an admin layout fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,27 @@ artifacts live under `specs/<feature>/`.
   `docs/developer-guide/bridge-and-liquidity.md` + `docs/runbooks/bridge-liquidity-operations.md` +
   `specs/067-bridge-pool-liquidity/`.
 
+- **Membership has ONE home, and the operations console reads the whole estate (spec 071).**
+  Membership lives on exactly one chain per environment cohort — Polygon on a mainnet build, Amoy on
+  a testnet build — resolved by `membershipChainId()` in `config/networks.js` and **derived** from
+  the existing `MAINNET_CHAIN_ID`/`TESTNET_CHAIN_ID` pair (never a second literal `137`, which would
+  silently read mainnet membership in a testnet build). `hasRoleOnChain`/`getUserTierOnChain`
+  **ignore the chain you pass** on the `WAGER_PARTICIPANT` path and always read the reference chain;
+  their admin-role branch still honours an explicit chain, because admin roles genuinely ARE
+  per-chain. Purchases settle on the reference chain too — membership is only readable from one
+  place if it is also written in one place. "All chains" ALWAYS means the build's **cohort**
+  (`cohortChainIds()`, never `listSupportedChainIds()`): constitution III forbids reads crossing the
+  testnet/mainnet boundary. Every estate read returns one of **three** states —
+  `read` / `not-deployed` / `unreadable` — and `value` exists only on `read` so `?? 0` has nowhere
+  to live; an unreachable chain must NEVER render as a zero, and any total missing one is labelled
+  partial and names it. Balances are **never summed across units** (`aggregate()` returns per-unit
+  subtotals only), and accrued (undrawn) is never added to treasury (received). Reads span chains;
+  **writes never do**: one transaction, one named chain, wallet required there, authority read from
+  the contract that will enforce it — and an *unconfirmed* authority read leaves the control offered
+  rather than hiding a killswitch on an RPC timeout. There is deliberately **no control that acts on
+  several chains at once**. Providers come from `getReadProvider`/`readProviderFor`, never
+  hand-built from `NETWORKS[chainId].rpcUrl`. See `docs/developer-guide/chain-estate-reads.md` +
+  `specs/071-multi-chain-admin-console/`.
 - **RPC endpoints belong to the MEMBER (spec 069), and network settings live in the user panel.**
   The `network` tab moved off the Tools nav group onto the account button beside Preferences (tab id +
   `/wallet?tab=network` unchanged); `NAV_GROUPS` must not carry it again. Endpoint resolution has ONE

--- a/docs/developer-guide/chain-estate-reads.md
+++ b/docs/developer-guide/chain-estate-reads.md
@@ -128,5 +128,10 @@ import { useScopedChain, writeGateReason, writeAllowed } from '../components/adm
    confirmation.
 6. Totals via `aggregate()` only.
 
-`frontend/src/test/admin/adminEstateGuard.test.js` enforces 3 and 6 at the source level, with a
-documented baseline for views not yet converted.
+`frontend/src/test/admin/adminEstateGuard.test.js` enforces 3 and 6 at the source level. Its
+allowlist of unconverted views is now **empty** — every admin view resolves its contract from a
+chain it was given. A view mid-conversion may be listed with a measured count and a sentence
+saying why; the guard also fails when a listed count drops, so a baseline cannot quietly drift.
+
+`frontend/src/test/admin/adminViewScope.test.jsx` covers the views themselves: two rendered end
+to end (deny-list, paymaster) across every per-chain state, and the rest structurally.

--- a/docs/developer-guide/chain-estate-reads.md
+++ b/docs/developer-guide/chain-estate-reads.md
@@ -1,0 +1,132 @@
+# Reading across chains: the estate, the reference chain, and honest gaps
+
+**Spec:** [071](../../specs/071-multi-chain-admin-console/) · **Code:** `frontend/src/lib/chains/`,
+`frontend/src/config/networks.js`
+
+Two questions the app used to answer with "wherever the wallet is pointed", and now answers
+properly.
+
+---
+
+## 1. Membership lives on ONE chain
+
+```js
+import { membershipChainId } from '../config/networks'
+```
+
+Membership exists in exactly one place per environment cohort — **Polygon (137)** on a mainnet
+build, **Amoy (80002)** on a testnet build. It is derived from the existing
+`MAINNET_CHAIN_ID`/`TESTNET_CHAIN_ID` pair, never declared again: a second literal `137` is a
+divergence waiting to happen, and a hardcoded one silently reads *mainnet* membership in a
+testnet build.
+
+**Every membership question resolves there**, whatever chain the wallet is on. `hasRoleOnChain`
+and `getUserTierOnChain` enforce this internally for the `WAGER_PARTICIPANT` path and **ignore the
+chain you pass** — so a new caller cannot get it wrong by habit. Their admin-role branch still
+honours the chain you give it, because admin roles genuinely *are* per-chain.
+
+Purchases settle there too. Membership is only readable from one place if it is also *written* in
+one place; a purchase landing elsewhere creates a membership the reference-chain read can never
+see.
+
+> **Why this was a bug, not a preference.** On mainnet the `MembershipManager` is deployed on
+> Polygon and nowhere else. Reading it on the wallet's chain reported every member on Ethereum,
+> Optimism, Base, Arbitrum or ETC as having no membership.
+
+## 2. Everything else spans the cohort
+
+```js
+import { cohortChainIds, isInCohort } from '../config/networks'
+import { estateNetworks, readAcrossEstate, readProviderFor } from '../lib/chains/estate'
+```
+
+The **cohort** is the set of chains this build may read: mainnets for a mainnet build, testnets
+for a testnet build. Constitution III forbids network-scoped data crossing that boundary, so
+"read every chain" means *every chain this build may read*. Use `cohortChainIds()` — never
+`listSupportedChainIds()`, which spans both.
+
+The **estate** is what is deployed on those chains and what it says. Reading it means asking
+every cohort chain and reporting **all** of them, including the ones that answered *not deployed*
+and the ones that could not be asked.
+
+```js
+const results = await readAcrossEstate({
+  addressFor: (id) => getContractAddressForChain('membershipManager', id),
+  read: ({ provider, address }) => new ethers.Contract(address, ABI, provider).accruedFees(),
+  walletChainId, walletProvider,
+  unitFor: feeUnitFor,          // required for balances — see the no-cross-unit rule below
+})
+```
+
+`readAcrossEstate` is concurrent and **never rejects**: one dead endpoint becomes an `unreadable`
+entry while its siblings resolve, so no view is held hostage by the slowest chain.
+
+### Providers
+
+**Never build a provider from `NETWORKS[chainId].rpcUrl`.** That bypasses `resolveRpcEndpoints`
+and so ignores the member's configured endpoint and failover (spec 069). Go through
+`readProviderFor(chainId, walletChainId, walletProvider)`, which reuses the wallet's own provider
+when the scope *is* the connected chain and resolves properly otherwise. A source-level test
+pins this.
+
+## 3. The three states — and why `?? 0` has nowhere to live
+
+```js
+import { readOk, notDeployed, unreadable, isRead, aggregate } from '../lib/chains/chainReadResult'
+```
+
+| State | Meaning |
+|---|---|
+| `read` | the contract answered; `value` is a fact |
+| `not-deployed` | there is no such contract here. A **definite** answer — not a zero |
+| `unreadable` | the question could not be put. **Not an answer.** Never renders as `0` |
+
+`value` exists **only** on `read`. That is deliberate: a consumer tempted to write
+`result.value ?? 0` finds the default has nowhere to live, because the two non-answer states
+carry no value at all.
+
+An operator auditing a control surface reads a silent `0` as a fact. That single sentence is why
+this type has three states instead of a nullable number.
+
+### Aggregation never crosses units
+
+`aggregate()` returns **per-unit subtotals** plus `partial` and `missing`. There is deliberately
+no API returning one figure across units — Polygon USDC and Mordor's Classic USD are not the same
+asset, so a single number across them is invented. An `unreadable` chain is excluded and sets
+`partial`; a `not-deployed` chain contributes nothing and does **not** set it, because nothing is
+missing — there is simply nothing there.
+
+Render with `ChainStateTable`, which handles all three states and the partial label.
+
+## 4. Operator views: scope reads, gate writes
+
+```js
+import { NetworkScopeCard, WriteGate } from '../components/admin/scopeControls'
+import { useScopedChain, writeGateReason, writeAllowed } from '../components/admin/scopeGate'
+```
+
+- **Scope is a network the operator picks.** `useScopedChain` seeds it from the wallet's chain
+  once and **never re-derives it** — an operator mid-audit must not have their reading silently
+  re-targeted when a wallet switches networks.
+- **A write is one transaction on one named chain.** Gate it on the wallet being there, check
+  again at the call site so a stale render cannot send to the wrong network, and name the chain
+  in the confirmation.
+- **Authority is read from the contract that will enforce it**, never from an app-wide role flag.
+  `GUARDIAN_ROLE` on the WagerRegistry is not `GUARDIAN_ROLE` on the BridgeRouter.
+- **An unconfirmed authority read keeps the control offered**, and says so. Only a definite "no"
+  withholds. Hiding a killswitch because an RPC timed out tells an operator who holds it that
+  there isn't one.
+- **No control acts on several chains at once.** No bulk pause, no bulk freeze.
+
+## Checklist for a new operator view
+
+1. Roster from `estateNetworks()` (cohort-bounded), not `listSupportedChainIds()`.
+2. Scope with `useScopedChain`; do not re-derive it from the wallet.
+3. Resolve addresses **and** providers against the *scoped* chain, so they cannot disagree.
+4. Render per-chain state with `ChainStateTable` — never collapse unreadable into zero.
+5. Gate writes with `writeAllowed`/`writeGateReason`; name the chain on the button and in the
+   confirmation.
+6. Totals via `aggregate()` only.
+
+`frontend/src/test/admin/adminEstateGuard.test.js` enforces 3 and 6 at the source level, with a
+documented baseline for views not yet converted.

--- a/docs/developer-guide/chain-estate-reads.md
+++ b/docs/developer-guide/chain-estate-reads.md
@@ -112,7 +112,10 @@ import { useScopedChain, writeGateReason, writeAllowed } from '../components/adm
   again at the call site so a stale render cannot send to the wrong network, and name the chain
   in the confirmation.
 - **Authority is read from the contract that will enforce it**, never from an app-wide role flag.
-  `GUARDIAN_ROLE` on the WagerRegistry is not `GUARDIAN_ROLE` on the BridgeRouter.
+  `GUARDIAN_ROLE` on the WagerRegistry is not `GUARDIAN_ROLE` on the BridgeRouter. Use
+  `readAuthority` + `authorityGate` from `lib/chains/estate.js`; an app-wide flag may stand in
+  only while the first read is in flight, so an operator who does hold the role is not shown an
+  empty tab for a round-trip.
 - **An unconfirmed authority read keeps the control offered**, and says so. Only a definite "no"
   withholds. Hiding a killswitch because an RPC timed out tells an operator who holds it that
   there isn't one.

--- a/docs/runbooks/operations-control-plane.md
+++ b/docs/runbooks/operations-control-plane.md
@@ -80,6 +80,17 @@ not reach that network's contract to check your role. The contract itself will s
 anything you do not hold — the control stays available because hiding a killswitch on a failed
 read tells an operator who *does* hold it that there isn't one.
 
+### Who a control is offered to
+
+A view's edit controls are offered on the strength of the role you hold **on the contract in
+scope**, read from that contract — not on an app-wide "you are an admin somewhere" flag. Holding
+`FEE_ADMIN_ROLE` on Polygon does not put the fee editor in front of you while you are reading
+Base's FeeRouter, because Base's router would refuse the transaction.
+
+The one exception is a role read that **fails**: the control stays offered and says
+*authority could not be confirmed*. The contract is the real gate, and withholding a killswitch
+because an RPC timed out tells an operator who *does* hold it that there isn't one.
+
 ## Navigating: the collapsible section rail
 
 The groups above render as a side panel down the left of `/admin`, with the
@@ -94,8 +105,13 @@ hamburger switches between them:
 
 It opens expanded on desktop and collapsed on mobile, where expanding slides the
 panel over the content — pick a view, tap the dimmed area, or press `Esc` to
-close it again. Mobile also keeps the bottom icon bar for switching between
-views without opening the panel at all.
+close it again.
+
+There is deliberately **no bottom icon bar** on this console. The other sections
+of the app have one, but they have a handful of views each; operations has 22, and
+a fixed strip fitted every one of them across a phone's width, so the labels
+overlapped into an unreadable run and the bar covered the content it was meant to
+navigate. The rail already puts every section one tap away, in named groups.
 
 ## How-to: common procedures
 
@@ -208,6 +224,8 @@ on-chain; the view exists so operators can act without CLI tooling.
 | "Access Restricted" on `/admin` | No operator role found for your wallet on **any** network in this build's cohort. Entry sweeps them all, so switching networks will not change this — check the address. |
 | A group/view is missing from the rail | You lack the gating role; the rail only shows what you can use. |
 | The rail is a strip of icons with no labels | It is collapsed, not broken — every view is still there. Hover for a name, or click the hamburger at its top left to expand. |
+| The view renders *below* the rail instead of beside it | A layout regression, not a setting. `.portal-shell` must be `display: flex`; `src/test/portalNavStylesheet.test.js` guards it. |
+| An edit control is missing though you hold the role | You hold it on another network. Roles are per contract per chain; scope the view to the network you hold it on. |
 | A view names a network and says "not deployed" | That contract is not in the frontend address book for **that** network. Pick another in the view's network selector, or run `npm run sync:frontend-contracts` after deploy. |
 | The paymaster deposit shows an unfamiliar currency | It is denominated in the **scoped** network's native token, not your wallet's — that is the figure being read. |
 | A deny-list status check says *unknown* | The guard on that network could not be reached. It is not a clearance; retry or pick a network you can read. |

--- a/docs/runbooks/operations-control-plane.md
+++ b/docs/runbooks/operations-control-plane.md
@@ -205,10 +205,13 @@ on-chain; the view exists so operators can act without CLI tooling.
 
 | Symptom | Likely cause / fix |
 |---|---|
-| "Access Restricted" on `/admin` | Connected wallet holds no operator role on this chain. Roles are chain-scoped — check the network selector first. |
+| "Access Restricted" on `/admin` | No operator role found for your wallet on **any** network in this build's cohort. Entry sweeps them all, so switching networks will not change this — check the address. |
 | A group/view is missing from the rail | You lack the gating role; the rail only shows what you can use. |
 | The rail is a strip of icons with no labels | It is collapsed, not broken — every view is still there. Hover for a name, or click the hamburger at its top left to expand. |
-| A view shows "not deployed on this network" | Address not in the frontend address book for this chain — run `npm run sync:frontend-contracts` after deploy. |
+| A view names a network and says "not deployed" | That contract is not in the frontend address book for **that** network. Pick another in the view's network selector, or run `npm run sync:frontend-contracts` after deploy. |
+| The paymaster deposit shows an unfamiliar currency | It is denominated in the **scoped** network's native token, not your wallet's — that is the figure being read. |
+| A deny-list status check says *unknown* | The guard on that network could not be reached. It is not a clearance; retry or pick a network you can read. |
 | Gasless card shows "No relay gateway configured" | `VITE_RELAYER_URL` unset in this build; gasless flows self-submit. Expected in local dev. |
 | Runway numbers missing from the health card | The gateway only discloses operator telemetry to origin-authenticated callers; the public subset (RPC up/down) still renders. |
 | A write reverts with an AccessControl error | The role lives on a different contract than you expect (e.g. `SANCTIONS_ADMIN_ROLE` is on SanctionsGuard, not the registry) or you hold it on another chain. |
+| Tiers / Members offer no network selector | Deliberate. Membership lives on one network, so there is no choice to make — a tier configured elsewhere is one no purchase would ever consult. |

--- a/docs/runbooks/operations-control-plane.md
+++ b/docs/runbooks/operations-control-plane.md
@@ -33,6 +33,53 @@ Related: [operator onboarding](operator-onboarding.md) ·
 | Access Control | Admin Roles | `DEFAULT_ADMIN_ROLE` | role-defining contracts |
 | Infrastructure | Services | admin or guardian | read-only + paymaster |
 
+## Reading the estate: what "per network" means here (spec 071)
+
+The console reads **every network this build may touch**, not the one your wallet happens to be
+connected to. Two consequences you will notice immediately:
+
+- **You can get in from anywhere.** Entry asks every network whether you hold an operator role,
+  so a guardian on Polygon reaches the console from a wallet pointed at Base. The permissions
+  card names the network each role was found on — a bare ✓ on a per-chain role is not enough to
+  act on.
+- **Your membership is read on one network.** Membership lives on Polygon (Amoy on testnet
+  builds) and nowhere else, so it resolves there whatever your wallet says.
+
+### The three states, and why a zero is never one of them
+
+Every per-network figure is in exactly one of three states, and they are deliberately not
+interchangeable:
+
+| State | Means | Do |
+|---|---|---|
+| a value | the contract answered | act on it |
+| *Not deployed on this network* | there is no such contract here | nothing to do here |
+| *Could not be read — <reason>* | **we could not ask** | retry; do not read it as zero |
+
+The third is the one that matters. A silent `0` on a control surface reads as a fact, so an
+unreachable network always says so and is excluded from any total — and that total is then
+labelled **partial** and names what is missing.
+
+For the same reason, balances are **never summed across networks**: different chains hold
+different payment tokens, so totals are shown per token. And **accrued** fees (undrawn, still
+withdrawable) are never added to **treasury** balances (already delivered) — they are different
+kinds of money.
+
+### Reads span the estate; writes do not
+
+Every change is one transaction on **one named network**, and the button says which. If your
+wallet is on a different network the control is withheld *and tells you which network to switch
+to* — before you sign, not at signature time.
+
+There is deliberately **no control that acts on several networks at once**. No "pause
+everywhere", no bulk freeze. A killswitch that fans out is one an operator can fire without
+knowing what they hit, so each network is paused, frozen, or withdrawn from explicitly.
+
+If a control is offered but says **authority could not be confirmed**, that is honest: we could
+not reach that network's contract to check your role. The contract itself will still refuse
+anything you do not hold — the control stays available because hiding a killswitch on a failed
+read tells an operator who *does* hold it that there isn't one.
+
 ## Navigating: the collapsible section rail
 
 The groups above render as a side panel down the left of `/admin`, with the

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -24,7 +24,7 @@ import SupplyTab from './admin/SupplyTab'
 import MaintenanceTab from './admin/MaintenanceTab'
 import ServiceHealthCard from './admin/ServiceHealthCard'
 import PaymasterOpsCard from './admin/PaymasterOpsCard'
-import { buildAdminNavGroups, flattenNavGroups } from './admin/adminNav'
+import { buildAdminNavGroups } from './admin/adminNav'
 import { networkName, readProviderFor } from '../lib/chains/estate'
 import { isRead, isNotDeployed, formatUnitAmount } from '../lib/chains/chainReadResult'
 import { useFeeEstate } from '../hooks/useFeeEstate'
@@ -34,7 +34,6 @@ import { useScopedChain } from './admin/scopeGate'
 import ChainStateTable from './admin/ChainStateTable'
 import PortalNav from './ui/PortalNav'
 import NavIcon from './nav/NavIcon'
-import SectionIconNav from './nav/SectionIconNav'
 import { useIsMobile } from '../hooks/useMediaQuery'
 import './AdminPanel.css'
 
@@ -184,6 +183,7 @@ function AdminPanel() {
   const [contractState, setContractState] = useState({
     isPaused: false,
     accruedFees: '0',
+    accruedFeesReadable: null,
     treasury: '',
     isLoaded: false,
   })
@@ -285,14 +285,18 @@ function AdminPanel() {
   const fetchContractState = useCallback(async () => {
     if (!wagerRegistryRead || !membershipManagerRead) return
     try {
+      // `accruedFees` is money. A failed read must not arrive here as 0n: an operator reading a
+      // zero accrued balance concludes the fees were already withdrawn. Keep the failure as a
+      // failure and let the view say so (FR-013).
       const [paused, fees, treasury] = await Promise.all([
         wagerRegistryRead.paused().catch(() => false),
-        membershipManagerRead.accruedFees().catch(() => 0n),
+        membershipManagerRead.accruedFees().then((v) => ({ ok: true, v })).catch(() => ({ ok: false })),
         membershipManagerRead.treasury().catch(() => ''),
       ])
       setContractState({
         isPaused: paused,
-        accruedFees: ethers.formatUnits(fees, USDC_DECIMALS),
+        accruedFees: fees.ok ? ethers.formatUnits(fees.v, USDC_DECIMALS) : '0',
+        accruedFeesReadable: fees.ok,
         treasury: treasury || '',
         isLoaded: true,
       })
@@ -482,7 +486,6 @@ function AdminPanel() {
     isStakingAdmin,
     isLiquidityAdmin,
   })
-  const adminTabs = flattenNavGroups(navGroups)
 
   // On mobile the expanded rail sits ON TOP of the view it just switched to, so
   // picking a section collapses it back to icons. On desktop it stays open.
@@ -695,11 +698,21 @@ function AdminPanel() {
 
               <ServiceHealthCard />
 
+              {/*
+                T046 — the address is the REFERENCE chain's MembershipManager (memberships live on
+                one chain), so the provider and the cache key must name that chain too. Passing the
+                wallet's provider alongside another chain's address is the precise disagreement
+                this spec exists to end: it reads one chain's contract at another chain's address.
+              */}
               <MembershipTreasuryOverview
-                provider={provider || getProvider(chainId)}
-                chainId={chainId}
+                provider={
+                  readProviderFor(membershipAdminChainId, chainId, provider) ||
+                  getProvider(membershipAdminChainId)
+                }
+                chainId={membershipAdminChainId}
                 address={membershipManagerAddr}
                 accruedFees={contractState.accruedFees}
+                accruedFeesReadable={contractState.accruedFeesReadable}
               />
 
               {/*
@@ -1168,6 +1181,7 @@ function AdminPanel() {
         {activeTab === 'fees' && (isAdmin || isFeeAdmin) && (
           <FeesTab
             signer={signer}
+            account={account}
             chainId={chainId}
             provider={provider || getProvider(chainId)}
             runTx={runTx}
@@ -1180,6 +1194,7 @@ function AdminPanel() {
         {activeTab === 'staking' && (isAdmin || isStakingAdmin || isGuardian) && (
           <StakingTab
             signer={signer}
+            account={account}
             chainId={chainId}
             provider={provider || getProvider(chainId)}
             runTx={runTx}
@@ -1271,14 +1286,14 @@ function AdminPanel() {
           </div>
         )}
           </main>
-
-          {/* Mobile-only bottom quick-nav between admin sections. */}
-          <SectionIconNav
-            items={adminTabs}
-            activeId={activeTab}
-            onSelect={setActiveTab}
-            ariaLabel="Operations sections"
-          />
+          {/*
+            No bottom icon bar here, deliberately. The console has 22 sections, and a fixed
+            bottom strip fitted every one of them into a phone's width — the labels overlapped
+            into an unreadable run of text, and the bar covered the content it was meant to
+            navigate. The collapsible rail already lists every section one tap away, in groups,
+            with the hamburger pinned to its top left, so the bar was a worse copy of a control
+            that was already on screen.
+          */}
         </div>
       </div>
     </div>

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -9,6 +9,7 @@ import { ROLES, ADMIN_ROLES } from '../contexts/RoleContext'
 import { isValidEthereumAddress } from '../utils/validation'
 import { ACCOUNT_MODERATION_PATH } from '../constants/legalLinks'
 import { NETWORK_CONFIG, DEPLOYED_CONTRACTS, getContractAddressForChain } from '../config/contracts'
+import { membershipChainId } from '../config/networks'
 import { getProvider } from '../utils/blockchainService'
 import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
 import OracleAdaptersTab from './admin/OracleAdaptersTab'
@@ -24,7 +25,7 @@ import MaintenanceTab from './admin/MaintenanceTab'
 import ServiceHealthCard from './admin/ServiceHealthCard'
 import PaymasterOpsCard from './admin/PaymasterOpsCard'
 import { buildAdminNavGroups, flattenNavGroups } from './admin/adminNav'
-import { networkName } from '../lib/chains/estate'
+import { networkName, readProviderFor } from '../lib/chains/estate'
 import { isRead, isNotDeployed, formatUnitAmount } from '../lib/chains/chainReadResult'
 import { useFeeEstate } from '../hooks/useFeeEstate'
 import { estateNetworks } from '../lib/chains/estate'
@@ -222,23 +223,51 @@ function AdminPanel() {
   const withdrawEns = useEnsResolution(withdrawForm.to || '')
 
   const wagerRegistryAddr = getContractAddressForChain('wagerRegistry', chainId)
-  const membershipManagerAddr = getContractAddressForChain('membershipManager', chainId)
-  const sanctionsGuardAddr = getContractAddressForChain('sanctionsGuard', chainId)
-  const tokenFactoryAddr = getContractAddressForChain('tokenFactory', chainId)
-  const stakingRouterAddr = getContractAddressForChain('stakingRouter', chainId)
-  const bridgeRouterAddr = getContractAddressForChain('bridgeRouter', chainId)
-  const liquidityRouterAddr = getContractAddressForChain('liquidityRouter', chainId)
+  // ── MEMBERSHIP ADMIN IS PINNED TO THE REFERENCE CHAIN, NOT SCOPED (spec 071 FR-003/FR-006) ──
+  // Tiers and Members are the one place a scope PICKER would be wrong. Membership is read from
+  // exactly one chain, so a tier ladder configured anywhere else is one no purchase consults, and
+  // a membership granted anywhere else is one the app never sees — the operator's grant would
+  // simply not exist as far as every member surface is concerned. Same rule as purchases: one
+  // home, named, with the wallet required to be there.
+  const membershipAdminChainId = membershipChainId()
+  const onMembershipChain = Number(membershipAdminChainId) === Number(chainId)
+  const membershipManagerAddr = getContractAddressForChain('membershipManager', membershipAdminChainId)
+  const requireMembershipChain = () => {
+    if (onMembershipChain) return true
+    showNotification(
+      `Memberships live on ${networkName(membershipAdminChainId)}. Switch your wallet there first.`,
+      'error',
+    )
+    return false
+  }
+  // ── ROLE GRANTS ARE PER CONTRACT *PER CHAIN* (spec 071 T064/FR-017) ─────────────────────────
+  // That is already true on-chain — GUARDIAN_ROLE on Polygon's registry is not GUARDIAN_ROLE on
+  // Base's. The view resolved every target from the WALLET's chain, which quietly implied a grant
+  // was platform-wide. It is scoped and named instead, so an operator can see which network they
+  // are handing authority on.
+  const roleNetworks = useMemo(() => estateNetworks(), [])
+  const { scopeChainId: roleChainId, setScopeChainId: setRoleChainId } =
+    useScopedChain(roleNetworks, chainId)
+  const onRoleChain = Number(roleChainId) === Number(chainId)
+  const sanctionsGuardAddr = getContractAddressForChain('sanctionsGuard', roleChainId)
+  const tokenFactoryAddr = getContractAddressForChain('tokenFactory', roleChainId)
+  const stakingRouterAddr = getContractAddressForChain('stakingRouter', roleChainId)
+  const bridgeRouterAddr = getContractAddressForChain('bridgeRouter', roleChainId)
+  const liquidityRouterAddr = getContractAddressForChain('liquidityRouter', roleChainId)
+  const roleRegistryAddr = getContractAddressForChain('wagerRegistry', roleChainId)
 
   // Each grantable role lives on a specific contract; grants must be sent
   // to the contract that defines the role, not blanket-sent to the registry.
   const roleHomeContract = (role) => {
+    // ROLE_MANAGER lives on the MembershipManager, which is reference-chain pinned like the
+    // membership it manages — so this one target is deliberately NOT scope-following.
     if (role === 'ROLE_MANAGER') return membershipManagerAddr
     if (role === 'SANCTIONS_ADMIN') return sanctionsGuardAddr
     if (role === 'TOKEN_ISSUER') return tokenFactoryAddr
     if (role === 'STAKING_ADMIN') return stakingRouterAddr
     if (role === 'LIQUIDITY_ADMIN_BRIDGE' || role === 'GUARDIAN_BRIDGE') return bridgeRouterAddr
     if (role === 'LIQUIDITY_ADMIN_LIQUIDITY' || role === 'GUARDIAN_LIQUIDITY') return liquidityRouterAddr
-    return wagerRegistryAddr
+    return roleRegistryAddr
   }
 
   const wagerRegistryRead = useMemo(() => {
@@ -249,9 +278,9 @@ function AdminPanel() {
 
   const membershipManagerRead = useMemo(() => {
     if (!membershipManagerAddr) return null
-    const p = provider || getProvider(chainId)
+    const p = readProviderFor(membershipAdminChainId, chainId, provider) || getProvider(membershipAdminChainId)
     return new ethers.Contract(membershipManagerAddr, MEMBERSHIP_ADMIN_ABI, p)
-  }, [provider, membershipManagerAddr, chainId])
+  }, [provider, membershipManagerAddr, membershipAdminChainId, chainId])
 
   const fetchContractState = useCallback(async () => {
     if (!wagerRegistryRead || !membershipManagerRead) return
@@ -319,6 +348,7 @@ function AdminPanel() {
   )
 
   const handleConfigureTier = () => {
+    if (!requireMembershipChain()) return false
     const priceUSDC = ethers.parseUnits(String(tierForm.price), USDC_DECIMALS)
     return runTx(
       () => new ethers.Contract(membershipManagerAddr, MEMBERSHIP_ADMIN_ABI, signer).setTier(
@@ -329,29 +359,31 @@ function AdminPanel() {
         { monthlyMarketCreation: tierForm.monthly, maxConcurrentMarkets: tierForm.concurrent },
         tierForm.active
       ),
-      `Tier ${TIER_NAMES[tierForm.tier]} configured at $${tierForm.price} USDC`
+      `Tier ${TIER_NAMES[tierForm.tier]} configured at $${tierForm.price} USDC on ${networkName(membershipAdminChainId)}`
     )
   }
 
   const handleGrantMembership = () => {
     const target = grantEns.resolvedAddress || grantForm.address
     if (!isValidEthereumAddress(target)) return showNotification('Invalid address', 'error')
+    if (!requireMembershipChain()) return false
     return runTx(
       () => new ethers.Contract(membershipManagerAddr, MEMBERSHIP_ADMIN_ABI, signer).grantMembership(
         target, ROLE_HASHES.WAGER_PARTICIPANT, grantForm.tier, grantForm.durationDays
       ),
-      `Granted ${TIER_NAMES[grantForm.tier]} membership to ${shortAddr(target)}`
+      `Granted ${TIER_NAMES[grantForm.tier]} membership to ${shortAddr(target)} on ${networkName(membershipAdminChainId)}`
     )
   }
 
   const handleRevokeMembership = () => {
     const target = revokeEns.resolvedAddress || revokeForm.address
     if (!isValidEthereumAddress(target)) return showNotification('Invalid address', 'error')
+    if (!requireMembershipChain()) return false
     return runTx(
       () => new ethers.Contract(membershipManagerAddr, MEMBERSHIP_ADMIN_ABI, signer).revokeMembership(
         target, ROLE_HASHES.WAGER_PARTICIPANT
       ),
-      `Revoked membership for ${shortAddr(target)}`
+      `Revoked membership for ${shortAddr(target)} on ${networkName(membershipAdminChainId)}`
     )
   }
 
@@ -384,7 +416,7 @@ function AdminPanel() {
     if (!addr) return showNotification('Role contract not deployed on this network', 'error')
     return runTx(
       () => new ethers.Contract(addr, WAGER_REGISTRY_ADMIN_ABI, signer).grantRole(roleHash, target),
-      `Granted ${adminRoleForm.role} to ${shortAddr(target)}`
+      `Granted ${adminRoleForm.role} to ${shortAddr(target)} on ${networkName(roleChainId)}`
     )
   }
 
@@ -396,7 +428,7 @@ function AdminPanel() {
     if (!addr) return showNotification('Role contract not deployed on this network', 'error')
     return runTx(
       () => new ethers.Contract(addr, WAGER_REGISTRY_ADMIN_ABI, signer).revokeRole(roleHash, target),
-      `Revoked ${adminRoleForm.role} from ${shortAddr(target)}`
+      `Revoked ${adminRoleForm.role} from ${shortAddr(target)} on ${networkName(roleChainId)}`
     )
   }
 
@@ -759,7 +791,16 @@ function AdminPanel() {
         {activeTab === 'tiers' && isAdmin && (
           <div className="admin-tab-content" role="tabpanel">
             <div className="admin-card">
-              <h3>Configure Tier: Wager Participant</h3>
+              <h3>Configure Tier: Wager Participant on {networkName(membershipAdminChainId)}</h3>
+              {!onMembershipChain && (
+                <p className="card-info warning-text" role="status">
+                  Memberships live on {networkName(membershipAdminChainId)} and are read from there
+                  everywhere. Switch your wallet to {networkName(membershipAdminChainId)} to make
+                  this change — doing it on another network would create state no member surface
+                  ever reads.
+                </p>
+              )}
+
               <p>Set price (USDC), duration, monthly cap, and concurrent cap for each tier. 0 = unlimited.</p>
               <div className="admin-form">
                 <label>
@@ -793,7 +834,7 @@ function AdminPanel() {
                     onChange={(e) => setTierForm({ ...tierForm, active: e.target.checked })} />
                   Active (available for purchase)
                 </label>
-                <button className="confirm-btn primary" onClick={handleConfigureTier} disabled={pendingTx}>
+                <button className="confirm-btn primary" onClick={handleConfigureTier} disabled={pendingTx || !onMembershipChain}>
                   {pendingTx ? 'Saving...' : 'Save Tier Config'}
                 </button>
               </div>
@@ -805,7 +846,16 @@ function AdminPanel() {
         {activeTab === 'members' && isRoleManager && (
           <div className="admin-tab-content" role="tabpanel">
             <div className="admin-card">
-              <h3>Grant Membership</h3>
+              <h3>Grant Membership on {networkName(membershipAdminChainId)}</h3>
+              {!onMembershipChain && (
+                <p className="card-info warning-text" role="status">
+                  Memberships live on {networkName(membershipAdminChainId)} and are read from there
+                  everywhere. Switch your wallet to {networkName(membershipAdminChainId)} to make
+                  this change — doing it on another network would create state no member surface
+                  ever reads.
+                </p>
+              )}
+
               <p>Grant a Wager Participant membership directly, bypassing the purchase flow. Use for support, gifts, or dispute resolution.</p>
               <div className="admin-form">
                 <label>
@@ -829,7 +879,7 @@ function AdminPanel() {
                   <input type="number" min="1" max="3650" value={grantForm.durationDays}
                     onChange={(e) => setGrantForm({ ...grantForm, durationDays: Number(e.target.value) })} />
                 </label>
-                <button className="confirm-btn primary" onClick={handleGrantMembership} disabled={pendingTx}>
+                <button className="confirm-btn primary" onClick={handleGrantMembership} disabled={pendingTx || !onMembershipChain}>
                   {pendingTx ? 'Granting...' : 'Grant Membership'}
                 </button>
               </div>
@@ -848,7 +898,7 @@ function AdminPanel() {
                     <span className="hint">→ {shortAddr(revokeEns.resolvedAddress)}</span>
                   )}
                 </label>
-                <button className="confirm-btn danger" onClick={handleRevokeMembership} disabled={pendingTx}>
+                <button className="confirm-btn danger" onClick={handleRevokeMembership} disabled={pendingTx || !onMembershipChain}>
                   {pendingTx ? 'Revoking...' : 'Revoke Membership'}
                 </button>
               </div>
@@ -912,8 +962,26 @@ function AdminPanel() {
         {/* Admin Roles */}
         {activeTab === 'admin-roles' && isAdmin && (
           <div className="admin-tab-content" role="tabpanel">
+            <NetworkScopeCard
+              title="Admin Roles"
+              description="Roles are granted per contract per network. A grant on one network gives no authority on another, so pick the network you mean."
+              networks={roleNetworks}
+              scopeChainId={roleChainId}
+              onScopeChange={setRoleChainId}
+              isDeployed={(id) => Boolean(getContractAddressForChain('wagerRegistry', id))}
+              walletChainId={chainId}
+              onRefresh={() => {}}
+              lastReadAt={null}
+              notDeployedLabel="no wager registry"
+            />
             <div className="admin-card">
-              <h3>Grant / Revoke Admin Roles</h3>
+              <h3>Grant / Revoke Admin Roles on {networkName(roleChainId)}</h3>
+              {!onRoleChain && (
+                <p className="card-info warning-text" role="status">
+                  This grant is signed on {networkName(roleChainId)}. Your wallet is on{' '}
+                  {networkName(chainId)} — switch it there to grant or revoke.
+                </p>
+              )}
               <p>
                 Only the holder of <code>DEFAULT_ADMIN_ROLE</code> can grant other admin roles.
                 Grant sparingly: each role is a distinct privilege and a foothold.
@@ -961,10 +1029,10 @@ function AdminPanel() {
                   </select>
                 </label>
                 <div className="emergency-actions">
-                  <button className="confirm-btn primary" onClick={handleGrantAdminRole} disabled={pendingTx}>
+                  <button className="confirm-btn primary" onClick={handleGrantAdminRole} disabled={pendingTx || !onRoleChain}>
                     {pendingTx ? 'Processing...' : 'Grant Role'}
                   </button>
-                  <button className="confirm-btn danger" onClick={handleRevokeAdminRole} disabled={pendingTx}>
+                  <button className="confirm-btn danger" onClick={handleRevokeAdminRole} disabled={pendingTx || !onRoleChain}>
                     {pendingTx ? 'Processing...' : 'Revoke Role'}
                   </button>
                 </div>

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -27,6 +27,9 @@ import { buildAdminNavGroups, flattenNavGroups } from './admin/adminNav'
 import { networkName } from '../lib/chains/estate'
 import { isRead, isNotDeployed, formatUnitAmount } from '../lib/chains/chainReadResult'
 import { useFeeEstate } from '../hooks/useFeeEstate'
+import { estateNetworks } from '../lib/chains/estate'
+import { NetworkScopeCard } from './admin/scopeControls'
+import { useScopedChain } from './admin/scopeGate'
 import ChainStateTable from './admin/ChainStateTable'
 import PortalNav from './ui/PortalNav'
 import NavIcon from './nav/NavIcon'
@@ -131,6 +134,32 @@ function AdminPanel() {
 
   // Fees across every cohort chain (US3), independent of where the wallet is connected.
   const feeEstate = useFeeEstate({ walletChainId: chainId, walletProvider: provider })
+
+  // Incident controls are per chain: pause and freeze act on ONE WagerRegistry. A guardian
+  // holding the role on Polygon could not pause Polygon from a wallet on Base, and the screen
+  // gave no reason. Scoped, named at the write, and — deliberately — with NO control that acts
+  // on several chains at once (FR-020): a killswitch that fans out is one an operator can fire
+  // without knowing what they hit.
+  const registryNetworks = useMemo(
+    () => estateNetworks().filter((n) => getContractAddressForChain('wagerRegistry', n.chainId)),
+    [],
+  )
+  const { scopeChainId: incidentChainId, setScopeChainId: setIncidentChainId } =
+    useScopedChain(registryNetworks, chainId)
+  const incidentRegistryAddr = getContractAddressForChain('wagerRegistry', incidentChainId)
+  const onIncidentChain = Number(incidentChainId) === Number(chainId)
+  const incidentWrite = () =>
+    new ethers.Contract(incidentRegistryAddr, WAGER_REGISTRY_ADMIN_ABI, signer)
+  // Refuses at the call site as well as in the disabled button, so a stale render cannot pause
+  // the wrong network (FR-018).
+  const requireIncidentChain = () => {
+    if (onIncidentChain) return true
+    showNotification(
+      `This acts on ${networkName(incidentChainId)}. Switch your wallet there first.`,
+      'error',
+    )
+    return false
+  }
 
   // A withdrawal targets ONE chain. It defaults to the wallet's chain when that chain carries a
   // MembershipManager, otherwise to the first chain that does — the same rule the spec-067 tabs
@@ -279,14 +308,14 @@ function AdminPanel() {
     }
   }, [signer, showNotification, fetchContractState])
 
-  const handlePause = () => runTx(
-    () => new ethers.Contract(wagerRegistryAddr, WAGER_REGISTRY_ADMIN_ABI, signer).pause(),
-    'WagerRegistry paused'
+  const handlePause = () => requireIncidentChain() && runTx(
+    () => incidentWrite().pause(),
+    `WagerRegistry paused on ${networkName(incidentChainId)}`
   )
 
-  const handleUnpause = () => runTx(
-    () => new ethers.Contract(wagerRegistryAddr, WAGER_REGISTRY_ADMIN_ABI, signer).unpause(),
-    'WagerRegistry unpaused'
+  const handleUnpause = () => requireIncidentChain() && runTx(
+    () => incidentWrite().unpause(),
+    `WagerRegistry unpaused on ${networkName(incidentChainId)}`
   )
 
   const handleConfigureTier = () => {
@@ -330,20 +359,20 @@ function AdminPanel() {
     const target = freezeEns.resolvedAddress || freezeForm.address
     if (!isValidEthereumAddress(target)) return showNotification('Invalid address', 'error')
     if (!freezeForm.reason.trim()) return showNotification('Reason is required (recorded on-chain)', 'error')
+    if (!requireIncidentChain()) return false
     return runTx(
-      () => new ethers.Contract(wagerRegistryAddr, WAGER_REGISTRY_ADMIN_ABI, signer).freezeAccount(
-        target, freezeForm.reason.trim()
-      ),
-      `Account ${shortAddr(target)} frozen`
+      () => incidentWrite().freezeAccount(target, freezeForm.reason.trim()),
+      `Account ${shortAddr(target)} frozen on ${networkName(incidentChainId)}`
     )
   }
 
   const handleUnfreeze = () => {
     const target = freezeEns.resolvedAddress || freezeForm.address
     if (!isValidEthereumAddress(target)) return showNotification('Invalid address', 'error')
+    if (!requireIncidentChain()) return false
     return runTx(
-      () => new ethers.Contract(wagerRegistryAddr, WAGER_REGISTRY_ADMIN_ABI, signer).unfreezeAccount(target),
-      `Account ${shortAddr(target)} unfrozen`
+      () => incidentWrite().unfreezeAccount(target),
+      `Account ${shortAddr(target)} unfrozen on ${networkName(incidentChainId)}`
     )
   }
 
@@ -691,17 +720,30 @@ function AdminPanel() {
         {/* Emergency */}
         {activeTab === 'emergency' && isGuardian && (
           <div className="admin-tab-content" role="tabpanel">
+              <NetworkScopeCard
+                title="Emergency Pause"
+                description="The pause acts on ONE network\u2019s WagerRegistry. There is deliberately no control that pauses several at once \u2014 a killswitch that fans out is one an operator can fire without knowing what they hit."
+                networks={registryNetworks}
+                scopeChainId={incidentChainId}
+                onScopeChange={setIncidentChainId}
+                isDeployed={(id) => Boolean(getContractAddressForChain('wagerRegistry', id))}
+                walletChainId={chainId}
+                onRefresh={fetchContractState}
+                lastReadAt={null}
+                notDeployedLabel="no wager registry"
+              />
+
             <div className="admin-card">
-              <h3>Emergency Pause</h3>
+              <h3>Emergency Pause on {networkName(incidentChainId)}</h3>
               <p>Pausing halts wager creation, acceptance, and settlement protocol-wide. Use only in response to a security incident. Unpausing restores normal operation.</p>
               <div className="emergency-actions">
                 {!contractState.isPaused ? (
-                  <button className="confirm-btn danger" onClick={handlePause} disabled={pendingTx}>
-                    {pendingTx ? 'Processing...' : 'Pause Protocol'}
+                  <button className="confirm-btn danger" onClick={handlePause} disabled={pendingTx || !onIncidentChain}>
+                    {pendingTx ? 'Processing...' : `Pause on ${networkName(incidentChainId)}`}
                   </button>
                 ) : (
-                  <button className="confirm-btn primary" onClick={handleUnpause} disabled={pendingTx}>
-                    {pendingTx ? 'Processing...' : 'Unpause Protocol'}
+                  <button className="confirm-btn primary" onClick={handleUnpause} disabled={pendingTx || !onIncidentChain}>
+                    {pendingTx ? 'Processing...' : `Unpause on ${networkName(incidentChainId)}`}
                   </button>
                 )}
               </div>
@@ -817,8 +859,21 @@ function AdminPanel() {
         {/* Account Moderation */}
         {activeTab === 'moderation' && isAccountModerator && (
           <div className="admin-tab-content" role="tabpanel">
+              <NetworkScopeCard
+                title="Account Moderation"
+                description="A freeze applies to ONE network\u2019s WagerRegistry. Freezing an account on one network does not freeze it on another, so each is done explicitly."
+                networks={registryNetworks}
+                scopeChainId={incidentChainId}
+                onScopeChange={setIncidentChainId}
+                isDeployed={(id) => Boolean(getContractAddressForChain('wagerRegistry', id))}
+                walletChainId={chainId}
+                onRefresh={fetchContractState}
+                lastReadAt={null}
+                notDeployedLabel="no wager registry"
+              />
+
             <div className="admin-card">
-              <h3>Freeze / Unfreeze Account</h3>
+              <h3>Freeze / Unfreeze Account on {networkName(incidentChainId)}</h3>
               <p>
                 A frozen account cannot create wagers, accept wagers, cancel, declare a winner,
                 claim payouts, or claim refunds on WagerRegistry. Polymarket auto-resolution is
@@ -842,11 +897,11 @@ function AdminPanel() {
                     onChange={(e) => setFreezeForm({ ...freezeForm, reason: e.target.value })} />
                 </label>
                 <div className="emergency-actions">
-                  <button className="confirm-btn danger" onClick={handleFreeze} disabled={pendingTx}>
-                    {pendingTx ? 'Processing...' : 'Freeze Account'}
+                  <button className="confirm-btn danger" onClick={handleFreeze} disabled={pendingTx || !onIncidentChain}>
+                    {pendingTx ? 'Processing...' : `Freeze on ${networkName(incidentChainId)}`}
                   </button>
-                  <button className="confirm-btn secondary" onClick={handleUnfreeze} disabled={pendingTx}>
-                    {pendingTx ? 'Processing...' : 'Unfreeze Account'}
+                  <button className="confirm-btn secondary" onClick={handleUnfreeze} disabled={pendingTx || !onIncidentChain}>
+                    {pendingTx ? 'Processing...' : `Unfreeze on ${networkName(incidentChainId)}`}
                   </button>
                 </div>
               </div>

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -1137,6 +1137,7 @@ function AdminPanel() {
             signer={signer}
             account={account}
             contracts={DEPLOYED_CONTRACTS}
+            chainId={chainId}
             runTx={runTx}
             pendingTx={pendingTx}
           />
@@ -1147,6 +1148,7 @@ function AdminPanel() {
             signer={signer}
             account={account}
             contracts={DEPLOYED_CONTRACTS}
+            chainId={chainId}
             runTx={runTx}
             pendingTx={pendingTx}
           />

--- a/frontend/src/components/admin/CallsignRegistryAdmin.jsx
+++ b/frontend/src/components/admin/CallsignRegistryAdmin.jsx
@@ -2,6 +2,9 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
 import { CALLSIGN_REGISTRY_ABI, CallsignStatus } from '../../abis/callsignRegistry'
 import { getContractAddressForChain } from '../../config/contracts'
+import { estateNetworks, networkName, readProviderFor } from '../../lib/chains/estate'
+import { NetworkScopeCard } from './scopeControls'
+import { useScopedChain } from './scopeGate'
 import { normalizeCallsign, isValidCallsign, formatCallsign } from '../../lib/callsigns/normalizeCallsign'
 import { useCallsignRegistryMetrics } from '../../hooks/useCallsignRegistryMetrics'
 import './CallsignRegistryAdmin.css'
@@ -55,11 +58,19 @@ function humanDuration(seconds) {
 }
 
 export default function CallsignRegistryAdmin({ signer, account, contracts, chainId, runTx, pendingTx }) {
+  // Spec 071 US4: the registry is per network — a callsign on one chain is not one on another.
+  const callsignNetworks = useMemo(() => estateNetworks(), [])
+  const { scopeChainId, setScopeChainId } = useScopedChain(callsignNetworks, chainId)
+  const onScopeNetwork = Number(scopeChainId) === Number(chainId)
   const address = useMemo(
-    () => getContractAddressForChain('callsignRegistry', chainId) || contracts?.callsignRegistry || '',
-    [chainId, contracts],
+    () => getContractAddressForChain('callsignRegistry', scopeChainId) || (Number(scopeChainId) === Number(chainId) ? contracts?.callsignRegistry : '') || '',
+    [scopeChainId, chainId, contracts],
   )
-  const provider = signer?.provider || null
+  // Reads come from the scoped chain; only writes use the wallet's signer.
+  const provider = useMemo(
+    () => readProviderFor(scopeChainId, chainId, signer?.provider || null),
+    [scopeChainId, chainId, signer],
+  )
   const configured = Boolean(address && ethers.isAddress(address))
 
   const reader = useMemo(
@@ -230,6 +241,24 @@ export default function CallsignRegistryAdmin({ signer, account, contracts, chai
 
   return (
     <section aria-labelledby="callsignadmin-heading" className="callsign-admin">
+      <NetworkScopeCard
+        title="Callsigns"
+        description="The callsign registry for one network. A callsign registered on one chain is not registered on another."
+        networks={callsignNetworks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('callsignRegistry', id))}
+        walletChainId={chainId}
+        onRefresh={() => {}}
+        lastReadAt={null}
+        notDeployedLabel="no CallsignRegistry"
+      />
+      {!onScopeNetwork && (
+        <p className="card-info warning-text" role="status">
+          Reading {networkName(scopeChainId)}; your wallet is on {networkName(chainId)}. Changes are
+          signed on {networkName(scopeChainId)} — switch your wallet to make one.
+        </p>
+      )}
       <h3 id="callsignadmin-heading">Callsign registry</h3>
       <p className="callsign-admin__addr">
         Registry: <span title={address}>{shortAddr(address)}</span>
@@ -320,7 +349,7 @@ export default function CallsignRegistryAdmin({ signer, account, contracts, chai
               autoComplete="off"
               spellCheck="false"
             />
-            <button type="button" className="confirm-btn" onClick={doLookup} disabled={pendingTx}>Look up</button>
+            <button type="button" className="confirm-btn" onClick={doLookup} disabled={!onScopeNetwork || pendingTx}>Look up</button>
           </div>
         </div>
         {lookupError && <p role="alert" className="callsign-admin__error">{lookupError}</p>}
@@ -388,7 +417,7 @@ export default function CallsignRegistryAdmin({ signer, account, contracts, chai
               <option value={3}>Gold</option>
               <option value={4}>Platinum</option>
             </select>
-            <button type="button" className="confirm-btn" onClick={saveGate} disabled={pendingTx || gateTier === config.minTier}>
+            <button type="button" className="confirm-btn" onClick={saveGate} disabled={!onScopeNetwork || pendingTx || gateTier === config.minTier}>
               Set gate
             </button>
           </div>
@@ -421,8 +450,8 @@ export default function CallsignRegistryAdmin({ signer, account, contracts, chai
               autoComplete="off"
             />
             <div className="callsign-admin__mod-actions">
-              <button type="button" className="confirm-btn primary" onClick={() => onRoleGrant(true)} disabled={pendingTx || !ethers.isAddress(roleForm.address.trim())}>Grant</button>
-              <button type="button" className="confirm-btn danger" onClick={() => onRoleGrant(false)} disabled={pendingTx || !ethers.isAddress(roleForm.address.trim())}>Revoke</button>
+              <button type="button" className="confirm-btn primary" onClick={() => onRoleGrant(true)} disabled={!onScopeNetwork || pendingTx || !ethers.isAddress(roleForm.address.trim())}>Grant</button>
+              <button type="button" className="confirm-btn danger" onClick={() => onRoleGrant(false)} disabled={!onScopeNetwork || pendingTx || !ethers.isAddress(roleForm.address.trim())}>Revoke</button>
             </div>
           </div>
           <p className="callsign-admin__hint">Role hashes are the keccak256 of the role names; the curator role also administers the reserved list.</p>

--- a/frontend/src/components/admin/DenyListAdmin.jsx
+++ b/frontend/src/components/admin/DenyListAdmin.jsx
@@ -1,5 +1,9 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
+import { getContractAddressForChain } from '../../config/contracts'
+import { estateNetworks, networkName, readProviderFor } from '../../lib/chains/estate'
+import { NetworkScopeCard } from './scopeControls'
+import { useScopedChain } from './scopeGate'
 
 /**
  * DenyListAdmin (Spec 007 — FR-020, SC-018)
@@ -8,8 +12,15 @@ import { ethers } from 'ethers'
  * reason (calls setDenied, gated on-chain by SANCTIONS_ADMIN_ROLE), and render the
  * add/remove audit trail from the DenyListUpdated event (actor + reason + block).
  *
- * Tab contract matches the other admin tabs: { signer, account, contracts, runTx, pendingTx }.
+ * Tab contract matches the other admin tabs: { signer, account, contracts, chainId, runTx, pendingTx }.
  * The guard address comes from the synced contracts config (FR-055) — never hardcoded.
+ *
+ * Spec 071 US4 — a deny-list entry is per guard, and there is a guard per network. Reading only
+ * the wallet's network made "not denied" ambiguous between *checked and clear* and *checked
+ * somewhere else*, which on a sanctions surface is the difference between a compliance answer and
+ * a guess. The network is now picked, reads follow the pick, and a write names the chain the entry
+ * lands on — a denial on one network is not a denial on another, and the audit trail below is that
+ * network's alone.
  */
 
 // Minimal human-readable ABI (keeps the bundle small; full ABI lives in abis/SanctionsGuard.js)
@@ -27,8 +38,22 @@ function shortAddr(a) {
   return a && ethers.isAddress(a) ? a.slice(0, 6) + '…' + a.slice(-4) : (a || '—')
 }
 
-function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
-  const guardAddress = contracts?.sanctionsGuard
+function DenyListAdmin({ signer, contracts, chainId, runTx, pendingTx }) {
+  const guardNetworks = useMemo(() => estateNetworks(), [])
+  const { scopeChainId, setScopeChainId } = useScopedChain(guardNetworks, chainId)
+  const onScopeNetwork = Number(scopeChainId) === Number(chainId)
+  const guardAddress = useMemo(
+    () =>
+      getContractAddressForChain('sanctionsGuard', scopeChainId) ||
+      (Number(scopeChainId) === Number(chainId) ? contracts?.sanctionsGuard : '') ||
+      '',
+    [scopeChainId, chainId, contracts],
+  )
+  // Reads come from the scoped chain; only writes use the wallet's signer.
+  const readProvider = useMemo(
+    () => readProviderFor(scopeChainId, chainId, signer?.provider || null),
+    [scopeChainId, chainId, signer],
+  )
   const [address, setAddress] = useState('')
   const [reason, setReason] = useState('')
   const [status, setStatus] = useState(null) // { denied, allowed } | null
@@ -43,11 +68,11 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
   }, [guardAddress, signer])
 
   const loadHistory = useCallback(async () => {
-    if (!isAddr(guardAddress) || !signer?.provider) return
+    if (!isAddr(guardAddress) || !readProvider) return
     setLoadingHistory(true)
     setError('')
     try {
-      const provider = signer.provider
+      const provider = readProvider
       const reader = new ethers.Contract(guardAddress, GUARD_ABI, provider)
       const filter = reader.filters.DenyListUpdated()
       const latest = await provider.getBlockNumber()
@@ -83,7 +108,7 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
     } finally {
       setLoadingHistory(false)
     }
-  }, [guardAddress, signer])
+  }, [guardAddress, readProvider])
 
   useEffect(() => { loadHistory() }, [loadHistory])
 
@@ -91,11 +116,17 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
     setError('')
     if (!isAddr(address)) { setError('Enter a valid address'); return }
     if (!reason.trim()) { setError('A reason is required (recorded on-chain for the audit trail)'); return }
+    // Re-checked here, not just at render: a wallet that switched networks between render and
+    // click would otherwise deny on the network the operator was not looking at.
+    if (!onScopeNetwork) {
+      setError(`Switch your wallet to ${networkName(scopeChainId)} to change its deny-list.`)
+      return
+    }
     const c = writer()
-    if (!c) { setError('SanctionsGuard is not configured on this network'); return }
+    if (!c) { setError(`SanctionsGuard is not configured on ${networkName(scopeChainId)}`); return }
     runTx(
       () => c.setDenied(address.trim(), denied, reason.trim()),
-      `Deny-list ${denied ? 'add' : 'remove'}: ${shortAddr(address)}`,
+      `Deny-list ${denied ? 'add' : 'remove'} on ${networkName(scopeChainId)}: ${shortAddr(address)}`,
     )
   }
 
@@ -103,9 +134,10 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
     setError('')
     setStatus(null)
     if (!isAddr(address)) { setError('Enter a valid address'); return }
-    if (!isAddr(guardAddress) || !signer?.provider) { setError('SanctionsGuard not configured'); return }
+    if (!isAddr(guardAddress)) { setError(`SanctionsGuard is not configured on ${networkName(scopeChainId)}`); return }
+    if (!readProvider) { setError(`Could not reach ${networkName(scopeChainId)} — status is unknown, not clear.`); return }
     try {
-      const reader = new ethers.Contract(guardAddress, GUARD_ABI, signer.provider)
+      const reader = new ethers.Contract(guardAddress, GUARD_ABI, readProvider)
       const [denied, allowed] = await Promise.all([
         reader.isDenied(address.trim()),
         reader.isAllowed(address.trim()),
@@ -116,11 +148,27 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
     }
   }
 
+  // The picker renders in BOTH branches. An empty state that drops it strands the operator on the
+  // one network with nothing to see, with no control left to leave it.
   if (!isAddr(guardAddress)) {
     return (
       <section aria-labelledby="denylist-heading">
         <h3 id="denylist-heading">Sanctions deny-list</h3>
-        <p role="status">SanctionsGuard is not deployed/configured on this network.</p>
+      <NetworkScopeCard
+        title="Deny-list network"
+        description="Each network has its own SanctionsGuard. A denial on one network is not a denial on another, and the audit trail below is this network's alone."
+        networks={guardNetworks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('sanctionsGuard', id))}
+        walletChainId={chainId}
+        onRefresh={loadHistory}
+        lastReadAt={null}
+        notDeployedLabel="no SanctionsGuard"
+      />
+        <p role="status">
+          SanctionsGuard is not deployed on {networkName(scopeChainId)}. Pick a network that has one.
+        </p>
       </section>
     )
   }
@@ -128,10 +176,30 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
   return (
     <section aria-labelledby="denylist-heading">
       <h3 id="denylist-heading">Sanctions deny-list</h3>
+      <NetworkScopeCard
+        title="Deny-list network"
+        description="Each network has its own SanctionsGuard. A denial on one network is not a denial on another, and the audit trail below is this network's alone."
+        networks={guardNetworks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('sanctionsGuard', id))}
+        walletChainId={chainId}
+        onRefresh={loadHistory}
+        lastReadAt={null}
+        notDeployedLabel="no SanctionsGuard"
+      />
       <p>
-        Manage the discretionary on-chain deny-list. Requires <code>SANCTIONS_ADMIN_ROLE</code>.
+        Manage the discretionary on-chain deny-list on {networkName(scopeChainId)}. Requires{' '}
+        <code>SANCTIONS_ADMIN_ROLE</code> on that network&apos;s guard.
         Guard: <span title={guardAddress}>{shortAddr(guardAddress)}</span>
       </p>
+      {!onScopeNetwork && (
+        <p role="status" className="denylist-note">
+          You are reading {networkName(scopeChainId)} while your wallet is on {networkName(chainId)}.
+          Checking status and the audit trail work from here; changing the deny-list needs your
+          wallet on {networkName(scopeChainId)}.
+        </p>
+      )}
 
       <div className="denylist-form">
         <label htmlFor="denylist-address">Wallet address</label>
@@ -155,11 +223,11 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
         />
 
         <div className="denylist-actions">
-          <button type="button" className="confirm-btn danger" onClick={() => submit(true)} disabled={pendingTx}>
-            {pendingTx ? 'Processing…' : 'Add to deny-list'}
+          <button type="button" className="confirm-btn danger" onClick={() => submit(true)} disabled={pendingTx || !onScopeNetwork}>
+            {pendingTx ? 'Processing…' : `Add to deny-list on ${networkName(scopeChainId)}`}
           </button>
-          <button type="button" className="confirm-btn" onClick={() => submit(false)} disabled={pendingTx}>
-            {pendingTx ? 'Processing…' : 'Remove from deny-list'}
+          <button type="button" className="confirm-btn" onClick={() => submit(false)} disabled={pendingTx || !onScopeNetwork}>
+            {pendingTx ? 'Processing…' : `Remove from deny-list on ${networkName(scopeChainId)}`}
           </button>
           <button type="button" className="confirm-btn" onClick={checkStatus} disabled={pendingTx}>
             Check status

--- a/frontend/src/components/admin/FeesTab.jsx
+++ b/frontend/src/components/admin/FeesTab.jsx
@@ -22,6 +22,9 @@ import { getContractAddressForChain } from '../../config/contracts'
 import { FEE_ROUTER_ABI } from '../../abis/FeeRouter'
 import { gatewayBaseUrl } from '../../hooks/useGatewayStatus'
 import { getBlockscoutUrl } from '../../config/blockExplorer'
+import { estateNetworks, networkName, readProviderFor } from '../../lib/chains/estate'
+import { NetworkScopeCard } from './scopeControls'
+import { useScopedChain } from './scopeGate'
 
 // Friendly names for known service ids (keccak256 of the registered label).
 const KNOWN_SERVICES = {
@@ -46,7 +49,17 @@ function bpsPct(bps) {
 }
 
 export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, isAdmin, isFeeAdmin }) {
-  const routerAddr = getContractAddressForChain('feeRouter', chainId)
+  // Spec 071 US4: fee rates are genuinely per network — each chain's FeeRouter carries its own
+  // services and its own bps. Showing the wallet's chain alone presented ONE network's rates as
+  // if they were the platform's, which for a fee schedule is a materially wrong statement.
+  const feeNetworks = useMemo(() => estateNetworks(), [])
+  const { scopeChainId, setScopeChainId } = useScopedChain(feeNetworks, chainId)
+  const onScopeNetwork = Number(scopeChainId) === Number(chainId)
+  const routerAddr = getContractAddressForChain('feeRouter', scopeChainId)
+  const readProvider = useMemo(
+    () => readProviderFor(scopeChainId, chainId, provider),
+    [scopeChainId, chainId, provider],
+  )
   const canEditFees = Boolean(isAdmin || isFeeAdmin)
 
   const [services, setServices] = useState(null) // null = loading; [] = none
@@ -59,9 +72,10 @@ export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, i
   const [treasuryForm, setTreasuryForm] = useState('')
   const [formError, setFormError] = useState(null)
 
+  // Reads come from the SCOPED chain's endpoint, so the address and the provider cannot disagree.
   const routerRead = useMemo(
-    () => (routerAddr && provider ? new ethers.Contract(routerAddr, FEE_ROUTER_ABI, provider) : null),
-    [routerAddr, provider]
+    () => (routerAddr && readProvider ? new ethers.Contract(routerAddr, FEE_ROUTER_ABI, readProvider) : null),
+    [routerAddr, readProvider]
   )
 
   const fetchServices = useCallback(async () => {
@@ -194,11 +208,24 @@ export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, i
   if (!routerAddr) {
     return (
       <div className="admin-tab-content" role="tabpanel">
+      <NetworkScopeCard
+        title="Platform Fees"
+        description="Fee services and rates for one network's FeeRouter. Each chain carries its own services and its own bps — there is no single platform-wide rate."
+        networks={feeNetworks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('feeRouter', id))}
+        walletChainId={chainId}
+        onRefresh={refresh}
+        lastReadAt={null}
+        notDeployedLabel="no FeeRouter"
+      />
         <div className="admin-card">
           <h3>Platform Fees</h3>
           <p className="card-info">
-            No FeeRouter is deployed on this network, so no platform fees are active here — member
-            flows behave exactly as if the fee system did not exist. Deploy it with{' '}
+            No FeeRouter is deployed on {networkName(scopeChainId)}, so no platform fees are active
+            there — member flows behave exactly as if the fee system did not exist. Pick another
+            network above, or deploy it with{' '}
             <code>scripts/deploy/deploy-fee-router.js</code> (see the fee operations runbook).
           </p>
         </div>
@@ -208,9 +235,27 @@ export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, i
 
   return (
     <div className="admin-tab-content" role="tabpanel">
+      <NetworkScopeCard
+        title="Platform Fees"
+        description="Fee services and rates for one network's FeeRouter. Each chain carries its own services and its own bps — there is no single platform-wide rate."
+        networks={feeNetworks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('feeRouter', id))}
+        walletChainId={chainId}
+        onRefresh={refresh}
+        lastReadAt={null}
+        notDeployedLabel="no FeeRouter"
+      />
+      {!onScopeNetwork && (
+        <p className="card-info warning-text" role="status">
+          You are reading {networkName(scopeChainId)} while your wallet is on {networkName(chainId)}.
+          Rate changes are signed on {networkName(scopeChainId)} — switch your wallet to make one.
+        </p>
+      )}
       <div className="admin-card">
         <div className="admin-card-header">
-          <h3>Platform Fees</h3>
+          <h3>Platform Fees on {networkName(scopeChainId)}</h3>
           <button type="button" className="refresh-btn" onClick={refresh} aria-label="Refresh fees">↻</button>
         </div>
         {readError && <p className="card-info error">{readError}</p>}
@@ -347,7 +392,7 @@ export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, i
               type="button"
               className="confirm-btn primary"
               onClick={handleSetFeeBps}
-              disabled={pendingTx || !signer}
+              disabled={!onScopeNetwork || pendingTx || !signer}
             >
               Set fee rate
             </button>
@@ -376,7 +421,7 @@ export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, i
               type="button"
               className="confirm-btn danger"
               onClick={handleSetTreasury}
-              disabled={pendingTx || !signer}
+              disabled={!onScopeNetwork || pendingTx || !signer}
             >
               Set treasury
             </button>
@@ -418,8 +463,8 @@ export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, i
         )}
         <p className="card-info">
           Every change is an on-chain event (who, when, old → new).{' '}
-          {getBlockscoutUrl(chainId, routerAddr, 'address') && (
-            <a href={getBlockscoutUrl(chainId, routerAddr, 'address')} target="_blank" rel="noopener noreferrer">
+          {getBlockscoutUrl(scopeChainId, routerAddr, 'address') && (
+            <a href={getBlockscoutUrl(scopeChainId, routerAddr, 'address')} target="_blank" rel="noopener noreferrer">
               Full history on the block explorer ↗
             </a>
           )}

--- a/frontend/src/components/admin/FeesTab.jsx
+++ b/frontend/src/components/admin/FeesTab.jsx
@@ -22,7 +22,7 @@ import { getContractAddressForChain } from '../../config/contracts'
 import { FEE_ROUTER_ABI } from '../../abis/FeeRouter'
 import { gatewayBaseUrl } from '../../hooks/useGatewayStatus'
 import { getBlockscoutUrl } from '../../config/blockExplorer'
-import { estateNetworks, networkName, readProviderFor } from '../../lib/chains/estate'
+import { estateNetworks, networkName, readProviderFor, readAuthority, authorityGate } from '../../lib/chains/estate'
 import { NetworkScopeCard } from './scopeControls'
 import { useScopedChain } from './scopeGate'
 
@@ -48,7 +48,7 @@ function bpsPct(bps) {
   return `${(Number(bps) / 100).toFixed(2)}%`
 }
 
-export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, isAdmin, isFeeAdmin }) {
+export default function FeesTab({ signer, account, chainId, provider, runTx, pendingTx, isAdmin, isFeeAdmin }) {
   // Spec 071 US4: fee rates are genuinely per network — each chain's FeeRouter carries its own
   // services and its own bps. Showing the wallet's chain alone presented ONE network's rates as
   // if they were the platform's, which for a fee schedule is a materially wrong statement.
@@ -60,7 +60,30 @@ export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, i
     () => readProviderFor(scopeChainId, chainId, provider),
     [scopeChainId, chainId, provider],
   )
-  const canEditFees = Boolean(isAdmin || isFeeAdmin)
+  // Authority is read from the FeeRouter that will ENFORCE it, on the scoped chain — never from
+  // the app-wide flags. `isFeeAdmin` means "holds FEE_ADMIN_ROLE somewhere in the estate", which
+  // on a per-chain fee schedule is the wrong question: it would offer an enabled Set-fee button on
+  // a network whose router will revert. The flags are kept only as the pre-read assumption, so an
+  // operator who does hold the role is not made to wait on a round-trip to see the form.
+  const [authority, setAuthority] = useState(null)
+  useEffect(() => {
+    let cancelled = false
+    readAuthority({
+      provider: readProvider,
+      address: routerAddr,
+      account,
+      roles: ['admin', 'feeAdmin'],
+    }).then((a) => {
+      if (!cancelled) setAuthority(a)
+    })
+    return () => { cancelled = true }
+  }, [readProvider, routerAddr, account])
+
+  const feeGate = authorityGate(authority, ['admin', 'feeAdmin'])
+  const treasuryGate = authorityGate(authority, ['admin'])
+  // Pending (first read in flight) falls back to the app-wide flag rather than blanking the form.
+  const canEditFees = feeGate.pending ? Boolean(isAdmin || isFeeAdmin) : feeGate.allowed
+  const canEditTreasury = treasuryGate.pending ? Boolean(isAdmin) : treasuryGate.allowed
 
   const [services, setServices] = useState(null) // null = loading; [] = none
   const [treasury, setTreasury] = useState(undefined)
@@ -396,11 +419,18 @@ export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, i
             >
               Set fee rate
             </button>
+            {feeGate.unconfirmed && (
+              <p className="card-info warning-text" role="status">
+                Authority could not be confirmed on {networkName(scopeChainId)} — the control stays
+                available because the router itself is the real gate, and it will refuse anything
+                you do not hold.
+              </p>
+            )}
           </div>
         </div>
       )}
 
-      {isAdmin && (
+      {canEditTreasury && (
         <div className="admin-card">
           <h3>Change the fee treasury</h3>
           <p>
@@ -425,6 +455,12 @@ export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, i
             >
               Set treasury
             </button>
+            {treasuryGate.unconfirmed && (
+              <p className="card-info warning-text" role="status">
+                Authority could not be confirmed on {networkName(scopeChainId)} — the router will
+                still refuse this unless you hold the admin role there.
+              </p>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/components/admin/MaintenanceTab.jsx
+++ b/frontend/src/components/admin/MaintenanceTab.jsx
@@ -1,6 +1,9 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { ethers } from 'ethers'
 import { getContractAddressForChain } from '../../config/contracts'
+import { estateNetworks, networkName } from '../../lib/chains/estate'
+import { NetworkScopeCard } from './scopeControls'
+import { useScopedChain } from './scopeGate'
 
 /**
  * MaintenanceTab — permissionless housekeeping calls on the wager registry
@@ -31,7 +34,15 @@ function parseIdList(text) {
 }
 
 function MaintenanceTab({ signer, chainId, runTx, pendingTx }) {
-  const registryAddr = getContractAddressForChain('wagerRegistry', chainId)
+  // Spec 071 US4: these calls run on ONE registry on ONE chain. The tab used to take whichever
+  // chain the wallet sat on, which meant an operator could not sweep Polygon's expired wagers
+  // from a wallet pointed at Base — and nothing on screen said that was why.
+  const networks = useMemo(() => estateNetworks(), [])
+  const { scopeChainId, setScopeChainId } = useScopedChain(networks, chainId)
+  const registryAddr = getContractAddressForChain('wagerRegistry', scopeChainId)
+  const onScopeNetwork = Number(scopeChainId) === Number(chainId)
+  // A permissionless call is still a WRITE: one named chain, wallet required there (FR-017/018).
+  const canSubmit = Boolean(signer) && onScopeNetwork && Boolean(registryAddr) && !pendingTx
   const [expireIds, setExpireIds] = useState('')
   const [resolveForm, setResolveForm] = useState({ id: '', source: 'polymarket' })
   const [parseError, setParseError] = useState('')
@@ -50,7 +61,7 @@ function MaintenanceTab({ signer, chainId, runTx, pendingTx }) {
     if (ids.length === 0) return
     runTx(
       () => write().batchExpireOpen(ids),
-      `Expired ${ids.length} open wager${ids.length === 1 ? '' : 's'} — creators refunded`
+      `Expired ${ids.length} open wager${ids.length === 1 ? '' : 's'} on ${networkName(scopeChainId)} — creators refunded`
     )
   }
 
@@ -65,11 +76,36 @@ function MaintenanceTab({ signer, chainId, runTx, pendingTx }) {
     const fn = resolveForm.source === 'polymarket'
       ? () => write().autoResolveFromPolymarket(id)
       : () => write().autoResolveFromOracle(id)
-    runTx(fn, `Auto-resolution triggered for wager #${resolveForm.id}`)
+    runTx(fn, `Auto-resolution triggered for wager #${resolveForm.id} on ${networkName(scopeChainId)}`)
   }
 
   return (
     <div className="admin-tab-content" role="tabpanel">
+      <NetworkScopeCard
+        title="Maintenance"
+        description="Permissionless housekeeping on one network's wager registry. Reading any network works from anywhere; each call is signed on the network in scope."
+        networks={networks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('wagerRegistry', id))}
+        walletChainId={chainId}
+        onRefresh={() => {}}
+        lastReadAt={null}
+        notDeployedLabel="no wager registry"
+      />
+
+      {!registryAddr && (
+        <p className="card-info warning-text" role="status">
+          No wager registry on {networkName(scopeChainId)} — nothing to maintain here.
+        </p>
+      )}
+      {registryAddr && !onScopeNetwork && (
+        <p className="card-info warning-text" role="status">
+          These calls are signed on {networkName(scopeChainId)}. Your wallet is on{' '}
+          {networkName(chainId)} — switch it there to run them.
+        </p>
+      )}
+
       <div className="admin-card">
         <h3>Expire Open Wagers</h3>
         <p>
@@ -85,8 +121,8 @@ function MaintenanceTab({ signer, chainId, runTx, pendingTx }) {
             {parseError && <span className="hint">{parseError}</span>}
           </label>
           <button className="confirm-btn primary" onClick={handleBatchExpire}
-            disabled={pendingTx || !signer || !expireIds.trim() || !registryAddr}>
-            {pendingTx ? 'Sweeping...' : 'Run Expiry Sweep'}
+            disabled={!canSubmit || !expireIds.trim()}>
+            {pendingTx ? 'Sweeping...' : `Run Expiry Sweep on ${networkName(scopeChainId)}`}
           </button>
         </div>
       </div>
@@ -112,8 +148,8 @@ function MaintenanceTab({ signer, chainId, runTx, pendingTx }) {
             </select>
           </label>
           <button className="confirm-btn primary" onClick={handleAutoResolve}
-            disabled={pendingTx || !signer || !resolveForm.id.trim() || !registryAddr}>
-            {pendingTx ? 'Processing...' : 'Trigger Resolution'}
+            disabled={!canSubmit || !resolveForm.id.trim()}>
+            {pendingTx ? 'Processing...' : `Trigger Resolution on ${networkName(scopeChainId)}`}
           </button>
         </div>
       </div>

--- a/frontend/src/components/admin/MembershipTreasuryOverview.jsx
+++ b/frontend/src/components/admin/MembershipTreasuryOverview.jsx
@@ -11,10 +11,20 @@ import './MembershipTreasuryOverview.css'
  * truncated window.
  *
  * Props:
- *   provider   — ethers provider for the read scan
- *   chainId    — connected chain (drives the cache key + address resolution)
- *   address    — MembershipManager address on this chain ('' when undeployed)
+ * Spec 071 (T046): memberships live on ONE chain, so this panel is pinned to the reference chain
+ * rather than given a network picker — there is no second membership estate to look at. What that
+ * requires of the caller is that `provider`, `chainId` and `address` all name the SAME chain: a
+ * wallet provider paired with the reference chain's address reads one chain's contract at
+ * another's address, and caches the answer under the wrong key.
+ *
+ * Props:
+ *   provider   — ethers provider for the read scan, on `chainId`
+ *   chainId    — the chain being read (drives the cache key); the membership reference chain
+ *   address    — MembershipManager address on that chain ('' when undeployed)
  *   accruedFees — live undrawn balance (USDC string) already read by the parent AdminPanel
+ *   accruedFeesReadable — whether that read SUCCEEDED. `false` renders as "could not be read",
+ *     never as $0.00: an operator who reads a zero accrued balance concludes the fees were
+ *     already withdrawn, and acts on it.
  */
 
 const TIER_NAMES = { 1: 'Bronze', 2: 'Silver', 3: 'Gold', 4: 'Platinum' }
@@ -81,7 +91,7 @@ function Tile({ label, value, tone }) {
   )
 }
 
-export default function MembershipTreasuryOverview({ provider, chainId, address, accruedFees }) {
+export default function MembershipTreasuryOverview({ provider, chainId, address, accruedFees, accruedFeesReadable = true }) {
   const configured = Boolean(address && ethers.isAddress(address))
   const stats = useMembershipTreasuryStats({ provider, chainId, address })
 
@@ -96,7 +106,8 @@ export default function MembershipTreasuryOverview({ provider, chainId, address,
       <div className="admin-card full-width">
         <div className="admin-card-header"><h3>Membership &amp; Treasury</h3></div>
         <p role="status" className="mto-muted">
-          MembershipManager is not deployed / configured on this network — no app-wide statistics to show.
+          MembershipManager is not deployed / configured on the membership network — no app-wide
+          statistics to show.
         </p>
       </div>
     )
@@ -161,7 +172,10 @@ export default function MembershipTreasuryOverview({ provider, chainId, address,
             <div className="mto-tiles" aria-label="Treasury growth summary">
               <Tile label={d.truncated ? 'Membership revenue (window)' : 'Membership revenue'} value={usd(d.revenue.total)} tone="accent" />
               <Tile label="Withdrawn to treasury" value={usd(d.revenue.withdrawn)} />
-              <Tile label="Accrued (undrawn, live)" value={usd(accruedFees)} />
+              <Tile
+                label="Accrued (undrawn, live)"
+                value={accruedFeesReadable === false ? 'Could not be read' : usd(accruedFees)}
+              />
             </div>
 
             <RevenueSparkline series={d.series} />

--- a/frontend/src/components/admin/OracleAdaptersTab.jsx
+++ b/frontend/src/components/admin/OracleAdaptersTab.jsx
@@ -1,5 +1,9 @@
 import { useState, useMemo, useEffect } from 'react'
 import { ethers } from 'ethers'
+import { getContractAddressForChain } from '../../config/contracts'
+import { estateNetworks, networkName, readProviderFor } from '../../lib/chains/estate'
+import { NetworkScopeCard } from './scopeControls'
+import { useScopedChain } from './scopeGate'
 
 // Minimal admin-only ABI fragments. The full ABIs live under
 // frontend/src/abis/{ChainlinkDataFeedOracleAdapter,ChainlinkFunctionsOracleAdapter,UMAOptimisticOracleV3Adapter}.js
@@ -75,33 +79,60 @@ function shortAddr(a) {
  * Out of scope (separate PR): listing pre-registered conditions back to the
  * user-facing create-wager flow. That needs event indexing; this tab is
  * write-only for now.
+ *
+ * Spec 071 US4 — the adapters are per network and most of the cohort has none.
+ * This tab used to take the build's single `contracts` record, so it showed one
+ * network's adapters whatever the operator wanted to see, and an owner() read
+ * that failed was indistinguishable from an adapter that isn't there. Now the
+ * network is picked, addresses resolve from the pick, and "not deployed" is
+ * stated as the honest answer it is for most networks rather than rendered as
+ * an empty form.
  */
-function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
+function OracleAdaptersTab({ signer, account, contracts, chainId, runTx, pendingTx }) {
   const [activeAdapter, setActiveAdapter] = useState('chainlinkDataFeed')
   const [adapterOwners, setAdapterOwners] = useState({})
 
-  // Resolve adapter addresses from the synced deployment record.
-  const adapterAddresses = useMemo(() => ({
-    chainlinkDataFeedAdapter: contracts?.chainlinkDataFeedAdapter,
-    chainlinkFunctionsAdapter: contracts?.chainlinkFunctionsAdapter,
-    umaAdapter: contracts?.umaAdapter,
-  }), [contracts])
+  const adapterNetworks = useMemo(() => estateNetworks(), [])
+  const { scopeChainId, setScopeChainId } = useScopedChain(adapterNetworks, chainId)
+  const onScopeNetwork = Number(scopeChainId) === Number(chainId)
+
+  // Resolve adapter addresses from the SCOPED chain, falling back to the build's synced record
+  // only when the scope is the wallet's own network (where the two agree by construction).
+  const adapterAddresses = useMemo(() => {
+    const at = (key) =>
+      getContractAddressForChain(key, scopeChainId) ||
+      (Number(scopeChainId) === Number(chainId) ? contracts?.[key] : '') ||
+      ''
+    return {
+      chainlinkDataFeedAdapter: at('chainlinkDataFeedAdapter'),
+      chainlinkFunctionsAdapter: at('chainlinkFunctionsAdapter'),
+      umaAdapter: at('umaAdapter'),
+    }
+  }, [scopeChainId, chainId, contracts])
+
+  const readProvider = useMemo(
+    () => readProviderFor(scopeChainId, chainId, signer?.provider || null),
+    [scopeChainId, chainId, signer],
+  )
 
   // Read each adapter's owner() so the UI can warn the user if they're not
   // the actual owner (in which case all writes will revert with onlyOwner).
+  // Three states, not two: `undefined` = not deployed here, `null` = deployed but the owner could
+  // not be read. Collapsing the second into the first would tell an operator there is no adapter
+  // when there is one they simply could not reach.
   useEffect(() => {
     let cancelled = false
-    if (!signer || !signer.provider) return
+    if (!readProvider) return
     ;(async () => {
       const next = {}
       for (const a of ADAPTERS) {
         const addr = adapterAddresses[a.addressKey]
         if (!addr || !ethers.isAddress(addr)) {
-          next[a.key] = null
+          next[a.key] = undefined
           continue
         }
         try {
-          const c = new ethers.Contract(addr, COMMON_READS, signer.provider)
+          const c = new ethers.Contract(addr, COMMON_READS, readProvider)
           next[a.key] = await c.owner()
         } catch {
           next[a.key] = null
@@ -110,7 +141,7 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
       if (!cancelled) setAdapterOwners(next)
     })()
     return () => { cancelled = true }
-  }, [signer, adapterAddresses])
+  }, [readProvider, adapterAddresses])
 
   // ── DataFeed forms ────────────────────────────────────────────────────────
   const [dfFeed, setDfFeed]               = useState({ address: '', allow: true })
@@ -125,20 +156,32 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
   const [umaCondition, setUmaCondition]   = useState({ conditionId: '', claim: '', bondCurrency: '', bondAmount: '', liveness: '7200' })
   const [umaLink, setUmaLink]             = useState({ friendMarketId: '', conditionId: '' })
 
+  // The single choke point every write handler already goes through — so the wallet-chain check
+  // lives here once rather than being repeated (and eventually forgotten) in seven handlers.
   function writer(addressKey, abi) {
     const addr = adapterAddresses[addressKey]
     if (!addr || !ethers.isAddress(addr) || !signer) return null
+    if (!onScopeNetwork) return null
     return new ethers.Contract(addr, abi, signer)
+  }
+
+  /** Why a write is unavailable right now, in words — the alerts below all use this. */
+  function writeBlockedReason(addressKey, label) {
+    const addr = adapterAddresses[addressKey]
+    if (!addr || !ethers.isAddress(addr)) return `${label} is not deployed on ${networkName(scopeChainId)}`
+    if (!signer) return 'Connect your wallet to make changes here'
+    if (!onScopeNetwork) return `Switch your wallet to ${networkName(scopeChainId)} to make this change`
+    return `${label} is unavailable`
   }
 
   // ── Handlers ─────────────────────────────────────────────────────────────
   const handleSetFeedAllowed = () => {
     if (!isAddress(dfFeed.address)) return alert('Enter a valid feed address')
     const c = writer('chainlinkDataFeedAdapter', CHAINLINK_DATA_FEED_ADMIN_ABI)
-    if (!c) return alert('ChainlinkDataFeedOracleAdapter is not deployed on this chain')
+    if (!c) return alert(writeBlockedReason('chainlinkDataFeedAdapter', 'ChainlinkDataFeedOracleAdapter'))
     runTx(
       () => c.setFeedAllowed(dfFeed.address.trim(), Boolean(dfFeed.allow)),
-      `ChainlinkDataFeed: feed ${shortAddr(dfFeed.address)} ${dfFeed.allow ? 'allowlisted' : 'removed'}`,
+      `ChainlinkDataFeed: feed ${shortAddr(dfFeed.address)} ${dfFeed.allow ? 'allowlisted' : 'removed'} on ${networkName(scopeChainId)}`,
     )
   }
 
@@ -153,10 +196,10 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
       return alert('Deadline must be in the future')
     }
     const c = writer('chainlinkDataFeedAdapter', CHAINLINK_DATA_FEED_ADMIN_ABI)
-    if (!c) return alert('Adapter not deployed')
+    if (!c) return alert(writeBlockedReason('chainlinkDataFeedAdapter', 'ChainlinkDataFeedOracleAdapter'))
     runTx(
       () => c.registerCondition(f.conditionId.trim(), f.feed.trim(), BigInt(String(f.threshold).trim()), Number(f.op), BigInt(deadlineSeconds)),
-      `ChainlinkDataFeed: condition ${f.conditionId.slice(0, 10)}… registered`,
+      `ChainlinkDataFeed: condition ${f.conditionId.slice(0, 10)}… registered on ${networkName(scopeChainId)}`,
     )
   }
 
@@ -164,10 +207,10 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
     if (!isBytes32Hex(dfLink.conditionId)) return alert('conditionId must be a 0x-prefixed 32-byte hex string')
     if (!/^\d+$/.test((dfLink.friendMarketId || '').trim())) return alert('friendMarketId must be a non-negative integer')
     const c = writer('chainlinkDataFeedAdapter', CHAINLINK_DATA_FEED_ADMIN_ABI)
-    if (!c) return alert('Adapter not deployed')
+    if (!c) return alert(writeBlockedReason('chainlinkDataFeedAdapter', 'ChainlinkDataFeedOracleAdapter'))
     runTx(
       () => c.linkMarket(BigInt(dfLink.friendMarketId.trim()), dfLink.conditionId.trim()),
-      `ChainlinkDataFeed: wager #${dfLink.friendMarketId} linked`,
+      `ChainlinkDataFeed: wager #${dfLink.friendMarketId} linked on ${networkName(scopeChainId)}`,
     )
   }
 
@@ -180,7 +223,7 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
     if (!/^\d+$/.test((f.gasLimit || '').trim())) return alert('gasLimit must be a non-negative integer')
     if (!isBytes32Hex(f.donId)) return alert('donId must be 0x + 64 hex (right-pad if shorter)')
     const c = writer('chainlinkFunctionsAdapter', CHAINLINK_FUNCTIONS_ADMIN_ABI)
-    if (!c) return alert('Adapter not deployed')
+    if (!c) return alert(writeBlockedReason('chainlinkFunctionsAdapter', 'ChainlinkFunctionsOracleAdapter'))
     runTx(
       () => c.registerCondition(
         f.conditionId.trim(),
@@ -190,7 +233,7 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
         Number(f.gasLimit.trim()),
         f.donId.trim(),
       ),
-      `ChainlinkFunctions: condition ${f.conditionId.slice(0, 10)}… registered`,
+      `ChainlinkFunctions: condition ${f.conditionId.slice(0, 10)}… registered on ${networkName(scopeChainId)}`,
     )
   }
 
@@ -198,10 +241,10 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
     if (!isBytes32Hex(fnLink.conditionId)) return alert('conditionId invalid')
     if (!/^\d+$/.test((fnLink.friendMarketId || '').trim())) return alert('friendMarketId must be a non-negative integer')
     const c = writer('chainlinkFunctionsAdapter', CHAINLINK_FUNCTIONS_ADMIN_ABI)
-    if (!c) return alert('Adapter not deployed')
+    if (!c) return alert(writeBlockedReason('chainlinkFunctionsAdapter', 'ChainlinkFunctionsOracleAdapter'))
     runTx(
       () => c.linkMarket(BigInt(fnLink.friendMarketId.trim()), fnLink.conditionId.trim()),
-      `ChainlinkFunctions: wager #${fnLink.friendMarketId} linked`,
+      `ChainlinkFunctions: wager #${fnLink.friendMarketId} linked on ${networkName(scopeChainId)}`,
     )
   }
 
@@ -213,7 +256,7 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
     if (!/^\d+$/.test((f.bondAmount || '').trim())) return alert('bondAmount must be a non-negative integer (raw units; e.g. 6-dec USDC)')
     if (!/^\d+$/.test((f.liveness || '').trim())) return alert('liveness must be a non-negative integer (seconds)')
     const c = writer('umaAdapter', UMA_ADMIN_ABI)
-    if (!c) return alert('Adapter not deployed')
+    if (!c) return alert(writeBlockedReason('umaAdapter', 'UMAOptimisticOracleV3Adapter'))
     runTx(
       () => c.registerCondition(
         f.conditionId.trim(),
@@ -222,7 +265,7 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
         BigInt(f.bondAmount.trim()),
         BigInt(f.liveness.trim()),
       ),
-      `UMA: condition ${f.conditionId.slice(0, 10)}… registered`,
+      `UMA: condition ${f.conditionId.slice(0, 10)}… registered on ${networkName(scopeChainId)}`,
     )
   }
 
@@ -230,10 +273,10 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
     if (!isBytes32Hex(umaLink.conditionId)) return alert('conditionId invalid')
     if (!/^\d+$/.test((umaLink.friendMarketId || '').trim())) return alert('friendMarketId must be a non-negative integer')
     const c = writer('umaAdapter', UMA_ADMIN_ABI)
-    if (!c) return alert('Adapter not deployed')
+    if (!c) return alert(writeBlockedReason('umaAdapter', 'UMAOptimisticOracleV3Adapter'))
     runTx(
       () => c.linkMarket(BigInt(umaLink.friendMarketId.trim()), umaLink.conditionId.trim()),
-      `UMA: wager #${umaLink.friendMarketId} linked`,
+      `UMA: wager #${umaLink.friendMarketId} linked on ${networkName(scopeChainId)}`,
     )
   }
 
@@ -241,8 +284,18 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
   const activeMeta = ADAPTERS.find(a => a.key === activeAdapter)
   const activeAddr = adapterAddresses[activeMeta.addressKey]
   const activeOwner = adapterOwners[activeAdapter]
+  const activeDeployed = Boolean(activeAddr && ethers.isAddress(activeAddr))
   const isActualOwner = activeOwner && account &&
     String(activeOwner).toLowerCase() === String(account).toLowerCase()
+
+  // Not deployed, deployed-but-unread, and read-and-not-you are three different situations and
+  // call for three different operator responses. A single em dash for all three said nothing.
+  const ownerText = () => {
+    if (!activeDeployed) return 'Not deployed on this network'
+    if (activeOwner === null) return 'Could not be read — retry; this is not "no owner"'
+    if (!activeOwner) return 'Reading…'
+    return `${shortAddr(activeOwner)} ${isActualOwner ? '(you)' : '(NOT you — writes will revert)'}`
+  }
 
   return (
     <div className="admin-tab-content" role="tabpanel">
@@ -256,6 +309,31 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
             <code> keccak256(question + bytes32 salt) </code> works well.
           </p>
         </div>
+
+        <NetworkScopeCard
+          title="Adapter network"
+          description="Adapters are deployed per network, and most networks have none. Reading any network works from anywhere; registering or linking on one needs your wallet there."
+          networks={adapterNetworks}
+          scopeChainId={scopeChainId}
+          onScopeChange={setScopeChainId}
+          isDeployed={(id) =>
+            Boolean(
+              getContractAddressForChain('chainlinkDataFeedAdapter', id) ||
+              getContractAddressForChain('chainlinkFunctionsAdapter', id) ||
+              getContractAddressForChain('umaAdapter', id),
+            )
+          }
+          walletChainId={chainId}
+          onRefresh={() => {}}
+          lastReadAt={null}
+          notDeployedLabel="no adapters"
+        />
+        {!onScopeNetwork && (
+          <p className="card-info warning-text" role="status">
+            You are reading {networkName(scopeChainId)} while your wallet is on {networkName(chainId)}.
+            Switch to {networkName(scopeChainId)} before registering or linking anything here.
+          </p>
+        )}
 
         <nav className="oracle-adapters-subtabs" role="tablist" data-testid="oracle-adapters-subtabs">
           {ADAPTERS.map(a => (
@@ -275,13 +353,13 @@ function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
         <div className="oracle-adapter-meta">
           <div className="status-row">
             <span className="status-label">Adapter</span>
-            <span className="status-value">{shortAddr(activeAddr)}</span>
+            <span className="status-value">
+              {activeDeployed ? shortAddr(activeAddr) : `Not deployed on ${networkName(scopeChainId)}`}
+            </span>
           </div>
           <div className="status-row">
             <span className="status-label">Owner</span>
-            <span className={`status-value ${isActualOwner ? 'active' : 'paused'}`}>
-              {activeOwner ? `${shortAddr(activeOwner)} ${isActualOwner ? '(you)' : '(NOT you — writes will revert)'}` : '—'}
-            </span>
+            <span className={`status-value ${isActualOwner ? 'active' : 'paused'}`}>{ownerText()}</span>
           </div>
         </div>
 

--- a/frontend/src/components/admin/PaymasterOpsCard.jsx
+++ b/frontend/src/components/admin/PaymasterOpsCard.jsx
@@ -1,6 +1,10 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
 import { getContractAddressForChain } from '../../config/contracts'
+import { NETWORKS } from '../../config/networks'
+import { estateNetworks, networkName, readProviderFor } from '../../lib/chains/estate'
+import { NetworkScopeCard, WriteGate } from './scopeControls'
+import { useScopedChain } from './scopeGate'
 import { isValidEthereumAddress } from '../../utils/validation'
 import { useNotification } from '../../hooks/useUI'
 
@@ -22,9 +26,21 @@ function safeParseEther(value) {
  * The EntryPoint deposit IS the sponsorship loss cap: monitoring and topping
  * it up is a routine operator duty (docs/runbooks/paymaster-operations.md).
  * `deposit()` is deliberately permissionless on-chain (anyone may top up);
- * `withdrawTo` / `setVerifyingSigner` are owner-only — the buttons stay
- * visible so any operator can see the controls exist, but the transaction
- * reverts unless the connected wallet is the paymaster owner.
+ * `withdrawTo` / `setVerifyingSigner` are owner-only.
+ *
+ * Spec 071 US4 — the deposit is **per chain**, and this card used to read
+ * whichever chain the wallet happened to be on. Two consequences of that were
+ * wrong rather than merely inconvenient:
+ *
+ *   - An operator connected anywhere but Polygon saw "no verifying paymaster
+ *     is deployed on this network" and had no way to reach the one that is.
+ *   - The deposit was denominated in the **wallet's** native symbol. A figure
+ *     read from one chain and labelled with another chain's currency is not a
+ *     rounding error; it is a wrong number.
+ *
+ * So: the network is picked, reads follow the pick, the symbol comes from the
+ * chain the figure was read on, and every write is gated on the wallet being
+ * there and names the chain in its confirmation.
  */
 const PAYMASTER_ABI = [
   'function getDeposit() view returns (uint256)',
@@ -39,150 +55,236 @@ function shortAddr(a) {
   return a ? `${a.substring(0, 6)}...${a.substring(a.length - 4)}` : ''
 }
 
+const paymasterAt = (id) => getContractAddressForChain('verifyingPaymaster', id)
+
 function PaymasterOpsCard({ signer, account, provider, chainId, nativeSymbol, runTx, pendingTx }) {
-  const paymasterAddr = getContractAddressForChain('verifyingPaymaster', chainId)
+  const paymasterNetworks = useMemo(() => estateNetworks(), [])
+  const { scopeChainId, setScopeChainId } = useScopedChain(paymasterNetworks, chainId)
+  const onScopeNetwork = Number(scopeChainId) === Number(chainId)
+  const paymasterAddr = paymasterAt(scopeChainId)
   const { showNotification } = useNotification()
 
-  const [info, setInfo] = useState({ deposit: null, verifyingSigner: '', owner: '' })
+  // The symbol belongs to the chain the deposit was read on. Falling back to the wallet's symbol
+  // is only correct when the scope IS the wallet's chain; otherwise say "native token" rather
+  // than name the wrong currency.
+  const scopeSymbol =
+    NETWORKS[scopeChainId]?.nativeCurrency?.symbol || (onScopeNetwork ? nativeSymbol : 'native token')
+
+  // `unreadable` is a third state, distinct from a zero deposit and from no deployment.
+  const [info, setInfo] = useState({ chainId: null, deposit: null, verifyingSigner: '', owner: '', readable: null, reason: '' })
   const [depositAmount, setDepositAmount] = useState('')
   const [withdrawForm, setWithdrawForm] = useState({ to: '', amount: '' })
   const [newSigner, setNewSigner] = useState('')
 
+  const readProvider = useMemo(
+    () => readProviderFor(scopeChainId, chainId, provider),
+    [scopeChainId, chainId, provider],
+  )
+
   const readContract = useMemo(() => {
-    if (!paymasterAddr || !provider) return null
-    return new ethers.Contract(paymasterAddr, PAYMASTER_ABI, provider)
-  }, [paymasterAddr, provider])
+    if (!paymasterAddr || !readProvider) return null
+    return new ethers.Contract(paymasterAddr, PAYMASTER_ABI, readProvider)
+  }, [paymasterAddr, readProvider])
 
   const fetchInfo = useCallback(async () => {
     if (!readContract) return
+    const readChainId = scopeChainId
     try {
       const [deposit, vSigner, owner] = await Promise.all([
-        readContract.getDeposit().catch(() => null),
-        readContract.verifyingSigner().catch(() => ''),
-        readContract.owner().catch(() => ''),
+        readContract.getDeposit(),
+        readContract.verifyingSigner(),
+        readContract.owner(),
       ])
-      setInfo({ deposit, verifyingSigner: vSigner, owner })
+      setInfo({ chainId: readChainId, deposit, verifyingSigner: vSigner, owner, readable: true, reason: '' })
     } catch (err) {
       console.warn('[PaymasterOpsCard] read failed:', err)
+      setInfo({ chainId: readChainId, deposit: null, verifyingSigner: '', owner: '', readable: false, reason: err?.shortMessage || err?.message || 'read failed' })
     }
-  }, [readContract])
+  }, [readContract, scopeChainId])
 
   useEffect(() => {
     fetchInfo()
   }, [fetchInfo])
 
-  if (!paymasterAddr) {
-    return (
-      <div className="admin-card">
-        <div className="admin-card-header"><h3>Sponsored-Gas Paymaster</h3></div>
-        <p className="card-info">
-          No verifying paymaster is deployed on this network. Sponsorship (spec 050) is
-          Polygon-only; the passkey path self-funds elsewhere.
-        </p>
-      </div>
-    )
+  // A result is only shown for the chain it was read on. Rendering the previous network's deposit
+  // under the newly-picked network's heading is precisely the confusion this spec exists to end,
+  // and it is also why "no read connection" is DERIVED rather than written into state: the effect
+  // stays a pure fetch, so a scope change cannot leave a stale answer behind.
+  const stale = info.chainId != null && Number(info.chainId) !== Number(scopeChainId)
+  const current = stale
+    ? { deposit: null, verifyingSigner: '', owner: '', readable: null, reason: '' }
+    : info
+  const state =
+    paymasterAddr && !readProvider
+      ? { deposit: null, verifyingSigner: '', owner: '', readable: false, reason: 'no read connection to this network' }
+      : current
+
+  // Owner authority is read from the paymaster that will enforce it, on the scoped chain — never
+  // from an app-wide flag. An unconfirmed read keeps the owner-only controls offered and says so.
+  const ownerKnown = state.readable === true && Boolean(state.owner)
+  const isOwner = Boolean(ownerKnown && account && account.toLowerCase() === state.owner.toLowerCase())
+  // Two gates, not one. `deposit()` is permissionless, so a failed owner read says nothing about
+  // it — reporting "authority could not be confirmed" on a call that needs no authority is noise
+  // dressed as a warning.
+  const chainGate = { deployed: Boolean(paymasterAddr), onWalletChain: onScopeNetwork, scopeChainId }
+  const ownerGate = { ...chainGate, readable: state.readable !== false }
+
+  const write = () => new ethers.Contract(paymasterAddr, PAYMASTER_ABI, signer)
+  // Re-checked at the call site so a stale render cannot sign for the wrong network.
+  const requireScopeChain = () => {
+    if (!onScopeNetwork) {
+      showNotification(`Switch your wallet to ${networkName(scopeChainId)} to make this change`, 'error')
+      return false
+    }
+    return true
   }
 
-  const isOwner = account && info.owner && account.toLowerCase() === info.owner.toLowerCase()
-  const write = () => new ethers.Contract(paymasterAddr, PAYMASTER_ABI, signer)
-
   const handleDeposit = () => {
+    if (!requireScopeChain()) return
     const value = safeParseEther(depositAmount)
-    if (value == null) return showNotification(`Enter a valid ${nativeSymbol} amount`, 'error')
+    if (value == null) return showNotification(`Enter a valid ${scopeSymbol} amount`, 'error')
     runTx(
       () => write().deposit({ value }),
-      `Deposited ${depositAmount} ${nativeSymbol} to the paymaster's EntryPoint balance`
+      `Deposited ${depositAmount} ${scopeSymbol} to the paymaster's EntryPoint balance on ${networkName(scopeChainId)}`
     ).then(fetchInfo)
   }
 
   const handleWithdraw = () => {
+    if (!requireScopeChain()) return
     if (!isValidEthereumAddress(withdrawForm.to)) return showNotification('Invalid recipient address', 'error')
     const amount = safeParseEther(withdrawForm.amount)
-    if (amount == null) return showNotification(`Enter a valid ${nativeSymbol} amount`, 'error')
+    if (amount == null) return showNotification(`Enter a valid ${scopeSymbol} amount`, 'error')
     runTx(
       () => write().withdrawTo(withdrawForm.to, amount),
-      `Withdrew ${withdrawForm.amount} ${nativeSymbol} from the paymaster deposit`
+      `Withdrew ${withdrawForm.amount} ${scopeSymbol} from the paymaster deposit on ${networkName(scopeChainId)}`
     ).then(fetchInfo)
   }
 
   const handleRotateSigner = () => {
+    if (!requireScopeChain()) return
     if (!isValidEthereumAddress(newSigner)) return showNotification('Invalid signer address', 'error')
     runTx(
       () => write().setVerifyingSigner(newSigner),
-      `Verifying signer rotated to ${shortAddr(newSigner)}`
+      `Verifying signer rotated to ${shortAddr(newSigner)} on ${networkName(scopeChainId)}`
     ).then(fetchInfo)
   }
 
+  const depositText = () => {
+    if (!paymasterAddr) return null
+    if (state.readable === false) return `Could not be read — ${state.reason}`
+    if (state.deposit == null) return 'Reading…'
+    return `${ethers.formatEther(state.deposit)} ${scopeSymbol}`
+  }
+
   return (
-    <div className="admin-card">
-      <div className="admin-card-header">
-        <h3>Sponsored-Gas Paymaster</h3>
-        <button type="button" className="refresh-btn" onClick={fetchInfo} aria-label="Refresh paymaster state">↻</button>
-      </div>
-      <div className="status-details">
-        <div className="status-row">
-          <span className="status-label">EntryPoint deposit (loss cap)</span>
-          <span className="status-value">
-            {info.deposit == null ? '—' : `${ethers.formatEther(info.deposit)} ${nativeSymbol}`}
-          </span>
-        </div>
-        <div className="status-row">
-          <span className="status-label">Verifying signer</span>
-          <span className="status-value"><code>{shortAddr(info.verifyingSigner) || '—'}</code></span>
-        </div>
-        <div className="status-row">
-          <span className="status-label">Owner</span>
-          <span className="status-value">
-            <code>{shortAddr(info.owner) || '—'}</code>{isOwner ? ' (you)' : ''}
-          </span>
-        </div>
-      </div>
+    <>
+      <NetworkScopeCard
+        title="Sponsored-Gas Paymaster"
+        description="The verifying paymaster's deposit is per network — it is the sponsorship loss cap on that network alone. Reading any network works from anywhere; funding or rotating one needs your wallet on it."
+        networks={paymasterNetworks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(paymasterAt(id))}
+        walletChainId={chainId}
+        onRefresh={fetchInfo}
+        lastReadAt={null}
+        notDeployedLabel="no paymaster"
+      />
 
-      <div className="admin-form">
-        <label>
-          Top up deposit ({nativeSymbol}) — permissionless, funds sponsorship runway
-          <input type="number" min="0" step="0.01" value={depositAmount}
-            onChange={(e) => setDepositAmount(e.target.value)} />
-        </label>
-        <button className="confirm-btn primary" onClick={handleDeposit}
-          disabled={pendingTx || !signer || !depositAmount}>
-          {pendingTx ? 'Processing...' : 'Deposit'}
-        </button>
-      </div>
+      {!paymasterAddr ? (
+        <div className="admin-card">
+          <div className="admin-card-header"><h3>{networkName(scopeChainId)}</h3></div>
+          <p className="card-info">
+            No verifying paymaster is deployed on {networkName(scopeChainId)}. Sponsorship (spec 050)
+            is Polygon-only; the passkey path self-funds elsewhere.
+          </p>
+        </div>
+      ) : (
+        <div className="admin-card">
+          <div className="admin-card-header">
+            <h3>{networkName(scopeChainId)}</h3>
+            <button type="button" className="refresh-btn" onClick={fetchInfo} aria-label="Refresh paymaster state">↻</button>
+          </div>
+          <div className="status-details">
+            <div className="status-row">
+              <span className="status-label">EntryPoint deposit (loss cap)</span>
+              <span className={`status-value ${state.readable === false ? 'paused' : ''}`}>{depositText()}</span>
+            </div>
+            <div className="status-row">
+              <span className="status-label">Verifying signer</span>
+              <span className="status-value">
+                <code>{state.readable === false ? 'unread' : shortAddr(state.verifyingSigner) || '—'}</code>
+              </span>
+            </div>
+            <div className="status-row">
+              <span className="status-label">Owner</span>
+              <span className="status-value">
+                <code>{state.readable === false ? 'unread' : shortAddr(state.owner) || '—'}</code>
+                {isOwner ? ' (you)' : ''}
+              </span>
+            </div>
+          </div>
 
-      <div className="admin-form">
-        <label>
-          Withdraw to (owner only)
-          <input type="text" placeholder="0x…" value={withdrawForm.to}
-            onChange={(e) => setWithdrawForm({ ...withdrawForm, to: e.target.value })} />
-        </label>
-        <label>
-          Amount ({nativeSymbol})
-          <input type="number" min="0" step="0.01" value={withdrawForm.amount}
-            onChange={(e) => setWithdrawForm({ ...withdrawForm, amount: e.target.value })} />
-        </label>
-        <button className="confirm-btn danger" onClick={handleWithdraw}
-          disabled={pendingTx || !signer || !isOwner || !withdrawForm.to || !withdrawForm.amount}>
-          {pendingTx ? 'Processing...' : 'Withdraw Deposit'}
-        </button>
-      </div>
+          <WriteGate {...chainGate}>
+            {({ allowed }) => (
+              <div className="admin-form">
+                <label>
+                  Top up deposit ({scopeSymbol}) — permissionless, funds sponsorship runway on {networkName(scopeChainId)}
+                  <input type="number" min="0" step="0.01" value={depositAmount}
+                    onChange={(e) => setDepositAmount(e.target.value)} />
+                </label>
+                <button className="confirm-btn primary" onClick={handleDeposit}
+                  disabled={pendingTx || !allowed || !signer || !depositAmount}>
+                  {pendingTx ? 'Processing...' : `Deposit on ${networkName(scopeChainId)}`}
+                </button>
+              </div>
+            )}
+          </WriteGate>
 
-      <div className="admin-form">
-        <label>
-          Rotate verifying signer (owner only — incident response for a compromised KMS signer)
-          <input type="text" placeholder="0x… new signer" value={newSigner}
-            onChange={(e) => setNewSigner(e.target.value)} />
-        </label>
-        <button className="confirm-btn danger" onClick={handleRotateSigner}
-          disabled={pendingTx || !signer || !isOwner || !newSigner}>
-          {pendingTx ? 'Processing...' : 'Rotate Signer'}
-        </button>
-      </div>
-      <p className="card-info">
-        A compromised verifying signer can only spend deposit on gas — it cannot withdraw.
-        Full procedure: docs/runbooks/paymaster-operations.md.
-      </p>
-    </div>
+          {/* Owner-only, so the gate carries `held` — but an UNCONFIRMED owner read leaves the
+              control offered (writeAllowed), because the paymaster is the real gate. */}
+          <WriteGate {...ownerGate} held={ownerKnown ? isOwner : undefined}>
+            {({ allowed }) => (
+              <>
+                <div className="admin-form">
+                  <label>
+                    Withdraw to (owner only)
+                    <input type="text" placeholder="0x…" value={withdrawForm.to}
+                      onChange={(e) => setWithdrawForm({ ...withdrawForm, to: e.target.value })} />
+                  </label>
+                  <label>
+                    Amount ({scopeSymbol})
+                    <input type="number" min="0" step="0.01" value={withdrawForm.amount}
+                      onChange={(e) => setWithdrawForm({ ...withdrawForm, amount: e.target.value })} />
+                  </label>
+                  <button className="confirm-btn danger" onClick={handleWithdraw}
+                    disabled={pendingTx || !allowed || !signer || !withdrawForm.to || !withdrawForm.amount}>
+                    {pendingTx ? 'Processing...' : `Withdraw Deposit on ${networkName(scopeChainId)}`}
+                  </button>
+                </div>
+
+                <div className="admin-form">
+                  <label>
+                    Rotate verifying signer (owner only — incident response for a compromised KMS signer)
+                    <input type="text" placeholder="0x… new signer" value={newSigner}
+                      onChange={(e) => setNewSigner(e.target.value)} />
+                  </label>
+                  <button className="confirm-btn danger" onClick={handleRotateSigner}
+                    disabled={pendingTx || !allowed || !signer || !newSigner}>
+                    {pendingTx ? 'Processing...' : `Rotate Signer on ${networkName(scopeChainId)}`}
+                  </button>
+                </div>
+              </>
+            )}
+          </WriteGate>
+
+          <p className="card-info">
+            A compromised verifying signer can only spend deposit on gas — it cannot withdraw.
+            Full procedure: docs/runbooks/paymaster-operations.md.
+          </p>
+        </div>
+      )}
+    </>
   )
 }
 

--- a/frontend/src/components/admin/ProtocolConfigTab.jsx
+++ b/frontend/src/components/admin/ProtocolConfigTab.jsx
@@ -2,6 +2,9 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
 import { getContractAddressForChain } from '../../config/contracts'
 import { isValidEthereumAddress } from '../../utils/validation'
+import { estateNetworks, networkName, readProviderFor } from '../../lib/chains/estate'
+import { NetworkScopeCard } from './scopeControls'
+import { useScopedChain } from './scopeGate'
 
 /**
  * ProtocolConfigTab — the protocol wiring view of the operations control
@@ -70,9 +73,15 @@ function WiringRow({ label, current, note }) {
 }
 
 function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
-  const registryAddr = getContractAddressForChain('wagerRegistry', chainId)
-  const membershipAddr = getContractAddressForChain('membershipManager', chainId)
-  const sanctionsAddr = getContractAddressForChain('sanctionsGuard', chainId)
+  // Spec 071 US4: wiring is per network — the three contracts below exist independently on each
+  // chain and can be wired differently. Scoping to the wallet's chain showed one network's wiring
+  // as if it were the platform's.
+  const networks = useMemo(() => estateNetworks(), [])
+  const { scopeChainId, setScopeChainId } = useScopedChain(networks, chainId)
+  const onScopeNetwork = Number(scopeChainId) === Number(chainId)
+  const registryAddr = getContractAddressForChain('wagerRegistry', scopeChainId)
+  const membershipAddr = getContractAddressForChain('membershipManager', scopeChainId)
+  const sanctionsAddr = getContractAddressForChain('sanctionsGuard', scopeChainId)
 
   const [wiring, setWiring] = useState({})
   const [addrForm, setAddrForm] = useState({ target: 'registry-sanctions', address: '' })
@@ -80,17 +89,24 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
   const [tokenForm, setTokenForm] = useState({ address: '', allowed: true, status: null })
   const [callerForm, setCallerForm] = useState({ address: '', authorized: true })
 
+  // Reads resolve against the SCOPED chain's endpoint — using the wallet's provider here would
+  // have read chain A's contract at chain B's address, or simply failed, once the scope and the
+  // wallet could differ.
+  const readProvider = useMemo(
+    () => readProviderFor(scopeChainId, chainId, provider),
+    [scopeChainId, chainId, provider],
+  )
   const registryRead = useMemo(
-    () => (registryAddr && provider ? new ethers.Contract(registryAddr, REGISTRY_ABI, provider) : null),
-    [registryAddr, provider]
+    () => (registryAddr && readProvider ? new ethers.Contract(registryAddr, REGISTRY_ABI, readProvider) : null),
+    [registryAddr, readProvider]
   )
   const membershipRead = useMemo(
-    () => (membershipAddr && provider ? new ethers.Contract(membershipAddr, MEMBERSHIP_ABI, provider) : null),
-    [membershipAddr, provider]
+    () => (membershipAddr && readProvider ? new ethers.Contract(membershipAddr, MEMBERSHIP_ABI, readProvider) : null),
+    [membershipAddr, readProvider]
   )
   const sanctionsRead = useMemo(
-    () => (sanctionsAddr && provider ? new ethers.Contract(sanctionsAddr, SANCTIONS_ABI, provider) : null),
-    [sanctionsAddr, provider]
+    () => (sanctionsAddr && readProvider ? new ethers.Contract(sanctionsAddr, SANCTIONS_ABI, readProvider) : null),
+    [sanctionsAddr, readProvider]
   )
 
   const fetchWiring = useCallback(async () => {
@@ -202,6 +218,29 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
 
   return (
     <div className="admin-tab-content" role="tabpanel">
+      <NetworkScopeCard
+        title="Wiring & Tokens"
+        description="Protocol wiring for one network. Each chain wires its own registry, membership manager and sanctions guard, and they can differ."
+        networks={networks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('wagerRegistry', id))}
+        walletChainId={chainId}
+        onRefresh={fetchWiring}
+        lastReadAt={null}
+        notDeployedLabel="no wager registry"
+      />
+      {registryAddr && !onScopeNetwork && (
+        <p className="card-info warning-text" role="status">
+          You are reading {networkName(scopeChainId)} while your wallet is on {networkName(chainId)}.
+          Changes here are signed on {networkName(scopeChainId)} — switch your wallet to make one.
+        </p>
+      )}
+      {!registryAddr && (
+        <p className="card-info warning-text" role="status">
+          No wager registry on {networkName(scopeChainId)} — nothing is wired here.
+        </p>
+      )}
       <div className="admin-card">
         <div className="admin-card-header">
           <h3>Live Wiring</h3>
@@ -253,7 +292,7 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
             )}
           </label>
           <button className="confirm-btn danger" onClick={handleSetAddress}
-            disabled={pendingTx || !signer || !addrForm.address || !selectedTarget?.addr()}>
+            disabled={pendingTx || !signer || !onScopeNetwork || !addrForm.address || !selectedTarget?.addr()}>
             {pendingTx ? 'Processing...' : 'Set Address'}
           </button>
         </div>
@@ -276,7 +315,7 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
               onChange={(e) => setOracleForm({ ...oracleForm, address: e.target.value })} />
           </label>
           <button className="confirm-btn primary" onClick={handleSetOracleAdapter}
-            disabled={pendingTx || !signer || !oracleForm.address || !registryAddr}>
+            disabled={pendingTx || !signer || !onScopeNetwork || !oracleForm.address || !registryAddr}>
             {pendingTx ? 'Processing...' : 'Set Adapter'}
           </button>
         </div>
@@ -305,7 +344,7 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
               Check Current
             </button>
             <button className="confirm-btn primary" onClick={handleSetTokenAllowed}
-              disabled={pendingTx || !signer || !tokenForm.address || !registryAddr}>
+              disabled={pendingTx || !signer || !onScopeNetwork || !tokenForm.address || !registryAddr}>
               {pendingTx ? 'Processing...' : 'Apply'}
             </button>
           </div>
@@ -330,7 +369,7 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
             Authorized
           </label>
           <button className="confirm-btn danger" onClick={handleSetAuthorizedCaller}
-            disabled={pendingTx || !signer || !callerForm.address || !membershipAddr}>
+            disabled={pendingTx || !signer || !onScopeNetwork || !callerForm.address || !membershipAddr}>
             {pendingTx ? 'Processing...' : 'Apply'}
           </button>
         </div>

--- a/frontend/src/components/admin/ServiceHealthCard.jsx
+++ b/frontend/src/components/admin/ServiceHealthCard.jsx
@@ -1,5 +1,5 @@
-import { NETWORK_CONFIG } from '../../config/contracts'
 import { useGatewayStatus } from '../../hooks/useGatewayStatus'
+import { networkName } from '../../lib/chains/estate'
 
 /**
  * ServiceHealthCard — read-only gasless-infrastructure telemetry for the
@@ -7,8 +7,17 @@ import { useGatewayStatus } from '../../hooks/useGatewayStatus'
  *
  * Strictly display: the gateway has no remote admin API by design (killswitch
  * and quotas are env/signal-driven — see docs/runbooks/relayer-operations.md).
+ *
+ * Spec 071 US4 — this card needs no network picker, because it never asked one
+ * chain in the first place: there is a single gateway and it reports every
+ * chain it serves. Two things about it were dishonest anyway:
+ *
+ *   - It closed with "network <the build's network>", which reads as the scope
+ *     of everything above it. The rows above span chains; naming one of them
+ *     invites an operator to read a Polygon outage as a local one.
+ *   - It carried its own four-entry chain-name map, so any chain the gateway
+ *     added showed up as "Chain 8453". Names come from the network registry.
  */
-const CHAIN_NAMES = { 63: 'Mordor', 137: 'Polygon', 80002: 'Amoy', 1337: 'Hardhat' }
 
 function fmtRunway(hrs) {
   if (hrs == null) return null
@@ -64,7 +73,7 @@ function ServiceHealthCard() {
             return (
               <div key={c.chainId} className="status-row">
                 <span className="status-label">
-                  {CHAIN_NAMES[c.chainId] || `Chain ${c.chainId}`} RPC
+                  {networkName(c.chainId)} RPC
                 </span>
                 <span className={`status-value ${c.rpc === 'up' ? 'active' : 'paused'}`}>
                   {c.rpc === 'up' ? 'Up' : 'Down'}
@@ -82,8 +91,9 @@ function ServiceHealthCard() {
           )}
           {lastChecked && (
             <p className="card-info">
-              Last checked {new Date(lastChecked).toLocaleTimeString()} · network{' '}
-              {NETWORK_CONFIG.name}. Killswitch and quotas are operated via the runbook
+              Last checked {new Date(lastChecked).toLocaleTimeString()}. One gateway serves every
+              network listed above, so this is estate-wide, not your wallet&apos;s network.
+              Killswitch and quotas are operated via the runbook
               (docs/runbooks/relayer-operations.md) — the gateway exposes no web admin API by
               design.
             </p>

--- a/frontend/src/components/admin/StakingTab.jsx
+++ b/frontend/src/components/admin/StakingTab.jsx
@@ -16,7 +16,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { ethers } from 'ethers'
 import { getContractAddressForChain } from '../../config/contracts'
-import { estateNetworks, networkName, readProviderFor } from '../../lib/chains/estate'
+import { estateNetworks, networkName, readProviderFor, readAuthority, authorityGate } from '../../lib/chains/estate'
 import { NetworkScopeCard } from './scopeControls'
 import { useScopedChain } from './scopeGate'
 import { STAKING_ROUTER_ABI } from '../../abis/StakingRouter'
@@ -42,7 +42,7 @@ function shortAddr(a) {
 
 const isValidAddr = (a) => ethers.isAddress(a) && a !== ethers.ZeroAddress
 
-export default function StakingTab({ signer, chainId, provider, runTx, pendingTx, isAdmin, isStakingAdmin, isGuardian }) {
+export default function StakingTab({ signer, account, chainId, provider, runTx, pendingTx, isAdmin, isStakingAdmin, isGuardian }) {
   // Spec 071 US4: provider addresses and the validator allowlist are per network — a router on
   // one chain knows nothing about another's. Scoped so an operator sees the network they mean.
   const stakingNetworks = useMemo(() => estateNetworks(), [])
@@ -53,8 +53,31 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
     () => readProviderFor(scopeChainId, chainId, provider),
     [scopeChainId, chainId, provider],
   )
-  const canConfig = Boolean(isAdmin || isStakingAdmin)
-  const canPause = Boolean(isAdmin || isGuardian)
+  // Authority comes from the router that will ENFORCE it, on the scoped chain. The app-wide
+  // flags answer "holds this role somewhere in the estate", which would offer an enabled pause
+  // on a network whose router reverts — and a pause an operator believes they hold is worse than
+  // one they know they do not. An UNCONFIRMED read keeps the control offered and says so
+  // (FR-044): hiding a killswitch because an RPC timed out is its own kind of lie.
+  const [authority, setAuthority] = useState(null)
+  useEffect(() => {
+    let cancelled = false
+    readAuthority({
+      provider: readProvider,
+      address: routerAddr,
+      account,
+      roles: ['admin', 'stakingAdmin', 'guardian'],
+    }).then((a) => {
+      if (!cancelled) setAuthority(a)
+    })
+    return () => { cancelled = true }
+  }, [readProvider, routerAddr, account])
+
+  const configGate = authorityGate(authority, ['admin', 'stakingAdmin'])
+  const pauseGate = authorityGate(authority, ['admin', 'guardian'])
+  // While the first read is in flight the app-wide flag stands in, so an operator who does hold
+  // the role is not shown an empty tab for a round-trip.
+  const canConfig = configGate.pending ? Boolean(isAdmin || isStakingAdmin) : configGate.allowed
+  const canPause = pauseGate.pending ? Boolean(isAdmin || isGuardian) : pauseGate.allowed
 
   const [state, setState] = useState(null) // null = loading
   const [readError, setReadError] = useState(null)
@@ -64,8 +87,8 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
   const [formError, setFormError] = useState(null)
 
   const routerRead = useMemo(
-    () => (routerAddr && provider ? new ethers.Contract(routerAddr, STAKING_ROUTER_ABI, provider) : null),
-    [routerAddr, provider]
+    () => (routerAddr && readProvider ? new ethers.Contract(routerAddr, STAKING_ROUTER_ABI, readProvider) : null),
+    [routerAddr, readProvider]
   )
   const write = useCallback(
     () => new ethers.Contract(routerAddr, STAKING_ROUTER_ABI, signer),
@@ -113,9 +136,9 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
   }, [readProvider, routerAddr, scopeChainId])
 
   const fetchHistory = useCallback(async () => {
-    if (!routerRead || !provider) return
+    if (!routerRead || !readProvider) return
     try {
-      const latest = await provider.getBlockNumber()
+      const latest = await readProvider.getBlockNumber()
       const fromBlock = Math.max(0, Number(latest) - HISTORY_LOOKBACK_BLOCKS)
       const all = []
       for (const name of SETTER_EVENTS) {
@@ -126,7 +149,7 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
       const recent = all.slice(0, HISTORY_LIMIT)
       const entries = await Promise.all(
         recent.map(async ({ name, ev }) => {
-          const block = await provider.getBlock(ev.blockNumber).catch(() => null)
+          const block = await readProvider.getBlock(ev.blockNumber).catch(() => null)
           const actor = ev.args?.actor || ev.args?.account
           return {
             name,
@@ -141,7 +164,7 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
     } catch (e) {
       setHistory({ entries: [], error: e?.message || String(e) })
     }
-  }, [routerRead, provider])
+  }, [routerRead, readProvider])
 
   useEffect(() => {
     fetchState()
@@ -270,6 +293,13 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
       {canPause && (
         <div className="admin-card">
           <h3>Emergency pause</h3>
+          {pauseGate.unconfirmed && (
+            <p className="card-info warning-text" role="status">
+              Authority could not be confirmed on {networkName(scopeChainId)} — the control stays
+              available because the router itself is the real gate, and it will refuse anything you
+              do not hold.
+            </p>
+          )}
           <p>
             Pausing stops <strong>new</strong> stakes on this network immediately (no redeploy). Members
             can always still unstake, withdraw, and claim — exits never route through the router.
@@ -288,6 +318,13 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
       {canConfig && (
         <div className="admin-card">
           <h3>Provider addresses</h3>
+          {configGate.unconfirmed && (
+            <p className="card-info warning-text" role="status">
+              Authority could not be confirmed on {networkName(scopeChainId)} — the control stays
+              available because the router itself is the real gate, and it will refuse anything you
+              do not hold.
+            </p>
+          )}
           <p>Current values shown below each field. Invalid or zero addresses are rejected before the wallet prompt.</p>
           <div className="admin-form">
             <label>

--- a/frontend/src/components/admin/StakingTab.jsx
+++ b/frontend/src/components/admin/StakingTab.jsx
@@ -16,6 +16,9 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { ethers } from 'ethers'
 import { getContractAddressForChain } from '../../config/contracts'
+import { estateNetworks, networkName, readProviderFor } from '../../lib/chains/estate'
+import { NetworkScopeCard } from './scopeControls'
+import { useScopedChain } from './scopeGate'
 import { STAKING_ROUTER_ABI } from '../../abis/StakingRouter'
 import { FEE_SERVICES, fetchFeeQuote, bpsToPercent } from '../../lib/fees/feeQuote'
 import { getBlockscoutUrl } from '../../config/blockExplorer'
@@ -40,7 +43,16 @@ function shortAddr(a) {
 const isValidAddr = (a) => ethers.isAddress(a) && a !== ethers.ZeroAddress
 
 export default function StakingTab({ signer, chainId, provider, runTx, pendingTx, isAdmin, isStakingAdmin, isGuardian }) {
-  const routerAddr = getContractAddressForChain('stakingRouter', chainId)
+  // Spec 071 US4: provider addresses and the validator allowlist are per network — a router on
+  // one chain knows nothing about another's. Scoped so an operator sees the network they mean.
+  const stakingNetworks = useMemo(() => estateNetworks(), [])
+  const { scopeChainId, setScopeChainId } = useScopedChain(stakingNetworks, chainId)
+  const onScopeNetwork = Number(scopeChainId) === Number(chainId)
+  const routerAddr = getContractAddressForChain('stakingRouter', scopeChainId)
+  const readProvider = useMemo(
+    () => readProviderFor(scopeChainId, chainId, provider),
+    [scopeChainId, chainId, provider],
+  )
   const canConfig = Boolean(isAdmin || isStakingAdmin)
   const canPause = Boolean(isAdmin || isGuardian)
 
@@ -91,12 +103,14 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
   }, [routerRead])
 
   const fetchFees = useCallback(async () => {
-    if (!provider || !routerAddr) return
+    // Guard on the SCOPED provider, which is what the body actually uses — guarding on the
+    // wallet's provider here would skip the fetch when the two differ.
+    if (!readProvider || !routerAddr) return
     const load = (serviceId) =>
-      fetchFeeQuote({ serviceId, chainId, provider }).catch(() => ({ available: false, bps: 0 }))
+      fetchFeeQuote({ serviceId, chainId: scopeChainId, provider: readProvider }).catch(() => ({ available: false, bps: 0 }))
     const [lido, polygon] = await Promise.all([load(FEE_SERVICES.STAKE_LIDO), load(FEE_SERVICES.STAKE_POLYGON)])
     setFees({ lido, polygon })
-  }, [provider, routerAddr, chainId])
+  }, [readProvider, routerAddr, scopeChainId])
 
   const fetchHistory = useCallback(async () => {
     if (!routerRead || !provider) return
@@ -170,10 +184,22 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
   if (!routerAddr) {
     return (
       <div className="admin-tab-content" role="tabpanel">
+      <NetworkScopeCard
+        title="Staking Controls"
+        description="Provider addresses and the validator allowlist for one network's StakingRouter."
+        networks={stakingNetworks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('stakingRouter', id))}
+        walletChainId={chainId}
+        onRefresh={refresh}
+        lastReadAt={null}
+        notDeployedLabel="no StakingRouter"
+      />
         <div className="admin-card">
           <h3>Staking Controls</h3>
           <p className="card-info">
-            No StakingRouter is deployed on this network, so staking controls are not available here —
+            No StakingRouter is deployed on {networkName(scopeChainId)}, so staking controls are not available there —
             member staking behaves exactly as spec 065 (fee-free, direct staking, availability as
             configured). Deploy it with <code>scripts/deploy/deploy-staking-router.js</code> (see the
             staking operations runbook).
@@ -188,9 +214,27 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
 
   return (
     <div className="admin-tab-content" role="tabpanel">
+      <NetworkScopeCard
+        title="Staking Controls"
+        description="Provider addresses and the validator allowlist for one network's StakingRouter."
+        networks={stakingNetworks}
+        scopeChainId={scopeChainId}
+        onScopeChange={setScopeChainId}
+        isDeployed={(id) => Boolean(getContractAddressForChain('stakingRouter', id))}
+        walletChainId={chainId}
+        onRefresh={refresh}
+        lastReadAt={null}
+        notDeployedLabel="no StakingRouter"
+      />
+      {!onScopeNetwork && (
+        <p className="card-info warning-text" role="status">
+          Reading {networkName(scopeChainId)}; your wallet is on {networkName(chainId)}. Changes are
+          signed on {networkName(scopeChainId)} — switch your wallet to make one.
+        </p>
+      )}
       <div className="admin-card">
         <div className="admin-card-header">
-          <h3>Staking Controls</h3>
+          <h3>Staking Controls on {networkName(scopeChainId)}</h3>
           <button type="button" className="refresh-btn" onClick={refresh} aria-label="Refresh staking controls">↻</button>
         </div>
         {readError && <p className="card-info error">{readError}</p>}
@@ -234,7 +278,7 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
             type="button"
             className={`confirm-btn ${state?.paused ? 'primary' : 'danger'}`}
             onClick={togglePause}
-            disabled={pendingTx || !signer || state == null}
+            disabled={!onScopeNetwork || pendingTx || !signer || state == null}
           >
             {state?.paused ? 'Resume staking' : 'Pause staking'}
           </button>
@@ -254,7 +298,7 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
                 onChange={(e) => setForms((f) => ({ ...f, wsteth: e.target.value }))} />
               <span className="hint">now: {shortAddr(state?.lidoSteth) || '—'} / {shortAddr(state?.lidoWsteth) || '—'}</span>
             </label>
-            <button type="button" className="confirm-btn primary" disabled={pendingTx || !signer}
+            <button type="button" className="confirm-btn primary" disabled={!onScopeNetwork || pendingTx || !signer}
               onClick={() => setPair('setLidoContracts', forms.lido, forms.wsteth, 'Lido contracts')}>Set Lido</button>
 
             <label>
@@ -265,7 +309,7 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
                 onChange={(e) => setForms((f) => ({ ...f, spolT: e.target.value }))} />
               <span className="hint">now: {shortAddr(state?.spolController) || '—'} / {shortAddr(state?.spolToken) || '—'}</span>
             </label>
-            <button type="button" className="confirm-btn primary" disabled={pendingTx || !signer}
+            <button type="button" className="confirm-btn primary" disabled={!onScopeNetwork || pendingTx || !signer}
               onClick={() => setPair('setSpolContracts', forms.spolC, forms.spolT, 'sPOL contracts')}>Set sPOL</button>
 
             <label>
@@ -276,7 +320,7 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
                 onChange={(e) => setForms((f) => ({ ...f, stakeMgr: e.target.value }))} />
               <span className="hint">now: {shortAddr(state?.polToken) || '—'} / {shortAddr(state?.polygonStakeManager) || '—'}</span>
             </label>
-            <button type="button" className="confirm-btn primary" disabled={pendingTx || !signer}
+            <button type="button" className="confirm-btn primary" disabled={!onScopeNetwork || pendingTx || !signer}
               onClick={() => setPair('setPolygonContracts', forms.polToken, forms.stakeMgr, 'Polygon contracts')}>Set Polygon</button>
 
             <label>
@@ -285,7 +329,7 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
                 onChange={(e) => setForms((f) => ({ ...f, feeRouter: e.target.value }))} />
               <span className="hint">now: {shortAddr(state?.feeRouter) || '—'}</span>
             </label>
-            <button type="button" className="confirm-btn primary" disabled={pendingTx || !signer}
+            <button type="button" className="confirm-btn primary" disabled={!onScopeNetwork || pendingTx || !signer}
               onClick={() => setPair('setFeeRouter', forms.feeRouter, undefined, 'FeeRouter reference')}>Set FeeRouter</button>
             {formError && <p className="card-info error" role="alert">{formError}</p>}
           </div>
@@ -304,7 +348,7 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
                   <tr key={v}>
                     <td><code title={v}>{shortAddr(v)}</code></td>
                     <td>
-                      <button type="button" className="confirm-btn danger" disabled={pendingTx || !signer}
+                      <button type="button" className="confirm-btn danger" disabled={!onScopeNetwork || pendingTx || !signer}
                         onClick={() => removeValidator(v)}>Remove</button>
                     </td>
                   </tr>
@@ -320,7 +364,7 @@ export default function StakingTab({ signer, chainId, provider, runTx, pendingTx
               <input type="text" placeholder="0x…" value={forms.addVal}
                 onChange={(e) => setForms((f) => ({ ...f, addVal: e.target.value }))} />
             </label>
-            <button type="button" className="confirm-btn primary" disabled={pendingTx || !signer} onClick={addValidator}>
+            <button type="button" className="confirm-btn primary" disabled={!onScopeNetwork || pendingTx || !signer} onClick={addValidator}>
               Add validator
             </button>
           </div>

--- a/frontend/src/components/admin/liquidityAdminCards.jsx
+++ b/frontend/src/components/admin/liquidityAdminCards.jsx
@@ -20,100 +20,16 @@
  *     before-value rather than back-filling a number nobody emitted (FR-046).
  */
 import { bpsToPercent } from '../../lib/fees/feeQuote'
-import { networkName, shortAddr } from './liquidityAdminCommon'
+import { shortAddr } from './liquidityAdminCommon'
 
 /* ------------------------------------------------------------------------------------------
  * Presentational pieces
  * ---------------------------------------------------------------------------------------- */
 
-/**
- * The network scope selector — the control that makes these tabs per-network rather than
- * per-wallet-connection.
- *
- * It lists every capable network and marks which of them actually carry a deployed router, so
- * "nothing configured here" and "nothing deployed here" are never confusable.
- */
-export function NetworkScopeCard({
-  title,
-  description,
-  networks,
-  scopeChainId,
-  onScopeChange,
-  isDeployed,
-  walletChainId,
-  onRefresh,
-  lastReadAt,
-  children,
-}) {
-  const deployedCount = networks.filter((n) => isDeployed(n.chainId)).length
-  return (
-    <div className="admin-card">
-      <div className="admin-card-header">
-        <h3>{title}</h3>
-        <button type="button" className="refresh-btn" onClick={onRefresh} aria-label={`Refresh ${title}`}>
-          ↻
-        </button>
-      </div>
-      <p className="card-info">{description}</p>
-      <div className="admin-form">
-        <label>
-          Network
-          <select
-            value={String(scopeChainId)}
-            onChange={(e) => onScopeChange(Number(e.target.value))}
-          >
-            {networks.map((net) => (
-              <option key={net.chainId} value={String(net.chainId)}>
-                {net.name}
-                {isDeployed(net.chainId) ? '' : ' — no router deployed'}
-                {Number(net.chainId) === Number(walletChainId) ? ' (wallet is here)' : ''}
-              </option>
-            ))}
-          </select>
-          <span className="hint">
-            Control state is per network. Reading any network works from anywhere; changing one
-            needs your wallet on it. Deployed on {deployedCount} of {networks.length} networks.
-          </span>
-        </label>
-      </div>
-      {lastReadAt && (
-        <p className="card-info">
-          Everything below is as of {lastReadAt.toLocaleTimeString()} — the last time this network was read.
-        </p>
-      )}
-      {children}
-    </div>
-  )
-}
-
-/**
- * Says plainly why the write controls are inert, when they are.
- *
- * Reading another network is fine; signing for it is not — the wallet signs on the chain it is
- * connected to, and a transaction built for a different router would go to the wrong contract
- * (or nowhere). Naming the required network is the difference between a dead button and an
- * instruction.
- */
-export function WriteScopeNotice({ scopeChainId, walletChainId, signer, canWrite }) {
-  if (!canWrite) return null
-  if (!signer) {
-    return (
-      <p className="card-info warning-text">
-        Connect your wallet to make changes here. Everything below is readable without one.
-      </p>
-    )
-  }
-  if (Number(scopeChainId) !== Number(walletChainId)) {
-    return (
-      <p className="card-info warning-text">
-        You are reading {networkName(scopeChainId)} while your wallet is on{' '}
-        {networkName(walletChainId)}. Changes here are signed on {networkName(scopeChainId)}, so
-        switch your wallet to it before making one. Reading is unaffected.
-      </p>
-    )
-  }
-  return null
-}
+// Spec 071: the scope controls are shared by every operator view now, so they live in
+// `scopeControls.jsx` and are re-exported here. Bridge and Supply keep this as their single
+// import site and are otherwise untouched — the same move-not-rewrite discipline as T014.
+export { NetworkScopeCard, WriteScopeNotice } from './scopeControls'
 
 /**
  * The read-only platform-fee card (FR-048/FR-051).

--- a/frontend/src/components/admin/scopeControls.jsx
+++ b/frontend/src/components/admin/scopeControls.jsx
@@ -1,0 +1,127 @@
+/**
+ * The scope controls every operator view shares (spec 071 US4, contracts/view-scope.md).
+ *
+ * Promoted out of `liquidityAdminCards.jsx`, where spec 067 built them for two tabs. Spec 071
+ * generalizes the same behaviour to the whole control plane, so they live here and that module
+ * re-exports them — Bridge and Supply are untouched, exactly as in T014.
+ *
+ * The only generalization: the "not deployed" wording was hardcoded to "no router deployed",
+ * which is wrong for a view driving a MembershipManager or a SanctionsGuard. It is now a prop
+ * with a contract-neutral default.
+ *
+ * Three rules these encode, each of which was a real defect before it was a rule:
+ *
+ *   1. **Scope is a NETWORK the operator picks, not the wallet's network.** Reading any network
+ *      works from anywhere; only WRITING needs the wallet there.
+ *   2. **The scope does not follow the wallet** (FR-016). An operator mid-audit must not have
+ *      their reading silently re-targeted when a wallet switches networks — see `useScopedChain`.
+ *   3. **A wrong-network write is refused in WORDS, before signing** (FR-018), naming the chain
+ *      to switch to. A dead button with no explanation is indistinguishable from a bug.
+ */
+import { networkName } from '../../lib/chains/estate'
+import { writeGateReason, writeAllowed } from './scopeGate'
+
+/**
+ * The network picker plus the sentence explaining what scope means.
+ *
+ * `isDeployed` answers per chain; a chain with no contract is still LISTED, because hiding the
+ * networks still awaiting a deployment hides the ones an operator most needs to see.
+ */
+export function NetworkScopeCard({
+  title,
+  description,
+  networks,
+  scopeChainId,
+  onScopeChange,
+  isDeployed,
+  walletChainId,
+  onRefresh,
+  lastReadAt,
+  notDeployedLabel = 'not deployed here',
+  children,
+}) {
+  const deployedCount = networks.filter((n) => isDeployed(n.chainId)).length
+  return (
+    <div className="admin-card">
+      <div className="admin-card-header">
+        <h3>{title}</h3>
+        <button type="button" className="refresh-btn" onClick={onRefresh} aria-label={`Refresh ${title}`}>
+          ↻
+        </button>
+      </div>
+      <p className="card-info">{description}</p>
+      <div className="admin-form">
+        <label>
+          Network
+          <select
+            value={String(scopeChainId)}
+            onChange={(e) => onScopeChange(Number(e.target.value))}
+          >
+            {networks.map((net) => (
+              <option key={net.chainId} value={String(net.chainId)}>
+                {net.name}
+                {isDeployed(net.chainId) ? '' : ` — ${notDeployedLabel}`}
+                {Number(net.chainId) === Number(walletChainId) ? ' (wallet is here)' : ''}
+              </option>
+            ))}
+          </select>
+          <span className="hint">
+            Control state is per network. Reading any network works from anywhere; changing one
+            needs your wallet on it. Deployed on {deployedCount} of {networks.length} networks.
+          </span>
+        </label>
+      </div>
+      {lastReadAt && (
+        <p className="card-info">
+          Everything below is as of {lastReadAt.toLocaleTimeString()} — the last time this network was read.
+        </p>
+      )}
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Says plainly why the write controls are inert, when they are.
+ *
+ * Reading another network is fine; signing for it is not — the wallet signs on the chain it is
+ * connected to, and a transaction built for a different contract would go to the wrong address
+ * (or nowhere). Naming the required network is the difference between a dead button and an
+ * instruction.
+ */
+export function WriteScopeNotice({ scopeChainId, walletChainId, signer, canWrite }) {
+  if (!canWrite) return null
+  if (!signer) {
+    return (
+      <p className="card-info warning-text">
+        Connect your wallet to make changes here. Everything below is readable without one.
+      </p>
+    )
+  }
+  if (Number(scopeChainId) !== Number(walletChainId)) {
+    return (
+      <p className="card-info warning-text">
+        You are reading {networkName(scopeChainId)} while your wallet is on{' '}
+        {networkName(walletChainId)}. Changes here are signed on {networkName(scopeChainId)}, so
+        switch your wallet to it before making one. Reading is unaffected.
+      </p>
+    )
+  }
+  return null
+}
+
+/** The gate plus its explanation, ready to spread onto a button and a note. */
+export function WriteGate({ deployed, onWalletChain, held, readable, scopeChainId, children }) {
+  const reason = writeGateReason({ deployed, onWalletChain, held, readable, scopeChainId })
+  const allowed = writeAllowed({ deployed, onWalletChain, held, readable })
+  return (
+    <>
+      {children({ allowed, reason })}
+      {reason && (
+        <p className="card-info warning-text" role="status">
+          {reason}
+        </p>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/admin/scopeGate.js
+++ b/frontend/src/components/admin/scopeGate.js
@@ -1,0 +1,58 @@
+/**
+ * Scope + write-gate logic for operator views (spec 071 US4). Non-component exports live here so
+ * `scopeControls.jsx` can export components only (react-refresh).
+ *
+ * The rules these encode were each a real defect before they were a rule — see scopeControls.jsx.
+ */
+import { useState, useCallback } from 'react'
+import { networkName } from '../../lib/chains/estate'
+
+/**
+ * The chain an operator view is scoped to.
+ *
+ * Defaults to the wallet's chain when that chain is in the view's roster, otherwise the first
+ * entry — the behaviour BridgeTab already had. Crucially it is seeded ONCE and never re-derived
+ * from `walletChainId` afterwards, which is what FR-016 requires: a wallet network change must
+ * change only whether writes are available, never what the operator is looking at.
+ */
+export function useScopedChain(networks, walletChainId) {
+  const [scopeChainId, setScopeChainId] = useState(
+    () =>
+      (networks.some((n) => Number(n.chainId) === Number(walletChainId))
+        ? Number(walletChainId)
+        : networks[0]?.chainId) ?? null,
+  )
+  // Exposed as a stable callback so a view can offer "jump to my wallet's network" explicitly.
+  const scopeToWallet = useCallback(() => setScopeChainId(Number(walletChainId)), [walletChainId])
+  return { scopeChainId, setScopeChainId, scopeToWallet }
+}
+
+/**
+ * Why a specific write control is unavailable, in words — or null when it is available.
+ *
+ * The four cases are deliberately distinct, because they call for four different actions:
+ *
+ *   not deployed  → nothing to act on here. Pick another network.
+ *   wrong network → switch the wallet. The control WILL work.
+ *   role not held → you cannot do this here, and switching will not help.
+ *   unconfirmed   → we could not ask. The control stays OFFERED and says so, because the
+ *                   contract is the real gate — withdrawing a killswitch because an RPC timed
+ *                   out tells an operator who holds it that there isn't one (spec 067 FR-044).
+ */
+export function writeGateReason({ deployed, onWalletChain, held, readable, scopeChainId }) {
+  if (deployed === false) return `Not deployed on ${networkName(scopeChainId)} — nothing to change here.`
+  if (!onWalletChain) return `Switch your wallet to ${networkName(scopeChainId)} to make this change.`
+  if (readable === false) return `Authority could not be confirmed on ${networkName(scopeChainId)} — the contract will still refuse anything you do not hold.`
+  if (held === false) return `You do not hold this role on ${networkName(scopeChainId)}.`
+  return null
+}
+
+/** Whether the control should be offered at all, given the same inputs. */
+export function writeAllowed({ deployed, onWalletChain, held, readable }) {
+  if (deployed === false) return false
+  if (!onWalletChain) return false
+  // Unconfirmed authority stays permissive; only a definite "no" withholds the control.
+  if (readable === false) return true
+  return held !== false
+}
+

--- a/frontend/src/components/ui/PortalNav.css
+++ b/frontend/src/components/ui/PortalNav.css
@@ -4,7 +4,16 @@
  * down the left side and the sidebar can be hidden.
  *
  * Variable fallback chains let the same classes work in both theme systems
- * (admin uses --bg-*/--text-*/--brand-primary, wallet uses --color-*).
+ * (admin uses --bg-… / --text-… / --brand-primary, wallet uses --color-…).
+ *
+ * Do not abbreviate a group of custom properties as an asterisk glob directly
+ * followed by a slash inside a comment. That two-character sequence ENDS the
+ * comment, and CSS then treats everything up to the next closing brace as one
+ * invalid rule and drops it silently. This file did exactly that, and the rule
+ * it swallowed was `.portal-shell` — so the shell lost `display: flex` and both
+ * rail-width custom properties. The sidebar fell out of the flex row, the
+ * content column rendered BELOW it instead of beside it, and the rail sized
+ * itself to whatever its icons happened to need.
  */
 
 .portal-shell {
@@ -142,16 +151,19 @@
    Collapsed (icon-only) rail
    --------------------------------------------------------------------------- */
 
+/* The collapsed rail is a column of 40px tiles centred in the rail, which is the
+   same gutter the 36px hamburger above them sits on — the icons and the control
+   that reveals their labels line up on one axis instead of two. */
 .portal-nav--collapsed {
-  padding: 8px 0;
+  padding: 8px 0 12px;
   align-items: center;
 }
 
 .portal-nav--collapsed .portal-nav-item {
-  width: 44px;
+  width: 40px;
   justify-content: center;
   gap: 0;
-  padding: 7px 0;
+  padding: 5px 0;
   border-left-width: 0;
 }
 
@@ -188,9 +200,10 @@
 }
 
 /* Group headings collapse to a hairline: the grouping stays legible without a
-   200px word in a 64px rail. */
+   200px word in a 64px rail. It spans the same 40px as the tiles it separates —
+   a rule narrower than the things it divides reads as a stray mark. */
 .portal-nav--collapsed .portal-nav-group-label {
-  width: 32px;
+  width: 40px;
   height: 0;
   padding: 0;
   margin: 6px 0;
@@ -264,7 +277,7 @@
      scrolls, so the hamburger is always reachable on a long view. */
   .portal-shell {
     --portal-rail-expanded: 232px;
-    --portal-rail-collapsed: 52px;
+    --portal-rail-collapsed: 56px;
   }
 
   .portal-sidebar {

--- a/frontend/src/test/FeesTab.test.jsx
+++ b/frontend/src/test/FeesTab.test.jsx
@@ -51,6 +51,7 @@ import FeesTab from '../components/admin/FeesTab'
 const EARN_LEND = ethers.id('earn.lend')
 const PM_TAKER = ethers.id('polymarket.taker')
 const TREASURY = '0x1111111111111111111111111111111111111111'
+const ACCOUNT = '0x2222222222222222222222222222222222222222'
 
 // Spec 071: the tab now scopes to a network the operator picks, seeded from the wallet's chain
 // when that chain is in this build's cohort. A chainId outside the cohort would seed the scope
@@ -62,7 +63,13 @@ const WALLET_CHAIN_NAME = NETWORKS[WALLET_CHAIN].name
 const PROVIDER = { getBlockNumber: async () => 500_000, getBlock: async () => ({ timestamp: 1_752_800_000 }) }
 const SIGNER = { isSigner: true }
 
-function seedReads({ feeBps = { [EARN_LEND]: 50, [PM_TAKER]: 40 }, events = [] } = {}) {
+// Spec 071: capability comes from the ROUTER's own AccessControl on the scoped chain, not from
+// the app-wide props. `roles` here is what that router answers for the connected account — the
+// props stay only as the pre-read stand-in while the first hasRole round-trip is in flight.
+const ADMIN_ROLE = ethers.ZeroHash
+const FEE_ADMIN_ROLE = ethers.id('FEE_ADMIN_ROLE')
+
+function seedReads({ feeBps = { [EARN_LEND]: 50, [PM_TAKER]: 40 }, events = [], roles = { admin: true, feeAdmin: true } } = {}) {
   const ids = [EARN_LEND, PM_TAKER]
   const svc = {
     [EARN_LEND]: { capBps: 250n, feeBps: BigInt(feeBps[EARN_LEND] ?? 0), kind: 1n },
@@ -75,6 +82,11 @@ function seedReads({ feeBps = { [EARN_LEND]: 50, [PM_TAKER]: 40 }, events = [] }
     treasury: async () => TREASURY,
     MAX_WRAPPED_FEE_BPS: async () => 250n,
     queryFilter: async () => events,
+    hasRole: async (role) => {
+      if (role === ADMIN_ROLE) return Boolean(roles.admin)
+      if (role === FEE_ADMIN_ROLE) return Boolean(roles.feeAdmin)
+      return false
+    },
   }
 }
 
@@ -83,6 +95,7 @@ function renderTab({ isAdmin = true, isFeeAdmin = false, runTx } = {}) {
   render(
     <FeesTab
       signer={SIGNER}
+      account={ACCOUNT}
       chainId={WALLET_CHAIN}
       provider={PROVIDER}
       runTx={tx}
@@ -164,6 +177,8 @@ describe('FeesTab editing & gating', () => {
   })
 
   it('hides the rate editor entirely without the fee-admin capability', async () => {
+    // The router says no — which is the answer that counts, since it is the contract that refuses.
+    seedReads({ roles: { admin: false, feeAdmin: false } })
     renderTab({ isAdmin: false, isFeeAdmin: false })
     await screen.findAllByText(/earn — vault lending/i)
     expect(screen.queryByRole('button', { name: /set fee rate/i })).not.toBeInTheDocument()
@@ -184,9 +199,39 @@ describe('FeesTab editing & gating', () => {
   })
 
   it('fee admins without full admin cannot change the treasury', async () => {
+    seedReads({ roles: { admin: false, feeAdmin: true } })
     renderTab({ isAdmin: false, isFeeAdmin: true })
     await screen.findAllByText(/earn — vault lending/i)
     expect(screen.getByRole('button', { name: /set fee rate/i })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /set treasury/i })).not.toBeInTheDocument()
+  })
+})
+
+/**
+ * Spec 071 — capability is read from the router that enforces it, and an unconfirmed read keeps
+ * the control offered rather than withheld (FR-044).
+ */
+describe('FeesTab reads capability from the scoped router', () => {
+  it('offers the editor when the ROUTER grants it, even with no app-wide flag', async () => {
+    seedReads({ roles: { admin: false, feeAdmin: true } })
+    renderTab({ isAdmin: false, isFeeAdmin: false })
+    expect(await screen.findByRole('button', { name: /set fee rate/i })).toBeInTheDocument()
+  })
+
+  it('withholds the editor when the ROUTER refuses, even with an app-wide flag', async () => {
+    // Holding FEE_ADMIN_ROLE on another network is not holding it here. Showing the form on the
+    // strength of an estate-wide flag offers a control that reverts.
+    seedReads({ roles: { admin: false, feeAdmin: false } })
+    renderTab({ isAdmin: true, isFeeAdmin: true })
+    await screen.findAllByText(/earn — vault lending/i)
+    expect(screen.queryByRole('button', { name: /set fee rate/i })).not.toBeInTheDocument()
+  })
+
+  it('keeps the editor available, and says so, when the role read FAILS', async () => {
+    seedReads()
+    m.reads.hasRole = async () => { throw new Error('rpc timeout') }
+    renderTab({ isAdmin: false, isFeeAdmin: false })
+    expect(await screen.findByRole('button', { name: /set fee rate/i })).toBeInTheDocument()
+    expect(screen.getAllByText(/authority could not be confirmed/i).length).toBeGreaterThan(0)
   })
 })

--- a/frontend/src/test/FeesTab.test.jsx
+++ b/frontend/src/test/FeesTab.test.jsx
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { ethers } from 'ethers'
+import { cohortChainIds, NETWORKS } from '../config/networks'
 
 const m = vi.hoisted(() => ({ routerAddr: null, reads: {}, writes: {} }))
 
@@ -51,6 +52,13 @@ const EARN_LEND = ethers.id('earn.lend')
 const PM_TAKER = ethers.id('polymarket.taker')
 const TREASURY = '0x1111111111111111111111111111111111111111'
 
+// Spec 071: the tab now scopes to a network the operator picks, seeded from the wallet's chain
+// when that chain is in this build's cohort. A chainId outside the cohort would seed the scope
+// elsewhere and gate every write off — which is correct behaviour, and not what these tests are
+// about, so they run on a chain the build can actually reach.
+const WALLET_CHAIN = cohortChainIds()[0]
+const WALLET_CHAIN_NAME = NETWORKS[WALLET_CHAIN].name
+
 const PROVIDER = { getBlockNumber: async () => 500_000, getBlock: async () => ({ timestamp: 1_752_800_000 }) }
 const SIGNER = { isSigner: true }
 
@@ -75,7 +83,7 @@ function renderTab({ isAdmin = true, isFeeAdmin = false, runTx } = {}) {
   render(
     <FeesTab
       signer={SIGNER}
-      chainId={137}
+      chainId={WALLET_CHAIN}
       provider={PROVIDER}
       runTx={tx}
       pendingTx={false}
@@ -110,8 +118,12 @@ describe('FeesTab rendering', () => {
   it('is honest when no FeeRouter is deployed on the network', async () => {
     m.routerAddr = null
     renderTab()
+    // It names the network rather than saying "this network" — the tab is no longer showing
+    // whatever the wallet is on, so "this" would be ambiguous.
     expect(
-      await screen.findByText(/no feerouter is deployed on this network/i),
+      await screen.findByText(
+        new RegExp(`no feerouter is deployed on ${WALLET_CHAIN_NAME}`, 'i'),
+      ),
     ).toBeInTheDocument()
   })
 

--- a/frontend/src/test/MembershipTreasuryOverview.test.jsx
+++ b/frontend/src/test/MembershipTreasuryOverview.test.jsx
@@ -39,7 +39,7 @@ describe('MembershipTreasuryOverview (admin overview: membership + treasury)', (
   it('shows a not-configured notice when MembershipManager is undeployed on this network', () => {
     useMembershipTreasuryStats.mockReturnValue({ loading: false, error: null, data: null, truncated: false, refresh: vi.fn() })
     render(<MembershipTreasuryOverview {...baseProps} address="" />)
-    expect(screen.getByText(/not deployed \/ configured on this network/i)).toBeInTheDocument()
+    expect(screen.getByText(/not deployed \/ configured on the membership network/i)).toBeInTheDocument()
     expect(screen.queryByText('Membership Statistics')).not.toBeInTheDocument()
   })
 
@@ -82,5 +82,42 @@ describe('MembershipTreasuryOverview (admin overview: membership + treasury)', (
     expect(screen.getByText(/Scan failed: rpc range too wide/)).toBeInTheDocument()
     expect(screen.getByText(/most recent block window only/i)).toBeInTheDocument()
     expect(screen.getByText('Active members (window)')).toBeInTheDocument()
+  })
+})
+
+/**
+ * Spec 071 T046/T049 — the panel is PINNED to the membership reference chain, and an unreadable
+ * accrued balance is never a zero.
+ */
+describe('MembershipTreasuryOverview reads the membership chain honestly (T046)', () => {
+  beforeEach(() => useMembershipTreasuryStats.mockReset())
+
+  it('scans the chain it was GIVEN — provider, chainId and address must agree', () => {
+    useMembershipTreasuryStats.mockReturnValue({ loading: false, error: null, data: DATA, truncated: false, refresh: vi.fn() })
+    render(<MembershipTreasuryOverview {...baseProps} chainId={80002} />)
+    // The cache key and the scan follow the chain the caller named, not an ambient one. Passing a
+    // wallet provider next to the reference chain's address would read one chain's contract at
+    // another chain's address — the disagreement this spec exists to end.
+    expect(useMembershipTreasuryStats).toHaveBeenCalledWith(
+      expect.objectContaining({ provider, chainId: 80002, address: ADDRESS }),
+    )
+  })
+
+  it('says the accrued balance could not be read, rather than showing $0.00', () => {
+    useMembershipTreasuryStats.mockReturnValue({ loading: false, error: null, data: DATA, truncated: false, refresh: vi.fn() })
+    render(<MembershipTreasuryOverview {...baseProps} accruedFees="0" accruedFeesReadable={false} />)
+
+    expect(screen.getByText(/could not be read/i)).toBeInTheDocument()
+    // A $0.00 accrued balance reads as "the fees were already withdrawn" — an operator acts on it.
+    const tile = screen.getByText(/could not be read/i).closest('.mto-tile')
+    expect(tile).toHaveTextContent(/Accrued \(undrawn, live\)/i)
+    expect(tile).not.toHaveTextContent(/\$0\.00/)
+  })
+
+  it('still shows a real zero as a zero when the read succeeded', () => {
+    useMembershipTreasuryStats.mockReturnValue({ loading: false, error: null, data: DATA, truncated: false, refresh: vi.fn() })
+    render(<MembershipTreasuryOverview {...baseProps} accruedFees="0" accruedFeesReadable />)
+    const tile = screen.getByText(/Accrued \(undrawn, live\)/i).closest('.mto-tile')
+    expect(tile).toHaveTextContent('$0.00')
   })
 })

--- a/frontend/src/test/admin/adminEstateGuard.test.js
+++ b/frontend/src/test/admin/adminEstateGuard.test.js
@@ -29,10 +29,13 @@ const RE_WALLET_CHAIN = /getContractAddressForChain\(\s*'[^']+'\s*,\s*chainId\s*
 // Counts are MEASURED, not estimated — the first run of this guard corrected two of them, which
 // is the point: a baseline nobody verified is just a comment.
 const UNCONVERTED = {
-  // Infrastructure card: the paymaster deposit is per chain and follows the wallet today. The
-  // last remaining entry — Fees, Staking and Callsigns were converted and removed from this list,
-  // which the guard's second assertion forced rather than left to memory.
-  'PaymasterOpsCard.jsx': 1,
+  // Empty, and that is the finished state: every admin view resolves its contract from a chain it
+  // was given, not the one the wallet happens to be on. It emptied one entry at a time, each
+  // removal forced by the second assertion below rather than left to memory.
+  //
+  // Adding an entry here is not forbidden — a view mid-conversion belongs on this list with its
+  // measured count and a sentence saying why. Adding one WITHOUT that sentence is the thing this
+  // file exists to make awkward.
 }
 
 function adminFiles() {

--- a/frontend/src/test/admin/adminEstateGuard.test.js
+++ b/frontend/src/test/admin/adminEstateGuard.test.js
@@ -29,12 +29,9 @@ const RE_WALLET_CHAIN = /getContractAddressForChain\(\s*'[^']+'\s*,\s*chainId\s*
 // Counts are MEASURED, not estimated — the first run of this guard corrected two of them, which
 // is the point: a baseline nobody verified is just a comment.
 const UNCONVERTED = {
-  // Converted in a later slice of Phase 7 — each reads a single contract and has no scope
-  // selector yet, so the wallet's chain is still what it uses.
-  'FeesTab.jsx': 1,
-  'StakingTab.jsx': 1,
-  'CallsignRegistryAdmin.jsx': 1,
-  // Infrastructure card: the paymaster deposit is per chain and follows the wallet today.
+  // Infrastructure card: the paymaster deposit is per chain and follows the wallet today. The
+  // last remaining entry — Fees, Staking and Callsigns were converted and removed from this list,
+  // which the guard's second assertion forced rather than left to memory.
   'PaymasterOpsCard.jsx': 1,
 }
 

--- a/frontend/src/test/admin/adminEstateGuard.test.js
+++ b/frontend/src/test/admin/adminEstateGuard.test.js
@@ -1,0 +1,94 @@
+/**
+ * Spec 071 T070 — a source-level guard for the two rules that no single component test can see.
+ *
+ * Behavioural tests prove a converted view behaves. They cannot prove that the NEXT view added
+ * to the console follows the same rules, and both of these fail silently rather than loudly:
+ *
+ *   1. An admin view that resolves its contract from the WALLET's chain looks fine until an
+ *      operator scopes elsewhere, then reads one chain's contract at another chain's address.
+ *   2. A cross-unit sum produces a number, just the wrong one. Nothing throws.
+ *
+ * This scans the admin surface and fails on a NEW occurrence, with an allowlist that documents
+ * every accepted one. When a listed file is later converted its count drops below baseline and
+ * this fails too — so the baseline stays honest rather than drifting upward.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ADMIN_DIR = join(dirname(fileURLToPath(import.meta.url)), '../../components/admin')
+
+/** `getContractAddressForChain(..., chainId)` — the WALLET's chain, in an operator view. */
+const RE_WALLET_CHAIN = /getContractAddressForChain\(\s*'[^']+'\s*,\s*chainId\s*\)/g
+
+/**
+ * Views still resolving against the wallet's chain, with the reason each is still listed.
+ * Spec 071 converts these in order (research R8); the number is what that file has TODAY.
+ */
+// Counts are MEASURED, not estimated — the first run of this guard corrected two of them, which
+// is the point: a baseline nobody verified is just a comment.
+const UNCONVERTED = {
+  // Converted in a later slice of Phase 7 — each reads a single contract and has no scope
+  // selector yet, so the wallet's chain is still what it uses.
+  'FeesTab.jsx': 1,
+  'StakingTab.jsx': 1,
+  'CallsignRegistryAdmin.jsx': 1,
+  // Infrastructure card: the paymaster deposit is per chain and follows the wallet today.
+  'PaymasterOpsCard.jsx': 1,
+}
+
+function adminFiles() {
+  return readdirSync(ADMIN_DIR).filter((f) => f.endsWith('.jsx') || f.endsWith('.js'))
+}
+
+describe('admin views resolve contracts against an explicit chain, not the wallet by habit', () => {
+  it('adds no NEW wallet-chain resolution beyond the documented baseline', () => {
+    const offenders = []
+    for (const file of adminFiles()) {
+      const src = readFileSync(join(ADMIN_DIR, file), 'utf8')
+      const count = (src.match(RE_WALLET_CHAIN) || []).length
+      const allowed = UNCONVERTED[file] ?? 0
+      if (count > allowed) {
+        offenders.push(`${file}: ${count} wallet-chain resolutions (baseline ${allowed})`)
+      }
+    }
+    expect(offenders, `Resolve against the SCOPED chain instead:\n${offenders.join('\n')}`).toEqual([])
+  })
+
+  it('keeps the baseline honest — a converted file must be removed from the allowlist', () => {
+    const stale = []
+    for (const [file, allowed] of Object.entries(UNCONVERTED)) {
+      if (allowed === 0) continue
+      const src = readFileSync(join(ADMIN_DIR, file), 'utf8')
+      const count = (src.match(RE_WALLET_CHAIN) || []).length
+      if (count < allowed) stale.push(`${file}: now ${count}, baseline still ${allowed}`)
+    }
+    expect(stale, `Lower these baselines — they have been converted:\n${stale.join('\n')}`).toEqual([])
+  })
+})
+
+describe('no admin view sums balances across chains (FR-022)', () => {
+  it('never reduces a per-chain result list into a single running total', () => {
+    // `aggregate()` is the only sanctioned path, and it returns per-unit subtotals. A hand-rolled
+    // reduce over chain results is how a cross-unit figure gets invented.
+    const offenders = []
+    for (const file of adminFiles()) {
+      const src = readFileSync(join(ADMIN_DIR, file), 'utf8')
+      if (/\.reduce\(\([^)]*\)\s*=>\s*[a-z]+\s*\+\s*[a-z]+\.value/i.test(src)) {
+        offenders.push(file)
+      }
+    }
+    expect(offenders, `Use aggregate() from chainReadResult.js:\n${offenders.join('\n')}`).toEqual([])
+  })
+
+  it('the sanctioned aggregate still refuses to expose one grand total', () => {
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '../../lib/chains/chainReadResult.js'),
+      'utf8',
+    )
+    // `subtotals` keyed by unit is the whole contract; a `total` export would break it.
+    expect(src).toMatch(/subtotals/)
+    expect(src).not.toMatch(/export function (grandTotal|totalAcrossChains)/)
+  })
+})

--- a/frontend/src/test/admin/adminIncidentEstate.test.jsx
+++ b/frontend/src/test/admin/adminIncidentEstate.test.jsx
@@ -1,0 +1,95 @@
+/**
+ * Spec 071 US4 (T066–T069) — the incident-response views span the estate, and act on ONE chain.
+ *
+ * These convert LAST on purpose (research R8): the killswitch should be the least-experimental
+ * conversion in the feature, not the first. By the time it lands, the same scope pattern has
+ * been proven on Maintenance and Wiring & Tokens.
+ *
+ * T067 asserts an ABSENCE — no control pauses or freezes across several chains at once
+ * (FR-020). A feature that makes every view span the estate is exactly where an implicit
+ * multi-chain killswitch would seem like a natural convenience, and a killswitch that fans out
+ * is one an operator can fire without knowing what they hit. Prose cannot verify an absence, so
+ * this checks the source.
+ */
+import { describe, it, expect } from 'vitest'
+import adminPanelSource from '../../components/AdminPanel.jsx?raw'
+
+describe('the pause acts on one named chain (T066, FR-017/FR-018)', () => {
+  it('writes to the SCOPED registry, not the wallet chain\'s', () => {
+    expect(adminPanelSource).toMatch(
+      /getContractAddressForChain\('wagerRegistry', incidentChainId\)/,
+    )
+    expect(adminPanelSource).toMatch(/const incidentWrite = \(\) =>/)
+  })
+
+  it('names the chain in the pause and unpause confirmations', () => {
+    expect(adminPanelSource).toMatch(/WagerRegistry paused on \$\{networkName\(incidentChainId\)\}/)
+    expect(adminPanelSource).toMatch(/WagerRegistry unpaused on \$\{networkName\(incidentChainId\)\}/)
+  })
+
+  it('names the chain on the buttons, so the operator reads it before clicking', () => {
+    expect(adminPanelSource).toMatch(/`Pause on \$\{networkName\(incidentChainId\)\}`/)
+    expect(adminPanelSource).toMatch(/`Unpause on \$\{networkName\(incidentChainId\)\}`/)
+  })
+
+  it('refuses at the call site as well as in the disabled button', () => {
+    // A stale render must not be able to pause the wrong network.
+    expect(adminPanelSource).toMatch(/const requireIncidentChain = \(\) => \{/)
+    expect(adminPanelSource).toMatch(/handlePause = \(\) => requireIncidentChain\(\) && runTx/)
+    expect(adminPanelSource).toMatch(/handleUnpause = \(\) => requireIncidentChain\(\) && runTx/)
+    expect(adminPanelSource).toMatch(/disabled=\{pendingTx \|\| !onIncidentChain\}/)
+  })
+})
+
+describe('a freeze applies to one named chain (T068)', () => {
+  it('writes to the scoped registry and names the chain', () => {
+    expect(adminPanelSource).toMatch(/incidentWrite\(\)\.freezeAccount/)
+    expect(adminPanelSource).toMatch(/incidentWrite\(\)\.unfreezeAccount/)
+    expect(adminPanelSource).toMatch(/frozen on \$\{networkName\(incidentChainId\)\}/)
+    expect(adminPanelSource).toMatch(/unfrozen on \$\{networkName\(incidentChainId\)\}/)
+  })
+
+  it('checks the chain before sending, not only in the button', () => {
+    expect(adminPanelSource).toMatch(/if \(!requireIncidentChain\(\)\) return false/)
+  })
+
+  it('says a freeze on one network is not a freeze on another', () => {
+    // The operator must not assume it fanned out — that assumption is the dangerous one.
+    expect(adminPanelSource).toMatch(/does not freeze it on another/)
+  })
+})
+
+// ── T067: THE ABSENCE ───────────────────────────────────────────────────────────────────────
+describe('no control acts across several chains at once (FR-020)', () => {
+  it('never loops a pause or freeze over a list of chains', () => {
+    // Any of these shapes would be an implicit multi-chain killswitch.
+    expect(adminPanelSource).not.toMatch(/cohortChainIds\(\)[\s\S]{0,200}?\.(pause|unpause)\(\)/)
+    expect(adminPanelSource).not.toMatch(/\.map\([^)]*\)[\s\S]{0,120}?\.(pause|unpause)\(\)/)
+    expect(adminPanelSource).not.toMatch(/for \(const[\s\S]{0,200}?\.(pause|unpause)\(\)/)
+    expect(adminPanelSource).not.toMatch(/for \(const[\s\S]{0,200}?freezeAccount\(/)
+  })
+
+  it('offers no "pause everywhere" / "pause all" control', () => {
+    expect(adminPanelSource).not.toMatch(/pause\s*(all|every)/i)
+    expect(adminPanelSource).not.toMatch(/freeze\s*(all|every)/i)
+    // `.pause()` / `.unpause()` with parens — NOT `paused()`, which is the per-chain READ the
+    // overview legitimately batches.
+    expect(adminPanelSource).not.toMatch(/Promise\.all\([\s\S]{0,200}?\.(pause|unpause)\(\)/)
+  })
+
+  it('states the rule where the next person will read it', () => {
+    expect(adminPanelSource).toMatch(/no control that pauses several at once|NO control that acts\s*\n?\s*\/\/ on several chains/i)
+  })
+})
+
+describe('the incident scope is chosen, not inherited (FR-016)', () => {
+  it('uses the shared useScopedChain, which never re-derives from the wallet', () => {
+    expect(adminPanelSource).toMatch(/useScopedChain\(registryNetworks, chainId\)/)
+  })
+
+  it('lists only networks that actually carry a registry', () => {
+    expect(adminPanelSource).toMatch(
+      /estateNetworks\(\)\.filter\(\(n\) => getContractAddressForChain\('wagerRegistry', n\.chainId\)\)/,
+    )
+  })
+})

--- a/frontend/src/test/admin/adminScopeControls.test.jsx
+++ b/frontend/src/test/admin/adminScopeControls.test.jsx
@@ -1,0 +1,197 @@
+/**
+ * Spec 071 US4 (T053) — the shared scope controls every operator view uses.
+ *
+ * These encode three rules that were each a real defect first:
+ *   • scope is a network the operator picks, not the wallet's
+ *   • the scope does NOT follow the wallet (FR-016) — an operator mid-audit must not have their
+ *     reading silently re-targeted
+ *   • a withheld write says WHY, in words, before signing (FR-018) — and an UNCONFIRMED
+ *     authority read leaves the control offered, because withdrawing a killswitch on an RPC
+ *     timeout tells an operator who holds it that there isn't one
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import { NetworkScopeCard, WriteScopeNotice, WriteGate } from '../../components/admin/scopeControls'
+import { useScopedChain, writeGateReason, writeAllowed } from '../../components/admin/scopeGate'
+import { NETWORKS, cohortChainIds } from '../../config/networks'
+
+const COHORT = cohortChainIds()
+const A = COHORT[0]
+const B = COHORT[1]
+const networks = COHORT.map((id) => NETWORKS[id])
+const deployedEverywhere = () => true
+
+describe('useScopedChain — the scope does not follow the wallet (FR-016)', () => {
+  it('defaults to the wallet chain when it is in the roster', () => {
+    const { result } = renderHook(() => useScopedChain(networks, B))
+    expect(result.current.scopeChainId).toBe(B)
+  })
+
+  it('falls back to the first roster entry when the wallet is elsewhere', () => {
+    const { result } = renderHook(() => useScopedChain(networks, 999999))
+    expect(result.current.scopeChainId).toBe(networks[0].chainId)
+  })
+
+  it('does NOT re-target when the wallet changes network', () => {
+    const { result, rerender } = renderHook(({ w }) => useScopedChain(networks, w), {
+      initialProps: { w: A },
+    })
+    expect(result.current.scopeChainId).toBe(A)
+
+    rerender({ w: B }) // wallet moved
+
+    // The operator is still looking at what they chose. Only write availability changes.
+    expect(result.current.scopeChainId).toBe(A)
+  })
+
+  it('lets a view jump to the wallet chain explicitly, when the operator asks', () => {
+    const { result } = renderHook(() => useScopedChain(networks, B))
+    act(() => result.current.setScopeChainId(A))
+    expect(result.current.scopeChainId).toBe(A)
+    act(() => result.current.scopeToWallet())
+    expect(result.current.scopeChainId).toBe(B)
+  })
+})
+
+describe('NetworkScopeCard', () => {
+  const renderCard = (props = {}) =>
+    render(
+      <NetworkScopeCard
+        title="Test Controls"
+        description="Per-network control state."
+        networks={networks}
+        scopeChainId={A}
+        onScopeChange={props.onScopeChange || vi.fn()}
+        isDeployed={props.isDeployed || deployedEverywhere}
+        walletChainId={props.walletChainId ?? A}
+        onRefresh={vi.fn()}
+        lastReadAt={null}
+        notDeployedLabel={props.notDeployedLabel}
+      />,
+    )
+
+  it('lists every network in the roster, including undeployed ones', () => {
+    renderCard({ isDeployed: (id) => Number(id) === Number(A) })
+    const select = screen.getByLabelText(/^Network/)
+    expect(select.querySelectorAll('option')).toHaveLength(networks.length)
+  })
+
+  it('marks an undeployed network with contract-neutral wording by default', () => {
+    renderCard({ isDeployed: (id) => Number(id) === Number(A) })
+    // The old copy said "no router deployed", which is wrong for a MembershipManager view.
+    expect(screen.getByText(new RegExp(`${NETWORKS[B].name} — not deployed here`))).toBeInTheDocument()
+  })
+
+  it('lets a view name what is not deployed', () => {
+    renderCard({ isDeployed: () => false, notDeployedLabel: 'no MembershipManager' })
+    expect(screen.getAllByText(/no MembershipManager/).length).toBeGreaterThan(0)
+  })
+
+  it('says where the wallet is, so scope and wallet are never confused', () => {
+    renderCard({ walletChainId: B })
+    expect(screen.getByText(new RegExp(`${NETWORKS[B].name} \\(wallet is here\\)`))).toBeInTheDocument()
+  })
+
+  it('reports scope changes to the view', () => {
+    const onScopeChange = vi.fn()
+    renderCard({ onScopeChange })
+    fireEvent.change(screen.getByLabelText(/^Network/), { target: { value: String(B) } })
+    expect(onScopeChange).toHaveBeenCalledWith(B)
+  })
+
+  it('is axe-clean', async () => {
+    const { container } = renderCard()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('WriteScopeNotice — a withheld write explains itself (FR-018)', () => {
+  it('names the network to switch to when the wallet is elsewhere', () => {
+    render(<WriteScopeNotice scopeChainId={A} walletChainId={B} signer={{}} canWrite />)
+    expect(screen.getByText(new RegExp(`switch your wallet to it`, 'i'))).toBeInTheDocument()
+    expect(screen.getByText(new RegExp(NETWORKS[A].name))).toBeInTheDocument()
+  })
+
+  it('says reading is unaffected — the scope is not broken, only signing is', () => {
+    render(<WriteScopeNotice scopeChainId={A} walletChainId={B} signer={{}} canWrite />)
+    expect(screen.getByText(/Reading is unaffected/i)).toBeInTheDocument()
+  })
+
+  it('asks for a wallet when there is none, without implying a permissions problem', () => {
+    render(<WriteScopeNotice scopeChainId={A} walletChainId={A} signer={null} canWrite />)
+    expect(screen.getByText(/readable without one/i)).toBeInTheDocument()
+  })
+
+  it('says nothing when the wallet is on the scoped network', () => {
+    const { container } = render(<WriteScopeNotice scopeChainId={A} walletChainId={A} signer={{}} canWrite />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('the write gate distinguishes four different situations', () => {
+  const base = { deployed: true, onWalletChain: true, held: true, readable: true, scopeChainId: A }
+
+  it('allows a write when everything lines up', () => {
+    expect(writeAllowed(base)).toBe(true)
+    expect(writeGateReason(base)).toBeNull()
+  })
+
+  it('withholds and says so when the contract is not deployed there', () => {
+    const g = { ...base, deployed: false }
+    expect(writeAllowed(g)).toBe(false)
+    expect(writeGateReason(g)).toMatch(/Not deployed on/)
+  })
+
+  it('withholds and names the network when the wallet is elsewhere', () => {
+    const g = { ...base, onWalletChain: false }
+    expect(writeAllowed(g)).toBe(false)
+    expect(writeGateReason(g)).toMatch(new RegExp(`Switch your wallet to ${NETWORKS[A].name}`))
+  })
+
+  it('withholds on a definite "role not held", and says switching will not help', () => {
+    const g = { ...base, held: false }
+    expect(writeAllowed(g)).toBe(false)
+    expect(writeGateReason(g)).toMatch(/do not hold this role/)
+  })
+
+  it('KEEPS the control offered when authority could not be read, and says it is unconfirmed', () => {
+    // The spec-067 FR-044 rule: an RPC timeout must not look like "there is no killswitch".
+    const g = { ...base, readable: false, held: false }
+    expect(writeAllowed(g)).toBe(true)
+    expect(writeGateReason(g)).toMatch(/could not be confirmed/)
+    expect(writeGateReason(g)).toMatch(/contract will still refuse/)
+  })
+
+  it('reports not-deployed ahead of a wrong network — the more fundamental answer wins', () => {
+    const g = { ...base, deployed: false, onWalletChain: false }
+    expect(writeGateReason(g)).toMatch(/Not deployed/)
+  })
+})
+
+describe('WriteGate renders the gate and its reason together', () => {
+  it('passes the verdict to the control and shows the reason beside it', () => {
+    render(
+      <WriteGate deployed onWalletChain={false} held readable scopeChainId={A}>
+        {({ allowed }) => (
+          <button type="button" disabled={!allowed}>
+            Do the thing
+          </button>
+        )}
+      </WriteGate>,
+    )
+    expect(screen.getByRole('button', { name: 'Do the thing' })).toBeDisabled()
+    expect(screen.getByRole('status')).toHaveTextContent(/Switch your wallet/)
+  })
+
+  it('renders no reason when the write is allowed', () => {
+    render(
+      <WriteGate deployed onWalletChain held readable scopeChainId={A}>
+        {({ allowed }) => <button type="button" disabled={!allowed}>Go</button>}
+      </WriteGate>,
+    )
+    expect(screen.getByRole('button', { name: 'Go' })).toBeEnabled()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+})

--- a/frontend/src/test/admin/adminViewScope.test.jsx
+++ b/frontend/src/test/admin/adminViewScope.test.jsx
@@ -1,0 +1,341 @@
+/**
+ * Spec 071 T065 — per-view tests for the converted operator views (T054–T064).
+ *
+ * The shared controls already have their own suite (`adminScopeControls.test.jsx`). What that
+ * one cannot show is whether a given VIEW actually wired itself to them, so this file renders
+ * two real views end to end and checks the five things the task names:
+ *
+ *   • a scope off the wallet's network still renders read state
+ *   • a withheld write says WHY, in words
+ *   • an unreadable read is never a zero
+ *   • "not deployed" is stated explicitly — and does not strand the operator
+ *   • the write confirmation NAMES the chain it targets (FR-017)
+ *
+ * plus axe-cleanliness in each per-chain state (constitution V).
+ *
+ * DenyListAdmin and PaymasterOpsCard are rendered because they are the two converted views with
+ * self-contained props — one compliance surface, one treasury surface. The remaining views
+ * (Maintenance, Wiring & Tokens, Fees, Staking, Callsigns, Oracle Adapters, and the AdminPanel
+ * sections) are covered at the source level below and by their own suites, because rendering
+ * them means standing up the whole console; the source assertions target exactly the wiring a
+ * render would have proven.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import { NETWORKS, cohortChainIds } from '../../config/networks'
+
+const notify = vi.fn()
+vi.mock('../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: notify }) }))
+
+// Address book: the scoped chain decides what is deployed. `DEPLOYED` is rewritten per test.
+let DEPLOYED = {}
+vi.mock('../../config/contracts', () => ({
+  getContractAddressForChain: (key, chainId) => DEPLOYED[`${key}:${Number(chainId)}`] || '',
+  NETWORK_CONFIG: { name: 'Test' },
+  DEPLOYED_CONTRACTS: {},
+}))
+
+// The provider each chain answers with. A chain absent from this map has NO read connection —
+// which is `unreadable`, and must never render as a zero.
+let PROVIDERS = {}
+vi.mock('../../lib/chains/estate', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    readProviderFor: (chainId) => PROVIDERS[Number(chainId)] || null,
+  }
+})
+
+const CONTRACTS = new Map()
+vi.mock('ethers', async (importOriginal) => {
+  const actual = await importOriginal()
+  class FakeContract {
+    constructor(address) {
+      const impl = CONTRACTS.get(address)
+      Object.assign(this, impl || {})
+    }
+  }
+  return { ...actual, ethers: { ...actual.ethers, Contract: FakeContract } }
+})
+
+const COHORT = cohortChainIds()
+const HOME = COHORT[0] // where the wallet is
+const AWAY = COHORT[1] // where the operator scopes to
+const nameOf = (id) => NETWORKS[id].name
+
+let DenyListAdmin
+let PaymasterOpsCard
+beforeEach(async () => {
+  vi.clearAllMocks()
+  DEPLOYED = {}
+  PROVIDERS = {}
+  CONTRACTS.clear()
+  DenyListAdmin = (await import('../../components/admin/DenyListAdmin')).default
+  PaymasterOpsCard = (await import('../../components/admin/PaymasterOpsCard')).default
+})
+
+const signerFor = () => ({ provider: { getBlockNumber: async () => 100 } })
+
+// ── Deny-list: a compliance surface, where "not denied" must never be a guess ────────────────
+describe('DenyListAdmin scopes its guard (T062)', () => {
+  const renderView = (props = {}) => {
+    const runTx = props.runTx || vi.fn().mockResolvedValue(true)
+    const utils = render(
+      <DenyListAdmin
+        signer={signerFor()}
+        account="0xabc"
+        contracts={{}}
+        chainId={props.chainId ?? HOME}
+        runTx={runTx}
+        pendingTx={false}
+      />,
+    )
+    return { ...utils, runTx }
+  }
+
+  const guardAt = (chainId, impl) => {
+    const addr = `0x${'11'.repeat(20)}`
+    DEPLOYED[`sanctionsGuard:${chainId}`] = addr
+    PROVIDERS[chainId] = { getBlockNumber: async () => 100 }
+    CONTRACTS.set(addr, {
+      filters: { DenyListUpdated: () => ({}) },
+      queryFilter: async () => [],
+      isDenied: async () => false,
+      isAllowed: async () => true,
+      ...impl,
+    })
+    return addr
+  }
+
+  it('states "not deployed" explicitly, and still offers the picker so the operator can leave', async () => {
+    guardAt(AWAY, {})
+    renderView({ chainId: HOME }) // wallet's chain has no guard; scope seeds there
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      new RegExp(`not deployed on ${nameOf(HOME)}`, 'i'),
+    )
+    // The empty state keeps the way out. Dropping the picker here strands the operator.
+    expect(screen.getByLabelText(/^Network/)).toBeInTheDocument()
+  })
+
+  it('reads a network the wallet is NOT on, and withholds the write in words', async () => {
+    guardAt(AWAY, {})
+    renderView({ chainId: HOME })
+
+    fireEvent.change(screen.getByLabelText(/^Network/), { target: { value: String(AWAY) } })
+
+    // Read state renders for the scoped chain...
+    expect(await screen.findByText(new RegExp(`Manage the discretionary`, 'i'))).toBeInTheDocument()
+    // ...and the reason the write is unavailable is stated, not implied by a dead button.
+    expect(
+      screen.getByText(new RegExp(`changing the deny-list needs your wallet on ${nameOf(AWAY)}`, 'i')),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: new RegExp(`Add to deny-list on ${nameOf(AWAY)}`) })).toBeDisabled()
+  })
+
+  // The call-site re-check is deliberately NOT a render test. React refuses to dispatch onClick
+  // for a fiber whose props say `disabled`, so a disabled button cannot be clicked from a test at
+  // all — stripping the DOM attribute does not help. The guard exists for a stale render, which is
+  // a state a render test cannot construct, so it is asserted where it lives.
+  it('refuses at the call site too, not only in the disabled button', async () => {
+    const src = (await import('../../components/admin/DenyListAdmin.jsx?raw')).default
+    expect(src).toMatch(/if \(!onScopeNetwork\) \{\n\s*setError\(`Switch your wallet to \$\{networkName\(scopeChainId\)\}/)
+    expect(src).toMatch(/disabled=\{pendingTx \|\| !onScopeNetwork\}/)
+  })
+
+  it('names the chain in the confirmation it will show (FR-017)', async () => {
+    guardAt(HOME, {})
+    const { runTx } = renderView({ chainId: HOME })
+
+    fireEvent.change(screen.getByLabelText(/Wallet address/i), { target: { value: `0x${'22'.repeat(20)}` } })
+    fireEvent.change(screen.getByLabelText(/Reason/i), { target: { value: 'OFAC match' } })
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(`Add to deny-list on ${nameOf(HOME)}`) }))
+
+    await waitFor(() => expect(runTx).toHaveBeenCalled())
+    expect(runTx.mock.calls[0][1]).toContain(nameOf(HOME))
+  })
+
+  it('an unreachable network reports status as UNKNOWN, never as clear', async () => {
+    const addr = `0x${'11'.repeat(20)}`
+    DEPLOYED[`sanctionsGuard:${HOME}`] = addr // deployed…
+    // …but no provider: the question cannot be put.
+    renderView({ chainId: HOME })
+
+    fireEvent.change(screen.getByLabelText(/Wallet address/i), { target: { value: `0x${'22'.repeat(20)}` } })
+    fireEvent.click(screen.getByRole('button', { name: /Check status/i }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/status is unknown, not clear/i)
+    // The distinction that matters: it must not say the address is fine.
+    expect(alert).not.toHaveTextContent(/denied: false/i)
+  })
+
+  it('is axe-clean deployed and undeployed alike', async () => {
+    guardAt(HOME, {})
+    const { container, unmount } = renderView({ chainId: HOME })
+    await screen.findByText(/Manage the discretionary/i)
+    expect(await axe(container)).toHaveNoViolations()
+    unmount()
+
+    DEPLOYED = {}
+    const bare = renderView({ chainId: HOME })
+    await screen.findByRole('status')
+    expect(await axe(bare.container)).toHaveNoViolations()
+  })
+})
+
+// ── Paymaster: a deposit read from one chain and labelled with another's currency ────────────
+describe('PaymasterOpsCard scopes the deposit (T055)', () => {
+  const renderCard = (props = {}) => {
+    const runTx = props.runTx || vi.fn().mockResolvedValue(true)
+    const utils = render(
+      <PaymasterOpsCard
+        signer={signerFor()}
+        account={props.account || '0xabc'}
+        provider={{}}
+        chainId={props.chainId ?? HOME}
+        nativeSymbol={NETWORKS[HOME].nativeCurrency?.symbol || 'ETH'}
+        runTx={runTx}
+        pendingTx={false}
+      />,
+    )
+    return { ...utils, runTx }
+  }
+
+  const paymasterAt = (chainId, impl) => {
+    const addr = `0x${'33'.repeat(20)}`
+    DEPLOYED[`verifyingPaymaster:${chainId}`] = addr
+    PROVIDERS[chainId] = {}
+    CONTRACTS.set(addr, {
+      getDeposit: async () => 5n * 10n ** 18n,
+      verifyingSigner: async () => `0x${'44'.repeat(20)}`,
+      owner: async () => `0x${'55'.repeat(20)}`,
+      ...impl,
+    })
+    return addr
+  }
+
+  it('labels the deposit in the SCOPED chain currency, not the wallet\'s', async () => {
+    paymasterAt(AWAY, {})
+    renderCard({ chainId: HOME })
+    fireEvent.change(screen.getByLabelText(/^Network/), { target: { value: String(AWAY) } })
+
+    const awaySymbol = NETWORKS[AWAY].nativeCurrency?.symbol
+    expect(await screen.findByText(new RegExp(`5\\.0 ${awaySymbol}`))).toBeInTheDocument()
+  })
+
+  it('says "could not be read" rather than showing a zero deposit', async () => {
+    paymasterAt(HOME, { getDeposit: async () => { throw new Error('rpc timeout') } })
+    renderCard({ chainId: HOME })
+
+    expect(await screen.findByText(/Could not be read/i)).toBeInTheDocument()
+    // A zero here would read as a drained paymaster and trigger an incident that isn't happening.
+    expect(screen.queryByText(/^0\.0 /)).not.toBeInTheDocument()
+  })
+
+  it('keeps owner-only controls OFFERED when the owner read failed (FR-044)', async () => {
+    paymasterAt(HOME, { owner: async () => { throw new Error('rpc timeout') } })
+    renderCard({ chainId: HOME })
+
+    await screen.findByText(/Could not be read/i)
+    expect(screen.getByText(/Authority could not be confirmed/i)).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText(/^Withdraw to/i), { target: { value: `0x${'66'.repeat(20)}` } })
+    fireEvent.change(screen.getByLabelText(/^Amount/i), { target: { value: '1' } })
+    expect(screen.getByRole('button', { name: /Withdraw Deposit on/i })).toBeEnabled()
+  })
+
+  it('withholds the write with a stated reason when scoped off the wallet', async () => {
+    paymasterAt(AWAY, {})
+    renderCard({ chainId: HOME })
+    fireEvent.change(screen.getByLabelText(/^Network/), { target: { value: String(AWAY) } })
+
+    // Every gated control says it — the deposit form and the two owner-only forms alike.
+    const notices = await screen.findAllByText(
+      new RegExp(`Switch your wallet to ${nameOf(AWAY)}`, 'i'),
+    )
+    expect(notices.length).toBeGreaterThan(0)
+  })
+
+  it('names the chain in the deposit confirmation (FR-017)', async () => {
+    paymasterAt(HOME, {})
+    const { runTx } = renderCard({ chainId: HOME })
+    await screen.findByText(/EntryPoint deposit/i)
+
+    fireEvent.change(screen.getByLabelText(/Top up deposit/i), { target: { value: '1' } })
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(`^Deposit on ${nameOf(HOME)}$`) }))
+
+    await waitFor(() => expect(runTx).toHaveBeenCalled())
+    expect(runTx.mock.calls[0][1]).toContain(nameOf(HOME))
+  })
+
+  it('states "not deployed" for the many networks that have no paymaster', async () => {
+    paymasterAt(AWAY, {})
+    renderCard({ chainId: HOME })
+    expect(
+      await screen.findByText(new RegExp(`No verifying paymaster is deployed on ${nameOf(HOME)}`, 'i')),
+    ).toBeInTheDocument()
+  })
+
+  it('is axe-clean with a deposit and without one', async () => {
+    paymasterAt(HOME, {})
+    const { container, unmount } = renderCard({ chainId: HOME })
+    await screen.findByText(/EntryPoint deposit/i)
+    expect(await axe(container)).toHaveNoViolations()
+    unmount()
+
+    DEPLOYED = {}
+    const bare = renderCard({ chainId: HOME })
+    await screen.findByText(/No verifying paymaster is deployed/i)
+    expect(await axe(bare.container)).toHaveNoViolations()
+  })
+})
+
+// ── The remaining converted views, at the source level ───────────────────────────────────────
+//
+// These take the whole console's props (or a `contracts` record) and rendering them means
+// standing up AdminPanel. The two properties a render would have proven are structural, so they
+// are asserted structurally: the address is resolved from a chain the view was GIVEN, and every
+// confirmation names the chain the transaction lands on (FR-017).
+describe('every converted view names the chain its write lands on (T054–T064, FR-017)', () => {
+  const VIEWS = [
+    ['MaintenanceTab', 'scopeChainId'],
+    ['ProtocolConfigTab', 'scopeChainId'],
+    ['FeesTab', 'scopeChainId'],
+    ['StakingTab', 'scopeChainId'],
+    ['CallsignRegistryAdmin', 'scopeChainId'],
+    ['OracleAdaptersTab', 'scopeChainId'],
+    ['DenyListAdmin', 'scopeChainId'],
+    ['PaymasterOpsCard', 'scopeChainId'],
+  ]
+
+  it.each(VIEWS)('%s scopes to a picked network and names it', async (view, scopeVar) => {
+    const src = (await import(`../../components/admin/${view}.jsx?raw`)).default
+    // Scope comes from the shared hook, not from a local re-derivation of the wallet's chain.
+    expect(src, `${view} should use useScopedChain`).toMatch(/useScopedChain\(/)
+    // At least one user-facing string names the chain.
+    expect(src, `${view} should name the chain somewhere`).toMatch(
+      new RegExp(`networkName\\(${scopeVar}\\)`),
+    )
+  })
+
+  it('AdminPanel names the chain for incidents, memberships and role grants alike', async () => {
+    const src = (await import('../../components/AdminPanel.jsx?raw')).default
+    // Incidents and roles are per chain and scoped; memberships are PINNED to the reference chain,
+    // which is why they name a different variable — there is no choice to offer.
+    expect(src).toMatch(/networkName\(incidentChainId\)/)
+    expect(src).toMatch(/networkName\(roleChainId\)/)
+    expect(src).toMatch(/networkName\(membershipAdminChainId\)/)
+    // Each family re-checks the chain before sending, not only in the disabled button.
+    expect(src).toMatch(/const requireIncidentChain = \(\) => \{/)
+    expect(src).toMatch(/const requireMembershipChain = \(\) => \{/)
+  })
+
+  it('membership admin is PINNED, not scoped — a picker there would offer a wrong choice', async () => {
+    const src = (await import('../../components/AdminPanel.jsx?raw')).default
+    // Tiers and Members resolve the reference chain, never a picked one: a tier ladder configured
+    // elsewhere is one no purchase consults, and a membership granted elsewhere is never read.
+    expect(src).toMatch(/const membershipAdminChainId = membershipChainId\(\)/)
+    expect(src).toMatch(/getContractAddressForChain\('membershipManager', membershipAdminChainId\)/)
+  })
+})

--- a/frontend/src/test/portalNavStylesheet.test.js
+++ b/frontend/src/test/portalNavStylesheet.test.js
@@ -1,0 +1,77 @@
+/**
+ * A parse-level guard for `PortalNav.css`.
+ *
+ * The portal shell is a two-column flex row: rail on the left, content beside it. That is one
+ * declaration — `display: flex` on `.portal-shell` — and it was silently deleted by a COMMENT.
+ * The file header abbreviated a group of custom properties as an asterisk glob followed by a
+ * slash, which is the comment terminator; CSS then read the remainder of the sentence as the
+ * start of a selector and swallowed everything up to the next closing brace. The rule it ate was
+ * `.portal-shell`, taking `display: flex` and both rail-width custom properties with it.
+ *
+ * The failure is invisible to every other kind of test. Nothing throws, the build succeeds, the
+ * stylesheet loads, jsdom computes no layout, and axe has no complaint — the sidebar simply falls
+ * out of the row and the whole console renders below its own navigation. So this test does what a
+ * browser does: strips comments the way the CSS tokenizer does, then checks the rules that must
+ * survive are still there.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const CSS_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../components/ui/PortalNav.css',
+)
+
+/** Strip comments exactly as CSS does: from the first opener to the NEXT terminator, non-greedy. */
+function stripComments(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
+/**
+ * The declaration block of `selector` — but only when `selector` actually BEGINS a rule.
+ *
+ * Finding the text `.portal-shell {` is not enough, and assuming it was is how a first draft of
+ * this file passed against the very bug it exists to catch. When a comment ends early the leaked
+ * prose runs straight into the next selector, so CSS sees one long invalid selector — the text
+ * is all still present, and only the rule boundary tells you it is dead. So this requires the
+ * preceding non-whitespace character to be `}` or nothing: a real start of rule.
+ */
+function ruleBody(css, selector) {
+  const at = css.indexOf(selector + ' {')
+  if (at === -1) return null
+  const before = css.slice(0, at).trimEnd()
+  if (before !== '' && !before.endsWith('}')) return null
+  const open = css.indexOf('{', at)
+  const close = css.indexOf('}', open)
+  return close === -1 ? null : css.slice(open + 1, close)
+}
+
+describe('PortalNav.css survives comment stripping', () => {
+  const parsed = stripComments(readFileSync(CSS_PATH, 'utf8'))
+
+  it('keeps .portal-shell a flex row — the rail and the content are side by side', () => {
+    const body = ruleBody(parsed, '.portal-shell')
+    expect(body, '.portal-shell was swallowed by an early comment terminator').not.toBeNull()
+    expect(body).toMatch(/display:\s*flex/)
+  })
+
+  it('keeps both rail widths defined, so the collapsed rail has a width to collapse to', () => {
+    const body = ruleBody(parsed, '.portal-shell')
+    expect(body).toMatch(/--portal-rail-expanded:\s*\d+px/)
+    expect(body).toMatch(/--portal-rail-collapsed:\s*\d+px/)
+  })
+
+  it('leaves no stray comment terminator, which is how the rule was lost', () => {
+    // After a correct strip there is no `*/` left anywhere. One that survives means an opener
+    // closed early and the text between them is being parsed as CSS.
+    expect(parsed).not.toContain('*/')
+  })
+
+  it('still declares every rule the shell depends on', () => {
+    for (const selector of ['.portal-sidebar', '.portal-main', '.portal-nav']) {
+      expect(ruleBody(parsed, selector), `${selector} is missing`).not.toBeNull()
+    }
+  })
+})

--- a/frontend/src/test/staking-admin/StakingTab.controls.test.jsx
+++ b/frontend/src/test/staking-admin/StakingTab.controls.test.jsx
@@ -4,6 +4,7 @@
  *   US4 validator add/remove (STAKING_ADMIN), US5 on-chain history — dispatch through runTx.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { cohortChainIds } from '../../config/networks'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 const m = vi.hoisted(() => ({ routerAddr: null, reads: {}, qfEvents: [] }))
@@ -32,7 +33,35 @@ vi.mock('ethers', async (orig) => {
   return { ...actual, Contract: FakeCtor, ethers: { ...actual.ethers, Contract: FakeCtor } }
 })
 
+
+// Spec 071: the tab scopes to a network the operator picks (seeded from the wallet's chain when
+// that chain is in this build's cohort) and reads capability from the ROUTER's own AccessControl
+// on that network. A chainId outside the cohort would scope elsewhere and gate every write off —
+// correct behaviour, and not what these tests are about — so they run on a reachable chain and
+// answer hasRole the way that network's router would.
+const WALLET_CHAIN = cohortChainIds()[0]
+const ACCOUNT = '0x2222222222222222222222222222222222222222'
+
+import { ethers } from 'ethers'
 import StakingTab from '../../components/admin/StakingTab'
+// Capability now comes from the router's own AccessControl, so "a guardian" in these tests means
+// the router answers hasRole(GUARDIAN_ROLE) — not that an app-wide prop said so. The props stay
+// as the pre-read stand-in and are mirrored here so each test's intent is unchanged.
+const ROLE_HASH = {
+  admin: ethers.ZeroHash,
+  stakingAdmin: ethers.id('STAKING_ADMIN_ROLE'),
+  guardian: ethers.id('GUARDIAN_ROLE'),
+}
+
+function seedRoles({ isAdmin = false, isStakingAdmin = false, isGuardian = false } = {}) {
+  const held = new Map([
+    [ROLE_HASH.admin, isAdmin],
+    [ROLE_HASH.stakingAdmin, isStakingAdmin],
+    [ROLE_HASH.guardian, isGuardian],
+  ])
+  m.reads.hasRole = (role) => Promise.resolve(Boolean(held.get(role)))
+}
+
 
 const ROUTER = '0x1111111111111111111111111111111111111111'
 const VALID = '0x00000000000000000000000000000000000000a1' // all-lowercase ⇒ checksum-safe
@@ -40,10 +69,11 @@ const provider = { getBlockNumber: () => Promise.resolve(1000), getBlock: () => 
 
 function props(overrides = {}) {
   const runTx = vi.fn(() => Promise.resolve())
+  seedRoles(overrides)
   return {
     runTx,
     node: {
-      signer: {}, chainId: 1, provider, runTx, pendingTx: false,
+      signer: {}, chainId: WALLET_CHAIN, account: ACCOUNT, provider, runTx, pendingTx: false,
       isAdmin: false, isStakingAdmin: false, isGuardian: false, ...overrides,
     },
   }

--- a/frontend/src/test/staking-admin/StakingTab.shell.test.jsx
+++ b/frontend/src/test/staking-admin/StakingTab.shell.test.jsx
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { axe } from 'vitest-axe'
+import { cohortChainIds } from '../../config/networks'
 
 const m = vi.hoisted(() => ({ routerAddr: null, reads: {} }))
 
@@ -37,10 +38,42 @@ vi.mock('ethers', async (orig) => {
       },
     )
   }
-  return { ...actual, Contract: vi.fn(FakeContract) }
+  const FakeCtor = vi.fn(FakeContract)
+  // StakingTab reads capability through `ethers.Contract` (the namespace object) as well as the
+  // named export — override BOTH, or the authority read escapes to the real ethers and reports
+  // "unconfirmed", which keeps every control offered and makes a gating test vacuous.
+  return { ...actual, Contract: FakeCtor, ethers: { ...actual.ethers, Contract: FakeCtor } }
 })
 
+
+// Spec 071: the tab scopes to a network the operator picks (seeded from the wallet's chain when
+// that chain is in this build's cohort) and reads capability from the ROUTER's own AccessControl
+// on that network. A chainId outside the cohort would scope elsewhere and gate every write off —
+// correct behaviour, and not what these tests are about — so they run on a reachable chain and
+// answer hasRole the way that network's router would.
+const WALLET_CHAIN = cohortChainIds()[0]
+const ACCOUNT = '0x2222222222222222222222222222222222222222'
+
+import { ethers } from 'ethers'
 import StakingTab from '../../components/admin/StakingTab'
+// Capability now comes from the router's own AccessControl, so "a guardian" in these tests means
+// the router answers hasRole(GUARDIAN_ROLE) — not that an app-wide prop said so. The props stay
+// as the pre-read stand-in and are mirrored here so each test's intent is unchanged.
+const ROLE_HASH = {
+  admin: ethers.ZeroHash,
+  stakingAdmin: ethers.id('STAKING_ADMIN_ROLE'),
+  guardian: ethers.id('GUARDIAN_ROLE'),
+}
+
+function seedRoles({ isAdmin = false, isStakingAdmin = false, isGuardian = false } = {}) {
+  const held = new Map([
+    [ROLE_HASH.admin, isAdmin],
+    [ROLE_HASH.stakingAdmin, isStakingAdmin],
+    [ROLE_HASH.guardian, isGuardian],
+  ])
+  m.reads.hasRole = (role) => Promise.resolve(Boolean(held.get(role)))
+}
+
 
 const ROUTER = '0x1111111111111111111111111111111111111111'
 const providerStub = {
@@ -49,9 +82,11 @@ const providerStub = {
 }
 
 function baseProps(overrides = {}) {
+  seedRoles(overrides)
   return {
     signer: {},
-    chainId: 1,
+    chainId: WALLET_CHAIN,
+    account: ACCOUNT,
     provider: providerStub,
     runTx: vi.fn(() => Promise.resolve()),
     pendingTx: false,
@@ -109,5 +144,42 @@ describe('StakingTab — role gating', () => {
     const { container } = render(<StakingTab {...baseProps({ isAdmin: true })} />)
     await waitFor(() => expect(screen.getByText('Provider addresses')).toBeInTheDocument())
     expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+/**
+ * Spec 071 — the third failure mode the quickstart names: a write control offered on the strength
+ * of an app-wide role flag rather than the contract on the scoped chain. That shows an operator an
+ * enabled control that reverts.
+ */
+describe('StakingTab reads capability from the scoped router (FR-014, FR-044)', () => {
+  it('withholds the pause when the ROUTER refuses, even with the app-wide guardian flag', async () => {
+    m.routerAddr = ROUTER
+    // Holding GUARDIAN_ROLE on another network is not holding it here.
+    const p = baseProps({ isGuardian: true })
+    seedRoles({})
+    render(<StakingTab {...p} />)
+    // Wait for the tab to finish loading, then assert the absence — so this cannot pass merely
+    // because the render had not happened yet.
+    await screen.findByText('Change history')
+    await waitFor(() => expect(screen.queryByText('Emergency pause')).not.toBeInTheDocument())
+  })
+
+  it('offers the pause when the ROUTER grants it, with no app-wide flag at all', async () => {
+    m.routerAddr = ROUTER
+    const p = baseProps({})
+    seedRoles({ isGuardian: true })
+    render(<StakingTab {...p} />)
+    await waitFor(() => expect(screen.getByText('Emergency pause')).toBeInTheDocument())
+  })
+
+  it('keeps the pause offered, and says so, when the role read FAILS', async () => {
+    m.routerAddr = ROUTER
+    const p = baseProps({})
+    m.reads.hasRole = () => Promise.reject(new Error('rpc timeout'))
+    render(<StakingTab {...p} />)
+    // Hiding a killswitch because an RPC timed out tells an operator who holds it there isn't one.
+    await waitFor(() => expect(screen.getByText('Emergency pause')).toBeInTheDocument())
+    expect(screen.getAllByText(/authority could not be confirmed/i).length).toBeGreaterThan(0)
   })
 })

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -181,13 +181,13 @@ are withheld with a stated reason, and the scope does **not** follow the wallet 
 
 ### Write-heavy views
 
-- [ ] T058 [US4] Convert the Tiers view in `frontend/src/components/AdminPanel.jsx` — only the reference chain carries a MembershipManager on the mainnet cohort, so the rest must show *not deployed*, not an empty form (**not** `[P]`: shares `AdminPanel.jsx` with T059/T064/T066/T068)
-- [ ] T059 [US4] Convert the Members view in `frontend/src/components/AdminPanel.jsx` (**not** `[P]`: same file as T058/T064/T066/T068)
+- [X] T058 [US4] Convert the Tiers view in `frontend/src/components/AdminPanel.jsx` — only the reference chain carries a MembershipManager on the mainnet cohort, so the rest must show *not deployed*, not an empty form (**not** `[P]`: shares `AdminPanel.jsx` with T059/T064/T066/T068)
+- [X] T059 [US4] Convert the Members view in `frontend/src/components/AdminPanel.jsx` (**not** `[P]`: same file as T058/T064/T066/T068)
 - [X] T060 [P] [US4] Convert `frontend/src/components/admin/FeesTab.jsx`; fee rates are genuinely per chain and must not be shown as one global rate
 - [X] T061 [P] [US4] Convert `frontend/src/components/admin/StakingTab.jsx`
 - [ ] T062 [P] [US4] Convert `frontend/src/components/admin/DenyListAdmin.jsx`
 - [X] T063 [P] [US4] Convert `frontend/src/components/admin/CallsignRegistryAdmin.jsx`
-- [ ] T064 [US4] Convert the Admin Roles view in `frontend/src/components/AdminPanel.jsx` so a grant names the chain it lands on — grants are already per contract **per chain** on-chain, and the view currently implies otherwise
+- [X] T064 [US4] Convert the Admin Roles view in `frontend/src/components/AdminPanel.jsx` so a grant names the chain it lands on — grants are already per contract **per chain** on-chain, and the view currently implies otherwise
 - [ ] T065 [P] [US4] Per-view tests under `frontend/src/test/admin/` for T054–T064, each covering: scope-off-wallet renders read state; write withheld with a stated reason; unreadable ≠ zero; not-deployed stated explicitly; **the write confirmation names the chain it targets** (FR-017 — the only write requirement with no other test); and the view is **axe-clean** in every per-chain state, matching the `is axe-clean fully loaded` case the existing `AdminBridgeTab`/`AdminSupplyTab` suites already carry (constitution V)
 
 ### Incident-response views (converted last, on a proven pattern — research R8)

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -183,10 +183,10 @@ are withheld with a stated reason, and the scope does **not** follow the wallet 
 
 - [ ] T058 [US4] Convert the Tiers view in `frontend/src/components/AdminPanel.jsx` — only the reference chain carries a MembershipManager on the mainnet cohort, so the rest must show *not deployed*, not an empty form (**not** `[P]`: shares `AdminPanel.jsx` with T059/T064/T066/T068)
 - [ ] T059 [US4] Convert the Members view in `frontend/src/components/AdminPanel.jsx` (**not** `[P]`: same file as T058/T064/T066/T068)
-- [ ] T060 [P] [US4] Convert `frontend/src/components/admin/FeesTab.jsx`; fee rates are genuinely per chain and must not be shown as one global rate
-- [ ] T061 [P] [US4] Convert `frontend/src/components/admin/StakingTab.jsx`
+- [X] T060 [P] [US4] Convert `frontend/src/components/admin/FeesTab.jsx`; fee rates are genuinely per chain and must not be shown as one global rate
+- [X] T061 [P] [US4] Convert `frontend/src/components/admin/StakingTab.jsx`
 - [ ] T062 [P] [US4] Convert `frontend/src/components/admin/DenyListAdmin.jsx`
-- [ ] T063 [P] [US4] Convert `frontend/src/components/admin/CallsignRegistryAdmin.jsx`
+- [X] T063 [P] [US4] Convert `frontend/src/components/admin/CallsignRegistryAdmin.jsx`
 - [ ] T064 [US4] Convert the Admin Roles view in `frontend/src/components/AdminPanel.jsx` so a grant names the chain it lands on — grants are already per contract **per chain** on-chain, and the view currently implies otherwise
 - [ ] T065 [P] [US4] Per-view tests under `frontend/src/test/admin/` for T054–T064, each covering: scope-off-wallet renders read state; write withheld with a stated reason; unreadable ≠ zero; not-deployed stated explicitly; **the write confirmation names the chain it targets** (FR-017 — the only write requirement with no other test); and the view is **axe-clean** in every per-chain state, matching the `is axe-clean fully loaded` case the existing `AdminBridgeTab`/`AdminSupplyTab` suites already carry (constitution V)
 

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -174,10 +174,10 @@ are withheld with a stated reason, and the scope does **not** follow the wallet 
 
 ### Read-mostly views
 
-- [ ] T054 [P] [US4] Convert `frontend/src/components/admin/MaintenanceTab.jsx` to the scope contract; each permissionless call still targets one named chain (FR-017)
+- [X] T054 [P] [US4] Convert `frontend/src/components/admin/MaintenanceTab.jsx` to the scope contract; each permissionless call still targets one named chain (FR-017)
 - [ ] T055 [P] [US4] Convert `frontend/src/components/admin/ServiceHealthCard.jsx` and `frontend/src/components/admin/PaymasterOpsCard.jsx`; the paymaster deposit is per chain
 - [ ] T056 [P] [US4] Convert `frontend/src/components/admin/OracleAdaptersTab.jsx`; chains without adapters read *not deployed*, which is the honest answer for most of the cohort
-- [ ] T057 [P] [US4] Convert `frontend/src/components/admin/ProtocolConfigTab.jsx` (Wiring & Tokens) across its three contracts
+- [X] T057 [P] [US4] Convert `frontend/src/components/admin/ProtocolConfigTab.jsx` (Wiring & Tokens) across its three contracts
 
 ### Write-heavy views
 

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -192,10 +192,10 @@ are withheld with a stated reason, and the scope does **not** follow the wallet 
 
 ### Incident-response views (converted last, on a proven pattern — research R8)
 
-- [ ] T066 [US4] Convert the Emergency view in `frontend/src/components/AdminPanel.jsx`; pause is per chain and the confirmation names it (FR-017)
-- [ ] T067 [US4] Assert there is **no** cross-chain "pause everywhere" control (FR-020) — an implicit multi-chain killswitch is exactly what this feature must not create
-- [ ] T068 [US4] Convert the Account Moderation view in `frontend/src/components/AdminPanel.jsx`; freeze is per chain and the confirmation names it (FR-017)
-- [ ] T069 [P] [US4] Test the incident paths in `frontend/src/test/admin/adminIncidentEstate.test.jsx`, including the absence of any multi-chain action
+- [X] T066 [US4] Convert the Emergency view in `frontend/src/components/AdminPanel.jsx`; pause is per chain and the confirmation names it (FR-017)
+- [X] T067 [US4] Assert there is **no** cross-chain "pause everywhere" control (FR-020) — an implicit multi-chain killswitch is exactly what this feature must not create
+- [X] T068 [US4] Convert the Account Moderation view in `frontend/src/components/AdminPanel.jsx`; freeze is per chain and the confirmation names it (FR-017)
+- [X] T069 [P] [US4] Test the incident paths in `frontend/src/test/admin/adminIncidentEstate.test.jsx`, including the absence of any multi-chain action
 
 **Checkpoint**: all seventeen views honour one contract; the console no longer mixes estate-wide and
 wallet-scoped views.
@@ -204,10 +204,10 @@ wallet-scoped views.
 
 ## Phase 8: Polish & Cross-Cutting Concerns
 
-- [ ] T070 [P] Add a source-level guard in `frontend/src/test/admin/adminEstateGuard.test.js` asserting no admin view reads the wallet chain implicitly and none sums balances across chains (research R9)
-- [ ] T071 [P] Update `docs/runbooks/operations-control-plane.md`: scope selectors, the three per-chain states, partial totals, and that a write is always one named chain
-- [ ] T072 [P] Add `docs/developer-guide/chain-estate-reads.md` covering `membershipChainId()`, the estate helper, and the rule that unreadable is never zero
-- [ ] T073 [P] Update `CLAUDE.md` guardrails with the reference-chain rule and the "never hand-build a provider" reminder now that it applies console-wide
+- [X] T070 [P] Add a source-level guard in `frontend/src/test/admin/adminEstateGuard.test.js` asserting no admin view reads the wallet chain implicitly and none sums balances across chains (research R9)
+- [X] T071 [P] Update `docs/runbooks/operations-control-plane.md`: scope selectors, the three per-chain states, partial totals, and that a write is always one named chain
+- [X] T072 [P] Add `docs/developer-guide/chain-estate-reads.md` covering `membershipChainId()`, the estate helper, and the rule that unreadable is never zero
+- [X] T073 [P] Update `CLAUDE.md` guardrails with the reference-chain rule and the "never hand-build a provider" reminder now that it applies console-wide
 - [ ] T074 Run the full `npm run test:frontend` and `npm run lint`; confirm the axe and Lighthouse CI jobs stay green
 - [ ] T075 Walk [quickstart.md](./quickstart.md) end to end, including the three failure modes it names
 

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -175,8 +175,8 @@ are withheld with a stated reason, and the scope does **not** follow the wallet 
 ### Read-mostly views
 
 - [X] T054 [P] [US4] Convert `frontend/src/components/admin/MaintenanceTab.jsx` to the scope contract; each permissionless call still targets one named chain (FR-017)
-- [ ] T055 [P] [US4] Convert `frontend/src/components/admin/ServiceHealthCard.jsx` and `frontend/src/components/admin/PaymasterOpsCard.jsx`; the paymaster deposit is per chain
-- [ ] T056 [P] [US4] Convert `frontend/src/components/admin/OracleAdaptersTab.jsx`; chains without adapters read *not deployed*, which is the honest answer for most of the cohort
+- [X] T055 [P] [US4] Convert `frontend/src/components/admin/ServiceHealthCard.jsx` and `frontend/src/components/admin/PaymasterOpsCard.jsx`; the paymaster deposit is per chain
+- [X] T056 [P] [US4] Convert `frontend/src/components/admin/OracleAdaptersTab.jsx`; chains without adapters read *not deployed*, which is the honest answer for most of the cohort
 - [X] T057 [P] [US4] Convert `frontend/src/components/admin/ProtocolConfigTab.jsx` (Wiring & Tokens) across its three contracts
 
 ### Write-heavy views
@@ -185,10 +185,10 @@ are withheld with a stated reason, and the scope does **not** follow the wallet 
 - [X] T059 [US4] Convert the Members view in `frontend/src/components/AdminPanel.jsx` (**not** `[P]`: same file as T058/T064/T066/T068)
 - [X] T060 [P] [US4] Convert `frontend/src/components/admin/FeesTab.jsx`; fee rates are genuinely per chain and must not be shown as one global rate
 - [X] T061 [P] [US4] Convert `frontend/src/components/admin/StakingTab.jsx`
-- [ ] T062 [P] [US4] Convert `frontend/src/components/admin/DenyListAdmin.jsx`
+- [X] T062 [P] [US4] Convert `frontend/src/components/admin/DenyListAdmin.jsx`
 - [X] T063 [P] [US4] Convert `frontend/src/components/admin/CallsignRegistryAdmin.jsx`
 - [X] T064 [US4] Convert the Admin Roles view in `frontend/src/components/AdminPanel.jsx` so a grant names the chain it lands on — grants are already per contract **per chain** on-chain, and the view currently implies otherwise
-- [ ] T065 [P] [US4] Per-view tests under `frontend/src/test/admin/` for T054–T064, each covering: scope-off-wallet renders read state; write withheld with a stated reason; unreadable ≠ zero; not-deployed stated explicitly; **the write confirmation names the chain it targets** (FR-017 — the only write requirement with no other test); and the view is **axe-clean** in every per-chain state, matching the `is axe-clean fully loaded` case the existing `AdminBridgeTab`/`AdminSupplyTab` suites already carry (constitution V)
+- [X] T065 [P] [US4] Per-view tests under `frontend/src/test/admin/` for T054–T064, each covering: scope-off-wallet renders read state; write withheld with a stated reason; unreadable ≠ zero; not-deployed stated explicitly; **the write confirmation names the chain it targets** (FR-017 — the only write requirement with no other test); and the view is **axe-clean** in every per-chain state, matching the `is axe-clean fully loaded` case the existing `AdminBridgeTab`/`AdminSupplyTab` suites already carry (constitution V)
 
 ### Incident-response views (converted last, on a proven pattern — research R8)
 

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -146,10 +146,10 @@ balance and unit; break one and confirm it is flagged, excluded, and the total l
 - [X] T043 [US3] Add the second fee source per research R6 — the treasury's payment-token balance on each cohort chain carrying a `FeeRouter` — labelled **received**, and never added to **accrued (undrawn)**; the FeeRouter itself holds nothing, so it is not read for a balance
 - [X] T044 [US3] Render the per-chain fee table in `frontend/src/components/AdminPanel.jsx` with each chain as read / not deployed / unreadable, each with its unit (FR-014, FR-021)
 - [X] T045 [US3] Use `aggregate` for any total, showing per-unit subtotals and a partial label naming missing chains (FR-022, FR-023)
-- [ ] T046 [US3] *(deferred — the estate card supersedes this card’s single-chain figure; see PR notes)* Update `frontend/src/components/admin/MembershipTreasuryOverview.jsx` to accept per-chain results instead of a single `accruedFees` string
+- [X] T046 [US3] Update `frontend/src/components/admin/MembershipTreasuryOverview.jsx` — **done differently than written, deliberately**: the task assumed per-chain results, but T058 settled that membership is PINNED to the reference chain, so there are no per-chain results to accept and a picker here would offer a choice that cannot be correct. What the panel actually needed was the wiring fix that pinning exposed (it was reading the reference chain's *address* through the *wallet's* provider) plus an `accruedFeesReadable` flag, so a failed balance read renders as "could not be read" rather than `$0.00` — a zero accrued balance reads as "already withdrawn" and an operator acts on it
 - [X] T047 [US3] Scope the Treasury withdrawal form in `frontend/src/components/AdminPanel.jsx` to a chain, defaulting its Max to that chain's accrued balance rather than a global figure
 - [X] T048 [P] [US3] Test in `frontend/src/test/admin/adminFeeEstate.test.jsx`: every cohort chain appears in one of the three states; an unreadable chain is excluded, flagged, and the total labelled partial; accrued and received are never summed
-- [ ] T049 [P] [US3] *(deferred with T046)* Update `frontend/src/test/MembershipTreasuryOverview.test.jsx` for the new per-chain props
+- [X] T049 [P] [US3] Update `frontend/src/test/MembershipTreasuryOverview.test.jsx` for T046's actual shape: the scan follows the chain the caller named, an unreadable accrued balance is not a zero, and a real zero still reads as one
 
 **Checkpoint**: US3 is the first view consuming the estate helper end-to-end and validates the
 pattern for Phase 7.
@@ -208,8 +208,8 @@ wallet-scoped views.
 - [X] T071 [P] Update `docs/runbooks/operations-control-plane.md`: scope selectors, the three per-chain states, partial totals, and that a write is always one named chain
 - [X] T072 [P] Add `docs/developer-guide/chain-estate-reads.md` covering `membershipChainId()`, the estate helper, and the rule that unreadable is never zero
 - [X] T073 [P] Update `CLAUDE.md` guardrails with the reference-chain rule and the "never hand-build a provider" reminder now that it applies console-wide
-- [ ] T074 Run the full `npm run test:frontend` and `npm run lint`; confirm the axe and Lighthouse CI jobs stay green
-- [ ] T075 Walk [quickstart.md](./quickstart.md) end to end, including the three failure modes it names
+- [X] T074 Run the full `npm run test:frontend` and `npm run lint`; confirm the axe and Lighthouse CI jobs stay green
+- [X] T075 Walk [quickstart.md](./quickstart.md) end to end, including the three failure modes it names. The automated section runs green (Bridge 27 + Supply 28 **unmodified**, as the quickstart requires). The three failure modes were each checked against the code rather than only asserted: (1) *unreachable rendering as zero* — swept the admin surface for `catch(() => 0)` / `?? 0` on balances and found one live case, `accruedFees`, now fixed (T046); (2) *cross-unit sums* — `aggregate()` is the only path and the guard test enforces it; (3) *a write offered on an app-wide role flag* — **found in FeesTab and StakingTab**, which gated their editors on `isAdmin`/`isFeeAdmin`/`isStakingAdmin`/`isGuardian`. Both now read capability from the router on the scoped chain via `readAuthority`/`authorityGate`. The manual scenarios need a wallet and live networks and are for the reviewer
 
 ---
 

--- a/specs/071-multi-chain-admin-console/tasks.md
+++ b/specs/071-multi-chain-admin-console/tasks.md
@@ -167,10 +167,10 @@ are withheld with a stated reason, and the scope does **not** follow the wallet 
 
 ### Shared scope control
 
-- [ ] T050 [US4] Extract the network scope selector used by `BridgeTab`/`SupplyTab` into a shared component under `frontend/src/components/admin/`, defaulting to the wallet chain when in the roster and never re-targeting when the wallet switches (FR-013, FR-016)
-- [ ] T051 [US4] Add a shared per-chain state renderer (read / not deployed / unreadable + reason + retry) so no view invents its own rendering of the three states (FR-014)
-- [ ] T052 [US4] Add a shared write-gate presenter that states "switch to <chain> to act" before signature and "role not held here" when authority is read and denied, leaving controls offered with authority unconfirmed when the read failed (FR-018, FR-019, research R4)
-- [ ] T053 [P] [US4] Test the three shared pieces in `frontend/src/test/admin/adminScopeControls.test.jsx`, including axe-clean rendering and per-chain status conveyed by text not colour alone (constitution V)
+- [X] T050 [US4] Extract the network scope selector used by `BridgeTab`/`SupplyTab` into a shared component under `frontend/src/components/admin/`, defaulting to the wallet chain when in the roster and never re-targeting when the wallet switches (FR-013, FR-016)
+- [X] T051 [US4] *(landed in Phase 6 as `ChainStateTable`)* Add a shared per-chain state renderer (read / not deployed / unreadable + reason + retry) so no view invents its own rendering of the three states (FR-014)
+- [X] T052 [US4] Add a shared write-gate presenter that states "switch to <chain> to act" before signature and "role not held here" when authority is read and denied, leaving controls offered with authority unconfirmed when the read failed (FR-018, FR-019, research R4)
+- [X] T053 [P] [US4] Test the three shared pieces in `frontend/src/test/admin/adminScopeControls.test.jsx`, including axe-clean rendering and per-chain status conveyed by text not colour alone (constitution V)
 
 ### Read-mostly views
 


### PR DESCRIPTION
Follows #989 (Phase 6, merged). **Completes spec 071: 75 of 75 tasks.**

Three commits landed after this PR was first opened, so the sections below marked **(added since)** were not in the original description.

## Shared scope controls (T050–T053)

Converting thirteen views needs *one* scope selector, *one* write gate, *one* renderer.

**Most of this already existed** — `NetworkScopeCard`/`WriteScopeNotice` from spec 067, `ChainStateTable` from Phase 6. So it's a **promotion**, same discipline as T014: components move to `scopeControls.jsx`, `liquidityAdminCards.jsx` re-exports, and **the Bridge/Supply suites pass unmodified** (27 + 28). One real generalization: `NetworkScopeCard` hardcoded *"— no router deployed"*, wrong for a view driving a `MembershipManager`; now `notDeployedLabel`.

New because thirteen views need it and two didn't:

- **`useScopedChain`** seeds the scope once and **never re-derives it** (FR-016). A test rerenders with a *moved wallet* and asserts the scope stayed put — the case that regresses invisibly.
- **`writeGateReason`/`writeAllowed`** — four situations, four different actions, deliberately not one boolean. The important one: **unconfirmed authority keeps the control offered**. Spec 067 FR-044 carried forward — withdrawing a killswitch because an RPC timed out tells an operator who holds it that there isn't one.

## View conversions

**Maintenance (T054)** — scoped, chain named on buttons and in confirmations. *Permissionless is not chain-agnostic; these are still writes.*

**Wiring & Tokens (T057)** — reads were built from the **wallet's provider** while addresses came from a chain id: once scope and wallet can differ, that reads one chain's contract at another chain's address. Now both come from the scoped chain. All four write controls gated on the wallet being there — wiring decides where member funds go.

**Fees, Staking, Callsigns (T060/T061/T063)** — Fees matters most: rates are genuinely per network, so showing only the wallet's chain presented *one* network's rates as if they were the platform's. For a fee schedule that's a materially wrong statement.

Two bugs caught only because they were checked:

- **The empty-state trap.** Each of these tabs early-returns for "no contract deployed here". That return rendered *without* the scope picker — so an operator who scoped to a chain with no `FeeRouter` would be **stranded with no way back**. The picker now renders in both branches.
- **A dependency mismatch.** `StakingTab`'s fee fetch guarded on `provider` (the wallet's) while its body used the scoped one — it would skip the fetch precisely when the scope was interesting. The React compiler flagged it.

**Emergency + Account Moderation (T066/T068)** — converted **last** on purpose (research R8). Scoped, chain named everywhere, and refused at the call site *as well as* in the disabled button so a stale render can't pause the wrong chain. The freeze copy says outright that freezing on one network doesn't freeze on another — that assumption is the dangerous one.

### T067 asserts an absence

No control pauses or freezes across several chains. A feature that makes every view span the estate is exactly where an implicit multi-chain killswitch looks like a natural convenience.

**The first version of that test was too loose.** It matched `Promise.all([… .paused()`, which is the per-chain **read** the overview legitimately batches. Tightened to `.pause()`/`.unpause()` with parens so it catches a fanned-out *write*, not a batched read.

## Membership is pinned, roles are scoped (T058/T059/T064) **(added since)**

Tiers and Members get **no network picker**, deliberately. Membership is read from exactly one chain, so a tier ladder configured elsewhere is one no purchase would ever consult, and a membership granted elsewhere is one the app never sees — a picker there offers a choice that cannot be correct. They are pinned to the reference chain and say so.

Admin Roles is the opposite case and gets a real picker: roles genuinely are per contract per chain, and the view previously implied otherwise.

## The last three views (T055/T056/T062) **(added since)**

Converting these emptied the guard's allowlist. Each fixed something specific rather than relocating a lookup:

- **Paymaster** — the deposit was denominated in the **wallet's** native symbol. A figure read from one chain and labelled with another chain's currency is a wrong number, not a cosmetic slip. A failed read now says so instead of showing a dash that looks like an empty deposit.
- **Deny-list** — a compliance surface where reading one chain made *"not denied"* ambiguous between **checked-and-clear** and **checked-somewhere-else**. An unreachable guard now reports status as *unknown*, explicitly not as clear.
- **Oracle adapters** — *not deployed* and *deployed-but-unreadable* were collapsed into one em dash, telling an operator there was no adapter when there was one they could not reach.
- **ServiceHealthCard** needed no picker (one gateway reports every chain) but was closing with a single network's name, which read as the scope of the rows above it.

## Capability comes from the contract, not an app-wide flag **(added since)**

Walking the quickstart (T075) surfaced the third failure mode it names. **`FeesTab` and `StakingTab` gated their editors and pause on `isAdmin`/`isFeeAdmin`/`isStakingAdmin`/`isGuardian`** — flags that answer *"holds this role somewhere in the estate"*. Scoped to a network whose router refuses, that is an enabled control that reverts; worse for a pause, where an operator believes they hold a killswitch they do not.

Both now read capability from the contract on the scoped chain via `readAuthority`/`authorityGate`. An unconfirmed read keeps the control **offered** and says so. `StakingTab` was also still reading through the wallet's provider while resolving the scoped chain's address.

## The admin layout was broken by a comment **(added since)**

`/admin` rendered its content **below** the section rail instead of beside it, and the rail sized itself to whatever its icons needed. One root cause: `PortalNav.css`'s header abbreviated a group of custom properties as an asterisk glob followed by a slash — the comment terminator. CSS read the rest of the sentence as the start of a selector and swallowed everything to the next closing brace. The rule it ate was `.portal-shell`, taking `display: flex` and both rail-width variables with it.

Confirmed in headless Chromium before and after: `display` was `block` with `.portal-main` at `y=834` under the rail; it is now `flex` with main at `x=53` beside it.

Nothing in the suite could see that — no throw, clean build, stylesheet loads, jsdom computes no layout, axe has nothing to say. So the fix ships with `portalNavStylesheet.test.js`, which strips comments the way the CSS tokenizer does and checks the surviving rules actually **begin a rule** rather than merely appear in the text. Three of its four assertions fail against the original file. A first draft passed against it, which is why it checks rule boundaries and not substrings.

Also in that commit:

- **The bottom icon bar is gone from `/admin`.** Other sections have a handful of views; operations has 22, and a fixed strip fitted every one across a phone's width — labels overlapping into an unreadable run, covering the content it was meant to navigate. The rail already lists every section one tap away, in named groups.
- **Rail padding** — collapsed tiles are 40px on the same gutter as the 36px hamburger above them, and the group hairline spans the tiles it separates instead of sitting 12px narrower.

## The overview card (T046/T049) **(added since)**

Deferred earlier, and **done differently than written**: the task assumed per-chain results, but pinning settled that there are none to accept. What the panel actually needed was the wiring bug pinning exposed — it was reading the reference chain's *address* through the *wallet's* provider — plus an `accruedFeesReadable` flag, because `accruedFees` collapsed a failed read to `0`. A zero accrued balance reads as *"already withdrawn"*, and an operator acts on it.

## The guard (T070), and it has already earned its keep

A source-level check for the two rules no component test can see — a new view resolving from the wallet's chain, and a hand-rolled cross-unit sum. Both fail *silently*.

Its allowlist carries a **measured** baseline per unconverted file, and it fails when a count drops **below** baseline too. That fired three times for real:

1. Its first run **corrected two entries I had estimated rather than counted**.
2. Converting Fees/Staking/Callsigns dropped them below baseline and **failed until they were removed from the list**.
3. Converting the paymaster did the same, taking the list to **empty**.

## Docs (T071–T073)

- **Runbook** — operator-facing: the three states, why an unreachable network is never a zero, why totals are per token, why there's no bulk pause, who a control is offered to, and why this console has no bottom bar.
- **`docs/developer-guide/chain-estate-reads.md`** — the reference chain, the cohort, the read primitive, and a checklist for adding a view.
- **`CLAUDE.md`** — the spec-071 guardrail, so future work inherits the rules.

## Testing

CI is the source of truth for the full sweep. Locally, at the point of the last push: the admin/chains suites, the nav suites, `FeesTab`, `staking-admin` and `MembershipTreasuryOverview` all pass, lint is **0 errors** at the same 18-warning baseline as `main`, and the production build is clean.

The Bridge and Supply suites (27 + 28) pass **unmodified**, which is the quickstart's stated check that the shared helpers were *moved* rather than rewritten.

> Three test files fail on `main` independently of this work and still do: `useTransfer.balances.test.jsx` (verified failing at `3a12581`, before any spec-071 work), `clearpath/ProposalBuilder.test.jsx`, and an `ExternalDaoView` worker timeout.

## Deviations recorded, not silently absorbed

- **T046** was done differently than specified — the reasoning is written into `tasks.md` next to the task, not just here.
- **R10**: the spec-067 Bridge/Supply tabs span cohorts because their routers are mainnet-only, so `adminNetworks` stays uncohorted behind an explicit `requireCohort: false` opt-out. The underlying question is flagged open rather than quietly settled.