### PR TITLE
Cache read providers per resolved route to stop RPC retry-loop storms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,9 @@ artifacts live under `specs/<feature>/`.
 - `npm run test:frontend` — frontend tests
 - `npm run frontend` — run the frontend dev server
 - `npm run sync:frontend-contracts` — regenerate frontend contract artifacts
+- Only run the **full** frontend suite (`vitest run` with no filter) in CI — locally it
+  OOMs this environment. Scope local runs to specific files/dirs
+  (`npx vitest run src/test/foo.test.js`).
 
 ## Guardrails
 

--- a/frontend/src/test/rpcProvider.test.js
+++ b/frontend/src/test/rpcProvider.test.js
@@ -34,3 +34,23 @@ describe('makeReadProvider', () => {
     expect(p._getOption('batchMaxCount')).toBeGreaterThan(1)
   })
 })
+
+describe('makeReadProvider — provider caching', () => {
+  // Each `ethers` provider runs its own perpetual `_detectNetwork` retry loop when the
+  // endpoint is unreachable. Building a fresh one per call means every read from every
+  // hook piles up one more never-terminated loop hammering the same endpoint — this is
+  // what turned one flaky chain into a flood of parallel retries. One provider per
+  // resolved route caps that to a single loop per chain.
+  it('reuses the same provider instance for repeated calls with the same route', () => {
+    const a = makeReadProvider('https://example.invalid/rpc', 900001)
+    const b = makeReadProvider('https://example.invalid/rpc', 900001)
+    expect(b).toBe(a)
+  })
+
+  it('builds a fresh provider — and keeps it cached — when the resolved route changes', () => {
+    const a = makeReadProvider('https://example.invalid/rpc', 900002)
+    const b = makeReadProvider('https://example.invalid/other-rpc', 900002)
+    expect(b).not.toBe(a)
+    expect(makeReadProvider('https://example.invalid/other-rpc', 900002)).toBe(b)
+  })
+})

--- a/frontend/src/utils/rpcProvider.js
+++ b/frontend/src/utils/rpcProvider.js
@@ -30,6 +30,33 @@ import { resolveRpcEndpoints } from '../lib/network/rpcEndpoints'
 // Ethereum Classic mainnet (61) and Mordor testnet (63).
 const NO_BATCH_CHAIN_IDS = new Set([61, 63])
 
