### PR TITLE
White-label multi-tenant platform: spec 072 + tenant foundation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,26 @@ permissions:
   contents: read
 
 jobs:
+  # Gate (spec 072, FR-008): every tenants/<id>/manifest.json must be valid —
+  # structure, domain uniqueness, fee caps, cohort separation, dedicated-mode
+  # record presence. Must fail the pipeline loudly (Constitution IV). The
+  # validator is dependency-free, so no npm ci is needed.
+  tenant-manifests:
+    name: Tenant Manifest Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate tenant manifests
+        run: node scripts/tenants/validate-tenant-manifest.js
+
   smart-contract-tests:
     name: Smart Contract Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,21 @@ artifacts live under `specs/<feature>/`.
   several chains at once**. Providers come from `getReadProvider`/`readProviderFor`, never
   hand-built from `NETWORKS[chainId].rpcUrl`. See `docs/developer-guide/chain-estate-reads.md` +
   `specs/071-multi-chain-admin-console/`.
+- **White-label tenants (spec 072): the tenant manifest is the single source of truth.**
+  `tenants/<id>/manifest.json` defines a tenant's identity, settings, and contract set;
+  `tenants/fairwins/` is the default tenant and MUST reproduce the current product exactly.
+  Never hardcode a tenant identity value (name, logo, URL, PWA metadata, support/legal links)
+  in shipped paths — resolve via `frontend/src/config/tenant.js` (`tenantBrand()`,
+  `isFeatureEnabled()`, `tenantThemeClass()`). Tenant selection is BUILD-TIME
+  (`VITE_TENANT_ID`, one origin = one tenant, no runtime switching); an unknown id fails
+  loudly and never falls back to another tenant. Theming rides the existing `platform-<id>`
+  CSS class seam (default tokens stay in `theme.css`; non-default tenants inject from the
+  manifest). Isolation for value is ON-CHAIN via separate proxy instances: `TENANT_ID=<id>`
+  on deploy scripts tenant-prefixes CREATE2 salts and records under
+  `deployments/tenants/<id>/` (same schema); a dedicated tenant resolves ONLY its own set —
+  absence stays absence, no fallback to the shared estate. Manifests never contain secrets;
+  `npm run tenants:validate` gates in CI. See `docs/developer-guide/white-label-tenants.md`
+  + `specs/072-white-label-tenants/`.
 - **RPC endpoints belong to the MEMBER (spec 069), and network settings live in the user panel.**
   The `network` tab moved off the Tools nav group onto the account button beside Preferences (tab id +
   `/wallet?tab=network` unchanged); `NAV_GROUPS` must not carry it again. Endpoint resolution has ONE

--- a/docs/developer-guide/white-label-tenants.md
+++ b/docs/developer-guide/white-label-tenants.md
@@ -1,0 +1,67 @@
+# White-Label Tenants
+
+Spec 072 turns the single-brand product into a platform of **tenant instances**: each
+tenant (customer) runs its own branded instance with its own configuration and — for
+tenants that need asset isolation — its own contract deployments. The FairWins product
+is the **default tenant** (`tenants/fairwins/manifest.json`) and behaves exactly as
+before.
+
+Full design: `specs/072-white-label-tenants/` (spec, plan, research D1–D11, data-model,
+quickstart, tasks).
+
+## The tenant manifest is the single source of truth
+
+`tenants/<tenant-id>/manifest.json` describes one tenant: identity (name, domains, brand
+assets, theme tokens), settings (features, chains, membership tier pricing, fee bps),
+and contract set (`shared` | `dedicated`). Rules:
+
+- **Never hardcode a tenant identity value the manifest defines.** Member-visible
+  names, logos, URLs, PWA metadata, share text, and support/legal links resolve through
+  `frontend/src/config/tenant.js`.
+- **No secrets.** Manifests are public config, baked into client bundles.
+- `npm run tenants:validate` enforces structure, cross-manifest domain uniqueness, fee
+  caps, cohort separation, and dedicated-mode record presence. CI gates on it
+  (`tenant-manifests` job in `.github/workflows/test.yml`).
+
+## Frontend
+
+- **Selection is build-time**: `VITE_TENANT_ID` picks the manifest (default
+  `fairwins`). One origin = one tenant; there is no runtime tenant switching, so a
+  built instance physically contains only its own tenant's identity. An unknown id
+  throws at module init — absence never falls back to another tenant.
+- `frontend/src/config/tenant.js` exposes `getActiveTenant()`, `tenantBrand()`,
+  `tenantLinks()`, `isFeatureEnabled(id)`, `tenantChainIds(cohort)`,
+  `tenantThemeClass()`, `tenantContractMode()`.
+- **Theming rides the existing `platform-*` seam**: the default tenant's tokens stay
+  static in `frontend/src/theme.css`; non-default tenants get an equivalent
+  `.platform-<id>` rule set generated from their manifest and injected by
+  `frontend/src/theme/tenantTheme.js`. `ThemeContext` applies
+  `platform-<activeTenantId>` and persists `themePlatform` for the pre-hydration
+  script.
+- Feature gating: a feature absent from `settings.features` must be absent from
+  nav/routes — never present-but-broken.
+
+## Contract isolation (dedicated tenants)
+
+- Isolation for value-bearing state is **on-chain, by separate proxy instances** of the
+  audited implementations — never by a frontend/gateway filter alone. v1 ships zero
+  Solidity changes.
+- Deploys reuse the deterministic CREATE2 flow: setting `TENANT_ID=<id>` on the
+  existing deploy scripts prefixes salts (`tenant:<id>:…`) and writes records to
+  `deployments/tenants/<id>/<network>-chain<chainId>-v2.json` (same schema as the
+  shared records). `TENANT_ID` unset — or `fairwins` — is the shared estate,
+  byte-identical to before.
+- **A tenant id is immutable once deployed** (salts derive from it).
+- A dedicated tenant resolves ONLY its own contract set; a contract absent from the
+  set on a chain reads as not-deployed for that tenant there. No silent fallback to
+  the shared estate, ever.
+- Per-tenant gateway: run a relay-gateway instance against the tenant's deployment
+  records — its startup allowlist (spec 036 FR-025) then *is* the tenant scoping.
+
+## Lifecycle
+
+`draft → live ⇄ suspended → retired`, changed by PR (git history is the audit trail).
+Suspension never traps value: contracts don't know about suspension; members keep the
+documented direct-claim path. Shared-mode ("branding-only") tenants have cosmetic
+isolation only — this must be disclosed to the tenant, and graduation to dedicated
+contracts preserves claimability of positions opened on the shared estate.

--- a/docs/developer-guide/white-label-tenants.md
+++ b/docs/developer-guide/white-label-tenants.md
@@ -54,7 +54,13 @@ and contract set (`shared` | `dedicated`). Rules:
 - **A tenant id is immutable once deployed** (salts derive from it).
 - A dedicated tenant resolves ONLY its own contract set; a contract absent from the
   set on a chain reads as not-deployed for that tenant there. No silent fallback to
-  the shared estate, ever.
+  the shared estate, ever. The set is generated:
+  `node scripts/utils/sync-frontend-contracts.js --tenant <id> --network <n> --chainId <c>`
+  merges the tenant's record into `frontend/src/config/tenants/<id>.contracts.json`,
+  which the tenant-branding plugin injects via `virtual:tenant`;
+  `getContractAddress`/`getContractAddressForChain` consult it before (instead of) the
+  shared maps whenever `isDedicatedTenant()`. A **live** dedicated tenant with no
+  generated set fails the build.
 - Per-tenant gateway: run a relay-gateway instance against the tenant's deployment
   records — its startup allowlist (spec 036 FR-025) then *is* the tenant scoping.
 

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -13,6 +13,10 @@
 // with their display info for getDeployedNetworks(). Safe from import cycles:
 // networks.js intentionally does NOT import from this file.
 import { NETWORKS } from './networks'
+// Tenant contract-set resolution (spec 072): a DEDICATED tenant resolves only
+// its own generated set; shared-mode tenants (incl. the default) fall through
+// to the per-chain maps below. tenant.js has no import back into this file.
+import { isDedicatedTenant, tenantContractsForChain } from './tenant'
 
 // Mordor (Ethereum Classic testnet, chainId 63) — v2 P2P betting deployment.
 // CORE ONLY: no oracle adapters (ETC has no Polymarket/Chainlink/UMA), so those
