### PR TITLE
Make the global nav drawer an expandable icon gutter on larger screens

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -58,21 +58,26 @@ function AppLayout() {
       {/* App navigation redesign: the section menu ("us") is now a global left
           drawer opened by the clover logo, shared across every in-app route. */}
       <NavDrawerProvider>
-        <Header appMode />
-        <AppNavDrawer />
-        {/* Spec 043 (US3): persistent banner while operating as a vault, with switch-back. */}
-        <OperateAsIndicator />
-        {/* Spec 041: route a tapped push notification into in-app navigation. */}
-        <ActivityNotificationBridge />
-        {/* Spec 007 (US4): client-side eligibility notice gate before any app content. */}
-        <EntryGate />
-        {/* Entering the app with no account opens the unlock dialog by itself —
-            every surface below is inert until one is connected. */}
-        <AutoConnectPrompt />
-        <Outlet />
-        {/* Spec 010 (US2): condensed legal/policy footer inside the app. The menu
-            drawer carries its own copy; /wallet relies on that to avoid duplication. */}
-        {showPageFooter && <Footer variant="condensed" />}
+        {/* `app-shell` reserves room for AppNavDrawer's persistent desktop icon
+            gutter (see AppNavDrawer.css) — the drawer itself is fixed-position
+            and ignores this padding, but everything below needs to clear it. */}
+        <div className="app-shell">
+          <Header appMode />
+          <AppNavDrawer />
+          {/* Spec 043 (US3): persistent banner while operating as a vault, with switch-back. */}
+          <OperateAsIndicator />
+          {/* Spec 041: route a tapped push notification into in-app navigation. */}
+          <ActivityNotificationBridge />
+          {/* Spec 007 (US4): client-side eligibility notice gate before any app content. */}
+          <EntryGate />
+          {/* Entering the app with no account opens the unlock dialog by itself —
+              every surface below is inert until one is connected. */}
+          <AutoConnectPrompt />
+          <Outlet />
+          {/* Spec 010 (US2): condensed legal/policy footer inside the app. The menu
+              drawer carries its own copy; /wallet relies on that to avoid duplication. */}
+          {showPageFooter && <Footer variant="condensed" />}
+        </div>
       </NavDrawerProvider>
     </ActivityProvider>
   )