+// Every ethers provider runs its own `_detectNetwork` polling loop, which retries forever
+// (once a second) when the endpoint is unreachable — there is no signal back to the app
+// when that happens, and nothing ever calls `.destroy()`. Building a fresh provider on
+// every read (as this used to) means a single flaky chain accumulates one more permanent
+// retry loop per read, all hammering the endpoint independently and forever. Caching one
+// provider per resolved route keeps that to at most one loop per chain, and rebuilds
+// (replacing, not stacking) the moment the resolved route actually changes — e.g. a
+// member edits their endpoint in Network settings.
+const providerCache = new Map() // chainId -> { key, provider }
+
+function cachedProvider(chainId, key, build) {
+  if (chainId == null) return build()
+  const existing = providerCache.get(chainId)
+  if (existing && existing.key === key) return existing.provider
+  if (typeof existing?.provider?.destroy === 'function') {
+    try {
+      existing.provider.destroy()
+    } catch {
+      // best-effort cleanup — a provider that fails to tear down cleanly shouldn't block
+      // building its replacement.
+    }
+  }
+  const provider = build()
+  providerCache.set(chainId, { key, provider })
+  return provider
+}
+
 /**
  * Build one JsonRpcProvider for a single endpoint.
  *
@@ -81,23 +108,34 @@ export function makeReadProvider(rpcUrl, chainId = null) {
 
   // No member override → exactly the pre-069 behavior for the caller's URL.
   if (!route || route.source !== 'member' || !route.primary) {
-    return buildProvider(rpcUrl, null, chainId)
+    const key = JSON.stringify(['single', rpcUrl])
+    return cachedProvider(chainId, key, () => buildProvider(rpcUrl, null, chainId))
   }
 
   if (!route.failover) {
-    return buildProvider(route.primary.url, route.primary.headers, chainId)
+    const key = JSON.stringify(['single', route.primary.url, route.primary.headers])
+    return cachedProvider(chainId, key, () => buildProvider(route.primary.url, route.primary.headers, chainId))
   }
 
-  const primary = buildProvider(route.primary.url, route.primary.headers, chainId, { staticNetwork: true })
-  const failover = buildProvider(route.failover.url, route.failover.headers, chainId, { staticNetwork: true })
-  return new ethers.FallbackProvider(
-    [
-      { provider: primary, priority: 1, weight: 1, stallTimeout: 2000 },
-      { provider: failover, priority: 2, weight: 1 },
-    ],
-    new ethers.Network(`chain-${Number(chainId)}`, Number(chainId)),
-    { quorum: 1 },
-  )
+  const key = JSON.stringify([
+    'fallback',
+    route.primary.url,
+    route.primary.headers,
+    route.failover.url,
+    route.failover.headers,
+  ])
+  return cachedProvider(chainId, key, () => {
+    const primary = buildProvider(route.primary.url, route.primary.headers, chainId, { staticNetwork: true })
+    const failover = buildProvider(route.failover.url, route.failover.headers, chainId, { staticNetwork: true })
+    return new ethers.FallbackProvider(
+      [
+        { provider: primary, priority: 1, weight: 1, stallTimeout: 2000 },
+        { provider: failover, priority: 2, weight: 1 },
+      ],
+      new ethers.Network(`chain-${Number(chainId)}`, Number(chainId)),
+      { quorum: 1 },
+    )
+  })
 }
 
 /**


### PR DESCRIPTION
## Summary

Investigated the console flood of `JsonRpcProvider failed to detect network` / CORS errors against `etc.rivet.link` (Ethereum Classic mainnet, chain 61).

- Verified directly against `etc.rivet.link`: it responds correctly with `access-control-allow-origin: *` on both the CORS preflight and the actual `eth_chainId` call. The endpoint's CORS config is fine — this also isn't something we could "fix" on our side even if it weren't, since it's a third-party server.
- The real bug is in `frontend/src/utils/rpcProvider.js`: `makeReadProvider`/`getReadProvider` built a **brand-new `ethers.JsonRpcProvider` on every call**, with no caching. Every hook that reads from a chain (portfolio, earn, swap balances, DEX pool lookups) calls this on every render/poll. Each provider instance runs ethers v6's own perpetual `_detectNetwork` retry loop when the endpoint is unreachable — that's the literal source of the "retry in 1s" message — and nothing ever destroys the old ones. Over a session, this accumulates dozens of permanent, parallel retry loops hammering the same public endpoint, which is consistent with the endpoint then rate-limiting/bot-protecting the flood and dropping CORS headers under load, turning one hiccup into a storm.

## Changes

- `frontend/src/utils/rpcProvider.js`: cache one provider per resolved `(chainId, endpoint)` route, so the whole app shares — and can only ever run — a single retry loop per chain. When a member changes their RPC settings (spec 069) the resolved route changes, so a fresh provider is built and the stale one is `.destroy()`ed rather than left running.
- `frontend/src/test/rpcProvider.test.js`: added tests asserting the cache reuses an instance for a repeated identical route and rebuilds (and re-caches) on a route change.
- `CLAUDE.md`: noted that the full frontend vitest suite should only run in CI — running it unfiltered locally OOMs this environment.

## Test plan

- [x] `npx vitest run src/test/rpcProvider.test.js src/test/network/rpcProvider.endpoints.test.js` — 11/11 pass
- [x] `npx vitest run src/test/network src/test/custody src/test/reports src/test/earn` — 713/713 pass
- [x] Confirmed one pre-existing, unrelated failure (`useTransfer.balances.test.jsx`, a stale mock missing `getCurrentChainId`) reproduces identically with this change stashed out — not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTYsGXByHN1DTTAcKcGNGj)_