@@ -303,6 +307,13 @@ export function getDeploymentBlockForChain(contractName, chainId) {
  * @returns {string} Contract address
  */
 export function getContractAddress(contractName) {
+  // Dedicated tenant (spec 072): the tenant's own generated set is the ONLY
+  // source — no env overrides, no shared-estate fallback. Absence stays absence.
+  if (isDedicatedTenant()) {
+    const tenantSet = tenantContractsForChain(ACTIVE_CHAIN_ID)
+    return tenantSet ? tenantSet[contractName] : undefined
+  }
+
   // Check environment variables first (for custom deployments)
   // Support both legacy style (VITE_ROLEMANAGER_ADDRESS) and snake-case style (VITE_ROLE_MANAGER_ADDRESS)
   const upper = contractName.toUpperCase()
@@ -339,6 +350,13 @@ export function getContractAddress(contractName) {
  */
 export function getContractAddressForChain(contractName, chainId) {
   if (chainId == null) return getContractAddress(contractName)
+  // Dedicated tenant (spec 072): resolve ONLY from the tenant's own set —
+  // a chain absent from it reads as not-deployed for this tenant, never as
+  // the shared estate's deployment (FR-003/D6).
+  if (isDedicatedTenant()) {
+    const tenantSet = tenantContractsForChain(chainId)
+    return tenantSet ? tenantSet[contractName] : undefined
+  }
   const chainContracts = NETWORK_CONTRACTS[chainId]
   return chainContracts ? chainContracts[contractName] : undefined
 }

--- a/frontend/src/config/tenant.js
+++ b/frontend/src/config/tenant.js
@@ -20,7 +20,7 @@
  * for the active tenant.
  */
 
-import { activeTenantManifest, featureCatalog } from 'virtual:tenant'
+import { activeTenantManifest, featureCatalog, tenantContractSets } from 'virtual:tenant'
 
 export const DEFAULT_TENANT_ID = 'fairwins'
 
@@ -34,6 +34,7 @@ function deepFreeze(value) {
 
 const ACTIVE_TENANT = deepFreeze(activeTenantManifest)
 const FEATURE_CATALOG = deepFreeze(featureCatalog ?? [])
+const CONTRACT_SETS = deepFreeze(tenantContractSets ?? {})
 
 /**
  * Resolve a tenant id to its manifest. Only the active tenant is present in
@@ -131,10 +132,25 @@ export function tenantThemeClass() {
 /**
  * Contract-set mode: 'shared' fronts the platform estate (existing
  * config/contracts.js resolution unchanged); 'dedicated' resolves ONLY the
- * tenant's own generated set (frontend/src/config/tenants/<id>.contracts.js,
- * written by sync-frontend-contracts --tenant). Dedicated resolution lands
- * with spec 072 T016; shared mode is a pass-through by design.
+ * tenant's own generated set (frontend/src/config/tenants/<id>.contracts.json,
+ * written by sync-frontend-contracts --tenant and injected via virtual:tenant).
  */
 export function tenantContractMode() {
   return ACTIVE_TENANT.contractSet.mode
+}
+
+export function isDedicatedTenant() {
+  return ACTIVE_TENANT.contractSet.mode === 'dedicated'
+}
+
+/**
+ * The active tenant's address record for a chain — DEDICATED tenants only.
+ * Returns undefined for shared-mode tenants (callers fall through to the
+ * shared estate's maps) AND for chains absent from a dedicated tenant's set
+ * (absence stays absence — a dedicated tenant never resolves the shared
+ * estate's addresses, spec 072 FR-003/D6).
+ */
+export function tenantContractsForChain(chainId) {
+  if (!isDedicatedTenant()) return undefined
+  return CONTRACT_SETS[chainId] ?? CONTRACT_SETS[String(chainId)]
 }

--- a/frontend/src/config/tenant.js
+++ b/frontend/src/config/tenant.js
@@ -9,14 +9,18 @@
  * (spec 072 FR-007), so a built instance physically contains only its own
  * tenant's identity.
  *
- * An unknown tenant id fails at module init (fail loudly, FR-008) — it must
- * never silently fall back to another tenant's identity.
+ * An unknown tenant id fails the BUILD (the tenant-branding Vite plugin throws
+ * while resolving the virtual module) — it must never silently fall back to
+ * another tenant's identity.
+ *
+ * Only the active tenant's manifest exists in the bundle: `virtual:tenant` is
+ * provided by frontend/vite-plugins/tenant-branding.js and injects exactly one
+ * manifest. A built instance physically contains no other tenant's identity
+ * (spec 072, research D2) — which is also why resolveTenant() can only answer
+ * for the active tenant.
  */
 
-// Eagerly bundle every manifest + the feature catalog at build time. The glob
-// is relative to this file (frontend/src/config/ -> repo root /tenants).
-const manifestModules = import.meta.glob('../../../tenants/*/manifest.json', { eager: true })
-const featureCatalogModules = import.meta.glob('../../../tenants/features.json', { eager: true })
+import { activeTenantManifest, featureCatalog } from 'virtual:tenant'
 
 export const DEFAULT_TENANT_ID = 'fairwins'
 
@@ -28,47 +32,23 @@ function deepFreeze(value) {
   return value
 }
 
-function buildManifestIndex() {
-  const index = {}
-  for (const [modulePath, module] of Object.entries(manifestModules)) {
-    const match = modulePath.match(/\/tenants\/([^/]+)\/manifest\.json$/)
-    if (!match) continue
-    const dirId = match[1]
-    const manifest = module.default ?? module
-    if (manifest.id !== dirId) {
-      throw new Error(
-        `[tenant] manifest id "${manifest.id}" does not match its directory "tenants/${dirId}/" — refusing to load`
-      )
-    }
-    index[dirId] = deepFreeze(manifest)
-  }
-  return index
-}
-
-const MANIFESTS = buildManifestIndex()
-
-const FEATURE_CATALOG = deepFreeze(
-  Object.values(featureCatalogModules).map((m) => m.default ?? m)[0]?.features ?? []
-)
+const ACTIVE_TENANT = deepFreeze(activeTenantManifest)
+const FEATURE_CATALOG = deepFreeze(featureCatalog ?? [])
 
 /**
- * Resolve a tenant id to its manifest. Throws on unknown ids — absence must
- * never resolve to another tenant's identity.
+ * Resolve a tenant id to its manifest. Only the active tenant is present in
+ * this build (one origin = one tenant, FR-007); any other id throws.
  */
 export function resolveTenant(tenantId) {
-  const manifest = MANIFESTS[tenantId]
-  if (!manifest) {
-    const known = Object.keys(MANIFESTS).sort().join(', ')
+  if (tenantId !== ACTIVE_TENANT.id) {
     throw new Error(
-      `[tenant] unknown tenant id "${tenantId}" (known: ${known}). ` +
-        'Author tenants/<id>/manifest.json and run `npm run tenants:validate`.'
+      `[tenant] unknown tenant id "${tenantId}" — this build serves only "${ACTIVE_TENANT.id}" ` +
+        '(one origin = one tenant, spec 072 FR-007). Build with VITE_TENANT_ID=<id> after authoring ' +
+        'tenants/<id>/manifest.json and running `npm run tenants:validate`.'
     )
   }
-  return manifest
+  return ACTIVE_TENANT
 }
-
-const ACTIVE_TENANT_ID = import.meta.env.VITE_TENANT_ID || DEFAULT_TENANT_ID
-const ACTIVE_TENANT = resolveTenant(ACTIVE_TENANT_ID)
 
 /** The full frozen manifest of the tenant this build serves. */
 export function getActiveTenant() {

--- a/frontend/src/config/tenant.js
+++ b/frontend/src/config/tenant.js
@@ -1,0 +1,160 @@
+/**
+ * Active tenant resolution (spec 072).
+ *
+ * The tenant manifest (tenants/<id>/manifest.json at the repo root) is the
+ * single source of truth for a tenant's identity, settings, and contract set.
+ * Selection is BUILD-TIME: VITE_TENANT_ID picks the manifest (default
+ * "fairwins", the tenant that reproduces today's FairWins product). One served
+ * origin is one tenant — there is deliberately no runtime tenant switching
+ * (spec 072 FR-007), so a built instance physically contains only its own
+ * tenant's identity.
+ *
+ * An unknown tenant id fails at module init (fail loudly, FR-008) — it must
+ * never silently fall back to another tenant's identity.
+ */
+
+// Eagerly bundle every manifest + the feature catalog at build time. The glob
+// is relative to this file (frontend/src/config/ -> repo root /tenants).
+const manifestModules = import.meta.glob('../../../tenants/*/manifest.json', { eager: true })
+const featureCatalogModules = import.meta.glob('../../../tenants/features.json', { eager: true })
+
+export const DEFAULT_TENANT_ID = 'fairwins'
+
+function deepFreeze(value) {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value)
+    for (const key of Object.keys(value)) deepFreeze(value[key])
+  }
+  return value
+}
+
+function buildManifestIndex() {
+  const index = {}
+  for (const [modulePath, module] of Object.entries(manifestModules)) {
+    const match = modulePath.match(/\/tenants\/([^/]+)\/manifest\.json$/)
+    if (!match) continue
+    const dirId = match[1]
+    const manifest = module.default ?? module
+    if (manifest.id !== dirId) {
+      throw new Error(
+        `[tenant] manifest id "${manifest.id}" does not match its directory "tenants/${dirId}/" — refusing to load`
+      )
+    }
+    index[dirId] = deepFreeze(manifest)
+  }
+  return index
+}
+
+const MANIFESTS = buildManifestIndex()
+
+const FEATURE_CATALOG = deepFreeze(
+  Object.values(featureCatalogModules).map((m) => m.default ?? m)[0]?.features ?? []
+)
+
+/**
+ * Resolve a tenant id to its manifest. Throws on unknown ids — absence must
+ * never resolve to another tenant's identity.
+ */
+export function resolveTenant(tenantId) {
+  const manifest = MANIFESTS[tenantId]
+  if (!manifest) {
+    const known = Object.keys(MANIFESTS).sort().join(', ')
+    throw new Error(
+      `[tenant] unknown tenant id "${tenantId}" (known: ${known}). ` +
+        'Author tenants/<id>/manifest.json and run `npm run tenants:validate`.'
+    )
+  }
+  return manifest
+}
+
+const ACTIVE_TENANT_ID = import.meta.env.VITE_TENANT_ID || DEFAULT_TENANT_ID
+const ACTIVE_TENANT = resolveTenant(ACTIVE_TENANT_ID)
+
+/** The full frozen manifest of the tenant this build serves. */
+export function getActiveTenant() {
+  return ACTIVE_TENANT
+}
+
+export function getActiveTenantId() {
+  return ACTIVE_TENANT.id
+}
+
+export function isDefaultTenant() {
+  return ACTIVE_TENANT.id === DEFAULT_TENANT_ID
+}
+
+/** Identity + brand for member-visible surfaces (names, logos, PWA, share frames). */
+export function tenantBrand() {
+  return {
+    id: ACTIVE_TENANT.id,
+    displayName: ACTIVE_TENANT.identity.displayName,
+    tagline: ACTIVE_TENANT.identity.tagline ?? '',
+    appUrl: ACTIVE_TENANT.identity.appUrl,
+    logo: ACTIVE_TENANT.brand.logo,
+    logoMark: ACTIVE_TENANT.brand.logoMark,
+    favicon: ACTIVE_TENANT.brand.favicon,
+    pwa: ACTIVE_TENANT.brand.pwa,
+    htmlTitle: ACTIVE_TENANT.brand.htmlTitle ?? ACTIVE_TENANT.identity.displayName,
+  }
+}
+
+/** Support/social/legal links for footers, entry gates, and docs surfaces. */
+export function tenantLinks() {
+  return {
+    support: ACTIVE_TENANT.identity.support ?? {},
+    social: ACTIVE_TENANT.identity.social ?? {},
+    legal: ACTIVE_TENANT.identity.legal ?? {},
+  }
+}
+
+/** Feature ids this tenant enables (validated subset of tenants/features.json). */
+export function tenantFeatures() {
+  return ACTIVE_TENANT.settings.features
+}
+
+/**
+ * Whether a feature surface should exist in this tenant's instance. A disabled
+ * feature is absent from nav/routes — never present-but-broken.
+ */
+export function isFeatureEnabled(featureId) {
+  return ACTIVE_TENANT.settings.features.includes(featureId)
+}
+
+/** The known feature catalog (for admin/validation surfaces). */
+export function knownFeatureIds() {
+  return FEATURE_CATALOG
+}
+
+/**
+ * Chain ids the tenant enables for a cohort ('mainnet' | 'testnet'). Callers
+ * must still intersect with the build cohort rules (spec 071) — a tenant list
+ * never crosses the testnet/mainnet boundary.
+ */
+export function tenantChainIds(cohort) {
+  const chains = ACTIVE_TENANT.settings.chains
+  if (cohort !== 'mainnet' && cohort !== 'testnet') {
+    throw new Error(`[tenant] unknown cohort "${cohort}" — use 'mainnet' or 'testnet'`)
+  }
+  return chains[cohort]
+}
+
+/**
+ * The platform CSS class for the active tenant, consumed by ThemeContext and
+ * the pre-hydration script contract (theme-<mode> + platform-<id> on <html>).
+ * The default tenant's tokens live statically in theme.css; non-default
+ * tenants get theirs injected by src/theme/tenantTheme.js.
+ */
+export function tenantThemeClass() {
+  return `platform-${ACTIVE_TENANT.id}`
+}
+
+/**
+ * Contract-set mode: 'shared' fronts the platform estate (existing
+ * config/contracts.js resolution unchanged); 'dedicated' resolves ONLY the
+ * tenant's own generated set (frontend/src/config/tenants/<id>.contracts.js,
+ * written by sync-frontend-contracts --tenant). Dedicated resolution lands
+ * with spec 072 T016; shared mode is a pass-through by design.
+ */
+export function tenantContractMode() {
+  return ACTIVE_TENANT.contractSet.mode
+}

--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -1,11 +1,15 @@
 import { useState, useEffect, useCallback } from 'react'
 import { ThemeContext } from './ThemeContext'
+import { getActiveTenantId, tenantThemeClass } from '../config/tenant'
+import { applyTenantTheme } from '../theme/tenantTheme'
 
 /**
  * ThemeProvider manages the application's theme state
  * - Supports light/dark mode
  * - Persists theme preference to localStorage
  * - Default is light mode
+ * - Applies the active tenant's platform-<id> class (spec 072); the tenant is
+ *   fixed at build time, only the mode is user-switchable
  */
 export function ThemeProvider({ children }) {
   // Initialize with light mode as default
@@ -14,19 +18,29 @@ export function ThemeProvider({ children }) {
     return savedMode || 'light'
   })
 
+  // Inject non-default tenant theme tokens once (no-op for the default tenant)
+  useEffect(() => {
+    applyTenantTheme()
+  }, [])
+
   // Apply theme to document root
   useEffect(() => {
     const root = document.documentElement
 
-    // Remove existing theme classes
-    root.classList.remove('theme-light', 'theme-dark', 'platform-clearpath', 'platform-fairwins')
+    // Remove existing theme classes (any platform-* left by the pre-hydration script)
+    root.classList.remove('theme-light', 'theme-dark')
+    for (const cls of Array.from(root.classList)) {
+      if (cls.startsWith('platform-')) root.classList.remove(cls)
+    }
 
     // Add current theme classes
     root.classList.add(`theme-${mode}`)
-    root.classList.add('platform-fairwins')
+    root.classList.add(tenantThemeClass())
 
-    // Save to localStorage
+    // Save to localStorage; themePlatform feeds the index.html pre-hydration
+    // script so the correct platform class is applied before hydration
     localStorage.setItem('themeMode', mode)
+    localStorage.setItem('themePlatform', getActiveTenantId())
   }, [mode])
 
   const toggleMode = useCallback(() => {

--- a/frontend/src/test/tenantBranding.test.js
+++ b/frontend/src/test/tenantBranding.test.js
@@ -1,0 +1,98 @@
+/**
+ * Tenant branding plugin tests (spec 072, T008).
+ *
+ * The transforms are pure functions; the plugin itself is a strict no-op for
+ * the default tenant (US3 — static index.html/webmanifest stay the source).
+ */
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  transformIndexHtml,
+  buildWebManifest,
+  tenantBrandingPlugin,
+} from '../../vite-plugins/tenant-branding'
+
+const INDEX_HTML = fs.readFileSync(
+  path.resolve(__dirname, '..', '..', 'index.html'),
+  'utf8'
+)
+
+const ACME = {
+  id: 'acme',
+  identity: {
+    displayName: 'Acme Markets',
+    tagline: 'Wager with your crew',
+    metaDescription: 'Acme Markets - wagers "for" <friends> & co.',
+    appUrl: 'https://acme.example',
+  },
+  brand: {
+    htmlTitle: 'Acme Markets - Social Wagers',
+    logo: '/assets/acme_logo.svg',
+    logoMark: '/assets/acme_mark.svg',
+    favicon: '/assets/acme_logo.svg',
+    appleTouchIcon: '/assets/acme_mark.svg',
+    pwa: {
+      name: 'Acme Markets',
+      shortName: 'Acme',
+      appleTitle: 'Acme',
+      themeColor: '#AA00FF',
+      backgroundColor: '#101010',
+    },
+  },
+}
+
+describe('tenant branding plugin (spec 072)', () => {
+  it('rewrites every branded surface of index.html from the manifest', () => {
+    const html = transformIndexHtml(INDEX_HTML, ACME)
+    expect(html).toContain('<title>Acme Markets - Social Wagers</title>')
+    expect(html).toContain('<meta name="theme-color" content="#AA00FF"')
+    expect(html).toContain('content="Acme"')
+    expect(html).toContain('href="/assets/acme_logo.svg"')
+    expect(html).toContain('href="/assets/acme_mark.svg"')
+    // Meta description is escaped
+    expect(html).toContain('Acme Markets - wagers &quot;for&quot; &lt;friends> &amp; co.')
+    // Pre-hydration defaults point at the built tenant, not another tenant
+    expect(html).toContain("savedPlatform || 'acme'")
+    expect(html).toContain("'platform-acme'")
+    expect(html).not.toContain('FairWins')
+    expect(html).not.toContain('fairwins')
+  })
+
+  it('builds a webmanifest mirroring the static file shape', () => {
+    const wm = buildWebManifest(ACME)
+    expect(wm.name).toBe('Acme Markets')
+    expect(wm.short_name).toBe('Acme')
+    expect(wm.theme_color).toBe('#AA00FF')
+    expect(wm.background_color).toBe('#101010')
+    expect(wm.start_url).toBe('/?source=pwa')
+    expect(wm.icons).toHaveLength(2)
+    expect(wm.icons[0].src).toBe('/assets/acme_mark.svg')
+    expect(wm.icons[1].purpose).toBe('maskable')
+  })
+
+  it('does not touch HTML or the webmanifest for the default tenant (US3)', () => {
+    // The test env has no VITE_TENANT_ID → default tenant.
+    const plugin = tenantBrandingPlugin()
+    expect(plugin.name).toBe('tenant-branding')
+    expect(plugin.transformIndexHtml).toBeUndefined()
+    expect(plugin.closeBundle).toBeUndefined()
+  })
+
+  it('injects only the active tenant manifest via virtual:tenant', () => {
+    const plugin = tenantBrandingPlugin()
+    const resolved = plugin.resolveId('virtual:tenant')
+    const source = plugin.load.call({ addWatchFile: () => {} }, resolved)
+    expect(source).toContain('"id":"fairwins"')
+    expect(source).not.toContain('"id":"example"')
+    expect(source).toContain('featureCatalog')
+  })
+
+  it('refuses a production build of a non-live tenant (lifecycle gate)', () => {
+    const plugin = tenantBrandingPlugin()
+    // Default tenant is live: production build allowed.
+    expect(() =>
+      plugin.config({}, { command: 'build', mode: 'production' })
+    ).not.toThrow()
+  })
+})

--- a/frontend/src/test/tenantConfig.test.js
+++ b/frontend/src/test/tenantConfig.test.js
@@ -58,6 +58,21 @@ describe('tenant config (spec 072)', () => {
     expect(tenantContractMode()).toBe('shared')
   })
 
+  it('shared-mode tenants have no tenant contract overlay (resolution unchanged)', async () => {
+    const { isDedicatedTenant, tenantContractsForChain } = await import('../config/tenant')
+    expect(isDedicatedTenant()).toBe(false)
+    expect(tenantContractsForChain(137)).toBeUndefined()
+    expect(tenantContractsForChain(63)).toBeUndefined()
+  })
+
+  it('shared-mode resolution through contracts.js is untouched (US3)', async () => {
+    const { getContractAddressForChain } = await import('../config/contracts')
+    // Mordor (63) is the test-pinned network with a live wagerRegistry record.
+    expect(getContractAddressForChain('wagerRegistry', 63)).toMatch(/^0x[0-9a-fA-F]{40}$/)
+    // A chain with no record still reads as not-deployed.
+    expect(getContractAddressForChain('wagerRegistry', 999999)).toBeUndefined()
+  })
+
   it('unknown tenant ids fail loudly instead of falling back', () => {
     expect(() => resolveTenant('not-a-tenant')).toThrow(/unknown tenant id "not-a-tenant"/)
   })

--- a/frontend/src/test/tenantConfig.test.js
+++ b/frontend/src/test/tenantConfig.test.js
@@ -1,0 +1,96 @@
+/**
+ * Tenant config module tests (spec 072, Foundational T006).
+ *
+ * The default (fairwins) tenant must reproduce today's product exactly, and
+ * unknown tenants must fail loudly — never fall back to another identity.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_TENANT_ID,
+  getActiveTenant,
+  getActiveTenantId,
+  isDefaultTenant,
+  resolveTenant,
+  tenantBrand,
+  tenantChainIds,
+  tenantThemeClass,
+  tenantContractMode,
+  isFeatureEnabled,
+  knownFeatureIds,
+} from '../config/tenant'
+
+describe('tenant config (spec 072)', () => {
+  it('defaults to the fairwins tenant when VITE_TENANT_ID is unset', () => {
+    expect(DEFAULT_TENANT_ID).toBe('fairwins')
+    expect(getActiveTenantId()).toBe('fairwins')
+    expect(isDefaultTenant()).toBe(true)
+  })
+
+  it('default tenant reproduces the current product identity exactly (US3)', () => {
+    const brand = tenantBrand()
+    expect(brand.displayName).toBe('FairWins')
+    expect(brand.appUrl).toBe('https://fairwins.app')
+    expect(brand.htmlTitle).toBe('FairWins - Prediction Markets for Friends')
+    expect(brand.logo).toBe('/assets/logo_fairwins.svg')
+    expect(brand.logoMark).toBe('/assets/fairwins_no-text_logo.svg')
+    // Values from frontend/public/manifest.webmanifest
+    expect(brand.pwa.name).toBe('🍀FairWins')
+    expect(brand.pwa.shortName).toBe('FairWins')
+    expect(brand.pwa.themeColor).toBe('#36B37E')
+    expect(brand.pwa.backgroundColor).toBe('#0E141B')
+  })
+
+  it('default tenant theme tokens match the static theme.css values (US3)', () => {
+    const theme = getActiveTenant().brand.theme
+    expect(theme.base['--brand-primary']).toBe('#36B37E')
+    expect(theme.base['--brand-secondary']).toBe('#4C9AFF')
+    expect(theme.light['--primary-button']).toBe('#36B37E')
+    expect(theme.light['--primary-button-hover']).toBe('#2F9E6E')
+    expect(theme.dark['--primary-button']).toBe('#45C492')
+    expect(theme.dark['--primary-button-text']).toBe('#0E141B')
+  })
+
+  it('applies the platform-fairwins class for the default tenant', () => {
+    expect(tenantThemeClass()).toBe('platform-fairwins')
+  })
+
+  it('default tenant fronts the shared estate', () => {
+    expect(tenantContractMode()).toBe('shared')
+  })
+
+  it('unknown tenant ids fail loudly instead of falling back', () => {
+    expect(() => resolveTenant('not-a-tenant')).toThrow(/unknown tenant id "not-a-tenant"/)
+  })
+
+  it('feature gating reflects the manifest and only the manifest', () => {
+    expect(isFeatureEnabled('wagers')).toBe(true)
+    expect(isFeatureEnabled('predict')).toBe(true)
+    expect(isFeatureEnabled('definitely-not-a-feature')).toBe(false)
+  })
+
+  it('every enabled feature is in the known catalog', () => {
+    const catalog = knownFeatureIds()
+    for (const feature of getActiveTenant().settings.features) {
+      expect(catalog).toContain(feature)
+    }
+  })
+
+  it('tenant chain lists never cross the cohort boundary', () => {
+    const mainnet = tenantChainIds('mainnet')
+    const testnet = tenantChainIds('testnet')
+    expect(mainnet).toContain(137)
+    expect(testnet).toContain(63)
+    for (const chainId of mainnet) expect(testnet).not.toContain(chainId)
+    expect(() => tenantChainIds('devnet')).toThrow(/unknown cohort/)
+  })
+
+  it('manifests are frozen — shipped identity cannot be mutated at runtime', () => {
+    const tenant = getActiveTenant()
+    expect(Object.isFrozen(tenant)).toBe(true)
+    expect(Object.isFrozen(tenant.identity)).toBe(true)
+    expect(() => {
+      'use strict'
+      tenant.identity.displayName = 'Mallory'
+    }).toThrow()
+  })
+})

--- a/frontend/src/test/tenantTheme.test.js
+++ b/frontend/src/test/tenantTheme.test.js
@@ -1,0 +1,38 @@
+/**
+ * Tenant theme injection tests (spec 072, research D3).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { applyTenantTheme, buildTenantCss } from '../theme/tenantTheme'
+
+const SAMPLE_MANIFEST = {
+  id: 'acme',
+  brand: {
+    theme: {
+      base: { '--brand-primary': '#FF0000', '--brand-secondary': '#00FF00' },
+      light: { '--primary-button': '#FF0000', '--primary-button-hover': '#CC0000' },
+      dark: { '--primary-button': '#FF3333', '--primary-button-hover': '#FF6666' },
+    },
+  },
+}
+
+describe('tenant theme (spec 072)', () => {
+  afterEach(() => {
+    document.getElementById('tenant-theme')?.remove()
+  })
+
+  it('builds platform-scoped CSS blocks from a manifest', () => {
+    const css = buildTenantCss(SAMPLE_MANIFEST)
+    expect(css).toContain('.platform-acme {')
+    expect(css).toContain('--brand-primary: #FF0000;')
+    expect(css).toContain('.theme-light.platform-acme {')
+    expect(css).toContain('--primary-button-hover: #CC0000;')
+    expect(css).toContain('.theme-dark.platform-acme {')
+    expect(css).toContain('--primary-button: #FF3333;')
+  })
+
+  it('is a no-op for the default tenant — theme.css stays the source (US3)', () => {
+    // The test build runs as the default tenant (no VITE_TENANT_ID).
+    applyTenantTheme()
+    expect(document.getElementById('tenant-theme')).toBeNull()
+  })
+})

--- a/frontend/src/theme/tenantTheme.js
+++ b/frontend/src/theme/tenantTheme.js
@@ -1,0 +1,47 @@
+/**
+ * Tenant theme injection (spec 072, research D3).
+ *
+ * The theming seam is the existing platform-* CSS class contract: brand tokens
+ * live under .platform-<id> (base), .theme-light.platform-<id> and
+ * .theme-dark.platform-<id> (mode-specific) — see src/theme.css. The DEFAULT
+ * tenant's tokens stay static in theme.css (zero visual diff, spec US3);
+ * non-default tenants get an equivalent rule set generated from their manifest
+ * and injected once at bootstrap.
+ */
+
+import { getActiveTenant, isDefaultTenant } from '../config/tenant'
+
+const STYLE_ELEMENT_ID = 'tenant-theme'
+
+function cssBlock(selector, vars) {
+  const body = Object.entries(vars)
+    .map(([name, value]) => `  ${name}: ${value};`)
+    .join('\n')
+  return `${selector} {\n${body}\n}`
+}
+
+/**
+ * Build the CSS text for a tenant manifest's theme. Exported for tests.
+ */
+export function buildTenantCss(manifest) {
+  const { id } = manifest
+  const { base, light, dark } = manifest.brand.theme
+  return [
+    cssBlock(`.platform-${id}`, base),
+    cssBlock(`.theme-light.platform-${id}`, light),
+    cssBlock(`.theme-dark.platform-${id}`, dark),
+  ].join('\n\n')
+}
+
+/**
+ * Inject the active tenant's theme tokens. No-op for the default tenant
+ * (its tokens are the static theme.css rules). Idempotent.
+ */
+export function applyTenantTheme(doc = document) {
+  if (isDefaultTenant()) return
+  if (doc.getElementById(STYLE_ELEMENT_ID)) return
+  const style = doc.createElement('style')
+  style.id = STYLE_ELEMENT_ID
+  style.textContent = buildTenantCss(getActiveTenant())
+  doc.head.appendChild(style)
+}

--- a/frontend/vite-plugins/tenant-branding.js
+++ b/frontend/vite-plugins/tenant-branding.js
@@ -1,0 +1,197 @@
+/**
+ * Tenant branding Vite plugin (spec 072, T008).
+ *
+ * Makes the HTML shell and PWA manifest tenant-driven for NON-default tenants:
+ * - index.html title/meta/theme-color/icons/pre-hydration default are rewritten
+ *   from the active tenant's manifest at build/serve time
+ * - manifest.webmanifest is generated from the manifest (overriding the static
+ *   public/ copy)
+ *
+ * For the DEFAULT tenant this plugin is a strict no-op: the static
+ * frontend/index.html and frontend/public/manifest.webmanifest remain the
+ * source, guaranteeing byte-identical default-tenant output (spec US3/SC-003).
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_TENANT_ID = 'fairwins'
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+// Virtual module consumed by src/config/tenant.js. Only the ACTIVE tenant's
+// manifest is injected into the bundle — a built instance must physically
+// contain no other tenant's identity (spec 072, research D2).
+const VIRTUAL_ID = 'virtual:tenant'
+const RESOLVED_VIRTUAL_ID = '\0' + VIRTUAL_ID
+
+function manifestPathFor(tenantId) {
+  return path.join(REPO_ROOT, 'tenants', tenantId, 'manifest.json')
+}
+
+function loadManifest(tenantId) {
+  const manifestPath = manifestPathFor(tenantId)
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(
+      `[tenant-branding] unknown tenant id "${tenantId}" — no manifest at tenants/${tenantId}/manifest.json. ` +
+        'Author it and run `npm run tenants:validate`.'
+    )
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+  if (manifest.id !== tenantId) {
+    throw new Error(
+      `[tenant-branding] manifest id "${manifest.id}" does not match its directory "tenants/${tenantId}/"`
+    )
+  }
+  return manifest
+}
+
+function loadFeatureCatalog() {
+  const catalogPath = path.join(REPO_ROOT, 'tenants', 'features.json')
+  return JSON.parse(fs.readFileSync(catalogPath, 'utf8')).features
+}
+
+function escapeAttr(value) {
+  return String(value).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
+}
+
+/**
+ * Rewrite the branded parts of index.html from a tenant manifest.
+ * Pure; exported for tests.
+ */
+export function transformIndexHtml(html, manifest) {
+  const { identity, brand } = manifest
+  const title = brand.htmlTitle ?? identity.displayName
+  let out = html
+
+  out = out.replace(/<title>[^<]*<\/title>/, `<title>${title}</title>`)
+  out = out.replace(
+    /(<meta name="description" content=")[^"]*(")/,
+    `$1${escapeAttr(identity.metaDescription ?? identity.tagline ?? '')}$2`
+  )
+  out = out.replace(
+    /(<meta name="theme-color" content=")[^"]*(")/,
+    `$1${brand.pwa.themeColor}$2`
+  )
+  out = out.replace(
+    /(<meta name="apple-mobile-web-app-title" content=")[^"]*(")/,
+    `$1${escapeAttr(brand.pwa.appleTitle ?? brand.pwa.shortName)}$2`
+  )
+  out = out.replace(
+    /(<link rel="icon"[^>]*href=")[^"]*(")/,
+    `$1${brand.favicon}$2`
+  )
+  out = out.replace(
+    /(<link rel="apple-touch-icon" href=")[^"]*(")/,
+    `$1${brand.appleTouchIcon ?? brand.logoMark}$2`
+  )
+  // Pre-hydration script defaults: platform falls back to the built tenant,
+  // never to another tenant's class.
+  out = out.replaceAll(`savedPlatform || '${DEFAULT_TENANT_ID}'`, `savedPlatform || '${manifest.id}'`)
+  out = out.replaceAll(`'platform-${DEFAULT_TENANT_ID}'`, `'platform-${manifest.id}'`)
+  out = out.replaceAll(`default to ${DEFAULT_TENANT_ID}`, `default to ${manifest.id}`)
+
+  return out
+}
+
+/**
+ * Build the PWA webmanifest object from a tenant manifest.
+ * Pure; exported for tests. Mirrors the shape of public/manifest.webmanifest.
+ */
+export function buildWebManifest(manifest) {
+  const { identity, brand } = manifest
+  const icon = brand.logoMark
+  return {
+    name: brand.pwa.name,
+    short_name: brand.pwa.shortName,
+    description: identity.metaDescription ?? identity.tagline ?? '',
+    id: '/',
+    start_url: '/?source=pwa',
+    scope: '/',
+    display: 'standalone',
+    display_override: ['standalone', 'minimal-ui', 'browser'],
+    orientation: 'portrait-primary',
+    background_color: brand.pwa.backgroundColor,
+    theme_color: brand.pwa.themeColor,
+    categories: ['finance', 'social'],
+    icons: [
+      { src: icon, sizes: 'any', type: 'image/svg+xml', purpose: 'any' },
+      { src: icon, sizes: 'any', type: 'image/svg+xml', purpose: 'maskable' },
+    ],
+  }
+}
+
+export function tenantBrandingPlugin() {
+  const tenantId = process.env.VITE_TENANT_ID || DEFAULT_TENANT_ID
+  // Unknown VITE_TENANT_ID fails here — build, dev server, and tests alike
+  // (fail loudly, FR-008; never fall back to another tenant's identity).
+  const manifest = loadManifest(tenantId)
+  const featureCatalog = loadFeatureCatalog()
+  const isDefault = tenantId === DEFAULT_TENANT_ID
+
+  const virtualModuleHooks = {
+    // Lifecycle gate (spec 072 data-model): only a live tenant may produce a
+    // production build. Draft/retired tenants build only in non-production
+    // modes (previews); suspended tenants fail here until the unavailability
+    // shell ships — failing beats silently serving a suspended tenant.
+    config(_config, { command, mode }) {
+      if (command === 'build' && mode === 'production' && manifest.lifecycle !== 'live') {
+        throw new Error(
+          `[tenant-branding] tenant "${tenantId}" has lifecycle "${manifest.lifecycle}" — ` +
+            'only a "live" tenant may produce a production build. Use a non-production mode ' +
+            'for previews (vite build --mode staging), or update the manifest via PR.'
+        )
+      }
+    },
+    resolveId(id) {
+      if (id === VIRTUAL_ID) return RESOLVED_VIRTUAL_ID
+    },
+    load(id) {
+      if (id !== RESOLVED_VIRTUAL_ID) return
+      this.addWatchFile(manifestPathFor(tenantId))
+      return (
+        `export const activeTenantManifest = ${JSON.stringify(manifest)};\n` +
+        `export const featureCatalog = ${JSON.stringify(featureCatalog)};\n`
+      )
+    },
+  }
+
+  // Default tenant: the virtual module only — the static index.html and
+  // public/manifest.webmanifest stay the source of truth (US3 byte-equivalence).
+  if (isDefault) {
+    return { name: 'tenant-branding', ...virtualModuleHooks }
+  }
+
+  const webManifestJson = JSON.stringify(buildWebManifest(manifest), null, 2) + '\n'
+  let outDir = 'dist'
+
+  return {
+    name: 'tenant-branding',
+    ...virtualModuleHooks,
+    configResolved(config) {
+      outDir = config.build.outDir
+    },
+    transformIndexHtml(html) {
+      return transformIndexHtml(html, manifest)
+    },
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url === '/manifest.webmanifest') {
+          res.setHeader('Content-Type', 'application/manifest+json')
+          res.end(webManifestJson)
+          return
+        }
+        next()
+      })
+    },
+    // public/ is copied into outDir by Vite core, so overwrite the static
+    // webmanifest after the bundle is fully written.
+    closeBundle() {
+      const target = path.resolve(outDir, 'manifest.webmanifest')
+      if (fs.existsSync(path.dirname(target))) {
+        fs.writeFileSync(target, webManifestJson)
+      }
+    },
+  }
+}

--- a/frontend/vite-plugins/tenant-branding.js
+++ b/frontend/vite-plugins/tenant-branding.js
@@ -52,6 +52,35 @@ function loadFeatureCatalog() {
   return JSON.parse(fs.readFileSync(catalogPath, 'utf8')).features
 }
 
+function tenantContractSetPath(tenantId) {
+  return path.join(REPO_ROOT, 'frontend', 'src', 'config', 'tenants', `${tenantId}.contracts.json`)
+}
+
+/**
+ * Load the generated per-chain contract set for a DEDICATED tenant
+ * (written by `sync-frontend-contracts --tenant <id>` from the tenant's
+ * deployments/tenants/<id>/ records). A live dedicated tenant without a
+ * generated set fails the build — a dedicated instance must never silently
+ * resolve the shared estate's addresses (spec 072 FR-003/D6). Shared-mode
+ * tenants get an empty set: their resolution stays the shared estate.
+ */
+function loadTenantContractSets(tenantId, manifest) {
+  if (manifest.contractSet.mode !== 'dedicated') return {}
+  const setPath = tenantContractSetPath(tenantId)
+  if (!fs.existsSync(setPath)) {
+    if (manifest.lifecycle === 'live') {
+      throw new Error(
+        `[tenant-branding] dedicated tenant "${tenantId}" has no generated contract set at ` +
+          `frontend/src/config/tenants/${tenantId}.contracts.json. Run ` +
+          `\`node scripts/utils/sync-frontend-contracts.js --tenant ${tenantId} --network <n> --chainId <id>\` ` +
+          'after deploying — a dedicated build must never fall back to the shared estate.'
+      )
+    }
+    return {}
+  }
+  return JSON.parse(fs.readFileSync(setPath, 'utf8'))
+}
+
 function escapeAttr(value) {
   return String(value).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
 }
@@ -150,9 +179,11 @@ export function tenantBrandingPlugin() {
     load(id) {
       if (id !== RESOLVED_VIRTUAL_ID) return
       this.addWatchFile(manifestPathFor(tenantId))
+      const contractSets = loadTenantContractSets(tenantId, manifest)
       return (
         `export const activeTenantManifest = ${JSON.stringify(manifest)};\n` +
-        `export const featureCatalog = ${JSON.stringify(featureCatalog)};\n`
+        `export const featureCatalog = ${JSON.stringify(featureCatalog)};\n` +
+        `export const tenantContractSets = ${JSON.stringify(contractSets)};\n`
       )
     },
   }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -50,6 +50,13 @@ export default defineConfig({
     strictPort: true,
     host: true
   },
+  server: {
+    fs: {
+      // Tenant manifests (spec 072) live at the repo root in tenants/ and are
+      // imported by src/config/tenant.js; allow the dev server to serve them.
+      allow: ['..']
+    }
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,7 @@
 import process from 'node:process'
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
+import { tenantBrandingPlugin } from './vite-plugins/tenant-branding.js'
 
 // Fails a production build if Pinata write credentials are present in the build
 // environment. Any VITE_*-prefixed value is inlined into the client bundle in
@@ -30,7 +31,7 @@ function pinataSecretGuard() {
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), pinataSecretGuard()],
+  plugins: [react(), pinataSecretGuard(), tenantBrandingPlugin()],
   build: {
     outDir: 'dist',
     emptyOutDir: true,
@@ -49,13 +50,6 @@ export default defineConfig({
     port: 4173,
     strictPort: true,
     host: true
-  },
-  server: {
-    fs: {
-      // Tenant manifests (spec 072) live at the repo root in tenants/ and are
-      // imported by src/config/tenant.js; allow the dev server to serve them.
-      allow: ['..']
-    }
   },
   test: {
     globals: true,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "verify:polygon": "hardhat run scripts/deploy/verify.js --network polygon",
     "verify:passkey-support": "node scripts/ops/verify-passkey-support.js",
     "check:storage-layout": "hardhat run scripts/deploy/check-storage-layout.js",
+    "tenants:validate": "node scripts/tenants/validate-tenant-manifest.js",
     "sync:frontend-contracts": "node scripts/utils/sync-frontend-contracts.js --network mordor --chainId 63",
     "sync:frontend-contracts:amoy": "node scripts/utils/sync-frontend-contracts.js --network amoy --chainId 80002",
     "sync:frontend-contracts:polygon": "node scripts/utils/sync-frontend-contracts.js --network polygon --chainId 137",

--- a/scripts/deploy/lib/helpers.js
+++ b/scripts/deploy/lib/helpers.js
@@ -41,12 +41,38 @@ function hexByteLength(hex) {
 }
 
 /**
- * Generate a deterministic salt from an identifier string
+ * Resolve the active tenant id from the TENANT_ID env var (spec 072).
+ *
+ * Returns null when no tenant is in scope — including TENANT_ID=fairwins,
+ * because the default tenant IS the shared estate (unprefixed salts, records
+ * at deployments/<network>-chain<id>-v2.json). With a non-default tenant set,
+ * salts are tenant-prefixed and records live under deployments/tenants/<id>/,
+ * yielding a deterministic, isolated address set per tenant on the same chain.
+ *
+ * The id is validated against the manifest id pattern; the id feeds CREATE2
+ * salts, so it must never change once a tenant has deployed (see tenants/README.md).
+ */
+function activeTenantId() {
+  const id = (process.env.TENANT_ID || "").trim();
+  if (!id || id === "fairwins") return null;
+  if (!/^[a-z][a-z0-9-]{1,30}$/.test(id)) {
+    throw new Error(
+      `TENANT_ID "${id}" is invalid — must match ^[a-z][a-z0-9-]{1,30}$ (see tenants/README.md)`
+    );
+  }
+  return id;
+}
+
+/**
+ * Generate a deterministic salt from an identifier string.
+ * When a tenant is in scope (TENANT_ID env), the salt is tenant-prefixed so
+ * the tenant gets its own deterministic address set (spec 072, research D5).
  * @param {string} identifier - Salt identifier
  * @returns {string} 32-byte hex salt
  */
 function generateSalt(identifier) {
-  return ethers.id(identifier);
+  const tenant = activeTenantId();
+  return ethers.id(tenant ? `tenant:${tenant}:${identifier}` : identifier);
 }
 
 // =============================================================================
@@ -542,10 +568,21 @@ async function safeTransferOwnership(name, contract, from, to) {
 // =============================================================================
 
 /**
+ * Resolve the deployments directory for the current scope: the shared estate
+ * lives in deployments/, a tenant's dedicated estate under
+ * deployments/tenants/<id>/ with the SAME record schema (spec 072).
+ */
+function deploymentsDirForScope() {
+  const base = path.join(process.cwd(), "deployments");
+  const tenant = activeTenantId();
+  return tenant ? path.join(base, "tenants", tenant) : base;
+}
+
+/**
  * Save deployment information to JSON file
  */
 function saveDeployment(filename, deploymentInfo) {
-  const deploymentsDir = path.join(process.cwd(), "deployments");
+  const deploymentsDir = deploymentsDirForScope();
   if (!fs.existsSync(deploymentsDir)) fs.mkdirSync(deploymentsDir, { recursive: true });
 
   const outPath = path.join(deploymentsDir, filename);
@@ -558,7 +595,7 @@ function saveDeployment(filename, deploymentInfo) {
  * Load deployment information from JSON file
  */
 function loadDeployment(filename) {
-  const deploymentsDir = path.join(process.cwd(), "deployments");
+  const deploymentsDir = deploymentsDirForScope();
   const filePath = path.join(deploymentsDir, filename);
 
   if (!fs.existsSync(filePath)) {
@@ -630,6 +667,7 @@ module.exports = {
   sleep,
   hexByteLength,
   generateSalt,
+  activeTenantId,
 
   // Verification
   verifyOnBlockscout,

--- a/scripts/tenants/validate-tenant-manifest.js
+++ b/scripts/tenants/validate-tenant-manifest.js
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/**
+ * Tenant manifest validator (spec 072, FR-008).
+ *
+ * Validates every tenants/<id>/manifest.json against the structural rules in
+ * tenants/manifest.schema.json plus the cross-manifest rules JSON Schema cannot
+ * express (domain uniqueness, fee caps, cohort separation, dedicated-mode
+ * deployment-record presence). Dependency-free by design so it can run as a
+ * bare CI step. Exits non-zero on the first tenant set that is not fully valid,
+ * after printing EVERY error found (fail loudly, fail completely).
+ *
+ * Usage: node scripts/tenants/validate-tenant-manifest.js [tenantId ...]
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const TENANTS_DIR = path.join(REPO_ROOT, "tenants");
+const DEPLOYMENTS_DIR = path.join(REPO_ROOT, "deployments");
+
+const ID_PATTERN = /^[a-z][a-z0-9-]{1,30}$/;
+const HEX_COLOR = /^#[0-9A-Fa-f]{6}$/;
+const CSS_VAR = /^--[a-z][a-z0-9-]*$/;
+const DOMAIN_PATTERN = /^[a-z0-9.-]+$/;
+
+const LIFECYCLES = ["draft", "live", "suspended", "retired"];
+const CONTRACT_MODES = ["shared", "dedicated"];
+
+// Platform fee caps in bps (spec 057 + spec 060). Anything not named falls
+// under the wrapped-service cap.
+const FEE_CAPS = { "polymarket.taker": 100, "polymarket.maker": 50 };
+const DEFAULT_FEE_CAP = 250;
+
+// Tokens the theme MUST resolve (mirrors frontend/src/utils/validateTheme.js:
+// the brand-scoped subset — neutrals live on :root, not on the platform class).
+const REQUIRED_BASE_TOKENS = ["--brand-primary", "--brand-secondary"];
+const REQUIRED_MODE_TOKENS = ["--primary-button", "--primary-button-hover"];
+
+// Known chain ids per cohort (source: frontend/src/config/networks.js cohorts).
+const MAINNET_CHAINS = new Set([1, 10, 137, 8453, 42161, 61]);
+const TESTNET_CHAINS = new Set([80002, 63, 11155111, 560048, 1337]);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function loadFeatureCatalog() {
+  const catalog = readJson(path.join(TENANTS_DIR, "features.json"));
+  return new Set(catalog.features);
+}
+
+function isPlainObject(v) {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function validateThemeVars(vars, label, errors) {
+  if (!isPlainObject(vars)) {
+    errors.push(`brand.theme.${label} must be an object of CSS custom properties`);
+    return;
+  }
+  for (const [name, value] of Object.entries(vars)) {
+    if (!CSS_VAR.test(name)) {
+      errors.push(`brand.theme.${label}: "${name}" is not a valid CSS custom property name`);
+    }
+    if (typeof value !== "string" || value.trim() === "") {
+      errors.push(`brand.theme.${label}: "${name}" must be a non-empty string`);
+    }
+  }
+}
+
+function validateManifest(id, manifest, knownFeatures) {
+  const errors = [];
+  const err = (msg) => errors.push(msg);
+
+  if (manifest.schemaVersion !== 1) err("schemaVersion must be 1");
+  if (manifest.id !== id) err(`id "${manifest.id}" must equal directory name "${id}"`);
+  if (typeof manifest.id !== "string" || !ID_PATTERN.test(manifest.id)) {
+    err(`id must match ${ID_PATTERN}`);
+  }
+  if (!LIFECYCLES.includes(manifest.lifecycle)) {
+    err(`lifecycle must be one of ${LIFECYCLES.join(", ")}`);
+  }
+
+  // --- identity ---
+  const identity = manifest.identity;
+  if (!isPlainObject(identity)) {
+    err("identity is required");
+  } else {
+    if (!identity.displayName || typeof identity.displayName !== "string") {
+      err("identity.displayName is required");
+    }
+    if (!Array.isArray(identity.domains) || identity.domains.length === 0) {
+      err("identity.domains must be a non-empty array");
+    } else {
+      for (const domain of identity.domains) {
+        if (typeof domain !== "string" || !DOMAIN_PATTERN.test(domain)) {
+          err(`identity.domains: "${domain}" is not a valid domain`);
+        }
+      }
+    }
+    if (typeof identity.appUrl !== "string" || !identity.appUrl.startsWith("https://")) {
+      err("identity.appUrl must be an https:// URL");
+    }
+  }
+
+  // --- brand ---
+  const brand = manifest.brand;
+  if (!isPlainObject(brand)) {
+    err("brand is required");
+  } else {
+    for (const key of ["logo", "logoMark", "favicon"]) {
+      if (typeof brand[key] !== "string" || brand[key].trim() === "") {
+        err(`brand.${key} is required`);
+      }
+    }
+    const pwa = brand.pwa;
+    if (!isPlainObject(pwa)) {
+      err("brand.pwa is required");
+    } else {
+      for (const key of ["name", "shortName"]) {
+        if (typeof pwa[key] !== "string" || pwa[key].trim() === "") err(`brand.pwa.${key} is required`);
+      }
+      for (const key of ["themeColor", "backgroundColor"]) {
+        if (typeof pwa[key] !== "string" || !HEX_COLOR.test(pwa[key])) {
+          err(`brand.pwa.${key} must be a #rrggbb color`);
+        }
+      }
+    }
+    const theme = brand.theme;
+    if (!isPlainObject(theme) || !isPlainObject(theme.base) || !isPlainObject(theme.light) || !isPlainObject(theme.dark)) {
+      err("brand.theme must define base, light, and dark token sets");
+    } else {
+      validateThemeVars(theme.base, "base", errors);
+      validateThemeVars(theme.light, "light", errors);
+      validateThemeVars(theme.dark, "dark", errors);
+      for (const token of REQUIRED_BASE_TOKENS) {
+        if (!theme.base[token]) err(`brand.theme.base must define ${token}`);
+      }
+      for (const mode of ["light", "dark"]) {
+        for (const token of REQUIRED_MODE_TOKENS) {
+          if (!theme[mode] || !theme[mode][token]) err(`brand.theme.${mode} must define ${token}`);
+        }
+      }
+    }
+  }
+
+  // --- settings ---
+  const settings = manifest.settings;
+  if (!isPlainObject(settings)) {
+    err("settings is required");
+  } else {
+    if (!Array.isArray(settings.features)) {
+      err("settings.features must be an array");
+    } else {
+      for (const feature of settings.features) {
+        if (!knownFeatures.has(feature)) {
+          err(`settings.features: "${feature}" is not in tenants/features.json`);
+        }
+      }
+    }
+
+    const chains = settings.chains;
+    if (!isPlainObject(chains) || !Array.isArray(chains.mainnet) || !Array.isArray(chains.testnet)) {
+      err("settings.chains must define mainnet and testnet arrays");
+    } else {
+      for (const chainId of chains.mainnet) {
+        if (!MAINNET_CHAINS.has(chainId)) {
+          err(`settings.chains.mainnet: ${chainId} is not a known mainnet chain (cohorts never mix)`);
+        }
+      }
+      for (const chainId of chains.testnet) {
+        if (!TESTNET_CHAINS.has(chainId)) {
+          err(`settings.chains.testnet: ${chainId} is not a known testnet chain (cohorts never mix)`);
+        }
+      }
+    }
+
+    if (settings.fees !== undefined) {
+      if (!isPlainObject(settings.fees)) {
+        err("settings.fees must be an object of serviceId -> bps");
+      } else {
+        for (const [serviceId, bps] of Object.entries(settings.fees)) {
+          const cap = FEE_CAPS[serviceId] ?? DEFAULT_FEE_CAP;
+          if (!Number.isInteger(bps) || bps < 0) {
+            err(`settings.fees["${serviceId}"] must be a non-negative integer (bps)`);
+          } else if (bps > cap) {
+            err(`settings.fees["${serviceId}"] = ${bps} bps exceeds the platform cap of ${cap} bps`);
+          }
+        }
+      }
+    }
+  }
+
+  // --- contractSet ---
+  const contractSet = manifest.contractSet;
+  if (!isPlainObject(contractSet) || !CONTRACT_MODES.includes(contractSet.mode)) {
+    err(`contractSet.mode must be one of ${CONTRACT_MODES.join(", ")}`);
+  } else if (contractSet.mode === "dedicated" && manifest.lifecycle === "live") {
+    // A live dedicated tenant must have a recorded estate (or an explicit,
+    // honest pendingChains entry) for every enabled chain. Silent absence is
+    // exactly the failure FR-008 exists to prevent.
+    const pending = new Set(contractSet.pendingChains || []);
+    const enabled = []
+      .concat(settings?.chains?.mainnet || [])
+      .concat(settings?.chains?.testnet || []);
+    const tenantDeployDir = path.join(DEPLOYMENTS_DIR, "tenants", id);
+    const records = fs.existsSync(tenantDeployDir) ? fs.readdirSync(tenantDeployDir) : [];
+    for (const chainId of enabled) {
+      const hasRecord = records.some((f) => f.endsWith(`-chain${chainId}-v2.json`));
+      if (!hasRecord && !pending.has(chainId)) {
+        err(
+          `contractSet: live dedicated tenant enables chain ${chainId} but has no record at ` +
+            `deployments/tenants/${id}/*-chain${chainId}-v2.json and does not list it in pendingChains`
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+function main() {
+  const requested = process.argv.slice(2);
+  const dirs = fs
+    .readdirSync(TENANTS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => requested.length === 0 || requested.includes(name));
+
+  if (dirs.length === 0) {
+    console.error(requested.length ? `No matching tenant directories for: ${requested.join(", ")}` : "No tenant directories found");
+    process.exit(1);
+  }
+
+  const knownFeatures = loadFeatureCatalog();
+  let failed = false;
+  const domainOwners = new Map();
+  const manifests = [];
+
+  for (const id of dirs) {
+    const manifestPath = path.join(TENANTS_DIR, id, "manifest.json");
+    if (!fs.existsSync(manifestPath)) {
+      console.error(`✖ ${id}: missing manifest.json`);
+      failed = true;
+      continue;
+    }
+    let manifest;
+    try {
+      manifest = readJson(manifestPath);
+    } catch (parseError) {
+      console.error(`✖ ${id}: manifest.json is not valid JSON — ${parseError.message}`);
+      failed = true;
+      continue;
+    }
+    manifests.push({ id, manifest });
+  }
+
+  // Cross-manifest rule: domains are globally unique. Checked over ALL
+  // manifests even when a subset was requested, so a collision cannot hide
+  // behind a partial run.
+  const allDirs = fs
+    .readdirSync(TENANTS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+  for (const id of allDirs) {
+    const manifestPath = path.join(TENANTS_DIR, id, "manifest.json");
+    if (!fs.existsSync(manifestPath)) continue;
+    let manifest;
+    try {
+      manifest = readJson(manifestPath);
+    } catch {
+      continue; // parse failures already reported for requested tenants
+    }
+    for (const domain of manifest?.identity?.domains || []) {
+      const owner = domainOwners.get(domain);
+      if (owner && owner !== id) {
+        console.error(`✖ domain "${domain}" is claimed by both "${owner}" and "${id}"`);
+        failed = true;
+      } else {
+        domainOwners.set(domain, id);
+      }
+    }
+  }
+
+  for (const { id, manifest } of manifests) {
+    const errors = validateManifest(id, manifest, knownFeatures);
+    if (errors.length > 0) {
+      failed = true;
+      console.error(`✖ ${id}: ${errors.length} error(s)`);
+      for (const message of errors) console.error(`    - ${message}`);
+    } else {
+      console.log(`✔ ${id}: valid (${manifest.contractSet.mode}, ${manifest.lifecycle})`);
+    }
+  }
+
+  if (failed) {
+    console.error("\nTenant manifest validation FAILED.");
+    process.exit(1);
+  }
+  console.log(`\n${manifests.length} tenant manifest(s) valid.`);
+}
+
+main();

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -11,6 +11,7 @@ function parseArgs(argv) {
     else if (a === '--chainId') out.chainId = Number(argv[++i])
     else if (a === '--deploymentFile') out.deploymentFile = argv[++i]
     else if (a === '--contractsFile') out.contractsFile = argv[++i]
+    else if (a === '--tenant') out.tenant = argv[++i]
   }
   return out
 }
@@ -218,6 +219,67 @@ function resolveBlockName(source, chainId, contractsFile) {
   return blockName
 }
 
+/**
+ * Tenant mode (spec 072, T015): `--tenant <id>` reads the tenant's records
+ * from deployments/tenants/<id>/ and MERGES the per-chain v2 mapping into
+ * frontend/src/config/tenants/<id>.contracts.json — the generated set a
+ * dedicated tenant build resolves from (injected via virtual:tenant). It never
+ * touches contracts.js: the shared estate's maps stay the default tenant's.
+ */
+function syncTenant({ repoRoot, tenant, network, chainId, deploymentFileArg }) {
+  if (tenant === 'fairwins') {
+    throw new Error(
+      '--tenant fairwins is the default tenant (the shared estate); run the sync without --tenant.'
+    )
+  }
+  if (!/^[a-z][a-z0-9-]{1,30}$/.test(tenant)) {
+    throw new Error(`--tenant "${tenant}" is invalid — must match ^[a-z][a-z0-9-]{1,30}$`)
+  }
+
+  const deploymentsDir = path.join(repoRoot, 'deployments', 'tenants', tenant)
+  const deploymentFile = deploymentFileArg
+    ? path.resolve(repoRoot, deploymentFileArg)
+    : findDeploymentFile({ deploymentsDir, network, chainId })
+
+  if (!deploymentFile || !fs.existsSync(deploymentFile)) {
+    throw new Error(
+      `Tenant deployment JSON not found for "${tenant}". Looked for ${network} chainId=${chainId} ` +
+        `in ${deploymentsDir}. Deploy with TENANT_ID=${tenant} first, or pass --deploymentFile <path>.`
+    )
+  }
+
+  const deployment = readJson(deploymentFile)
+  const deployed = deployment.contracts || {}
+  const deploymentChainId = Number(deployment.chainId) || chainId
+
+  // Same v2 key surface as the shared sync below — one record schema (D5).
+  const record = {}
+  const keys = [
+    'wagerRegistry', 'membershipManager', 'membershipVoucher', 'voucherBatchMinter',
+    'keyRegistry', 'sanctionsGuard', 'tokenFactory', 'externalDAORegistry',
+    'backupPointerRegistry', 'wagerPoolFactory', 'callsignRegistry', 'feeRouter',
+    'stakingRouter', 'bridgeRouter', 'liquidityRouter', 'safeProposalHub',
+    'safePolicyGuard', 'safePolicyGuardV2', 'policyGuardSetup', 'entryPoint',
+    'accountFactory', 'p256Verifier', 'polymarketAdapter', 'chainlinkDataFeedAdapter',
+    'chainlinkFunctionsAdapter', 'umaAdapter',
+  ]
+  for (const key of keys) {
+    if (deployed[key]) record[key] = deployed[key]
+  }
+  if (deployment.paymentToken) record.paymentToken = deployment.paymentToken
+  if (deployment.wmatic) record.wmatic = deployment.wmatic
+  if (deployment.deployer) record.deployer = deployment.deployer
+
+  const outPath = path.join(repoRoot, 'frontend', 'src', 'config', 'tenants', `${tenant}.contracts.json`)
+  fs.mkdirSync(path.dirname(outPath), { recursive: true })
+  const existing = fs.existsSync(outPath) ? readJson(outPath) : {}
+  existing[deploymentChainId] = record
+  fs.writeFileSync(outPath, JSON.stringify(existing, null, 2) + '\n')
+
+  console.log(`Synced tenant "${tenant}" contracts from: ${deploymentFile}`)
+  console.log(`Updated: ${outPath} (chain ${deploymentChainId})`)
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2))
 
@@ -226,6 +288,11 @@ function main() {
 
   const network = args.network || 'amoy'
   const chainId = Number.isFinite(args.chainId) ? args.chainId : 80002
+
+  if (args.tenant) {
+    syncTenant({ repoRoot, tenant: args.tenant, network, chainId, deploymentFileArg: args.deploymentFile })
+    return
+  }
 
   const deploymentFile = args.deploymentFile
     ? path.resolve(repoRoot, args.deploymentFile)

--- a/specs/072-white-label-tenants/data-model.md
+++ b/specs/072-white-label-tenants/data-model.md
@@ -1,0 +1,130 @@
+# Data Model: White-label multi-tenant platform
+
+**Feature**: `072-white-label-tenants` | **Date**: 2026-07-31
+
+## Entities
+
+### Tenant Manifest (`tenants/<tenant-id>/manifest.json`)
+
+The single source of truth for one tenant. Repo-tracked, schema-validated
+(`tenants/manifest.schema.json`), no secrets ever.
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "id": "fairwins",                     // ^[a-z][a-z0-9-]{1,30}$ — used in salts, paths, CSS class
+  "lifecycle": "live",                  // draft | live | suspended | retired
+
+  "identity": {
+    "displayName": "FairWins",
+    "legalName": "FairWins, Inc.",
+    "tagline": "Prediction Markets for Friends",
+    "domains": ["fairwins.app"],       // globally unique across manifests (validator-enforced)
+    "appUrl": "https://fairwins.app",
+    "support": { "email": "Howdy@FairWins.App" },
+    "social": { "x": "https://x.com/fairwins_app" },
+    "legal": { "termsPath": "/terms", "privacyPath": "/privacy", "riskPath": "/risk" }
+  },
+
+  "brand": {
+    "logo": "/assets/logo_fairwins.svg",
+    "logoMark": "/assets/fairwins_no-text_logo.svg",
+    "favicon": "/assets/logo_fairwins.svg",
+    "pwa": {
+      "name": "FairWins",
+      "shortName": "FairWins",
+      "themeColor": "#36B37E",
+      "backgroundColor": "#0B1221"
+    },
+    "theme": {                          // CSS custom properties injected under .platform-<id>
+      "light": { "--brand-primary": "#36B37E", "--brand-secondary": "…", "…": "…" },
+      "dark":  { "--brand-primary": "…", "…": "…" }
+    }
+  },
+
+  "settings": {
+    "features": ["wagers", "pools", "predict", "collect", "earn", "bridge", "protect", "callsigns"],
+    "chains": { "mainnet": [137, 1, 10, 8453, 42161, 61], "testnet": [80002, 63] },
+    "membership": {                     // seeded tier pricing for the tenant's manager
+      "tiers": { "bronze": 2, "silver": 8, "gold": 25, "platinum": 100 }
+    },
+    "fees": {                           // per-service bps, validated ≤ platform caps
+      "polymarket.taker": 50
+    },
+    "gateway": { "relayerUrl": null, "bundlerUrls": {}, "paymaster": {} },
+    "subgraph": { "urls": {} }          // per-chain, dedicated tenants only
+  },
+
+  "contractSet": {
+    "mode": "shared",                   // "shared" (platform estate) | "dedicated"
+    "saltPrefix": null                  // dedicated only; defaults to id — NEVER change after first deploy
+  }
+}
+```
+
+**Validation rules (validator-enforced, FR-008):**
+
+- Required: `schemaVersion`, `id`, `lifecycle`, `identity.displayName`,
+  `identity.domains` (≥1, each unique across ALL manifests, none equal to another
+  tenant's), `brand.pwa.name`, `brand.theme` (both modes resolving every token
+  `validateTheme.js` asserts), `settings.features` (⊆ known feature ids),
+  `settings.chains` (⊆ supported chain ids; testnet/mainnet never mixed in one cohort
+  list), `contractSet.mode`.
+- Every `settings.fees` entry ≤ the platform cap for that service id.
+- `mode: "dedicated"` + `lifecycle: "live"` requires, for every enabled chain, either a
+  record at `deployments/tenants/<id>/<network>-chain<chainId>-v2.json` or the chain
+  listed in `contractSet.pendingChains` (explicit, honest absence).
+- `id` immutable once any deployment record exists (salt derivation depends on it).
+
+### Contract Set (dedicated mode)
+
+`deployments/tenants/<tenant-id>/<network>-chain<chainId>-v2.json` — **identical schema**
+to the existing per-network records (network, chainId, deployer, treasury, paymentToken,
+`contracts: { membershipManager, membershipManagerImpl, wagerRegistry, …, feeRouter }`).
+The shared estate's existing `deployments/<network>-chain<id>-v2.json` files are the
+default tenant's contract set.
+
+Derivations:
+
+- CREATE2 salt: `generateSalt(`${saltPrefix}:${contractIdentifier}`)` when a tenant is in
+  scope; unprefixed (today's salts) for the default tenant → default addresses unchanged.
+- Frontend generated set: `frontend/src/config/tenants/<id>.contracts.js`, written by
+  `sync-frontend-contracts --tenant <id>`; consumed only when
+  `VITE_TENANT_ID === <id>` and mode is dedicated.
+
+### Active Tenant (frontend, build-time)
+
+`frontend/src/config/tenant.js` resolves `VITE_TENANT_ID` (default `"fairwins"`) to a
+frozen manifest object at build time. Accessors:
+
+| Accessor | Returns | Notes |
+|---|---|---|
+| `getActiveTenant()` | full frozen manifest | throws at module init if id unknown (fail loudly) |
+| `tenantBrand()` | identity + brand | drives titles, logos, PWA, share frames |
+| `isFeatureEnabled(id)` | boolean | absent feature ⇒ nav/routes omit it |
+| `tenantChainIds(cohort)` | number[] | intersected with build cohort rules (spec 071) |
+| `tenantContractsForChain(chainId)` | address record \| undefined | dedicated: tenant set only; shared: existing shared lookup |
+| `tenantThemeClass()` | `platform-<id>` | applied by ThemeContext |
+
+### Instance
+
+Not a stored object — an instance is (built bundle + serving config) for one tenant:
+`VITE_TENANT_ID` + tenant URLs as build args, one service, one domain set, optional
+tenant-scoped gateway process (`TENANT_ID` env + tenant record path) and subgraph.
+
+### Lifecycle states
+
+`draft → live ⇄ suspended → retired`. Enforced by the validator (e.g. a `draft` tenant
+fails the build of a production instance; a `suspended` tenant builds only the
+unavailability shell with the documented direct-claim path per FR-013). Transitions are
+git commits to the manifest — auditable per SC-005.
+
+## Relationships
+
+```text
+Tenant 1—1 Manifest
+Tenant 1—0..N per-network Contract Set records (dedicated) — or —> shared estate (shared)
+Tenant 1—1..N Domains (globally unique)
+Tenant 1—0..1 gateway process, 0..N subgraph deployments
+Manifest —build-time—> Active Tenant module —> every branded/config surface
+```

--- a/specs/072-white-label-tenants/plan.md
+++ b/specs/072-white-label-tenants/plan.md
@@ -1,0 +1,150 @@
+# Implementation Plan: White-label multi-tenant platform
+
+**Branch**: `claude/white-label-multi-tenant-m9uhsg` (feature id `072-white-label-tenants`) | **Date**: 2026-07-31 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/072-white-label-tenants/spec.md`
+
+## Summary
+
+Turn the single-brand FairWins product into a platform of tenant instances. A repo-tracked,
+schema-validated **tenant manifest** becomes the single source of truth for a tenant's
+identity, settings, and contract set. Tenant selection is build-time (`VITE_TENANT_ID`,
+one origin = one tenant); branding flows through the existing `platform-*` CSS seam plus a
+new `frontend/src/config/tenant.js` module; **dedicated tenants get isolated on-chain
+estates** produced by the existing deterministic CREATE2 deployer with tenant-scoped salts,
+recorded under `deployments/tenants/<id>/` in the existing schema. Zero Solidity changes in
+v1 — isolation comes from separate proxy instances of the audited implementations. The
+existing product becomes the default tenant with byte-identical behavior. Full decision log
+in [research.md](./research.md).
+
+## Technical Context
+
+**Language/Version**: JavaScript (Node 22) for frontend + scripts; Solidity via Hardhat
+(no contract changes in v1)
+
+**Primary Dependencies**: React + Vite + Vitest (frontend); Hardhat + Safe Singleton
+Factory CREATE2 flow (`scripts/deploy/`); nginx + Docker + Cloud Run (serving);
+relay-gateway (Node, env-configured)
+
+**Storage**: Tenant manifests as repo JSON (`tenants/<id>/manifest.json`); per-tenant
+deployment records (`deployments/tenants/<id>/<network>-chain<id>-v2.json`); no new
+databases or services
+
+**Testing**: Vitest (tenant loader, theming, resolution, CSP twins); Hardhat
+(two-tenant isolation suite); Node script tests for manifest validation
+
+**Target Platform**: Static SPA per tenant instance (Docker/nginx/Cloud Run), EVM chains
+already supported
+
+**Project Type**: Web app (frontend + contracts + services + scripts)
+
+**Performance Goals**: No regression to build size/startup for the default tenant;
+manifest resolution is build-time (zero runtime cost)
+
+**Constraints**: Default-tenant build must be behaviorally identical (SC-003); dedicated
+tenants must never resolve shared-estate addresses (FR-003/D6); no runtime tenant
+switching (FR-007); no secrets in manifests
+
+**Scale/Scope**: Tens of tenants; each tenant = 1 manifest + 0..N per-network deployment
+records + 1 built instance
+
+## Constitution Check
+
+*GATE: assessed against `.specify/memory/constitution.md` v1.0.0.*
+
+- **I. Security-first contracts** — PASS. v1 ships **no Solidity changes**; dedicated
+  tenants are additional proxy instances of already-reviewed implementations deployed by
+  the existing deterministic scripts. Tenant-salted CREATE2 does not alter bytecode.
+  Access-control reasoning (per-tenant admin keys, on-chain fee caps) is documented in
+  research D8; the two-tenant isolation suite (D9) exercises the highest-risk surface
+  (cross-tenant authority/funds) explicitly.
+- **II. Test-first / coverage** — PASS. New behavior lands with Vitest suites (tenant
+  loader/validation/theming/resolution) and a Hardhat two-tenant isolation suite; existing
+  suites must pass unmodified (SC-003 is itself a test gate).
+- **III. Honest state** — PASS by design. Absence stays absence for tenant contract sets
+  (no silent fallback, D6); suspension never traps value (FR-013); testnet/mainnet cohort
+  rules apply per tenant unchanged. No mocks in shipped paths.
+- **IV. Fail loudly in CI** — PASS. Manifest validation is a build/CI gate that fails on
+  invalid manifests (FR-008); no `continue-on-error` introduced.
+- **V. Accessible, consistent frontend** — PASS. Theming stays on the validated token
+  contract (`validateTheme.js`); contract addresses keep flowing from generated sync
+  artifacts — the tenant dimension extends the sync path rather than hand-copying.
+- **Additional constraints** — PASS. No new core technology; deployments stay
+  deterministic and recorded; manifests contain no secrets; archived code untouched.
+
+No violations → Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/072-white-label-tenants/
+├── spec.md
+├── plan.md              # This file
+├── research.md          # Decisions D1–D11
+├── data-model.md        # Manifest schema + entities
+├── quickstart.md        # How to author/launch a tenant
+└── tasks.md             # /speckit-tasks output
+```
+
+### Source Code (repository root)
+
+```text
+tenants/
+├── README.md                          # Authoring guide + lifecycle
+├── manifest.schema.json               # JSON Schema for manifests
+└── fairwins/
+    └── manifest.json                  # Default tenant (reproduces today)
+
+frontend/src/config/
+├── tenant.js                          # Active-tenant module (loader + accessors)
+└── tenants/                           # Generated per-tenant contract sets (dedicated mode)
+frontend/src/contexts/ThemeContext.jsx # platform-<tenantId> application
+frontend/src/theme/tenantTheme.js      # Token injection for non-default tenants
+frontend/index.html                    # Values templated from manifest via Vite plugin
+frontend/vite.config.js                # tenant html/manifest plugin, VITE_TENANT_ID
+
+scripts/
+├── tenants/validate-tenant-manifest.js  # Schema + cross-field validation (CI gate)
+├── deploy/lib/helpers.js                # tenant-aware salt + deployment file paths
+└── utils/sync-frontend-contracts.js     # --tenant <id> generation path
+
+deployments/
+└── tenants/<tenant-id>/<network>-chain<id>-v2.json   # Dedicated estates
+
+services/relay-gateway/                 # TENANT_ID + tenant record path (per-tenant process)
+
+test/integration/tenant-isolation.test.js  # Two-tenant on-chain isolation suite
+
+docs/developer-guide/white-label-tenants.md
+docs/runbooks/tenant-operations.md
+```
+
+**Structure Decision**: Web-app layout already in place; the feature adds the `tenants/`
+root (manifests), a tenant dimension inside existing directories (`deployments/tenants/`,
+`frontend/src/config/tenants/`), and per-feature docs. No new top-level services.
+
+## Delivery phases
+
+1. **Foundation (US3 first, deliberately)** — introduce `tenants/fairwins/manifest.json`
+   capturing today's identity/config, the schema + validator, and
+   `frontend/src/config/tenant.js`; wire ThemeContext + index.html/PWA templating through
+   it. Gate: default build behaviorally identical; suites pass unmodified.
+2. **Dedicated estates (US1/US2 on-chain half)** — tenant dimension in deploy lib
+   (salts + record paths), sync `--tenant`, two-tenant isolation suite on Hardhat.
+3. **Instance serving (US1 off-chain half)** — tenant build args through
+   Dockerfile/cloudbuild parameterization; per-tenant CSP entries via the nginx template;
+   gateway `TENANT_ID` scoping docs + config.
+4. **Brand-string migration (US1 completion, SC-004)** — sweep member-visible surfaces
+   onto `tenant.js` accessors, highest-leverage first (titles/PWA, WalletConnect metadata,
+   share/QR frames, footer, entry gate, legal links).
+5. **Tenant admin + lifecycle (US4, FR-012)** — operator runbook + validation-backed
+   lifecycle states; tenant-admin surfaces read authority from the tenant's own contracts
+   (existing role model).
+6. **Shared→dedicated graduation (US5, FR-015)** — manifest `mode` switch flow +
+   disclosure copy + claims-preserving repoint procedure (runbook + tests).
+
+## Complexity Tracking
+
+*No constitution violations to justify.*

--- a/specs/072-white-label-tenants/quickstart.md
+++ b/specs/072-white-label-tenants/quickstart.md
@@ -45,5 +45,8 @@ behavior; existing suites must pass unmodified.
 ## Lifecycle
 
 Edit `lifecycle` in the manifest via PR (auditable): `draft → live ⇄ suspended → retired`.
+Only a `live` tenant can produce a **production** build (the tenant-branding Vite plugin
+refuses otherwise); preview a `draft` tenant with a non-production mode, e.g.
+`VITE_TENANT_ID=<id> npx vite build --mode staging`.
 Suspension serves the unavailability shell and never traps value — members retain the
 documented direct-contract claim path.

--- a/specs/072-white-label-tenants/quickstart.md
+++ b/specs/072-white-label-tenants/quickstart.md
@@ -1,0 +1,49 @@
+# Quickstart: Launching a tenant
+
+**Feature**: `072-white-label-tenants`
+
+## Branding-only (shared estate) tenant
+
+1. **Author the manifest** — copy `tenants/fairwins/manifest.json` to
+   `tenants/<id>/manifest.json`; set `id`, identity, brand assets/theme tokens, domains,
+   features; keep `contractSet.mode: "shared"`.
+2. **Validate** — `npm run tenants:validate` (fails loudly on missing fields, domain
+   collisions, over-cap fees, unresolved theme tokens).
+3. **Build the instance** — `VITE_TENANT_ID=<id> npm run build` (from `frontend/`), or the
+   Docker build with `--build-arg VITE_TENANT_ID=<id>` plus the tenant's
+   `VITE_APP_URL`/relayer/subgraph args.
+4. **Serve + bind domain** — deploy the image as its own service; bind the tenant domain
+   at the edge per `infra/cloudflare/` (origin lock per instance).
+5. **Verify** — the served app carries only the tenant's identity; value flows use the
+   shared estate; the operator docs for the tenant state that asset isolation is not in
+   effect (spec FR-015).
+
+## Dedicated (isolated estate) tenant
+
+1. Author + validate the manifest with `contractSet.mode: "dedicated"`.
+2. **Deploy the estate** per enabled network:
+   `TENANT_ID=<id> npx hardhat run scripts/deploy/deploy.js --network <network>`
+   then the supplementary deployers the tenant's features need (fee router, pool factory,
+   …). Records land in `deployments/tenants/<id>/<network>-chain<chainId>-v2.json`;
+   addresses are deterministic under the tenant salt.
+3. **Sync the frontend set** —
+   `node scripts/utils/sync-frontend-contracts.js --tenant <id> --network <network> --chainId <chainId>`
+   → `frontend/src/config/tenants/<id>.contracts.js`.
+4. (Optional) **Gateway**: run a relay-gateway instance with `TENANT_ID=<id>` so its
+   startup allowlist loads the tenant's records; per-tenant quotas/killswitch/paymaster.
+   (Optional) **Subgraph**: deploy with the tenant's addresses; record URLs in the
+   manifest.
+5. Build, serve, bind domain as above.
+6. **Prove isolation** — `npm test -- test/integration/tenant-isolation.test.js` covers
+   the two-tenant probes (membership, admin authority, fee accrual, gateway refusal).
+
+## Default tenant / regression
+
+`npm run build` with no `VITE_TENANT_ID` is the FairWins product, byte-identical in
+behavior; existing suites must pass unmodified.
+
+## Lifecycle
+
+Edit `lifecycle` in the manifest via PR (auditable): `draft → live ⇄ suspended → retired`.
+Suspension serves the unavailability shell and never traps value — members retain the
+documented direct-contract claim path.

--- a/specs/072-white-label-tenants/research.md
+++ b/specs/072-white-label-tenants/research.md
@@ -1,0 +1,283 @@
+# Research: White-label multi-tenant platform
+
+**Feature**: `072-white-label-tenants` | **Date**: 2026-07-31
+
+This document records the architecture survey and the decisions that resolve every
+technical unknown in the spec. Each decision states the alternatives considered and why
+they were rejected.
+
+## Current-state survey (what exists today)
+
+### Branding
+
+- The brand is hardcoded: "FairWins" appears ~843 times across ~327 frontend files.
+  `frontend/index.html` hardcodes title, meta description, `theme-color`,
+  `apple-mobile-web-app-title`, favicon and touch icons; `frontend/public/manifest.webmanifest`
+  hardcodes PWA name/colors/icons; `frontend/src/wagmi.js#resolveAppUrl` falls back to
+  `https://fairwins.app`; `mkdocs.yml`, legal pages, share/QR frames, and the
+  `frontend/src/components/fairwins/` module namespace all embed the brand.
+- **One real theming seam exists**: the `platform-*` CSS class contract.
+  `frontend/src/theme.css` scopes brand tokens (`--brand-primary`, `--brand-secondary`,
+  `--brand-accent`, semantic and chart colors, button/accent tokens per light/dark mode) under
+  `.platform-fairwins`; `frontend/index.html` has a pre-hydration script applying
+  `theme-<mode>` + `platform-<platform>` classes from localStorage (defaulting
+  `platform-fairwins`); `frontend/src/contexts/ThemeContext.jsx` currently removes
+  `platform-clearpath`/`platform-fairwins` and unconditionally re-adds `platform-fairwins`.
+  A dormant `platform-clearpath` and a stray `tokenmint_no-text_logo.svg` asset show the
+  seam was intended to scale.
+
+### Configuration and address resolution
+
+- `frontend/src/config/contracts.js` holds per-network address records
+  (`POLYGON_CONTRACTS`, `AMOY_CONTRACTS`, …) assembled into `NETWORK_CONTRACTS` keyed by
+  chainId. `getContractAddressForChain(name, chainId)` is a pure lookup; absence
+  (`undefined`) deliberately means "not deployed on this network".
+- `scripts/utils/sync-frontend-contracts.js` rewrites those address blocks in place from
+  `deployments/<network>-chain<id>-v2.json`.
+- **Everything is keyed by `(network, chainId)` only.** There is no dimension for "which
+  instance on this chain" anywhere: deployment records, sync script, frontend resolution,
+  or the relay-gateway's startup allowlist (which reads `deployments/*-chain<ID>-v2.json`
+  and refuses to encode calls to any other address — spec 036 FR-025).
+
+### Deployment tooling
+
+- `scripts/deploy/deploy.js` is a deterministic full-stack deployer via the Safe Singleton
+  Factory (salted CREATE2, `generateSalt(identifier)` in `scripts/deploy/lib/helpers.js`),
+  deploying MembershipManager (UUPS proxy + seeded tiers), WagerRegistry (UUPS proxy),
+  SanctionsGuard, oracle adapters, KeyRegistry, TokenFactory, then
+  `saveDeployment(getDeploymentFilename(network, "v2"), record)`. Supplementary deployers
+  (fee router, pool factory, callsign registry, …) append to the same record.
+- Because addresses are deterministic **per salt**, a tenant-scoped salt prefix yields a
+  distinct, reproducible address set per tenant on the same chain.
+
+### Contract primitives relevant to tenancy
+
+- `MembershipManager` is bytes32-role-keyed by design ("future paid roles without a
+  redeploy") — but `treasury`, `paymentToken`, `accruedFees`, and `sanctionsGuard` are
+  per-deployment singletons. **Per-tenant economics therefore requires a per-tenant
+  MembershipManager deployment**, not a role key inside the shared one.
+- `WagerPoolFactory` (spec 034) is the working in-repo reference for "one factory produces
+  isolated per-group instances with a stable relayer anchor" — the pattern proof that
+  instance isolation via separate contract state works in this codebase.
+- `FeeRouter` (spec 060) is per-deployment: its treasury and service table are exactly the
+  per-tenant fee surface once deployed per tenant.
+
+### Serving and infra
+
+- One Docker image bakes all `VITE_*` config at build time; `cloudbuild.yaml` hardcodes one
+  set of build args (`VITE_APP_URL=https://fairwins.app`, network 137, relayer/bundler
+  URLs) and one Cloud Run service. Runtime envsubst covers only Pinata JWT + origin lock.
+- CSP lives in `frontend/nginx.conf.template` + `frontend/nginx.conf`, kept identical by
+  `frontend/src/test/nginxCsp{ScriptSrc,ConnectSrc}.test.js`.
+- `services/relay-gateway` is configured purely by env; per-chain quotas, killswitch,
+  paymaster ceilings — all singleton-per-process.
+
+## Decisions
+
+### D1. Tenant manifest: one JSON document per tenant, in-repo, schema-validated
+
+**Decision**: A tenant is described by `tenants/<tenant-id>/manifest.json` at the repo
+root, validated by `scripts/tenants/validate-tenant-manifest.js` against a documented
+schema. The manifest carries: identity (id, display name, legal name, domains, brand
+assets, theme tokens per light/dark mode, support/legal links, social), settings (enabled
+features, enabled chain IDs, membership tier pricing, fee service rates), and the contract
+set declaration (`mode: "shared" | "dedicated"`).
+
+**Rationale**: The constitution makes deterministic artifacts in-repo the source of truth
+(`deployments/`); tenant manifests follow the same rule. A repo-tracked JSON document is
+auditable (FR-012/SC-005 via git history), consumable by all four consumers (frontend
+build, deploy scripts, gateway config, docs), and needs no new service.
+
+**Alternatives rejected**: An on-chain TenantRegistry contract (adds a value-adjacent
+contract surface with zero enforcement value — isolation comes from separate instances,
+not from a registry; YAGNI under constitution §Simplicity). A hosted tenant-config service
+(new core technology, new availability dependency; contradicts the static per-instance
+build model).
+
+### D2. Tenant selection: build-time, one origin = one tenant
+
+**Decision**: `VITE_TENANT_ID` selects the manifest at build time; unset means `fairwins`
+(the default tenant). Each tenant instance is its own build + serve (own Docker image
+build args, own Cloud Run service or equivalent, own domain). No runtime tenant
+switching from client input (spec FR-007).
+
+**Rationale**: Matches the existing static-hosting model and the strong-isolation
+requirement: an instance physically contains only its own tenant's identity and contract
+set, so a whole class of cross-tenant leaks (wrong-manifest render, host-header spoofing)
+is structurally impossible. The Vite pipeline already bakes config this way.
+
+**Alternatives rejected**: Host-header-based runtime multi-tenancy in one served bundle
+(one bundle would carry every tenant's manifest and addresses — a data-leak surface and a
+CSP nightmare; also contradicts "unknown domain must not render any tenant"). Runtime
+manifest fetch (adds an availability dependency and a spoofable input; the edge case
+"manifest store unreachable" exists precisely because built-in manifests avoid it).
+
+### D3. Theming: extend the existing `platform-*` seam, tokens from the manifest
+
+**Decision**: Keep the `platform-<id>` class contract. The active tenant's theme tokens
+(from the manifest) are materialized as CSS custom properties scoped under
+`.platform-<tenant-id>` — injected at app bootstrap for non-default tenants, while the
+default tenant continues to use the static `theme.css` rules unchanged.
+`ThemeContext.jsx` applies `platform-<activeTenantId>` instead of the hardcoded
+`platform-fairwins`. `validateTheme.js` keeps asserting the required tokens resolve.
+
+**Rationale**: The seam already exists and is validated; the token vocabulary
+(`--brand-*`, `--semantic-*`, `--primary-button*`, chart series) is already consumed
+everywhere. Injecting vars for non-default tenants means zero visual diff for the default
+tenant (US3) and no fork of `theme.css` per tenant.
+
+**Alternatives rejected**: Per-tenant compiled CSS files (build complexity, drift risk
+against `theme.css` structure). CSS-in-JS re-theming (new core technology, wholesale
+refactor).
+
+### D4. Brand surface: a single `tenant.js` config module; strings resolved, not hardcoded
+
+**Decision**: `frontend/src/config/tenant.js` exposes the active tenant
+(`getActiveTenant()`, `tenantBrand()`, `tenantLinks()`, `tenantFeatures()`,
+`isFeatureEnabled(id)`, `tenantContractsForChain(chainId)`), loaded from the manifest via
+`VITE_TENANT_ID`. Member-visible identity strings/assets migrate to it incrementally
+(FR-002), starting with the highest-leverage surfaces: `index.html` title/meta/PWA
+manifest (templated at build via a small Vite plugin reading the manifest),
+`wagmi.js#resolveAppUrl` (WalletConnect metadata), share/QR frames, footer, entry gate.
+
+**Rationale**: One import point makes "no hardcoded tenant identity in shipped paths"
+(FR-001) lintable and auditable (SC-004 becomes a grep). The Vite plugin keeps
+`index.html`/`manifest.webmanifest` static-file semantics (no runtime templating) while
+sourcing values from the manifest.
+
+**Alternatives rejected**: Env vars per brand field (`VITE_APP_NAME`, …) — sprawling,
+unvalidated, and already proven insufficient (no such vars exist; the manifest is the
+validated unit). Runtime string replacement — violates honest-state simplicity and CSP.
+
+### D5. Contract sets: tenant dimension layered on the existing deployment records
+
+**Decision**: The shared estate keeps its records exactly where they are
+(`deployments/<network>-chain<id>-v2.json` — these become the *default tenant's* contract
+set). Dedicated tenant sets are recorded as
+`deployments/tenants/<tenant-id>/<network>-chain<id>-v2.json` with the **same schema**.
+Deploy tooling gains a tenant dimension: `TENANT_ID` env (or `--tenant` flag) causes
+(a) `generateSalt` to prefix identifiers with the tenant id — producing deterministic,
+distinct, reproducible per-tenant addresses via the existing CREATE2 flow — and
+(b) `getDeploymentFilename`/`saveDeployment`/`loadDeployment` to read/write under the
+tenant subdirectory. With no tenant set, behavior is byte-identical to today.
+
+**Rationale**: Reuses the deterministic deployer wholesale (spec FR-004); the salt is the
+one lever needed for N isolated instances of audited implementations on one chain.
+Same-schema records mean `sync-frontend-contracts.js`, the gateway's FR-025 startup
+check, and verification tooling extend by path, not by format.
+
+**Alternatives rejected**: A factory contract that clones the whole platform per tenant
+(months of new audited contract surface; UUPS proxies per tenant already give isolation
+and upgradeability; the WagerPoolFactory pattern fits pools, not a 15-contract estate).
+Multi-tenant records inside one JSON file (breaks the sync script's regex model and
+the gateway's one-record-per-chain assumption more invasively than a path dimension).
+
+### D6. Frontend address resolution: tenant overlay with honest absence
+
+**Decision**: For a dedicated tenant, the tenant build's address records are generated
+from the tenant's own deployment records (sync script `--tenant <id>` writes the tenant's
+per-chain map into the tenant manifest's generated companion,
+`frontend/src/config/tenants/<id>.contracts.js`), and `getContractAddressForChain`
+resolves **only** from the active tenant's set — absence stays absence (spec FR-003); a
+dedicated tenant never falls back to the shared estate's addresses. For a shared-mode
+tenant, resolution is unchanged (the shared records). The default tenant's generated set
+IS the current `contracts.js` data, so default behavior is unchanged.
+
+**Rationale**: Preserves the existing "undefined means not-deployed" contract the whole
+app is built on, and makes the isolation property structural: a dedicated build does not
+contain another tenant's addresses at all.
+
+**Alternatives rejected**: Runtime overlay merging shared + tenant maps (silent fallback
+to another estate is exactly the FR-008/edge-case failure the spec forbids).
+
+### D7. Gateway and indexing: one scoped instance per dedicated tenant
+
+**Decision**: A dedicated tenant that wants gasless rails runs its own relay-gateway
+process configured with `TENANT_ID` + the tenant's deployment records; the existing
+FR-025 startup allowlist then *is* the tenant scoping (it already refuses any address not
+in its records — spec FR-009 falls out for free). Quotas, killswitch, paymaster deposits
+are per-process, hence per-tenant. Same for subgraph: dedicated tenants get their own
+subgraph deployment parameterized with their addresses (the manifest records the
+per-tenant subgraph URL); shared-mode tenants use the shared subgraph. The gateway module
+and subgraph remain optional per tenant — every flow keeps its self-submit fallback
+(existing never-stranded rule).
+
+**Rationale**: Process-per-tenant reuses every existing safety property (allowlist,
+quotas, killswitch) without making any of them multi-tenant-aware — far smaller and safer
+than teaching one process to segregate tenants internally.
+
+**Alternatives rejected**: One multi-tenant gateway with per-tenant allowlists/quotas
+(large blast radius: one process compromise or quota bug spans tenants; contradicts
+"no shared barrier is the only barrier").
+
+### D8. Membership and fees: per-tenant proxies, not role-keying
+
+**Decision**: A dedicated tenant gets its own `MembershipManager` proxy (own treasury,
+payment token, tiers, terms hash) and its own `FeeRouter` proxy (own service table,
+caps, treasury), deployed by the existing scripts under the tenant salt. Tenant-admin
+guardrails (spec FR-011) use the existing on-chain role model on the *tenant's* contracts
+(`DEFAULT_ADMIN_ROLE`, `FEE_ADMIN_ROLE`, per-service hard caps already enforced on-chain
+by spec 060).
+
+**Rationale**: The survey shows treasury/paymentToken/sanctions are per-deployment
+singletons in MembershipManager — per-tenant economics cannot be role-keyed. Fee caps
+enforced on-chain (existing `FeeRouter` behavior) satisfy "guardrails enforced on-chain,
+not merely hidden in UI" with zero new contract code.
+
+**Alternatives rejected**: Tenant-as-bytes32-role inside shared MembershipManager (shared
+treasury and payment token defeats asset isolation; acceptable only for shared-mode
+tenants, where it is simply "the shared estate"). New contract code for tenancy (none is
+needed — v1 ships zero Solidity changes, keeping the audited surface unchanged).
+
+### D9. Isolation guarantees and their tests
+
+**Decision**: The isolation test suite (SC-002) deploys two tenants' estates on one
+Hardhat network via the salted deployer and asserts: cross-tenant membership is
+unrecognized; cross-tenant admin calls revert; fee accrual lands only in the acting
+tenant's router/treasury; and a gateway configured for tenant A refuses an intent
+targeting tenant B's registry (unit-level against the allowlist loader). Frontend Vitest
+covers: unknown `VITE_TENANT_ID` fails the build/loader loudly; dedicated resolution
+never returns a shared address; default tenant resolves today's exact values.
+
+**Rationale**: Isolation must be proven by construction *and* by test (constitution II);
+these are the probes named in US2.
+
+### D10. Per-tenant serving, domains, CSP
+
+**Decision**: Per-tenant instances are produced by parameterizing the existing pipeline:
+tenant build args (`VITE_TENANT_ID` + tenant URLs) into the existing Dockerfile, one
+service per tenant, tenant domain bound at the edge (existing Cloudflare origin-lock +
+geo docs extend per domain). CSP stays per-instance: tenant-specific hosts
+(relayer/bundler/subgraph/IPFS) enter `connect-src`/`img-src` via the nginx template for
+that instance; the `nginxCsp*` twin tests continue to gate template/config agreement.
+
+**Rationale**: The pipeline is already one-image-one-config; running it N times with N
+arg sets is the smallest change that yields true isolation at the serving layer too.
+
+**Alternatives rejected**: Edge-side dynamic branding (rewriting HTML per host at the
+CDN) — reintroduces runtime multi-tenancy and its leak surface.
+
+### D11. Member-scoped storage tenancy
+
+**Decision**: Client storage that is member-scoped gains a tenant dimension where it is
+tenant-specific (spec FR-014): storage namespaces derive from the active tenant id for
+tenant-scoped data (preferences tied to tenant surfaces), while genuinely
+account-global data (device RPC endpoints, spec 069) stays global. Backup/sync objects
+record the tenant id they were created under; restore into a different tenant surfaces
+skipped tenant-scoped objects honestly.
+
+**Rationale**: Since instances are separate origins, browser storage is already
+origin-isolated — this decision covers only the sync/backup rail (spec 032) that crosses
+devices and could cross tenants via a shared account.
+
+## Resolved unknowns
+
+| Unknown | Resolution |
+|---|---|
+| Where does a second deployment on the same chain live? | `deployments/tenants/<id>/…` + tenant-prefixed CREATE2 salts (D5) |
+| How does a tenant get distinct addresses deterministically? | Existing singleton-factory CREATE2 with tenant-scoped salt (D5) |
+| Can membership be tenant-scoped inside one contract? | No — treasury/paymentToken are singletons; per-tenant proxy (D8) |
+| How does branding change without forking CSS? | `platform-<id>` class + injected tokens from manifest (D3) |
+| How is the gateway tenant-scoped? | One process per tenant; FR-025 allowlist is the scope (D7) |
+| What does "unknown domain" serve? | Nothing tenant-flavored — each instance serves only its own tenant; unbound domains never reach a tenant instance (D2/D10) |
+| Does v1 need new Solidity? | No — zero contract changes; isolation via separate proxy instances (D8) |

--- a/specs/072-white-label-tenants/spec.md
+++ b/specs/072-white-label-tenants/spec.md
@@ -1,0 +1,294 @@
+# Feature Specification: White-label multi-tenant platform
+
+**Feature Branch**: `claude/white-label-multi-tenant-m9uhsg` (feature id `072-white-label-tenants`)
+
+**Created**: 2026-07-31
+
+**Status**: Draft
+
+**Input**: User description: "Evolve this into a white-label, multi-tenant platform where each
+tenant (customer) can have an isolated instance with their own branding, configuration, and
+(where appropriate) their own contract deployments. Smart contracts are on-chain. Each tenant
+instance can be isolated. I need both strong isolation (especially for assets and contracts)
+and full white-label capabilities (custom branding, custom domains, tenant-specific settings)."
+
+## Overview
+
+Today the platform is a single product with a single identity: one brand, one domain, one set
+of contract deployments per network, one membership base, one treasury. Everything a member
+sees and everything the contracts enforce assumes there is exactly one operator — FairWins —
+and that every member belongs to it.
+
+This feature turns that single product into a **platform that operators license**. A *tenant*
+is a customer organization that runs its own instance of the platform: its own name, logo,
+colors, and domain in front of its members; its own feature selection, fee schedule, and
+network list; and — where value is at stake — its own contract deployments, so its members'
+funds, memberships, roles, and treasury are isolated on-chain from every other tenant's.
+
+Two properties are non-negotiable and in tension, and this spec holds both:
+
+- **Strong isolation.** Assets, memberships, administrative authority, and treasury balances
+  belong to exactly one tenant. Isolation for value-bearing state is enforced *on-chain* by
+  separate contract instances — never by a frontend filter or a gateway check alone. A
+  compromise or misconfiguration of one tenant must not be able to reach another tenant's
+  funds or authority.
+- **Full white-label.** A member of a tenant experiences a complete product under the
+  tenant's identity. The platform's own brand does not leak into a tenant's UI, domain,
+  metadata, notifications, or documents unless the tenant chooses to show it.
+
+The existing FairWins product does not migrate anywhere: it becomes the **default tenant**,
+whose manifest reproduces today's behavior byte-for-byte. A build with no tenant configured
+is a FairWins build.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - An operator launches a new branded tenant (Priority: P1)
+
+The platform operator signs a customer. Using only configuration and the existing
+deterministic deployment tooling — no code changes — they provision the tenant: record its
+identity (name, brand assets, theme, legal and support links), choose its feature set and
+networks, deploy its dedicated contract set on the networks it needs, and bind its custom
+domain. A member who visits the tenant's domain sees a complete product under the tenant's
+brand, can purchase the tenant's membership, and can create and settle wagers escrowed in the
+tenant's own registry.
+
+**Why this priority**: This is the product. If a tenant cannot be brought live from
+configuration plus deployment records, there is no white-label business — every sale becomes
+a fork of the codebase, which is exactly the outcome multi-tenancy exists to avoid.
+
+**Independent Test**: Author a second tenant manifest beside the default one, run the
+deployment tooling for a test network, build the frontend against the new tenant, and confirm
+the resulting app carries only the new tenant's identity and resolves only the new tenant's
+contract addresses.
+
+**Acceptance Scenarios**:
+
+1. **Given** a complete tenant manifest and a recorded contract set for a network, **When** the tenant's app is built and served, **Then** every member-visible surface (app name, logos, colors, page titles, PWA metadata, share text, document footers) shows the tenant's identity and none shows the platform default.
+2. **Given** a tenant manifest that enables a subset of features, **When** the tenant's app renders, **Then** disabled features are absent from navigation and routes — not present-but-broken.
+3. **Given** the tenant's recorded contract set, **When** a member creates a wager or purchases a membership, **Then** the transaction is escrowed/settled in the tenant's own contracts and never in another tenant's or the default tenant's.
+4. **Given** a tenant manifest missing a required field or referencing an undeployed contract on an enabled network, **When** the build or app starts, **Then** it fails loudly (build) or degrades honestly by naming what is missing (runtime) — it never silently falls back to another tenant's value.
+
+---
+
+### User Story 2 - Tenant isolation holds on-chain and off (Priority: P1)
+
+Members and administrators of tenant A interact only with tenant A's estate. Tenant A's
+membership grants nothing in tenant B's app; tenant A's admin keys hold no role in tenant B's
+contracts; fees accrued from tenant A's members flow only to tenant A's treasury; and no
+frontend, gateway, or indexing surface shows tenant B's members, wagers, or balances inside
+tenant A's instance.
+
+**Why this priority**: Isolation is the trust promise being sold. A single cross-tenant fund
+path or authority path is a platform-ending defect, and it must be impossible by
+construction (separate contract instances), not merely unlikely by filtering.
+
+**Independent Test**: Deploy two tenants' contract sets on one test network. Verify a member
+with tenant A membership is unentitled in tenant B's app; verify tenant A's admin cannot call
+admin functions on tenant B's contracts; verify a fee-bearing action in tenant A credits only
+tenant A's treasury; verify tenant B's wagers are invisible in tenant A's app and indexes.
+
+**Acceptance Scenarios**:
+
+1. **Given** two tenants with dedicated contract sets on the same network, **When** a member of tenant A opens tenant B's app, **Then** they are treated as a non-member of B, offered B's purchase path, and their A-membership is neither recognized nor revealed.
+2. **Given** an account holding an admin role in tenant A's contracts, **When** it attempts the same admin action against tenant B's contracts, **Then** the contracts revert; no shared role or key grants authority across tenants.
+3. **Given** fee-bearing activity in tenant A, **When** fees settle, **Then** they accrue only in tenant A's fee router/treasury, and tenant B's treasury reads are unaffected.
+4. **Given** tenant A's app, gateway, and index, **When** queried by any means they expose, **Then** no wager, pool, member, balance, or event originating in tenant B's contracts is returned.
+5. **Given** a relayer/gateway instance serving a tenant, **When** it receives an intent addressed to a contract outside that tenant's recorded contract set, **Then** it refuses the intent.
+
+---
+
+### User Story 3 - Existing FairWins behavior is preserved as the default tenant (Priority: P1)
+
+Nothing changes for today's members. The FairWins app, domain, contracts, membership base,
+and treasury continue exactly as they are; internally they are now described by the default
+tenant's manifest rather than by scattered hardcoded values.
+
+**Why this priority**: The migration risk is regression of a live product. Making the default
+tenant the first consumer of the tenant abstraction proves the abstraction is real while
+guaranteeing the live product is untouched.
+
+**Independent Test**: Build the app with no tenant override and diff observable behavior
+against the pre-feature build: same name/branding, same contract addresses resolved, same
+features enabled, same fees disclosed. Existing test suites pass unmodified.
+
+**Acceptance Scenarios**:
+
+1. **Given** a build with no tenant specified, **When** it starts, **Then** it is the FairWins product: identical branding, contract addresses, feature set, and fee behavior to the pre-feature build.
+2. **Given** the existing frontend and contract test suites, **When** run after this feature lands, **Then** they pass without weakening.
+
+---
+
+### User Story 4 - A tenant administrator manages their own instance (Priority: P2)
+
+A tenant's own administrator — not the platform operator — signs in to their instance's admin
+surface and manages what is theirs: brand assets and theme, support/legal links, membership
+tier pricing, fee rates within platform-set caps, and feature toggles the operator has made
+available to them. They cannot touch another tenant, and they cannot exceed the guardrails
+(fee caps, mandatory compliance surfaces) the platform sets.
+
+**Why this priority**: Self-service is what makes tenants cheap to operate, but it is
+worthless before US1–US3 exist, and every control it exposes must respect the isolation and
+guardrails those stories establish.
+
+**Independent Test**: As tenant A's admin, change a fee rate within cap and a brand asset;
+confirm both take effect in tenant A only. Attempt to exceed the fee cap and confirm refusal.
+Confirm tenant A's admin surface offers no control naming tenant B.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tenant admin authorized in their tenant's contracts, **When** they adjust a fee rate at or below the platform cap, **Then** the change takes effect for their tenant and is disclosed to members before signature, per existing fee rules.
+2. **Given** a tenant admin, **When** they attempt to set a fee above the platform cap, **Then** the change is refused on-chain, not merely hidden in the UI.
+3. **Given** a tenant admin, **When** they update branding or settings, **Then** the change affects only their tenant's instance.
+
+---
+
+### User Story 5 - A tenant starts shared and graduates to dedicated deployments (Priority: P3)
+
+A small customer launches as a **branding-only tenant**: their own domain, identity, and
+settings in front of the platform's shared contract estate (shared membership, shared
+registry, platform treasury). Later, when their volume justifies it, the operator provisions
+dedicated contracts and the tenant's members are pointed at the new estate going forward,
+with the transition disclosed honestly (existing positions settle where they were opened;
+new activity opens on the dedicated estate).
+
+**Why this priority**: It lowers the cost of acquiring small tenants, but it is an economic
+optimization on top of the isolation model — never a substitute for it. A tenant on shared
+contracts has cosmetic isolation only, and the platform must say so plainly to the tenant.
+
+**Independent Test**: Configure a tenant whose manifest points at the shared contract set;
+confirm the branded app works end-to-end against shared contracts. Then repoint the manifest
+at a dedicated set and confirm new activity lands on the dedicated contracts while previously
+opened wagers remain claimable where they were escrowed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a branding-only tenant manifest, **When** its app runs, **Then** all value flows use the shared estate and the tenant's operator-facing documentation states that asset isolation is not in effect.
+2. **Given** a tenant graduating to dedicated contracts, **When** the manifest is repointed, **Then** new wagers/memberships use the dedicated estate and existing escrowed positions remain resolvable and claimable at their original addresses.
+
+---
+
+### Edge Cases
+
+- A domain reaches the platform that no tenant manifest claims: the request must not render
+  any tenant's instance (including the default) with another tenant's data; it lands on a
+  neutral "unknown instance" response.
+- A tenant's manifest enables a network on which its contract set has no recorded deployment:
+  the network is treated as not-deployed for that tenant (honest absence), never resolved via
+  another tenant's addresses.
+- Two tenants' manifests claim the same domain, or a manifest claims the platform's own
+  domain: provisioning validation refuses the manifest.
+- A tenant is suspended by the operator: its app states unavailability honestly; members'
+  on-chain positions remain claimable directly (a suspension must never trap value —
+  contracts do not know about suspension).
+- A member holds memberships in two tenants from one wallet: each instance sees only its own
+  membership; neither instance reveals the other's existence.
+- Tenant branding assets fail to load: the instance degrades to neutral placeholders, never
+  to another tenant's or the platform's brand.
+- The tenant registry/manifest store is unreachable at runtime: already-built tenant apps
+  (which carry their manifest) keep working; anything requiring a live manifest read degrades
+  honestly.
+- A backup/sync object created in one tenant's instance is restored in another tenant's
+  instance: tenant-scoped data does not cross; the restore surfaces what was skipped and why.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The platform MUST define a **tenant manifest** as the single source of truth for
+  a tenant's identity (name, brand assets, theme tokens, domains, legal/support links),
+  settings (features, networks, fee services, membership tiers), and **contract set**
+  (per-network addresses for every platform contract the tenant uses). No shipped code path
+  may hardcode a tenant identity value that the manifest defines.
+- **FR-002**: The system MUST resolve every member-visible identity surface (app name, logos,
+  favicon, theme colors, page titles, PWA manifest, share/QR text, notification copy,
+  document/report headers and footers, email/legal links) from the active tenant manifest.
+- **FR-003**: The system MUST resolve all contract addresses for the active tenant from the
+  tenant's contract set, layered on the existing per-network deployment records; a contract
+  absent from the tenant's set on a network MUST read as not-deployed for that tenant there.
+- **FR-004**: Dedicated-tenant provisioning MUST reuse the existing deterministic deployment
+  scripts to produce a complete, recorded, per-tenant contract set (registry, membership,
+  fee router, and the optional modules the tenant enables), with per-tenant admin/guardian
+  keys and per-tenant treasury addresses.
+- **FR-005**: Isolation of value-bearing state between dedicated tenants MUST be enforced by
+  distinct contract instances. No frontend, gateway, or indexer check may be the only barrier
+  between one tenant's assets/authority and another's.
+- **FR-006**: The default (FairWins) tenant manifest MUST reproduce current behavior exactly;
+  a build with no tenant selected uses the default manifest.
+- **FR-007**: Tenant selection MUST be determined at build/serve time per instance (one
+  origin, one tenant); a served instance MUST NOT switch tenants based on client-side input.
+- **FR-008**: Manifest validation MUST fail provisioning/build loudly on: missing required
+  identity fields, unclaimed or conflicting domains, fee rates above platform caps, enabled
+  features whose required contracts are absent from the contract set on every enabled network.
+- **FR-009**: The gateway/relayer layer MUST be tenant-scoped: an instance serving a tenant
+  MUST accept intents/sponsorship requests only for addresses in that tenant's contract set,
+  and per-tenant quotas/killswitches MUST be independent.
+- **FR-010**: Indexing MUST be tenant-scoped: a tenant's instance queries an index (or index
+  scope) covering only its own contract set.
+- **FR-011**: Tenant administrators MUST be able to change tenant-scoped settings only within
+  platform guardrails, with value-affecting guardrails (fee caps) enforced on-chain in the
+  tenant's own contracts.
+- **FR-012**: Platform-operator tooling MUST support the tenant lifecycle: create (validate
+  manifest), provision (deploy/record contract set), bind domain, suspend/resume, and
+  graduate a branding-only tenant to dedicated contracts — each step auditable.
+- **FR-013**: Suspension or decommissioning of a tenant MUST NOT trap member value: on-chain
+  positions remain resolvable/claimable via direct contract interaction, and the platform
+  MUST document that path.
+- **FR-014**: Member-scoped stored data (preferences, backups, address books, activity
+  ledger) MUST be scoped so data created under one tenant is not read into another tenant's
+  instance.
+- **FR-015**: Branding-only (shared-estate) tenants MUST be supported as an explicit manifest
+  mode, with operator-facing disclosure that asset isolation is not in effect; graduation to
+  dedicated contracts MUST preserve claimability of positions opened on the shared estate.
+
+### Key Entities
+
+- **Tenant**: A customer organization operating an instance. Identity + settings + contract
+  set + lifecycle state (draft, live, suspended, retired). Exactly one manifest per tenant.
+- **Tenant Manifest**: The validated document describing a tenant. Versioned; the record of
+  what the tenant's instance is built and served from.
+- **Contract Set**: A per-tenant, per-network mapping of platform contract names to deployed
+  addresses, layered over the existing deployment-record format. May be `shared` (points at
+  the platform estate) or `dedicated` (tenant-owned proxies with tenant-held admin keys).
+- **Instance**: A served origin (domain) bound to exactly one tenant manifest and one
+  environment cohort (mainnet or testnet), running the frontend and any tenant-scoped
+  gateway/index services.
+- **Default Tenant**: The manifest reproducing today's FairWins product; the fallback for
+  builds with no tenant configured and the reference for regression testing.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A new branding-only tenant can be brought live by authoring a manifest and
+  serving a build — zero application-code changes — and a new dedicated tenant additionally
+  requires only running the existing deployment tooling.
+- **SC-002**: In a two-tenant test deployment, automated isolation tests show zero
+  cross-tenant results across all probed surfaces: membership recognition, admin authority,
+  fee accrual, wager visibility, and gateway intent acceptance.
+- **SC-003**: The default-tenant build is behaviorally identical to the pre-feature build:
+  existing frontend and contract test suites pass unmodified, and resolved contract addresses
+  are unchanged on every supported network.
+- **SC-004**: An audit of a built tenant instance finds no platform-brand string, asset, or
+  domain in member-visible surfaces beyond what the tenant's manifest opts into.
+- **SC-005**: Every tenant lifecycle action (create, provision, bind, suspend, graduate) is
+  recorded in an auditable artifact identifying who, what tenant, and when.
+
+## Assumptions
+
+- The platform operator (FairWins) remains the deployer/operator of record for tenant
+  provisioning; tenants do not self-deploy contracts in v1. Tenant admin keys may be handed
+  to the tenant after provisioning per the existing key-management workflow.
+- One served origin maps to exactly one tenant (per-instance builds/config), rather than one
+  origin dynamically serving many tenants; this matches the strong-isolation requirement and
+  the existing static-hosting model. Multi-tenant-per-origin serving is out of scope for v1.
+- Per-tenant subgraph/indexing scope may initially be delivered by address-filtering at the
+  query layer for shared-estate tenants and by dedicated index deployments for dedicated
+  tenants; a shared cross-tenant index is acceptable only where the query layer cannot leak
+  another tenant's data into an instance.
+- Contract *code* is shared (same audited implementations); isolation comes from separate
+  proxy instances and storage, not from per-tenant forks. Tenants do not get custom contract
+  logic in v1.
+- Existing constitution rules (security-first contracts, honest state, deterministic
+  deployments, no secrets in repo) apply unchanged to every tenant instance.
+- Billing/settlement between the platform and tenants (revenue share on tenant fees) is
+  out of scope for v1 beyond what per-tenant fee routers already make accountable.

--- a/specs/072-white-label-tenants/tasks.md
+++ b/specs/072-white-label-tenants/tasks.md
@@ -1,0 +1,140 @@
+# Tasks: White-label multi-tenant platform
+
+**Input**: Design documents from `/specs/072-white-label-tenants/`
+
+**Prerequisites**: plan.md, spec.md, research.md (D1–D11), data-model.md
+
+**Organization**: Grouped by user story. Note the deliberate ordering: US3 (default
+tenant preserved) is implemented FIRST because the tenant abstraction is only real once
+the existing product runs through it unchanged.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup
+
+- [ ] T001 Create `tenants/` root: `tenants/README.md` (authoring guide, lifecycle,
+      no-secrets rule) and `tenants/manifest.schema.json` per data-model.md
+- [ ] T002 [P] Add npm scripts: `tenants:validate` → `scripts/tenants/validate-tenant-manifest.js`
+
+## Phase 2: Foundational (blocking)
+
+- [ ] T003 Write `scripts/tenants/validate-tenant-manifest.js`: JSON-Schema check +
+      cross-manifest domain uniqueness + fee-cap check + theme-token completeness +
+      dedicated-mode deployment-record presence (FR-008); non-zero exit on any failure
+- [ ] T004 Author `tenants/fairwins/manifest.json` capturing today's identity, brand,
+      theme tokens (from `frontend/src/theme.css` `.platform-fairwins` blocks), features,
+      chains, `contractSet.mode: "shared"` (the shared estate IS the default set)
+- [ ] T005 Implement `frontend/src/config/tenant.js`: build-time resolution of
+      `VITE_TENANT_ID` (default `fairwins`), frozen manifest export, accessors
+      (`getActiveTenant`, `tenantBrand`, `isFeatureEnabled`, `tenantChainIds`,
+      `tenantContractsForChain`, `tenantThemeClass`); unknown id throws at init
+- [ ] T006 Vitest: `frontend/src/test/tenantConfig.test.js` — default tenant resolves
+      today's exact values; unknown tenant fails loudly; feature gating shape
+- [ ] T007 Wire CI: run `tenants:validate` in the existing lint/build workflow (fail
+      loudly, no continue-on-error)
+
+**Checkpoint**: manifest + loader exist; nothing user-visible changed yet
+
+## Phase 3: US3 — Default tenant preserved (P1) 🎯 first, on purpose
+
+- [ ] T008 [US3] Vite plugin in `frontend/vite.config.js`: template `frontend/index.html`
+      title/meta/theme-color/apple-title/favicon + emit `manifest.webmanifest` from the
+      active tenant manifest; default-tenant output must be byte-equivalent to current files
+- [ ] T009 [US3] `frontend/src/theme/tenantTheme.js`: inject `.platform-<id>` CSS custom
+      properties from manifest for NON-default tenants only (default keeps static
+      `theme.css`); keep `frontend/src/utils/validateTheme.js` assertions passing
+- [ ] T010 [US3] `frontend/src/contexts/ThemeContext.jsx`: apply
+      `platform-<activeTenantId>` (from `tenantThemeClass()`) instead of hardcoded
+      `platform-fairwins`; update `frontend/index.html` pre-hydration default via T008
+- [ ] T011 [P] [US3] Vitest: default-build equivalence — resolved addresses unchanged per
+      network, `platform-fairwins` applied, generated index/manifest values match current
+- [ ] T012 [US3] Run full frontend + contract suites in CI unmodified (SC-003 gate)
+
+**Checkpoint**: app is manifest-driven with zero behavior change — MVP of the abstraction
+
+## Phase 4: US1 — Operator launches a branded tenant (P1)
+
+- [ ] T013 [US1] Deploy lib tenant dimension in `scripts/deploy/lib/helpers.js`:
+      `TENANT_ID` env → salt prefix in `generateSalt`, `getDeploymentFilename`/
+      `saveDeployment`/`loadDeployment` under `deployments/tenants/<id>/`; no tenant ⇒
+      byte-identical behavior (D5)
+- [ ] T014 [US1] Thread tenant context through `scripts/deploy/deploy.js` +
+      supplementary deployers (fee router, pool factory, callsigns, …): treasury/tiers/
+      payment token from the tenant manifest when `TENANT_ID` set
+- [ ] T015 [US1] `scripts/utils/sync-frontend-contracts.js --tenant <id>`: generate
+      `frontend/src/config/tenants/<id>.contracts.js` from the tenant's records
+- [ ] T016 [US1] Dedicated-mode resolution in `frontend/src/config/tenant.js` +
+      `frontend/src/config/contracts.js`: dedicated tenant resolves ONLY its generated
+      set; absence stays absence; shared mode unchanged (D6)
+- [ ] T017 [P] [US1] Brand-surface sweep #1 (high leverage): `frontend/src/wagmi.js`
+      `resolveAppUrl` + WalletConnect metadata; `frontend/src/components/Footer.jsx`;
+      `frontend/src/components/compliance/EntryGate.jsx`;
+      `frontend/src/components/ui/ShareModal.jsx` + `AddressQRModal.jsx`;
+      `frontend/src/utils/metadataGenerator.js` external URLs → `tenantBrand()`
+- [ ] T018 [P] [US1] Brand-surface sweep #2: remaining member-visible strings/assets
+      (landing page, legal links via `frontend/src/constants/legalLinks.js`, notification
+      copy, report/document footers); add a lint/grep gate for the platform brand string
+      in shipped paths (SC-004)
+- [ ] T019 [US1] Feature gating: drive `frontend/src/config/appNav.js` visibility +
+      route registration from `isFeatureEnabled` so disabled features are absent, not
+      broken
+- [ ] T020 [US1] Instance pipeline: parameterize root `Dockerfile` build args with
+      `VITE_TENANT_ID` + tenant URLs; document (and template) per-tenant
+      `cloudbuild.yaml` substitutions; per-tenant CSP hosts through
+      `frontend/nginx.conf.template` keeping `frontend/src/test/nginxCsp*.test.js` green
+- [ ] T021 [US1] Vitest: second-tenant fixture build resolves only its identity + its
+      contract set (Acceptance US1.1–US1.4)
+
+**Checkpoint**: a second tenant can be authored, deployed, built, and served
+
+## Phase 5: US2 — Isolation proven (P1)
+
+- [ ] T022 [US2] Hardhat two-tenant isolation suite
+      `test/integration/tenant-isolation.test.js`: deploy two salted estates on one
+      network; assert cross-tenant membership unrecognized, cross-tenant admin reverts,
+      fee accrual lands only in acting tenant's router/treasury (Acceptance US2.1–US2.3)
+- [ ] T023 [P] [US2] Gateway tenant scoping: `TENANT_ID` env in
+      `services/relay-gateway` config → allowlist loads
+      `deployments/tenants/<id>/…`; unit test: intent for the other tenant's registry is
+      refused (US2.5); README/env.example updates
+- [ ] T024 [P] [US2] Indexing scope: per-tenant subgraph parameterization docs +
+      manifest `settings.subgraph.urls` consumption; shared-tenant path unchanged (US2.4)
+- [ ] T025 [US2] Member-storage tenancy (FR-014): tenant id recorded on
+      backup/sync objects (`frontend/src/lib/backup/syncedObjects.js` rail); restore into
+      a different tenant skips tenant-scoped objects and says so
+
+**Checkpoint**: SC-002 probes all green
+
+## Phase 6: US4 — Tenant admin self-service (P2)
+
+- [ ] T026 [US4] Tenant admin surfaces read authority from the TENANT's contracts
+      (existing role model — `FEE_ADMIN_ROLE` on tenant FeeRouter, admin roles on tenant
+      manager); fee edits stay cap-bound on-chain (US4.1–US4.2)
+- [ ] T027 [P] [US4] Manifest-editable settings flow for tenant admins (brand assets,
+      links, toggles the operator exposes) + validation on submit; changes affect only
+      their tenant (US4.3)
+
+## Phase 7: US5 — Shared → dedicated graduation (P3)
+
+- [ ] T028 [US5] Graduation procedure: manifest `mode` repoint; new activity on dedicated
+      estate; positions opened on the shared estate remain claimable at original
+      addresses (test: open wager pre-switch, claim post-switch) (US5.2)
+- [ ] T029 [P] [US5] Shared-mode disclosure copy (operator-facing) that asset isolation
+      is not in effect (US5.1 / FR-015)
+
+## Phase 8: Polish & cross-cutting
+
+- [ ] T030 [P] `docs/developer-guide/white-label-tenants.md` +
+      `docs/runbooks/tenant-operations.md` (lifecycle, suspension never traps value,
+      direct-claim path per FR-013)
+- [ ] T031 [P] CLAUDE.md guardrail entry for spec 072 (tenant manifest is the single
+      source of truth; no hardcoded brand in shipped paths; dedicated never falls back)
+- [ ] T032 Unknown-domain behavior at the edge documented in `infra/cloudflare/`
+      (unbound domains never reach a tenant instance)
+
+## Dependencies & execution order
+
+- Setup (T001–T002) → Foundational (T003–T007) blocks everything
+- US3 (T008–T012) before US1 — the abstraction must first reproduce the product
+- US1 on-chain half (T013–T016) blocks US2 (T022) and US5 (T028)
+- US2/US4/US5 can proceed in parallel after their blockers; Polish last

--- a/tenants/README.md
+++ b/tenants/README.md
@@ -1,0 +1,40 @@
+# Tenant manifests (spec 072)
+
+One directory per tenant; `tenants/<tenant-id>/manifest.json` is the **single source of
+truth** for that tenant's identity, settings, and contract set. The default tenant is
+`fairwins` — its manifest reproduces the FairWins product exactly, and a build with no
+`VITE_TENANT_ID` set uses it.
+
+- Schema: [`manifest.schema.json`](./manifest.schema.json) (structure) +
+  `scripts/tenants/validate-tenant-manifest.js` (cross-manifest rules). Run
+  `npm run tenants:validate` — CI gates on it.
+- Feature catalog: [`features.json`](./features.json). A manifest may only enable listed
+  features; an absent feature is absent from the tenant's nav/routes.
+- Consumers: `frontend/src/config/tenant.js` (build-time, via `VITE_TENANT_ID`),
+  deploy scripts (`TENANT_ID` env → tenant-salted CREATE2 + records under
+  `deployments/tenants/<id>/`), gateway/subgraph provisioning, docs.
+
+## Rules
+
+1. **No secrets, ever.** Manifests are public config baked into client bundles.
+2. **`id` is immutable once deployed** — CREATE2 salts derive from it; changing it after
+   any deployment record exists would orphan the tenant's addresses. The validator
+   enforces `id` == directory name.
+3. **Domains are globally unique** across all manifests; the validator refuses collisions.
+4. **`contractSet.mode`**:
+   - `shared` — the tenant fronts the platform estate (`deployments/<network>-chain<id>-v2.json`).
+     Cosmetic isolation only; operator-facing docs must disclose that asset isolation is
+     not in effect (spec 072 FR-015).
+   - `dedicated` — the tenant's own proxy instances, recorded at
+     `deployments/tenants/<id>/<network>-chain<chainId>-v2.json` (same schema as the
+     shared records). A dedicated tenant never falls back to shared addresses: absence is
+     absence.
+5. **Lifecycle** (`draft → live ⇄ suspended → retired`) changes are ordinary PRs — git
+   history is the audit trail. Suspension never traps value: contracts don't know about
+   suspension, and members keep the documented direct-claim path.
+6. **Fees** are bps per spec-060 service id and must respect platform caps
+   (`polymarket.taker` ≤ 100, `polymarket.maker` ≤ 50, others ≤ 250). On dedicated
+   estates the same caps are enforced on-chain by the tenant's FeeRouter.
+
+See `specs/072-white-label-tenants/` (spec, plan, research, data-model, quickstart) and
+`docs/developer-guide/white-label-tenants.md`.

--- a/tenants/example/manifest.json
+++ b/tenants/example/manifest.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": 1,
+  "id": "example",
+  "lifecycle": "draft",
+
+  "identity": {
+    "displayName": "Example Wagers",
+    "legalName": "Example Wagers LLC",
+    "tagline": "A reference tenant manifest",
+    "metaDescription": "Example Wagers - reference tenant manifest for the white-label platform (spec 072). Never served to members.",
+    "domains": ["example.invalid"],
+    "appUrl": "https://example.invalid",
+    "support": { "email": "support@example.invalid" },
+    "social": {},
+    "legal": { "termsPath": "/terms", "privacyPath": "/privacy", "riskPath": "/risk" }
+  },
+
+  "brand": {
+    "logo": "/assets/logo_fairwins.svg",
+    "logoMark": "/assets/fairwins_no-text_logo.svg",
+    "favicon": "/assets/logo_fairwins.svg",
+    "appleTouchIcon": "/assets/fairwins_no-text_logo.svg",
+    "htmlTitle": "Example Wagers - Social Wagers",
+    "pwa": {
+      "name": "Example Wagers",
+      "shortName": "Example",
+      "appleTitle": "Example",
+      "themeColor": "#5B6EE1",
+      "backgroundColor": "#101623"
+    },
+    "theme": {
+      "base": {
+        "--brand-primary": "#5B6EE1",
+        "--brand-primary-rgb": "91, 110, 225",
+        "--brand-secondary": "#E1A85B",
+        "--brand-secondary-rgb": "225, 168, 91",
+        "--brand-accent": "#9BB0FF",
+        "--brand-accent-rgb": "155, 176, 255",
+        "--semantic-win": "#2ECC71",
+        "--semantic-active": "#5B6EE1",
+        "--semantic-warning": "#F5A623",
+        "--semantic-loss": "#E5533D",
+        "--chart-series-a": "#5B6EE1",
+        "--chart-series-b": "#E1A85B",
+        "--chart-series-c": "#9BB0FF",
+        "--chart-series-d": "#F5A623",
+        "--chart-series-e": "#9AA6B2"
+      },
+      "light": {
+        "--primary-button": "#5B6EE1",
+        "--primary-button-hover": "#4A5BC7",
+        "--primary-button-text": "#FFFFFF",
+        "--accent-color": "#E1A85B",
+        "--highlight-color": "#9BB0FF"
+      },
+      "dark": {
+        "--primary-button": "#7385F0",
+        "--primary-button-hover": "#8A9AF5",
+        "--primary-button-text": "#101623",
+        "--accent-color": "#E1A85B",
+        "--highlight-color": "#9BB0FF"
+      }
+    }
+  },
+
+  "settings": {
+    "features": ["wagers", "pools", "predict"],
+    "chains": {
+      "mainnet": [137],
+      "testnet": [80002]
+    },
+    "membership": {
+      "tiers": { "bronze": 2, "silver": 8, "gold": 25, "platinum": 100 }
+    },
+    "fees": {},
+    "gateway": { "relayerUrl": null, "bundlerUrls": {}, "paymaster": {} },
+    "subgraph": { "urls": {} }
+  },
+
+  "contractSet": {
+    "mode": "shared",
+    "saltPrefix": null
+  }
+}

--- a/tenants/fairwins/manifest.json
+++ b/tenants/fairwins/manifest.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": 1,
+  "id": "fairwins",
+  "lifecycle": "live",
+
+  "identity": {
+    "displayName": "FairWins",
+    "legalName": "FairWins",
+    "tagline": "Prediction Markets for Friends",
+    "metaDescription": "FairWins - Open prediction markets where anyone can create, join, and resolve markets. Fair participation, transparent resolution, and privacy-preserving mechanisms for collective wisdom.",
+    "domains": ["fairwins.app"],
+    "appUrl": "https://fairwins.app",
+    "support": { "email": "Howdy@FairWins.App" },
+    "social": { "x": "https://x.com/fairwins_app" },
+    "legal": { "termsPath": "/terms", "privacyPath": "/privacy", "riskPath": "/risk" }
+  },
+
+  "brand": {
+    "logo": "/assets/logo_fairwins.svg",
+    "logoMark": "/assets/fairwins_no-text_logo.svg",
+    "favicon": "/assets/logo_fairwins.svg",
+    "appleTouchIcon": "/assets/fairwins_no-text_logo.svg",
+    "htmlTitle": "FairWins - Prediction Markets for Friends",
+    "pwa": {
+      "name": "🍀FairWins",
+      "shortName": "FairWins",
+      "appleTitle": "🍀FairWins",
+      "themeColor": "#36B37E",
+      "backgroundColor": "#0E141B"
+    },
+    "theme": {
+      "base": {
+        "--brand-primary": "#36B37E",
+        "--brand-primary-rgb": "54, 179, 126",
+        "--brand-secondary": "#4C9AFF",
+        "--brand-secondary-rgb": "76, 154, 255",
+        "--brand-accent": "#7BDCB5",
+        "--brand-accent-rgb": "123, 220, 181",
+        "--semantic-win": "#2ECC71",
+        "--semantic-active": "#4C9AFF",
+        "--semantic-warning": "#F5A623",
+        "--semantic-loss": "#E5533D",
+        "--chart-series-a": "#36B37E",
+        "--chart-series-b": "#4C9AFF",
+        "--chart-series-c": "#7BDCB5",
+        "--chart-series-d": "#F5A623",
+        "--chart-series-e": "#9AA6B2"
+      },
+      "light": {
+        "--primary-button": "#36B37E",
+        "--primary-button-hover": "#2F9E6E",
+        "--primary-button-text": "#FFFFFF",
+        "--accent-color": "#4C9AFF",
+        "--highlight-color": "#7BDCB5"
+      },
+      "dark": {
+        "--primary-button": "#45C492",
+        "--primary-button-hover": "#5ED6A6",
+        "--primary-button-text": "#0E141B",
+        "--accent-color": "#4C9AFF",
+        "--highlight-color": "#7BDCB5"
+      }
+    }
+  },
+
+  "settings": {
+    "features": [
+      "wagers",
+      "pools",
+      "predict",
+      "collect",
+      "earn",
+      "staking",
+      "swap",
+      "bridge",
+      "protect",
+      "callsigns",
+      "clearpath",
+      "token-mint",
+      "bitcoin",
+      "recovery"
+    ],
+    "chains": {
+      "mainnet": [137, 1, 10, 8453, 42161, 61],
+      "testnet": [80002, 63]
+    },
+    "membership": {
+      "tiers": { "bronze": 2, "silver": 8, "gold": 25, "platinum": 100 }
+    },
+    "fees": {
+      "polymarket.taker": 50,
+      "polymarket.maker": 0
+    },
+    "gateway": {
+      "relayerUrl": "https://relay.fairwins.app",
+      "bundlerUrls": {},
+      "paymaster": {}
+    },
+    "subgraph": { "urls": {} }
+  },
+
+  "contractSet": {
+    "mode": "shared",
+    "saltPrefix": null
+  }
+}

--- a/tenants/features.json
+++ b/tenants/features.json
@@ -1,0 +1,19 @@
+{
+  "description": "Catalog of feature ids a tenant manifest may enable. Consumed by scripts/tenants/validate-tenant-manifest.js and frontend/src/config/tenant.js. Adding a feature here requires the corresponding surface to honor isFeatureEnabled().",
+  "features": [
+    "wagers",
+    "pools",
+    "predict",
+    "collect",
+    "earn",
+    "staking",
+    "swap",
+    "bridge",
+    "protect",
+    "callsigns",
+    "clearpath",
+    "token-mint",
+    "bitcoin",
+    "recovery"
+  ]
+}

--- a/tenants/manifest.schema.json
+++ b/tenants/manifest.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://fairwins.app/schemas/tenant-manifest.schema.json",
+  "title": "Tenant Manifest",
+  "description": "Single source of truth for one white-label tenant (spec 072). Enforced by scripts/tenants/validate-tenant-manifest.js — which also applies cross-manifest rules (domain uniqueness, fee caps, dedicated-mode deployment-record presence) that JSON Schema cannot express. Never put secrets in a manifest.",
+  "type": "object",
+  "required": ["schemaVersion", "id", "lifecycle", "identity", "brand", "settings", "contractSet"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{1,30}$",
+      "description": "Immutable once any deployment record exists — CREATE2 salts derive from it. Must equal the manifest's directory name."
+    },
+    "lifecycle": { "enum": ["draft", "live", "suspended", "retired"] },
+    "identity": {
+      "type": "object",
+      "required": ["displayName", "domains", "appUrl"],
+      "additionalProperties": false,
+      "properties": {
+        "displayName": { "type": "string", "minLength": 1 },
+        "legalName": { "type": "string" },
+        "tagline": { "type": "string" },
+        "metaDescription": { "type": "string" },
+        "domains": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "pattern": "^[a-z0-9.-]+$" },
+          "description": "Globally unique across all manifests (validator-enforced)."
+        },
+        "appUrl": { "type": "string", "pattern": "^https://" },
+        "support": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": { "email": { "type": "string" }, "url": { "type": "string" } }
+        },
+        "social": { "type": "object", "additionalProperties": { "type": "string" } },
+        "legal": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "termsPath": { "type": "string" },
+            "privacyPath": { "type": "string" },
+            "riskPath": { "type": "string" }
+          }
+        }
+      }
+    },
+    "brand": {
+      "type": "object",
+      "required": ["logo", "logoMark", "favicon", "pwa", "theme"],
+      "additionalProperties": false,
+      "properties": {
+        "logo": { "type": "string" },
+        "logoMark": { "type": "string" },
+        "favicon": { "type": "string" },
+        "appleTouchIcon": { "type": "string" },
+        "pwa": {
+          "type": "object",
+          "required": ["name", "shortName", "themeColor", "backgroundColor"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "shortName": { "type": "string" },
+            "appleTitle": { "type": "string" },
+            "themeColor": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+            "backgroundColor": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" }
+          }
+        },
+        "htmlTitle": { "type": "string" },
+        "theme": {
+          "type": "object",
+          "required": ["base", "light", "dark"],
+          "additionalProperties": false,
+          "description": "CSS custom properties materialized under .platform-<id> (base), .theme-light.platform-<id> (light), .theme-dark.platform-<id> (dark). base MUST define --brand-primary and --brand-secondary; light and dark MUST each define --primary-button and --primary-button-hover (the tokens frontend/src/utils/validateTheme.js asserts).",
+          "properties": {
+            "base": { "$ref": "#/definitions/cssVars" },
+            "light": { "$ref": "#/definitions/cssVars" },
+            "dark": { "$ref": "#/definitions/cssVars" }
+          }
+        }
+      }
+    },
+    "settings": {
+      "type": "object",
+      "required": ["features", "chains"],
+      "additionalProperties": false,
+      "properties": {
+        "features": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Subset of tenants/features.json. An absent feature is absent from nav/routes — not present-but-broken."
+        },
+        "chains": {
+          "type": "object",
+          "required": ["mainnet", "testnet"],
+          "additionalProperties": false,
+          "properties": {
+            "mainnet": { "type": "array", "items": { "type": "integer" } },
+            "testnet": { "type": "array", "items": { "type": "integer" } }
+          },
+          "description": "Cohorts never mix (constitution III); validator refuses a chain listed in the wrong cohort."
+        },
+        "membership": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "tiers": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "bronze": { "type": "number", "minimum": 0 },
+                "silver": { "type": "number", "minimum": 0 },
+                "gold": { "type": "number", "minimum": 0 },
+                "platinum": { "type": "number", "minimum": 0 }
+              },
+              "description": "USD tier prices seeded into the tenant's MembershipManager at provisioning."
+            }
+          }
+        },
+        "fees": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 },
+          "description": "bps per spec-060 serviceId. Validator enforces platform caps (polymarket.taker <= 100, polymarket.maker <= 50, all others <= 250)."
+        },
+        "gateway": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "relayerUrl": { "type": ["string", "null"] },
+            "bundlerUrls": { "type": "object", "additionalProperties": { "type": "string" } },
+            "paymaster": { "type": "object" }
+          }
+        },
+        "subgraph": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "urls": { "type": "object", "additionalProperties": { "type": "string" } }
+          }
+        }
+      }
+    },
+    "contractSet": {
+      "type": "object",
+      "required": ["mode"],
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "enum": ["shared", "dedicated"],
+          "description": "shared: the platform estate (cosmetic isolation only — disclose per FR-015). dedicated: tenant-owned proxies recorded under deployments/tenants/<id>/."
+        },
+        "saltPrefix": {
+          "type": ["string", "null"],
+          "description": "Dedicated only. Defaults to id. NEVER change after the first deployment — addresses derive from it."
+        },
+        "pendingChains": {
+          "type": "array",
+          "items": { "type": "integer" },
+          "description": "Dedicated + live: chains enabled in settings.chains whose deployment records intentionally do not exist yet (honest absence)."
+        }
+      }
+    }
+  },
+  "definitions": {
+    "cssVars": {
+      "type": "object",
+      "propertyNames": { "pattern": "^--[a-z][a-z0-9-]*$" },
+      "additionalProperties": { "type": "string" }
+    }
+  }
+}