--- a/frontend/src/components/nav/AppNavDrawer.css
+++ b/frontend/src/components/nav/AppNavDrawer.css
@@ -1,5 +1,7 @@
-/* Global navigation drawer ("us") — a left slide-over opened by the clover logo
-   on every in-app route. Sits above the sticky header. */
+/* Global navigation drawer ("us"). Mobile: a left slide-over opened by the
+   clover logo, sitting above the sticky header. Desktop (min-width: 769px,
+   the breakpoint PortalNav.css and useIsMobile already use): a persistent
+   icon gutter that expands in place — see the media query below. */
 
 .app-nav-backdrop {
   position: fixed;
@@ -59,10 +61,11 @@
   color: var(--text-primary, var(--color-text, #1F2933));
 }
 
-.app-nav-drawer-close {
+.app-nav-drawer-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex: 0 0 auto;
   width: 32px;
   height: 32px;
   border: none;
@@ -74,14 +77,20 @@
   transition: background 0.15s ease, color 0.15s ease;
 }
 
-.app-nav-drawer-close:hover {
+.app-nav-drawer-toggle:hover {
   background: var(--bg-primary, var(--color-surface-hover, rgba(0, 0, 0, 0.05)));
   color: var(--text-primary, var(--color-text, #1F2933));
 }
 
-.app-nav-drawer-close:focus-visible {
+.app-nav-drawer-toggle:focus-visible {
   outline: 2px solid var(--brand-primary, var(--color-primary, #36B37E));
   outline-offset: 2px;
+}
+
+/* Collapsed (desktop gutter): only the toggle remains, so it centres in the rail. */
+.app-nav-drawer.collapsed .app-nav-drawer-header {
+  justify-content: center;
+  padding: 16px 0;
 }
 
 /* The section list grows to fill so the footer sits at the bottom. */
@@ -105,5 +114,44 @@
   }
   .app-nav-backdrop {
     animation: none;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Desktop / larger screens: icon gutter, expandable in place
+   ---------------------------------------------------------------------------
+   Below 769px the rules above stand: fully off-canvas until the clover logo
+   opens it as an overlay. At 769px+ the drawer never leaves the screen — it's
+   a slim always-on rail (PortalNav's own `collapsed` prop renders its icons
+   only) that widens to the full panel instead of sliding in from nowhere. */
+@media (min-width: 769px) {
+  :root {
+    --app-nav-gutter-width: 64px;
+  }
+
+  .app-nav-drawer {
+    width: var(--app-nav-gutter-width);
+    transform: none;
+    visibility: visible;
+    box-shadow: none;
+    transition: width 0.22s ease, box-shadow 0.22s ease;
+  }
+
+  .app-nav-drawer.open {
+    width: min(84vw, 300px);
+    box-shadow: 2px 0 16px rgba(0, 0, 0, 0.18);
+  }
+
+  /* The gutter is fixed and ignores this wrapper's padding, but Header /
+     Outlet / Footer live in normal flow inside it — reserve the gutter's
+     width so nothing renders underneath the always-visible rail. */
+  .app-shell {
+    padding-left: var(--app-nav-gutter-width, 64px);
+  }
+}
+
+@media (min-width: 769px) and (prefers-reduced-motion: reduce) {
+  .app-nav-drawer {
+    transition: none;
   }
 }

--- a/frontend/src/components/nav/AppNavDrawer.jsx
+++ b/frontend/src/components/nav/AppNavDrawer.jsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useNavDrawer } from '../../contexts/NavDrawerContext.js'
+import { useIsMobile } from '../../hooks/useMediaQuery'
 import PortalNav from '../ui/PortalNav'
+import NavIcon from './NavIcon'
 import Footer from '../Footer'
 import { HOME_ITEM, PORTFOLIO_ITEM, WAGERS_ITEM, NAV_GROUPS, pathForNavItem, visibleNavGroups } from '../../config/appNav'
 import { useChainTokens } from '../../hooks/useChainTokens'
@@ -46,17 +48,22 @@ function resolveActiveId(location) {
 }
 
 /**
- * AppNavDrawer — the global left navigation drawer ("us"), opened by the clover
- * logo on every in-app route. Replaces the per-page section rail that used to
- * live only on My Account. Selecting an entry routes to the section and closes
- * the drawer; the in-app legal footer is pinned to the bottom.
+ * AppNavDrawer — the global left navigation ("us"). On mobile it's a slide-over
+ * drawer opened by the clover logo, exactly as before. On larger screens it's
+ * always visible as a persistent icon-only gutter (no page content renders
+ * under it — see the `.app-shell` padding in this file's CSS) that expands in
+ * place to the full labelled panel; it never fully hides on desktop, so a
+ * section is always one click away. Selecting an entry routes to the section
+ * and returns to the gutter; the in-app legal footer only fits once expanded.
  */
 export default function AppNavDrawer() {
-  const { isOpen, close } = useNavDrawer()
+  const { isOpen, close, toggle } = useNavDrawer()
   const navigate = useNavigate()
   const location = useLocation()
   const activeId = resolveActiveId(location)
   const { capabilities } = useChainTokens()
+  const isMobile = useIsMobile()
+  const drawerRef = useRef(null)
   const drawerGroups = useMemo(
     () =>
       buildDrawerGroups({
@@ -65,6 +72,10 @@ export default function AppNavDrawer() {
       }),
     [capabilities],
   )
+
+  // Desktop never fully closes: `collapsed` is the icon gutter, `isOpen` is the
+  // expanded panel. Mobile keeps the original fully-hidden/fully-open pair.
+  const collapsed = !isMobile && !isOpen
 
   // Close on Escape while open.
   useEffect(() => {
@@ -76,14 +87,33 @@ export default function AppNavDrawer() {
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [isOpen, close])
 
+  // Desktop's expanded panel has no modal backdrop (the gutter beside it stays
+  // usable), so a click outside it collapses back to the gutter instead.
+  useEffect(() => {
+    if (!isOpen || isMobile) return
+    const onPointerDown = (event) => {
+      if (drawerRef.current && !drawerRef.current.contains(event.target)) {
+        close()
+      }
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    return () => document.removeEventListener('mousedown', onPointerDown)
+  }, [isOpen, isMobile, close])
+
   const handleSelect = (id) => {
     navigate(pathForNavItem(id))
     close()
   }
 
+  // Mobile: always fully closes. Desktop: flips between gutter and expanded.
+  const handleToggleClick = () => {
+    if (isMobile) close()
+    else toggle()
+  }
+
   return (
     <>
-      {isOpen && (
+      {isOpen && isMobile && (
         <button
           type="button"
           className="app-nav-backdrop"
@@ -92,20 +122,21 @@ export default function AppNavDrawer() {
         />
       )}
       <aside
+        ref={drawerRef}
         id="app-nav-drawer"
-        className={`app-nav-drawer ${isOpen ? 'open' : ''}`}
-        aria-hidden={!isOpen}
+        className={`app-nav-drawer ${isOpen ? 'open' : ''} ${collapsed ? 'collapsed' : ''}`}
+        aria-hidden={isMobile && !isOpen}
         aria-label="Site navigation"
       >
         <div className="app-nav-drawer-header">
-          <span className="app-nav-drawer-title">Menu</span>
+          {!collapsed && <span className="app-nav-drawer-title">Menu</span>}
           <button
             type="button"
-            className="app-nav-drawer-close"
-            aria-label="Close menu"
-            onClick={close}
+            className="app-nav-drawer-toggle"
+            aria-label={collapsed ? 'Expand menu' : 'Close menu'}
+            onClick={handleToggleClick}
           >
-            <span aria-hidden="true">✕</span>
+            {collapsed ? <NavIcon name="menu" /> : <span aria-hidden="true">✕</span>}
           </button>
         </div>
 
@@ -115,9 +146,10 @@ export default function AppNavDrawer() {
           activeId={activeId}
           onSelect={handleSelect}
           ariaLabel="Site sections"
+          collapsed={collapsed}
         />
 
-        <Footer variant="drawer" />
+        {!collapsed && <Footer variant="drawer" />}
       </aside>
     </>
   )

--- a/frontend/src/test/AppNavDrawer.test.jsx
+++ b/frontend/src/test/AppNavDrawer.test.jsx
@@ -1,10 +1,26 @@
 import { useEffect } from 'react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 import AppNavDrawer from '../components/nav/AppNavDrawer'
 import { NavDrawerProvider } from '../contexts/NavDrawerContext.jsx'
 import { useNavDrawer } from '../contexts/NavDrawerContext.js'
+
+// useIsMobile() reads window.matchMedia('(max-width: 768px)'). setup.js mocks
+// matches: false for every query, i.e. desktop — which these tests rely on
+// unless a block below opts into the mobile matcher instead.
+function mockViewport({ mobile }) {
+  window.matchMedia = vi.fn().mockImplementation((query) => ({
+    matches: mobile && /max-width/.test(query),
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
 
 // The drawer is aria-hidden while closed (off-screen), so open it on mount to
 // exercise its contents — mirrors the clover-logo trigger.
@@ -108,5 +124,65 @@ describe('AppNavDrawer (global nav drawer)', () => {
     expect(
       within(footer).getByRole('link', { name: /Terms & Conditions/i })
     ).toHaveAttribute('href', '/terms')
+  })
+})
+
+// Larger screens: the drawer is a persistent icon gutter that expands in
+// place rather than sliding fully off-canvas — see AppNavDrawer.jsx.
+describe('AppNavDrawer (desktop icon gutter)', () => {
+  afterEach(() => {
+    // Restore the desktop-by-default matcher the rest of this file relies on.
+    mockViewport({ mobile: false })
+  })
+
+  it('shows a collapsed icon gutter by default, not hidden off-canvas', () => {
+    mockViewport({ mobile: false })
+    render(
+      <MemoryRouter initialEntries={['/app']}>
+        <NavDrawerProvider>
+          <AppNavDrawer />
+        </NavDrawerProvider>
+      </MemoryRouter>
+    )
+
+    const aside = document.getElementById('app-nav-drawer')
+    expect(aside).not.toHaveAttribute('aria-hidden', 'true')
+    expect(aside.className).toContain('collapsed')
+    expect(screen.getByRole('button', { name: 'Expand menu' })).toBeInTheDocument()
+    // Entries stay reachable (label visually hidden, not removed) — the
+    // accessible name still resolves them.
+    expect(screen.getByRole('button', { name: 'Trade' })).toBeInTheDocument()
+  })
+
+  it('expands to the full labelled panel once opened', () => {
+    mockViewport({ mobile: false })
+    render(
+      <MemoryRouter initialEntries={['/app']}>
+        <NavDrawerProvider>
+          <OpenOnMount />
+          <AppNavDrawer />
+        </NavDrawerProvider>
+      </MemoryRouter>
+    )
+
+    const aside = document.getElementById('app-nav-drawer')
+    expect(aside.className).not.toContain('collapsed')
+    expect(screen.getByText('Finance')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close menu' })).toBeInTheDocument()
+  })
+
+  it('stays fully hidden off-canvas on mobile until opened', () => {
+    mockViewport({ mobile: true })
+    render(
+      <MemoryRouter initialEntries={['/app']}>
+        <NavDrawerProvider>
+          <AppNavDrawer />
+        </NavDrawerProvider>
+      </MemoryRouter>
+    )
+
+    const aside = document.getElementById('app-nav-drawer')
+    expect(aside).toHaveAttribute('aria-hidden', 'true')
+    expect(aside.className).not.toContain('collapsed')
   })
 })


### PR DESCRIPTION
## Summary

- On larger screens (≥769px, matching the existing `useIsMobile` breakpoint), the global nav drawer (`AppNavDrawer`, opened by the clover logo) no longer slides fully off-canvas. It's always visible as a persistent icon-only gutter — reusing `PortalNav`'s existing `collapsed` rail rendering — and expands in place to the full labelled panel when toggled.
- Toggling: click the clover logo (or the gutter's own header button) to expand; collapse back via Escape, selecting a nav entry, or clicking outside the expanded panel (no modal backdrop on desktop, since the gutter beside it stays usable).
- Mobile (<769px) behavior is unchanged: fully hidden off-canvas until opened, with the existing backdrop + full-drawer overlay.
- `App.jsx` wraps the app layout in a new `.app-shell` div so page content (`Header`, `Outlet`, `Footer`) reserves room for the fixed-position gutter's width; the gutter itself ignores this padding since it's fixed to the viewport.

## Test plan

- [x] `npx vitest run src/test/AppNavDrawer.test.jsx` — 10 tests pass (7 existing + 3 new covering the collapsed gutter, expand-to-panel, and mobile off-canvas behavior)
- [x] `npx vitest run` across nav/footer/layout-adjacent suites (PortalNav, SidebarNav, adminNav, Footer, SectionIconNav, feedNavigation, collectibles nav visibility) — all pass
- [x] `npx eslint src/components/nav/AppNavDrawer.jsx src/App.jsx` — clean
- [x] `npx vite build` — builds successfully


---
_Generated by [Claude Code](https://claude.ai/code/session_01QT4njvcpSTFe93whRP9M3y)_