--- a/test/integration/tenant-isolation.test.js
+++ b/test/integration/tenant-isolation.test.js
@@ -1,0 +1,113 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const { deployMembershipManager } = require("../helpers/proxy");
+
+/**
+ * Two-tenant isolation suite (spec 072, US2 / SC-002, T022).
+ *
+ * Dedicated tenants are isolated by SEPARATE contract instances (research D8):
+ * two MembershipManager proxies on one chain model tenant A's and tenant B's
+ * estates. These probes codify the isolation promise at the contract layer —
+ * cross-tenant membership recognition, admin authority, and fee accrual must
+ * all be impossible by construction, not merely filtered off-chain.
+ */
+
+const Tier = { None: 0, Bronze: 1, Silver: 2, Gold: 3, Platinum: 4 };
+const WAGER_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes("WAGER_PARTICIPANT_ROLE"));
+const ROLE_MANAGER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("ROLE_MANAGER_ROLE"));
+const DEFAULT_ADMIN_ROLE = ethers.ZeroHash;
+
+const usdc = (n) => ethers.parseUnits(String(n), 6);
+
+describe("Tenant isolation (spec 072)", function () {
+  async function twoTenantFixture() {
+    const [adminA, adminB, member, treasuryA, treasuryB] = await ethers.getSigners();
+
+    // One payment token on the chain — tenants may well share USDC; isolation
+    // must come from the contract instances, not from the token.
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const token = await MockERC20.deploy("USD Coin", "USDC", 0);
+    await token.waitForDeployment();
+
+    const tenantA = await deployMembershipManager([adminA.address, await token.getAddress(), treasuryA.address]);
+    const tenantB = await deployMembershipManager([adminB.address, await token.getAddress(), treasuryB.address]);
+
+    const limits = { monthlyMarketCreation: 15, maxConcurrentMarkets: 5 };
+    await tenantA.connect(adminA).setTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze, usdc(50), 30, limits, true);
+    await tenantB.connect(adminB).setTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze, usdc(80), 30, limits, true);
+
+    await token.mint(member.address, usdc(10_000));
+    await token.connect(member).approve(await tenantA.getAddress(), ethers.MaxUint256);
+    await token.connect(member).approve(await tenantB.getAddress(), ethers.MaxUint256);
+
+    return { token, tenantA, tenantB, adminA, adminB, member, treasuryA, treasuryB };
+  }
+
+  it("separate proxies have distinct addresses and independent config", async () => {
+    const { tenantA, tenantB } = await loadFixture(twoTenantFixture);
+    expect(await tenantA.getAddress()).to.not.equal(await tenantB.getAddress());
+
+    const cfgA = await tenantA.getTierConfig(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+    const cfgB = await tenantB.getTierConfig(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+    expect(cfgA.priceUSDC).to.equal(usdc(50));
+    expect(cfgB.priceUSDC).to.equal(usdc(80));
+  });
+
+  it("US2.1: a membership purchased in tenant A grants nothing in tenant B", async () => {
+    const { tenantA, tenantB, member } = await loadFixture(twoTenantFixture);
+
+    await tenantA.connect(member).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+
+    expect(await tenantA.hasActiveRole(member.address, WAGER_PARTICIPANT_ROLE)).to.be.true;
+    expect(await tenantB.hasActiveRole(member.address, WAGER_PARTICIPANT_ROLE)).to.be.false;
+    expect(await tenantB.getActiveTier(member.address, WAGER_PARTICIPANT_ROLE)).to.equal(Tier.None);
+  });
+
+  it("US2.2: tenant A's admin holds no authority in tenant B's contracts", async () => {
+    const { tenantA, tenantB, adminA, adminB } = await loadFixture(twoTenantFixture);
+
+    expect(await tenantB.hasRole(DEFAULT_ADMIN_ROLE, adminA.address)).to.be.false;
+    expect(await tenantA.hasRole(DEFAULT_ADMIN_ROLE, adminB.address)).to.be.false;
+
+    const limits = { monthlyMarketCreation: 1, maxConcurrentMarkets: 1 };
+    await expect(
+      tenantB.connect(adminA).setTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze, usdc(1), 30, limits, true)
+    ).to.be.reverted;
+    await expect(tenantB.connect(adminA).setTreasury(adminA.address)).to.be.reverted;
+    await expect(tenantB.connect(adminA).withdrawFees(1, adminA.address)).to.be.reverted;
+    await expect(
+      tenantB.connect(adminA).grantRole(ROLE_MANAGER_ROLE, adminA.address)
+    ).to.be.reverted;
+  });
+
+  it("US2.3: fees accrue only in the acting tenant's contract and treasury", async () => {
+    const { token, tenantA, tenantB, adminA, member, treasuryA, treasuryB } =
+      await loadFixture(twoTenantFixture);
+
+    await tenantA.connect(member).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+
+    expect(await tenantA.accruedFees()).to.equal(usdc(50));
+    expect(await tenantB.accruedFees()).to.equal(0);
+
+    await tenantA.connect(adminA).withdrawFees(usdc(50), treasuryA.address);
+    expect(await token.balanceOf(treasuryA.address)).to.equal(usdc(50));
+    expect(await token.balanceOf(treasuryB.address)).to.equal(0);
+    expect(await tenantB.accruedFees()).to.equal(0);
+  });
+
+  it("a member can hold independent memberships in both tenants (edge case)", async () => {
+    const { tenantA, tenantB, member } = await loadFixture(twoTenantFixture);
+
+    await tenantA.connect(member).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+    await tenantB.connect(member).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+
+    // Each instance sees only its own membership state.
+    const inA = await tenantA.getMembership(member.address, WAGER_PARTICIPANT_ROLE);
+    const inB = await tenantB.getMembership(member.address, WAGER_PARTICIPANT_ROLE);
+    expect(inA.tier).to.equal(Tier.Bronze);
+    expect(inB.tier).to.equal(Tier.Bronze);
+    expect(await tenantA.accruedFees()).to.equal(usdc(50));
+    expect(await tenantB.accruedFees()).to.equal(usdc(80));
+  });
+});

--- a/test/tenants/tenantDeployHelpers.test.js
+++ b/test/tenants/tenantDeployHelpers.test.js
@@ -1,0 +1,50 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { generateSalt, activeTenantId } = require("../../scripts/deploy/lib/helpers");
+
+/**
+ * Tenant dimension of the deploy helpers (spec 072, research D5 / T013).
+ *
+ * TENANT_ID scopes CREATE2 salts (and deployment record paths) so a tenant
+ * gets a deterministic, distinct address set. With no tenant in scope —
+ * including TENANT_ID=fairwins, the default tenant — behavior is byte-identical
+ * to before the tenant dimension existed.
+ */
+describe("tenant deploy helpers (spec 072)", function () {
+  const ORIGINAL = process.env.TENANT_ID;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.TENANT_ID;
+    else process.env.TENANT_ID = ORIGINAL;
+  });
+
+  it("no TENANT_ID: salts are unprefixed (default estate unchanged)", () => {
+    delete process.env.TENANT_ID;
+    expect(activeTenantId()).to.equal(null);
+    expect(generateSalt("FairWins-v2:WagerRegistry")).to.equal(ethers.id("FairWins-v2:WagerRegistry"));
+  });
+
+  it("TENANT_ID=fairwins is the default tenant: identical to no tenant", () => {
+    process.env.TENANT_ID = "fairwins";
+    expect(activeTenantId()).to.equal(null);
+    expect(generateSalt("FairWins-v2:WagerRegistry")).to.equal(ethers.id("FairWins-v2:WagerRegistry"));
+  });
+
+  it("a tenant in scope prefixes salts deterministically and distinctly", () => {
+    process.env.TENANT_ID = "acme";
+    expect(activeTenantId()).to.equal("acme");
+    const acmeSalt = generateSalt("FairWins-v2:WagerRegistry");
+    expect(acmeSalt).to.equal(ethers.id("tenant:acme:FairWins-v2:WagerRegistry"));
+    expect(acmeSalt).to.not.equal(ethers.id("FairWins-v2:WagerRegistry"));
+
+    process.env.TENANT_ID = "other";
+    expect(generateSalt("FairWins-v2:WagerRegistry")).to.not.equal(acmeSalt);
+  });
+
+  it("rejects invalid tenant ids loudly (salts must never derive from typos)", () => {
+    for (const bad of ["Acme", "a", "-acme", "acme_x", "tenant with spaces"]) {
+      process.env.TENANT_ID = bad;
+      expect(() => activeTenantId(), `TENANT_ID="${bad}"`).to.throw(/invalid/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Evolves FairWins toward a **white-label, multi-tenant platform**: each tenant (customer) gets an isolated instance with its own branding, configuration, and — where value is at stake — its own contract deployments. This PR ships the full Spec Kit design (`specs/072-white-label-tenants/`) plus the foundational implementation, with the existing product preserved exactly as the **default tenant**.

## Design (specs/072-white-label-tenants/)

- **spec.md** — 5 prioritized user stories, 15 FRs. Non-negotiables: *strong isolation* (assets/authority isolated by separate on-chain contract instances, never by a frontend/gateway filter alone) and *full white-label* (no platform-brand leakage into a tenant's UI/domain/metadata).
- **research.md** — decisions D1–D11 grounded in an architecture survey: repo-tracked tenant manifests; build-time tenant selection (one origin = one tenant); theming over the existing `platform-*` CSS seam; tenant-salted CREATE2 for deterministic per-tenant estates; per-tenant MembershipManager/FeeRouter proxies (treasury/paymentToken are per-deployment singletons); per-tenant gateway processes reusing the spec-036 FR-025 allowlist as the tenant scope. **Zero Solidity changes in v1.**
- **plan.md** (constitution check passes, no violations), **data-model.md** (manifest schema + validation rules), **quickstart.md** (launching shared/dedicated tenants), **tasks.md** (T001–T032 by user story).

## Implementation

**Tenant manifests + validation (Phases 1–2)**
- `tenants/<id>/manifest.json` — single source of truth per tenant; JSON Schema + feature catalog + authoring guide; `tenants/fairwins/` captures today's exact identity, theme tokens, features, chains, tiers, and fees; `tenants/example/` is a draft reference manifest.
- `scripts/tenants/validate-tenant-manifest.js` — dependency-free validator (structure, cross-manifest domain uniqueness, fee caps, cohort separation, dedicated-mode record presence); `npm run tenants:validate`; new **CI gate** (`tenant-manifests` job).

**Build-time tenant selection + branding (US3 + T008)**
- `frontend/src/config/tenant.js` — resolution via `VITE_TENANT_ID` (default `fairwins`); unknown ids **fail the build**; accessors for brand, links, features, chains, theme class, contract mode.
- `frontend/vite-plugins/tenant-branding.js` — `virtual:tenant` injects ONLY the active tenant's manifest (a built instance physically contains no other tenant's identity); rewrites index.html title/meta/theme-color/icons/pre-hydration defaults and generates `manifest.webmanifest` for non-default tenants; **lifecycle gate**: only a `live` tenant can produce a production build. Strict no-op for the default tenant (byte-equivalent output, verified).
- `frontend/src/theme/tenantTheme.js` + `ThemeContext.jsx` — non-default tenants inject `.platform-<id>` tokens from their manifest; default keeps static `theme.css`.

**Isolated on-chain estates (T013/T015/T016/T022)**
- `scripts/deploy/lib/helpers.js` — `TENANT_ID=<id>` prefixes CREATE2 salts (`tenant:<id>:…`) and routes records to `deployments/tenants/<id>/` (same schema); unset or `fairwins` is byte-identical to before.
- `sync-frontend-contracts --tenant <id>` — merges tenant records into `frontend/src/config/tenants/<id>.contracts.json`, injected via `virtual:tenant`.
- `getContractAddress`/`getContractAddressForChain` — dedicated tenants resolve ONLY their own set; absence stays absence, never a fallback to the shared estate; a live dedicated tenant with no generated set fails the build. Shared-mode (incl. default) resolution untouched.
- `test/integration/tenant-isolation.test.js` — two-tenant estate on one chain proves US2.1–US2.3: cross-tenant membership unrecognized, cross-tenant admin reverts, fees accrue only in the acting tenant's contract/treasury, plus the dual-membership edge case.

**Docs**: `docs/developer-guide/white-label-tenants.md`, `docs/runbooks`-bound lifecycle notes in `tenants/README.md`, CLAUDE.md guardrail entry.

## Testing

- Hardhat: 9 new tests (two-tenant isolation + tenant-salt determinism) passing.
- Vitest: 20 new tests (tenant loader, theming, branding plugin, resolution seams) passing; 205-test admin regression suite and theme-dependent suites re-run green.
- ESLint clean on changed files; `npm run tenants:validate` passes.
- Default production build verified byte-equivalent (index.html/webmanifest untouched, same resolved addresses); draft-tenant production build correctly refused; example-tenant preview build fully branded.

## What's next (tracked in tasks.md)

Brand-string sweeps of member-visible surfaces (T017–T018), feature-gated nav/routes (T019), instance pipeline parameterization (T020), gateway `TENANT_ID` scoping (T023), per-tenant subgraph/backup scoping (T024–T025), tenant-admin surfaces (T026–T027), and graduation flow (T028–T029).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqtmZu8A2dxqyt9prZPRWT