### PR TITLE
Spec 072 completion: tenant-driven surfaces, gateway scoping, instance pipeline + platform repositioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,17 @@ COPY frontend/package*.json ./
 # Install dependencies
 RUN npm ci
 
-# Copy source code
+# Copy source code + tenant manifests (spec 072 — the tenant-branding plugin
+# resolves tenants/ as a sibling of the frontend tree; the build fails loudly
+# if the directory is missing)
 COPY frontend/ .
+COPY tenants/ ../tenants/
 
 # Build arguments for environment variables (baked into JS bundle at build time)
 # Note: VITE_PINATA_JWT is NOT included here - it's handled at runtime via nginx proxy
+# Tenant selection (spec 072): one image = one tenant. Unset => the default
+# (fairwins) tenant, byte-identical to the pre-072 build.
+ARG VITE_TENANT_ID
 ARG VITE_WALLETCONNECT_PROJECT_ID
 ARG VITE_APP_URL
 ARG VITE_NETWORK_ID
@@ -33,6 +39,7 @@ ARG VITE_BUNDLER_URLS_POLYGON
 ARG VITE_SPONSOR_PAYMASTER_POLYGON
 
 # Set environment variables from build args
+ENV VITE_TENANT_ID=${VITE_TENANT_ID}
 ENV VITE_WALLETCONNECT_PROJECT_ID=${VITE_WALLETCONNECT_PROJECT_ID}
 ENV VITE_APP_URL=${VITE_APP_URL}
 ENV VITE_NETWORK_ID=${VITE_NETWORK_ID}

--- a/README.md
+++ b/README.md
@@ -1,25 +1,62 @@
-# FairWins — P2P Wager Management Layer
+# FairWins — Multi-Chain Financial Platform
 
-> Smart-contract escrow for peer-to-peer wagers, resolved by the participants
-> or by external oracles. Live on Polygon mainnet at [fairwins.app](https://fairwins.app).
+> A self-custody **financial control plane**: payments, peer-to-peer wagers,
+> prediction markets, collectibles, earning, swaps, bridging, Bitcoin, and
+> multisig custody — one app, many chains, and the member holds the keys the
+> whole time. Live at [fairwins.app](https://fairwins.app).
 
-FairWins is **not** a prediction market. It's a wager management layer that
-enables friends to create private 1-v-1 wagers whose stakes are locked in
-escrow and whose outcomes are settled by whoever the parties agreed to trust:
-themselves, a neutral arbitrator, or trusted external sources like Polymarket,
-Chainlink, and UMA's optimistic oracle.
+FairWins began as a peer-to-peer wager management layer. It has grown into a
+multi-chain platform where the wager escrow sits beside a full financial
+surface — while keeping the property it started with: **the platform never
+takes custody of member funds.** Every value-bearing action is signed by the
+member's own wallet (passkey smart account, browser/mobile wallet, or Safe
+multisig vault) against audited, deterministic-deployed contracts.
 
 📖 **Full documentation:** [docs/](docs/index.md) (MkDocs site — user guide,
-architecture, contract reference)
+architecture, contract reference, runbooks)
 
-## Key Insight
+## The platform
 
-Rather than compete with established prediction markets, FairWins
-**leverages** them. When you and a friend want to bet on whether Bitcoin will
-hit $100k, FairWins handles the stake escrow and payout — while the actual
-outcome is determined by battle-tested oracles.
+| Surface | What it does | Where |
+|---------|--------------|-------|
+| **Transfer** | Pay/request USDC like a payments app — QR codes, address book, gasless sends (EIP-3009 + relayer, spec 035/036) | All EVM networks |
+| **Wagers** | 1v1 wagers, open challenges, and group pools with smart-contract escrow and oracle/participant resolution | Polygon, Mordor/ETC |
+| **Predict** | Trade real Polymarket prediction markets, member wallet signs every order (spec 057) | Polygon |
+| **Collect** | NFT portfolio with live floors; list/sell via OpenSea (specs 055/056) | EVM mainnets |
+| **Earn** | Third-party lending vaults, liquid staking, supplied liquidity (specs 050/065/067) | Per-network |
+| **Swap** | DEX trading through the right venue per chain — Uniswap / ETCswap (spec 033) | Per-network |
+| **Bridge** | Cross-chain transfers via Across; unfilled deposits refund to the member (spec 067) | EVM mainnets |
+| **Bitcoin** | Native BTC wallet beside the EVM accounts — client-side keys, rotating addresses (spec 061) | Bitcoin |
+| **Protect** | Safe multisig custody vaults with an on-chain policy engine (specs 043/049/068) | Multi-chain |
+| **Recovery** | Encrypted backup/sync, legacy key recovery, asset sweeps (specs 032/062) | Client-side |
+| **ClearPath / Token Mint** | External DAO connections and token issuance (specs 028/030) | Per-network |
 
-## Features
+An **operations console** (spec 071) gives operators estate-wide reads across
+every chain — membership, fees, treasury, pauses — with honest
+`read / not-deployed / unreadable` states and single-chain writes.
+
+## White-label multi-tenant (spec 072)
+
+FairWins is one tenant of its own platform. A **tenant manifest**
+(`tenants/<id>/manifest.json`) defines an instance's identity (brand, theme,
+domains), settings (features, chains, tiers, fees), and contract set:
+
+- **Branding-only tenants** front the shared contract estate under their own
+  domain and brand.
+- **Dedicated tenants** get an isolated on-chain estate: tenant-salted CREATE2
+  deployments of the same audited contracts, recorded under
+  `deployments/tenants/<id>/`, with their own membership base, fee router,
+  treasury, and admin keys. Isolation is enforced by separate contract
+  instances — never by a frontend filter.
+
+See `docs/developer-guide/white-label-tenants.md` and
+`docs/runbooks/tenant-operations.md`.
+
+## The wager layer
+
+The original core, still central: private 1-v-1 wagers whose stakes are locked
+in escrow and settled by whoever the parties agreed to trust — themselves, a
+neutral arbitrator, or external oracles (Polymarket, Chainlink, UMA).
 
 ### Eight resolution types
 
@@ -38,20 +75,19 @@ outcome is determined by battle-tested oracles.
   at a creator-set multiplier where the settler puts up the majority stake
 - **Open challenges** — post a wager with no named opponent, gated by a
   four-word claim code; whoever you share the code with can take the other side
-  (Silver+ to create, any active tier to take)
+- **Group pools** — multi-party wager pools resolved by a member-approved
+  payout matrix (spec 034)
 - **QR / deep-link sharing** — the opponent scans a code and accepts in-app
-- **Mutual draws** — both parties (or the arbitrator) can settle a push; each
-  side gets its own stake back
+- **Mutual draws** — both parties (or the arbitrator) can settle a push
 - **End-to-end encrypted terms** — envelope encryption (X-Wing post-quantum
-  hybrid KEM) with keys published in an on-chain `KeyRegistry`; ciphertext on
-  IPFS, only a hash on-chain
+  hybrid KEM) with keys published in an on-chain `KeyRegistry`
 
 ### Safety mechanisms
 
 - **Stake escrow** — both stakes locked in `WagerRegistry` until resolution
 - **Refund paths everywhere** — expired offers, declined wagers, and wagers
-  whose resolve deadline passes unresolved all return stakes to their owners;
-  funds can never get stuck
+  whose resolve deadline passes unresolved all return stakes; funds can never
+  get stuck
 - **Pull-based payouts** — the winner claims the pot; claims can't be redirected
 - **Sanctions screening** — `SanctionsGuard` checks the Chainalysis oracle on
   every create and accept
@@ -71,27 +107,16 @@ four-tier ladder is anchored at **$2 Bronze** in USDC:
 | Platinum | $100 | Unlimited | Unlimited |
 
 A membership can be **bought directly** (soulbound) or acquired by **redeeming
-a `MembershipVoucher`** — a transferable ERC-721 bought with USDC at a tier's
-price that can be gifted or resold, then redeemed (burned) for the soulbound
-membership.
+a `MembershipVoucher`** — a transferable ERC-721 that is burned for the
+soulbound membership. Membership lives on one reference chain per environment
+(spec 071) and follows the member across networks.
 
 The operator team retains a narrow set of on-chain powers, each bound to a
-distinct OpenZeppelin AccessControl role:
-
-- `GUARDIAN_ROLE` — emergency pause of WagerRegistry (security incidents).
-- `ACCOUNT_MODERATOR_ROLE` — per-account freeze / unfreeze. A frozen account
-  cannot create, accept, settle, claim, or refund on the registry. See the
-  [Account Moderation Policy](docs/system-overview/account-moderation.md)
-  for full disclosure.
-- `ROLE_MANAGER_ROLE` — grant / revoke memberships outside the purchase
-  flow (support, gifts, dispute resolution).
-- `UPGRADER_ROLE` — authorize UUPS implementation upgrades on the proxies
-  (logic swaps at stable addresses; no other privilege).
-- `DEFAULT_ADMIN_ROLE` — tier config, treasury, and authority to grant the
-  roles above.
-
-See [Roles and Tiers](docs/system-overview/roles-and-tiers.md) for the full
-privilege matrix. No role can move escrowed stakes.
+distinct OpenZeppelin AccessControl role (`GUARDIAN_ROLE`,
+`ACCOUNT_MODERATOR_ROLE`, `ROLE_MANAGER_ROLE`, `UPGRADER_ROLE`,
+`DEFAULT_ADMIN_ROLE`). See
+[Roles and Tiers](docs/system-overview/roles-and-tiers.md) for the full
+privilege matrix. **No role can move escrowed stakes.**
 
 ## Architecture
 
@@ -114,18 +139,22 @@ privilege matrix. No role can move escrowed stakes.
 └───────────────┘  └──────────────┘  redeemed via MembershipManager
 ```
 
+Around that core sit the platform contracts: `WagerPoolFactory` (group pools),
+`FeeRouter` (the single fee source of truth, spec 060), `CallsignRegistry`
+(optional naming, spec 054), `TokenFactory`, `StakingRouter`, `BridgeRouter` +
+`LiquidityRouter` (no-custody routers, spec 067), Safe policy guards
+(specs 049/068), and the ERC-4337 account stack (spec 041/050).
+
 `WagerRegistry` and `MembershipManager` are UUPS-upgradeable behind stable
 proxy addresses — logic is swappable in place while escrowed state is
-preserved (see [ADR 004](docs/adr/004-upgradeable-registry-uups.md)). The
-`MembershipVoucher` ERC-721 is the deliberate exception: a tradable bearer
-asset is kept immutable.
+preserved (see [ADR 004](docs/adr/004-upgradeable-registry-uups.md)).
 
 Frontend: React + Vite SPA (no backend) served by nginx on Cloud Run behind
-Cloudflare. Deployed addresses are recorded in [`deployments/`](deployments/).
-The testnets — Polygon Amoy (80002) and Mordor/ETC (63) — run the
-feature-complete upgradeable set; Polygon mainnet (137) is still the pre-UUPS
-set pending migration. Full picture:
-[Architecture guide](docs/developer-guide/architecture.md).
+Cloudflare, one build per tenant instance. Optional services: the
+relay-gateway (gasless intents + paymaster, per-tenant scoped) and subgraph.
+Deployed addresses are recorded in [`deployments/`](deployments/) (shared
+estate) and `deployments/tenants/<id>/` (dedicated tenant estates). Full
+picture: [Architecture guide](docs/developer-guide/architecture.md).
 
 ## Quick Start
 
@@ -143,6 +172,7 @@ npm test                # contract suite
 npm run test:fork       # fork tests
 npm run test:coverage   # coverage
 npm run test:frontend   # frontend (Vitest)
+npm run tenants:validate # tenant manifest validation
 ```
 
 ### Run the app locally
@@ -183,59 +213,38 @@ registry.claimRefund(id);
 2. Wire it into `WagerRegistry`'s adapter slot for its resolution type
 3. Write tests (unit + fork) and update the docs
 
-```solidity
-contract MyOracleAdapter is IOracleAdapter {
-    function isConditionResolved(bytes32 conditionId) external view returns (bool);
-    function getOutcome(bytes32 conditionId) external view returns (
-        bool outcome, uint256 confidence, uint256 resolvedAt
-    );
-    function getConditionMetadata(bytes32 conditionId) external view returns (
-        string memory description, uint256 expectedResolutionTime
-    );
-}
-```
-
 ## Contracts
 
 | Contract | Location | Description |
 |----------|----------|-------------|
 | `WagerRegistry` | `contracts/wagers/` | Wager lifecycle + stake escrow, incl. open challenges (UUPS proxy) |
+| `WagerPoolFactory` / `WagerPool` | `contracts/pools/` | Group wager pools (factory + immutable clones) |
 | `MembershipManager` | `contracts/access/` | Tiered memberships, rate limits, voucher redemption (UUPS proxy) |
 | `MembershipVoucher` | `contracts/access/` | Transferable ERC-721 voucher → soulbound membership (immutable) |
 | `SanctionsGuard` | `contracts/access/` | Chainalysis screening + deny list |
+| `FeeRouter` | `contracts/fees/` | Single source of truth for platform fees (UUPS proxy) |
 | `KeyRegistry` | `contracts/privacy/` | Encryption public keys |
-| `PolymarketOracleAdapter` | `contracts/oracles/` | Polymarket CTF outcomes |
-| `ChainlinkDataFeedOracleAdapter` | `contracts/oracles/` | Price-threshold conditions |
-| `ChainlinkFunctionsOracleAdapter` | `contracts/oracles/` | Custom DON computations |
-| `UMAOptimisticOracleV3Adapter` | `contracts/oracles/` | Optimistic assertions |
+| `CallsignRegistry` | `contracts/identity/` | Optional %callsign naming (UUPS proxy) |
+| `BridgeRouter` / `LiquidityRouter` | `contracts/bridge/`, `contracts/liquidity/` | No-custody bridge + liquidity routers |
+| `SafePolicyGuard(V2)` | `contracts/custody/` | Multisig vault policy engines (non-upgradeable by design) |
+| Oracle adapters | `contracts/oracles/` | Polymarket · Chainlink DataFeed/Functions · UMA OOv3 |
 
-`contracts-archive/` holds superseded research (governance, conditional-token
-markets, friend-group factories) — reference only, never deploy.
+`contracts-archive/` holds superseded research — reference only, never deploy.
 
 Details: [Smart Contracts guide](docs/developer-guide/smart-contracts.md).
 
-## Why Not Build a Prediction Market?
+## Design principles
 
-Prediction markets are hard:
-
-1. **Liquidity** — Need market makers and deep order books
-2. **Oracles** — Need reliable resolution for every market
-3. **Regulation** — Complex legal landscape
-4. **Competition** — Polymarket, Kalshi, etc. already exist
-
-FairWins sidesteps these by:
-
-1. **No liquidity needed** — Fixed stakes, no AMM required
-2. **Leverage existing oracles** — Polymarket, Chainlink, UMA do the hard work
-3. **P2P focus** — Friends betting with friends
-4. **Complementary** — Use alongside prediction markets, not instead of
-
-## Development
-
-This repo uses [Spec Kit](https://github.com/github/spec-kit) for spec-driven
-feature development — see [CLAUDE.md](CLAUDE.md) and the binding standards in
-`.specify/memory/constitution.md`. Contract changes must follow
-checks-effects-interactions and pass Slither/Medusa in CI.
+1. **Self-custody, always** — no contract or operator role can move member
+   funds; escrow is pull-based and refund paths cover every timeout.
+2. **Leverage, don't rebuild** — Polymarket, Chainlink, UMA, Uniswap, Across,
+   OpenSea, and Safe do what they're best at; FairWins is the control plane
+   that composes them under one honest UI.
+3. **Honest state** — fees disclosed before signature, absence shown as
+   absence, no mocked data in shipped paths (constitution III).
+4. **Deterministic operations** — salted CREATE2 deployments, repo-recorded
+   addresses, spec-driven development ([Spec Kit](https://github.com/github/spec-kit),
+   see [CLAUDE.md](CLAUDE.md) and `.specify/memory/constitution.md`).
 
 ## License
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,6 +5,12 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
+      # Tenant selection (spec 072): this pipeline builds the DEFAULT (fairwins)
+      # instance. A per-tenant instance is the same pipeline with its own
+      # VITE_TENANT_ID + tenant URLs and its own Cloud Run service — see
+      # docs/runbooks/tenant-operations.md.
+      - '--build-arg'
+      - 'VITE_TENANT_ID=fairwins'
       - '--build-arg'
       - 'VITE_WALLETCONNECT_PROJECT_ID=c30d7d7a8d575fe3dcc72ed55e5b287e'
       - '--build-arg'

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,28 @@
 # Welcome to FairWins
 
-**Peer-to-peer wagers with friends, settled by smart-contract escrow and trustless oracles.**
+**A self-custody, multi-chain financial platform — one control plane for your
+money, and you hold the keys.**
 
-FairWins is a wager *management* layer — not a prediction market. Two people agree
-on a bet, both stakes are locked in an audited escrow contract on Polygon, and the
-wager is resolved either by the participants themselves, a neutral arbitrator, or
-an external oracle (Polymarket, Chainlink, UMA). There is no order book, no market
-making, and no house.
+FairWins began as a peer-to-peer wager management layer and has grown into a
+multi-chain financial control plane. One app now spans payments and requests
+(gasless USDC transfers), peer-to-peer wagers and group pools, Polymarket
+prediction-market trading, an NFT portfolio with OpenSea selling, lending and
+staking, DEX swaps, cross-chain bridging via Across, a native Bitcoin wallet,
+and Safe multisig custody vaults with an on-chain policy engine. The platform
+never takes custody: every value-bearing action is signed by the member's own
+wallet — passkey smart account, browser/mobile wallet, or multisig vault.
+
+The wager layer that started it all is unchanged in spirit: two people agree on
+a bet, both stakes are locked in an audited escrow contract, and the wager is
+resolved by the participants, a neutral arbitrator, or an external oracle
+(Polymarket, Chainlink, UMA). There is no order book, no market making, and no
+house.
+
+FairWins is also **white-label multi-tenant** (spec 072): the product you see
+at fairwins.app is the default tenant of a platform other operators can run
+under their own brand, domain, configuration, and — for full asset isolation —
+their own dedicated contract deployments. See the
+[White-Label Tenants guide](developer-guide/white-label-tenants.md).
 
 > **Important**: Before purchasing a tier or interacting with the protocol,
 > please read the [Roles and Tiers](system-overview/roles-and-tiers.md)
@@ -43,10 +59,14 @@ sequenceDiagram
 
 ## Where it runs
 
-| Network | Chain ID | Status |
-|---------|----------|--------|
-| Polygon Mainnet | 137 | **Live** — production at [fairwins.app](https://fairwins.app) |
-| Polygon Amoy | 80002 | Testnet (toggle in the wallet menu) |
+| Network | Chain ID | Role |
+|---------|----------|------|
+| Polygon Mainnet | 137 | **Live** — primary network + membership reference chain at [fairwins.app](https://fairwins.app) |
+| Ethereum Mainnet | 1 | Portfolio, custody, routers, bridge-LP |
+| Optimism / Base / Arbitrum | 10 / 8453 / 42161 | Portfolio, custody, routers |
+| Ethereum Classic | 61 | Custody + ETCswap trading |
+| Bitcoin | — | Native BTC wallet (portfolio/send/receive, spec 061) |
+| Polygon Amoy / Mordor | 80002 / 63 | Testnets (toggle in the wallet menu) |
 
 Recorded contract addresses live in [`deployments/`](https://github.com/chippr-robotics/prediction-dao-research/tree/main/deployments)
 — see the [Architecture guide](developer-guide/architecture.md) for the full map.

--- a/docs/runbooks/tenant-operations.md
+++ b/docs/runbooks/tenant-operations.md
@@ -1,0 +1,78 @@
+# Runbook: Tenant Operations
+
+Operating white-label tenants (spec 072). Developer-facing architecture lives in
+`docs/developer-guide/white-label-tenants.md`; this runbook is the operator's procedure
+reference. Every step here is auditable: manifests and deployment records are
+repo-tracked, so the PR history IS the tenant audit log (SC-005).
+
+## Launch a branding-only (shared-estate) tenant
+
+1. Author `tenants/<id>/manifest.json` (copy `tenants/example/`, set real values,
+   `contractSet.mode: "shared"`, `lifecycle: "draft"`). **No secrets in manifests.**
+2. `npm run tenants:validate` — fix everything it names.
+3. Preview: `VITE_TENANT_ID=<id> npx vite build --mode staging` (a draft tenant cannot
+   produce a production build — the lifecycle gate refuses).
+4. Merge the manifest PR; flip `lifecycle` to `live` in a second PR when contracted.
+5. Build the instance image: the standard `cloudbuild.yaml` pipeline with the tenant's
+   substitutions — `VITE_TENANT_ID=<id>`, `VITE_APP_URL=https://<tenant-domain>`, and the
+   tenant's relayer/subgraph URLs (or none). One image = one tenant = one Cloud Run
+   service (`<service>-<tenant-id>`).
+6. Bind the tenant domain at the edge (Cloudflare): DNS → the tenant's service, plus the
+   origin-lock Transform Rule with that instance's `ORIGIN_LOCK_SECRET`
+   (`infra/cloudflare/origin-lock.md`). Unbound domains must never route to any tenant's
+   instance (spec 072 edge case) — do not add wildcard routes.
+7. **Disclose to the tenant in writing that a shared-estate tenant has cosmetic isolation
+   only** (FR-015): value flows use the platform's shared contracts and treasury.
+
+## Provision a dedicated (isolated-estate) tenant
+
+1. Manifest as above with `contractSet.mode: "dedicated"`; list not-yet-deployed chains
+   in `contractSet.pendingChains` while `live` (honest absence, FR-008).
+2. Per enabled network, deploy with the tenant salt (floppy-keystore workflow as usual):
+   `TENANT_ID=<id> npx hardhat run scripts/deploy/deploy.js --network <network>`
+   then the supplementary deployers the tenant's features need (`deploy-fee-router.js`,
+   `deploy-wager-pool-factory.js`, …). Records land in
+   `deployments/tenants/<id>/<network>-chain<chainId>-v2.json`; addresses are
+   deterministic per tenant salt — a re-run reproduces them.
+   **The tenant id is immutable once deployed** (salts derive from it).
+3. Hand over / configure tenant admin keys: the deploy admin holds
+   `DEFAULT_ADMIN_ROLE`/`FEE_ADMIN_ROLE` on the TENANT's contracts only. Fee caps are
+   enforced on-chain by the tenant's own FeeRouter (spec 060 caps apply per instance).
+4. Generate the frontend set:
+   `node scripts/utils/sync-frontend-contracts.js --tenant <id> --network <network> --chainId <chainId>`
+   → commit `frontend/src/config/tenants/<id>.contracts.json`. A live dedicated tenant
+   without this file fails the build — that is the no-fallback guarantee working.
+5. Optional per-tenant gasless rails: run a dedicated relay-gateway process with
+   `TENANT_ID=<id>` (its FR-025 allowlist then only contains the tenant's addresses;
+   quotas/killswitch/paymaster deposits are per-process = per-tenant). Optional subgraph:
+   deploy with the tenant's addresses, record URLs in the manifest.
+6. Build/serve/bind as in the shared flow.
+7. Prove isolation before go-live:
+   `npx hardhat test test/integration/tenant-isolation.test.js` and the gateway
+   `test/tenant.test.js` suite must be green, and a manual spot-check on the tenant's
+   instance must show only tenant contracts in use (SC-002 probes).
+
+## Suspend / resume a tenant
+
+- Flip `lifecycle` to `suspended` via PR; production builds are refused, and the served
+  instance should be scaled to the unavailability shell.
+- **A suspension never traps value** (FR-013): the contracts do not know about
+  suspension. Members can always claim/settle directly against the tenant's contracts
+  (addresses are public in `deployments/tenants/<id>/`); include those addresses and the
+  ABI pointer in the suspension notice.
+- Resume = flip back to `live` + redeploy the instance.
+
+## Graduate shared → dedicated (FR-015)
+
+1. Provision the dedicated estate (above) while the tenant stays live on shared.
+2. Repoint the manifest: `contractSet.mode: "dedicated"` in one PR.
+3. Rebuild/redeploy the instance. New activity opens on the dedicated estate.
+4. Positions opened on the shared estate remain claimable at their original addresses —
+   the old instance's contracts stay resolvable forever; communicate the cutover date and
+   the direct-claim path for any stragglers.
+
+## Retire a tenant
+
+Flip `lifecycle` to `retired`, decommission the service and domain binding, keep the
+manifest + deployment records in the repo permanently (the estate's addresses must stay
+discoverable for direct claims).

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
          touch-action: manipulation (no double-tap zoom), a 16px input floor (no iOS
          focus zoom), and text-size-adjust (no auto-inflation) — see src/index.css. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="description" content="FairWins - Open prediction markets where anyone can create, join, and resolve markets. Fair participation, transparent resolution, and privacy-preserving mechanisms for collective wisdom." />
+    <meta name="description" content="FairWins is a self-custody, multi-chain financial platform: payments, peer-to-peer wagers, prediction markets, collectibles, earning, swaps, bridging, Bitcoin, and multisig custody — one control plane, and you hold the keys." />
 
     <!-- Progressive Web App: manifest + install/standalone metadata -->
     <link rel="manifest" href="/manifest.webmanifest" />
@@ -19,7 +19,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="🍀FairWins" />
     <link rel="apple-touch-icon" href="/assets/fairwins_no-text_logo.svg" />
-    <title>FairWins - Prediction Markets for Friends</title>
+    <title>FairWins - Multi-Chain Financial Platform</title>
     
     <!-- Preconnect to common external origins for better performance -->
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "🍀FairWins",
   "short_name": "FairWins",
-  "description": "Open prediction markets where anyone can create, join, and resolve markets. Fair participation, transparent resolution, and privacy-preserving mechanisms for collective wisdom.",
+  "description": "A self-custody, multi-chain financial platform: payments, peer-to-peer wagers, prediction markets, collectibles, earning, swaps, bridging, Bitcoin, and multisig custody — one control plane, and you hold the keys.",
   "id": "/",
   "start_url": "/?source=pwa",
   "scope": "/",

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { SHOW_ALL_ORACLE_MODELS } from '../constants/wagerDefaults'
 import { LEGAL_LINKS } from '../constants/legalLinks'
+import { tenantBrand, tenantLinks } from '../config/tenant'
 import './Footer.css'
 
 /**
@@ -14,10 +15,17 @@ import './Footer.css'
  * The copyright year is derived from the current date so it never goes stale (FR-008),
  * and the legal links come from the single LEGAL_LINKS source so the two footers can't
  * drift and never point at the external marketing site (FR-006/009, SC-002).
+ * Brand identity, docs, and community links resolve from the tenant manifest (spec 072) —
+ * columns whose links the tenant does not define are simply absent.
  */
+
+const SOCIAL_LABELS = { x: 'Twitter / X', discord: 'Discord', github: 'GitHub' }
+
 export default function Footer({ variant = 'full' }) {
+  const brand = tenantBrand()
+  const { social } = tenantLinks()
   const year = new Date().getFullYear()
-  const copyright = `© ${year} ChipprRobotics LLC. Apache License 2.0`
+  const copyright = `© ${year} ${brand.copyrightNotice}`
 
   if (variant === 'condensed' || variant === 'drawer') {
     const className = variant === 'drawer' ? 'app-footer app-footer--drawer' : 'app-footer'
@@ -33,13 +41,15 @@ export default function Footer({ variant = 'full' }) {
     )
   }
 
+  const socialEntries = Object.entries(social).filter(([, url]) => Boolean(url))
+
   return (
     <footer className="landing-footer">
       <div className="container">
         <div className="footer-content">
           <div className="footer-section footer-brand">
-            <FooterBrand />
-            <p>P2P wager management layer with multi-oracle resolution.</p>
+            <FooterBrand brand={brand} />
+            <p>{brand.tagline}</p>
           </div>
           <div className="footer-section">
             <h4>Oracles</h4>
@@ -53,14 +63,16 @@ export default function Footer({ variant = 'full' }) {
               )}
             </ul>
           </div>
-          <div className="footer-section">
-            <h4>Docs</h4>
-            <ul>
-              <li><a href="https://docs.FairWins.app/user-guide/getting-started/" target="_blank" rel="noopener noreferrer">User Guide</a></li>
-              <li><a href="https://docs.FairWins.app/developer-guide/setup/" target="_blank" rel="noopener noreferrer">Developer Docs</a></li>
-              <li><a href="https://docs.FairWins.app/security/" target="_blank" rel="noopener noreferrer">Security Audits</a></li>
-            </ul>
-          </div>
+          {brand.docsUrl && (
+            <div className="footer-section">
+              <h4>Docs</h4>
+              <ul>
+                <li><a href={`${brand.docsUrl}/user-guide/getting-started/`} target="_blank" rel="noopener noreferrer">User Guide</a></li>
+                <li><a href={`${brand.docsUrl}/developer-guide/setup/`} target="_blank" rel="noopener noreferrer">Developer Docs</a></li>
+                <li><a href={`${brand.docsUrl}/security/`} target="_blank" rel="noopener noreferrer">Security Audits</a></li>
+              </ul>
+            </div>
+          )}
           <div className="footer-section">
             <h4>Legal</h4>
             <ul>
@@ -69,14 +81,18 @@ export default function Footer({ variant = 'full' }) {
               ))}
             </ul>
           </div>
-          <div className="footer-section">
-            <h4>Community</h4>
-            <ul>
-              <li><a href="https://x.com/fairwins_app" target="_blank" rel="noopener noreferrer">Twitter / X</a></li>
-              <li><a href="https://discord.gg/rkYvPFdRRr" target="_blank" rel="noopener noreferrer">Discord</a></li>
-              <li><a href="https://github.com/chippr-robotics/prediction-dao-research" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-            </ul>
-          </div>
+          {socialEntries.length > 0 && (
+            <div className="footer-section">
+              <h4>Community</h4>
+              <ul>
+                {socialEntries.map(([key, url]) => (
+                  <li key={key}>
+                    <a href={url} target="_blank" rel="noopener noreferrer">{SOCIAL_LABELS[key] || key}</a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
         <div className="footer-bottom">
           <p>{copyright}</p>
@@ -87,15 +103,19 @@ export default function Footer({ variant = 'full' }) {
 }
 
 /** Brand logo with a text fallback if the SVG fails to load (matches prior landing behavior). */
-function FooterBrand() {
+function FooterBrand({ brand }) {
   const [logoError, setLogoError] = useState(false)
   if (logoError) {
-    return <div className="footer-logo-fallback" aria-label="FairWins">FW</div>
+    return (
+      <div className="footer-logo-fallback" aria-label={brand.displayName}>
+        {brand.displayName.slice(0, 2).toUpperCase()}
+      </div>
+    )
   }
   return (
     <img
-      src="/assets/logo_fairwins.svg"
-      alt="FairWins"
+      src={brand.logo}
+      alt={brand.displayName}
       className="footer-logo"
       width="40"
       height="40"

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -3,12 +3,40 @@ import { useNavigate } from 'react-router-dom'
 import Header from './Header'
 import Footer from './Footer'
 import { useChainTokens } from '../hooks/useChainTokens'
+import { tenantBrand, tenantLinks, isFeatureEnabled } from '../config/tenant'
 import './LandingPage.css'
+
+// Hero social icons by manifest social key (spec 072 — links come from the
+// tenant manifest; keys without an icon here are simply not rendered).
+const SOCIAL_ICONS = {
+  x: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+    </svg>
+  ),
+  discord: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+    </svg>
+  ),
+  github: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+    </svg>
+  ),
+  instagram: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+    </svg>
+  ),
+}
 
 function LandingPage() {
   const navigate = useNavigate()
   const [visibleSections, setVisibleSections] = useState(new Set())
   const { native: nativeSymbol } = useChainTokens()
+  const brand = tenantBrand()
+  const { support, social } = tenantLinks()
 
   const handleGetStarted = () => {
     navigate('/app')
@@ -55,15 +83,15 @@ function LandingPage() {
           </div>
 
           <h1 className="hero-headline">
-            Your Money.<br />
-            <span className="hero-headline-accent">Your Odds.</span><br />
+            Every Chain.<br />
+            <span className="hero-headline-accent">One Platform.</span><br />
             Your Keys.
           </h1>
 
           <p className="hero-subtitle">
-            Pay friends, wager head-to-head, trade prediction markets,
-            grow idle funds, swap tokens, and track your collectibles —
-            one app, and you hold the keys the whole time.
+            Your financial control plane: pay, wager, trade prediction markets,
+            earn, swap, bridge, and manage Bitcoin and multisig vaults — across
+            every chain you use, and you hold the keys the whole time.
           </p>
 
           <div className="hero-actions">
@@ -83,26 +111,13 @@ function LandingPage() {
           </div>
 
           <div className="hero-social">
-            <a href="https://x.com/fairwins_app" target="_blank" rel="noopener noreferrer" className="hero-social-link" aria-label="Twitter/X">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-              </svg>
-            </a>
-            <a href="https://discord.gg/rkYvPFdRRr" target="_blank" rel="noopener noreferrer" className="hero-social-link" aria-label="Discord">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
-              </svg>
-            </a>
-            <a href="https://github.com/chippr-robotics/prediction-dao-research" target="_blank" rel="noopener noreferrer" className="hero-social-link" aria-label="GitHub">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-              </svg>
-            </a>
-            <a href="https://instagram.com/fairwinsapp" target="_blank" rel="noopener noreferrer" className="hero-social-link" aria-label="Instagram">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
-              </svg>
-            </a>
+            {Object.entries(social)
+              .filter(([key, url]) => url && SOCIAL_ICONS[key])
+              .map(([key, url]) => (
+                <a key={key} href={url} target="_blank" rel="noopener noreferrer" className="hero-social-link" aria-label={key === 'x' ? 'Twitter/X' : key.charAt(0).toUpperCase() + key.slice(1)}>
+                  {SOCIAL_ICONS[key]}
+                </a>
+              ))}
           </div>
         </div>
 
@@ -143,9 +158,10 @@ function LandingPage() {
             <span className="section-tag">The Platform</span>
             <h2 className="section-title">Everything your money can do,<br />in one place</h2>
             <p className="section-subtitle">
-              FairWins started as peer-to-peer wagering. It grew into a full self-custody
-              money app — send, bet, trade, collect, earn, and swap without ever handing
-              over your funds.
+              {brand.displayName} started as peer-to-peer wagering. Today it is a
+              self-custody financial control plane spanning Polygon, Ethereum and its
+              L2s, Ethereum Classic, and Bitcoin — send, bet, trade, collect, earn,
+              swap, and bridge without ever handing over your funds.
             </p>
           </div>
 
@@ -161,8 +177,8 @@ function LandingPage() {
               <p>
                 See every asset you actually hold on-chain — tokens, stablecoins, positions,
                 and collectibles — organized and priced in one portfolio, with your full
-                activity in a single ledger. Your wallet signs every action. FairWins never
-                takes custody of your funds.
+                activity in a single ledger. Your wallet signs every action — the platform
+                never takes custody of your funds.
               </p>
             </div>
 
@@ -177,6 +193,7 @@ function LandingPage() {
               <p>Pay and request money like a payments app — big numpad, QR codes, address book, and USDC by default. Gasless sends mean no gas token required to move your money.</p>
             </div>
 
+            {isFeatureEnabled('wagers') && (
             <div className="value-card">
               <div className="value-icon">
                 <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -187,7 +204,9 @@ function LandingPage() {
               <h3>Wager</h3>
               <p>Head-to-head bets, open challenges, and group pools. Smart contracts escrow the stakes; outcomes settle by oracle or by the people you choose, with challenge periods to keep it fair.</p>
             </div>
+            )}
 
+            {isFeatureEnabled('predict') && (
             <div className="value-card">
               <div className="value-icon">
                 <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -198,7 +217,9 @@ function LandingPage() {
               <h3>Predict</h3>
               <p>Browse and trade real Polymarket prediction markets without leaving the app. Your own wallet signs every order, and every fee is disclosed before you commit.</p>
             </div>
+            )}
 
+            {isFeatureEnabled('collect') && (
             <div className="value-card">
               <div className="value-icon">
                 <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -210,7 +231,9 @@ function LandingPage() {
               <h3>Collect</h3>
               <p>Your NFTs, alongside the rest of your portfolio — with live floor prices and best offers. List and sell through OpenSea right from your collection.</p>
             </div>
+            )}
 
+            {isFeatureEnabled('earn') && (
             <div className="value-card">
               <div className="value-icon">
                 <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -223,7 +246,9 @@ function LandingPage() {
               <h3>Earn</h3>
               <p>Put idle assets to work in audited third-party lending vaults. Watch positions grow, claim rewards, and withdraw whenever you want — explained in plain language.</p>
             </div>
+            )}
 
+            {isFeatureEnabled('swap') && (
             <div className="value-card">
               <div className="value-icon">
                 <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -236,6 +261,34 @@ function LandingPage() {
               <h3>Swap</h3>
               <p>Exchange tokens through the right DEX for whichever chain you&apos;re on — Uniswap on Polygon and Ethereum networks, ETCswap on Ethereum Classic. Always labeled honestly.</p>
             </div>
+            )}
+          
+            {isFeatureEnabled('bridge') && (
+            <div className="value-card">
+              <div className="value-icon">
+                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M4 18V8a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v10" />
+                  <path d="M2 18h20" />
+                  <path d="M8 18v-4M12 18v-6M16 18v-4" />
+                </svg>
+              </div>
+              <h3>Bridge</h3>
+              <p>Move assets between chains through Across. Deposits refund straight to you if they can&apos;t be filled — the router never holds your funds, by design.</p>
+            </div>
+            )}
+
+            {isFeatureEnabled('bitcoin') && (
+            <div className="value-card">
+              <div className="value-icon">
+                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M9 8h4a2 2 0 0 1 0 4H9zM9 12h4.5a2 2 0 0 1 0 4H9zM10 6v2M10 16v2" />
+                </svg>
+              </div>
+              <h3>Bitcoin</h3>
+              <p>A real Bitcoin wallet beside your EVM accounts — rotating receive addresses, honest fee quotes before you sign, and keys that never leave your device.</p>
+            </div>
+            )}
           </div>
         </div>
       </section>
@@ -303,8 +356,8 @@ function LandingPage() {
             <span className="section-tag">Custody, Your Way</span>
             <h2 className="section-title">You hold the keys. Always.</h2>
             <p className="section-subtitle">
-              FairWins never custodies your funds. Choose how you want to control your
-              account — from a simple passkey to a shared multisig vault.
+              {brand.displayName} never custodies your funds. Choose how you want to
+              control your account — from a simple passkey to a shared multisig vault.
             </p>
           </div>
 
@@ -331,7 +384,7 @@ function LandingPage() {
                 </svg>
               </div>
               <h3>Your Own Wallet</h3>
-              <p>Bring the wallet you already trust — browser extension or any WalletConnect-compatible mobile wallet. FairWins is just an interface to your keys.</p>
+              <p>Bring the wallet you already trust — browser extension or any WalletConnect-compatible mobile wallet. {brand.displayName} is just an interface to your keys.</p>
               <span className="resolution-use-case">Best for: Existing crypto users</span>
             </div>
 
@@ -443,9 +496,11 @@ function LandingPage() {
               <polyline points="12 5 19 12 12 19" />
             </svg>
           </button>
-          <p className="cta-contact">
-            Questions? <a href="mailto:Howdy@FairWins.App">Howdy@FairWins.App</a>
-          </p>
+          {support.email && (
+            <p className="cta-contact">
+              Questions? <a href={`mailto:${support.email}`}>{support.email}</a>
+            </p>
+          )}
         </div>
       </section>
 

--- a/frontend/src/components/compliance/EntryGate.jsx
+++ b/frontend/src/components/compliance/EntryGate.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { getCurrentDocument } from '../../utils/legalDocs'
 import { readAck, writeAck } from '../../utils/entryGateAck'
 import { keepOnLanding } from '../../utils/appEntry'
+import { tenantBrand } from '../../config/tenant'
 import './EntryGate.css'
 
 /**
@@ -78,15 +79,15 @@ export default function EntryGate() {
         ref={dialogRef}
         onKeyDown={onKeyDown}
       >
-        <h2 id="entry-gate-title">Before you enter FairWins</h2>
+        <h2 id="entry-gate-title">Before you enter {tenantBrand().displayName}</h2>
         <p>
-          FairWins is peer-to-peer software. You wager directly against other participants;
-          FairWins is never your counterparty, sets no odds, and takes no share of any wager.
+          {tenantBrand().displayName} is peer-to-peer software. You wager directly against other participants;
+          {' '}{tenantBrand().displayName} is never your counterparty, sets no odds, and takes no share of any wager.
         </p>
         <p>By selecting <strong>Enter</strong>, you confirm that:</p>
         <ul>
           <li>You are at least 21 years old.</li>
-          <li>You are not accessing FairWins from any restricted jurisdiction listed in our Terms.</li>
+          <li>You are not accessing {tenantBrand().displayName} from any restricted jurisdiction listed in our Terms.</li>
           <li>You are not subject to sanctions and do not appear on any government restricted-party list.</li>
           <li>Accessing peer-to-peer wagering is lawful where you are located, and you accept full responsibility for compliance with your local laws.</li>
           <li>

--- a/frontend/src/components/ui/AddressQRModal.jsx
+++ b/frontend/src/components/ui/AddressQRModal.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import AddressQRCode from './AddressQRCode'
+import { tenantBrand } from '../../config/tenant'
 import { useClipboard } from '../../hooks/useClipboard'
 import { useBitcoinWallet } from '../../hooks/useBitcoinWallet'
 import { getBitcoinNetwork } from '../../config/bitcoinNetworks'
@@ -132,7 +133,7 @@ function BitcoinReceiveContent({ paletteId }) {
           </div>
 
           <p className="address-qr-wordmark" aria-hidden="true">
-            FairWins
+            {tenantBrand().displayName}
           </p>
 
           <p className="address-qr-address address-qr-address--bitcoin">{current.address}</p>
@@ -227,7 +228,7 @@ function AddressQRModal({ isOpen, onClose, address, variant = 'full', mode = 'ev
   // The full share payload: context line first, address alone on its own
   // line so recipients can copy it cleanly (research D7). Text-only — no
   // url/title, which messaging apps would turn into a mangling link preview.
-  const shareText = `My FairWins wallet address:\n${address}`
+  const shareText = `My ${tenantBrand().displayName} wallet address:\n${address}`
 
   const handleCopy = () => {
     copy(address)
@@ -322,7 +323,7 @@ function AddressQRModal({ isOpen, onClose, address, variant = 'full', mode = 'ev
             </div>
 
             <p className="address-qr-wordmark" aria-hidden="true">
-              FairWins
+              {tenantBrand().displayName}
             </p>
 
             {(!isQuick || copyError) && (

--- a/frontend/src/components/ui/ShareModal.jsx
+++ b/frontend/src/components/ui/ShareModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import WagerQRCode from './WagerQRCode'
+import { tenantBrand } from '../../config/tenant'
 import './ShareModal.css'
 
 function ShareModal({ isOpen, onClose, market, marketUrl }) {
@@ -102,14 +103,14 @@ function ShareModal({ isOpen, onClose, market, marketUrl }) {
           <div className="brand-section">
             <div className="brand-logo">
               <img
-                src="/assets/logo_fairwins.svg"
-                alt="FairWins"
+                src={tenantBrand().logo}
+                alt={tenantBrand().displayName}
                 className="logo-image"
                 width="48"
                 height="48"
               />
             </div>
-            <h2 className="brand-name">FairWins</h2>
+            <h2 className="brand-name">{tenantBrand().displayName}</h2>
             <p className="brand-tagline">Peer-to-Peer Wagers Between Friends.</p>
           </div>
 

--- a/frontend/src/config/appNav.js
+++ b/frontend/src/config/appNav.js
@@ -26,9 +26,34 @@ export const PORTFOLIO_ITEM = { id: 'portfolio', label: 'Portfolio', icon: 'tren
 // (see AppNavDrawer's DRAWER_GROUPS).
 export const WAGERS_ITEM = { id: 'wagers', label: 'Wagers', icon: 'ticket', to: '/wagers' }
 
+import { isFeatureEnabled } from './tenant'
+
+// Tenant feature gating (spec 072 T019/FR-002): nav item id -> manifest feature id.
+// Items not listed are core platform surfaces every tenant gets (transfer,
+// address book, reporting). A feature the tenant does not enable is ABSENT from
+// nav and groups — never present-but-broken. The default tenant enables every
+// feature, so its nav is unchanged.
+const NAV_FEATURE_IDS = {
+  wagers: 'wagers',
+  earn: 'earn',
+  trade: 'swap',
+  collectibles: 'collect',
+  predict: 'predict',
+  custody: 'protect',
+  security: 'recovery',
+  clearpath: 'clearpath',
+  tokens: 'token-mint',
+}
+
+export function isNavItemEnabledForTenant(id) {
+  const featureId = NAV_FEATURE_IDS[id]
+  return featureId ? isFeatureEnabled(featureId) : true
+}
+
 // Grouped section rail. `id` matches the WalletPage tab id; `icon` drives both
-// the drawer and the mobile bottom nav.
-export const NAV_GROUPS = [
+// the drawer and the mobile bottom nav. Defined raw, then filtered to the
+// active tenant's feature set below.
+const RAW_NAV_GROUPS = [
   {
     label: 'Finance',
     items: [
@@ -78,6 +103,12 @@ export const NAV_GROUPS = [
     ],
   },
 ]
+
+// The tenant-scoped nav model every consumer reads. Chain-based visibility
+// still applies at render time via visibleNavGroups(visibility).
+export const NAV_GROUPS = RAW_NAV_GROUPS
+  .map((group) => ({ ...group, items: group.items.filter((item) => isNavItemEnabledForTenant(item.id)) }))
+  .filter((group) => group.items.length > 0)
 
 // Path a section item navigates to. Home and Wagers have their own absolute routes.
 export function pathForNavItem(id) {

--- a/frontend/src/config/tenant.js
+++ b/frontend/src/config/tenant.js
@@ -71,6 +71,8 @@ export function tenantBrand() {
     displayName: ACTIVE_TENANT.identity.displayName,
     tagline: ACTIVE_TENANT.identity.tagline ?? '',
     appUrl: ACTIVE_TENANT.identity.appUrl,
+    docsUrl: ACTIVE_TENANT.identity.docsUrl ?? null,
+    copyrightNotice: ACTIVE_TENANT.identity.copyrightNotice ?? ACTIVE_TENANT.identity.legalName ?? ACTIVE_TENANT.identity.displayName,
     logo: ACTIVE_TENANT.brand.logo,
     logoMark: ACTIVE_TENANT.brand.logoMark,
     favicon: ACTIVE_TENANT.brand.favicon,

--- a/frontend/src/test/tenantConfig.test.js
+++ b/frontend/src/test/tenantConfig.test.js
@@ -30,7 +30,7 @@ describe('tenant config (spec 072)', () => {
     const brand = tenantBrand()
     expect(brand.displayName).toBe('FairWins')
     expect(brand.appUrl).toBe('https://fairwins.app')
-    expect(brand.htmlTitle).toBe('FairWins - Prediction Markets for Friends')
+    expect(brand.htmlTitle).toBe('FairWins - Multi-Chain Financial Platform')
     expect(brand.logo).toBe('/assets/logo_fairwins.svg')
     expect(brand.logoMark).toBe('/assets/fairwins_no-text_logo.svg')
     // Values from frontend/public/manifest.webmanifest

--- a/frontend/src/utils/metadataGenerator.js
+++ b/frontend/src/utils/metadataGenerator.js
@@ -1,3 +1,4 @@
+import { tenantBrand } from '../config/tenant'
 /**
  * @fileoverview Metadata generation utilities for creating OpenSea-compatible metadata
  * @module utils/metadataGenerator
@@ -52,7 +53,7 @@ export function generateMarketMetadata(params) {
   const metadata = {
     name,
     description, // Short question/title for the market
-    external_url: `https://fairwins.app/market/${marketId}`,
+    external_url: `${tenantBrand().appUrl}/market/${marketId}`,
     image: imageUrl,
     attributes: [
       {
@@ -216,7 +217,7 @@ export function generateTokenMetadata(params) {
     name,
     symbol,
     description,
-    external_url: links.website || `https://fairwins.app/token/${tokenAddress}`,
+    external_url: links.website || `${tenantBrand().appUrl}/token/${tokenAddress}`,
     image: imageUrl,
     attributes: [
       {
@@ -297,7 +298,7 @@ export function generateProposalMetadata(params) {
   const metadata = {
     name: title,
     description,
-    external_url: `https://fairwins.app/proposal/${proposalId}`,
+    external_url: `${tenantBrand().appUrl}/proposal/${proposalId}`,
     image: 'ipfs://QmDefaultProposalImage',
     attributes: [
       {
@@ -374,7 +375,7 @@ export function generateDAOMetadata(params) {
   const metadata = {
     name,
     description,
-    external_url: links.website || `https://fairwins.app/dao/${daoAddress}`,
+    external_url: links.website || `${tenantBrand().appUrl}/dao/${daoAddress}`,
     image: imageUrl,
     attributes: [
       {

--- a/frontend/src/wagmi.js
+++ b/frontend/src/wagmi.js
@@ -4,6 +4,7 @@ import { arbitrum, base, mainnet, optimism, sepolia } from 'wagmi/chains'
 import { injected, walletConnect } from 'wagmi/connectors'
 import { passkeyConnector } from './connectors/passkey'
 import { resolveRpcEndpoints } from './lib/network/rpcEndpoints'
+import { tenantBrand } from './config/tenant'
 
 // Define Hoodi — Ethereum's long-lived proof-of-stake testnet (spec 048). Not a
 // wagmi/chains built-in, so declared inline like the ETC-family chains. RPC/explorer
@@ -159,8 +160,8 @@ const resolveAppUrl = () => {
     return window.location.origin
   }
 
-  // As a last resort, return a fallback domain
-  return 'https://fairwins.app'
+  // As a last resort, return the active tenant's canonical URL (spec 072)
+  return tenantBrand().appUrl
 }
 
 const appUrl = resolveAppUrl()
@@ -234,10 +235,10 @@ export const config = createConfig({
     walletConnect({
       projectId: walletConnectProjectId,
       metadata: {
-        name: 'Prediction DAO',
-        description: 'Decentralized prediction markets and wagers',
+        name: tenantBrand().displayName,
+        description: tenantBrand().tagline || tenantBrand().displayName,
         url: appUrl,
-        icons: [`${appUrl}/assets/fairwins_no-text_logo.svg`]
+        icons: [`${appUrl}${tenantBrand().logoMark}`]
       },
       showQrModal: true,
     }),

--- a/frontend/vite-plugins/tenant-branding.js
+++ b/frontend/vite-plugins/tenant-branding.js
@@ -18,7 +18,28 @@ import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 const DEFAULT_TENANT_ID = 'fairwins'
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+/**
+ * Locate the tenants/ manifest directory. Normally <repo root>/tenants (two
+ * levels up from this plugin), but containerized builds copy frontend/ and
+ * tenants/ as siblings of an arbitrary base, so walk upward until the
+ * directory is found; TENANTS_DIR overrides for exotic layouts. Failing to
+ * find it is a loud build failure — never a silent unbranded build.
+ */
+function findTenantsDir() {
+  if (process.env.TENANTS_DIR) return path.resolve(process.env.TENANTS_DIR)
+  let dir = path.dirname(fileURLToPath(import.meta.url))
+  for (let i = 0; i < 6; i++) {
+    const candidate = path.join(dir, 'tenants')
+    if (fs.existsSync(path.join(candidate, 'features.json'))) return candidate
+    dir = path.dirname(dir)
+  }
+  throw new Error(
+    '[tenant-branding] could not locate the tenants/ directory (looked upward from the plugin; set TENANTS_DIR to override)'
+  )
+}
+
+const TENANTS_DIR = findTenantsDir()
 
 // Virtual module consumed by src/config/tenant.js. Only the ACTIVE tenant's
 // manifest is injected into the bundle — a built instance must physically
@@ -27,7 +48,7 @@ const VIRTUAL_ID = 'virtual:tenant'
 const RESOLVED_VIRTUAL_ID = '\0' + VIRTUAL_ID
 
 function manifestPathFor(tenantId) {
-  return path.join(REPO_ROOT, 'tenants', tenantId, 'manifest.json')
+  return path.join(TENANTS_DIR, tenantId, 'manifest.json')
 }
 
 function loadManifest(tenantId) {
@@ -48,12 +69,16 @@ function loadManifest(tenantId) {
 }
 
 function loadFeatureCatalog() {
-  const catalogPath = path.join(REPO_ROOT, 'tenants', 'features.json')
+  const catalogPath = path.join(TENANTS_DIR, 'features.json')
   return JSON.parse(fs.readFileSync(catalogPath, 'utf8')).features
 }
 
 function tenantContractSetPath(tenantId) {
-  return path.join(REPO_ROOT, 'frontend', 'src', 'config', 'tenants', `${tenantId}.contracts.json`)
+  // Lives inside the frontend source tree — resolve relative to this plugin,
+  // not the repo root, so containerized layouts (frontend copied standalone)
+  // keep working.
+  const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+  return path.join(frontendRoot, 'src', 'config', 'tenants', `${tenantId}.contracts.json`)
 }
 
 /**

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -15,3 +15,18 @@ The origin lock is enforced in `frontend/nginx.conf.template` (verified by
 
 > These runbooks can be promoted to IaC (Terraform `cloudflare_ruleset`) later; for now
 > they are the source of truth for the manual/staged dashboard configuration.
+
+## Tenant domains (spec 072)
+
+Each white-label tenant instance is its own origin (one Cloud Run service per tenant)
+behind its own domain(s) from `tenants/<id>/manifest.json`. Per tenant domain:
+
+- DNS routes ONLY to that tenant's service — never a shared/wildcard route. A domain no
+  manifest claims must not resolve to any tenant's instance (unknown domains land on
+  Cloudflare's default response, not another tenant's brand).
+- The geo gate and origin lock apply per zone/domain exactly as documented above, with a
+  per-instance `ORIGIN_LOCK_SECRET` (secrets are never shared across tenants).
+- Domain uniqueness across manifests is validator-enforced (`npm run tenants:validate`);
+  edge config must mirror it — one domain, one tenant, one origin.
+
+See `docs/runbooks/tenant-operations.md` for the full launch procedure.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: FairWins
-site_description: Peer-to-peer wagers with friends — smart-contract escrow, oracle resolution, end-to-end encrypted terms
+site_description: Self-custody multi-chain financial platform — payments, wagers, prediction markets, earning, bridging, Bitcoin, and multisig custody under your own keys
 site_author: Chippr Robotics
 site_url: https://docs.FairWins.app
 

--- a/services/relay-gateway/.env.example
+++ b/services/relay-gateway/.env.example
@@ -5,6 +5,12 @@
 # deployment record yet — enabling it fails the FR-025 startup check by design.
 ENABLED_CHAIN_IDS=137,80002,63
 
+# Tenant scope (spec 072): one gateway process serves ONE tenant. Set to a tenant id to
+# read that tenant's dedicated records (deployments/tenants/<id>/) — the FR-025 allowlist
+# then IS the tenant boundary, and quotas/killswitch/paymaster are per-process = per-tenant.
+# UNSET (or fairwins) => the shared/default estate, exactly as before.
+#TENANT_ID=
+
 # >=2 endpoints per chain, comma-separated, failover order (FR-007). Defaults are public pairs.
 #RPC_URLS_137=https://polygon-rpc.com,https://polygon-bor-rpc.publicnode.com
 #RPC_URLS_80002=https://rpc-amoy.polygon.technology,https://polygon-amoy-bor-rpc.publicnode.com

--- a/services/relay-gateway/src/config/index.js
+++ b/services/relay-gateway/src/config/index.js
@@ -157,7 +157,21 @@ function loadDeployment(deploymentsDir, chainId) {
  * @param {{deploymentsDir?: string}} [opts]
  */
 export function loadConfig(env = process.env, opts = {}) {
-  const deploymentsDir = opts.deploymentsDir || opt(env, 'DEPLOYMENTS_DIR', DEFAULT_DEPLOYMENTS_DIR)
+  // Tenant scope (spec 072, T023): one gateway process serves ONE tenant.
+  // TENANT_ID resolves the records dir to the tenant's dedicated estate
+  // (deployments/tenants/<id>/, same schema) — the FR-025 allowlist below then
+  // IS the tenant boundary: an intent targeting another tenant's contracts is
+  // refused because those addresses are simply not in this process's records.
+  // Unset (or the default tenant) reads the shared estate, exactly as before.
+  const tenantId = opt(env, 'TENANT_ID', '')
+  if (tenantId && !/^[a-z][a-z0-9-]{1,30}$/.test(tenantId)) {
+    throw new Error(`[relay-gateway] invalid TENANT_ID "${tenantId}" — must match ^[a-z][a-z0-9-]{1,30}$`)
+  }
+  const tenantScoped = Boolean(tenantId) && tenantId !== 'fairwins'
+  const defaultDir = tenantScoped
+    ? path.join(DEFAULT_DEPLOYMENTS_DIR, 'tenants', tenantId)
+    : DEFAULT_DEPLOYMENTS_DIR
+  const deploymentsDir = opts.deploymentsDir || opt(env, 'DEPLOYMENTS_DIR', defaultDir)
 
   const enabledChainIds = opt(env, 'ENABLED_CHAIN_IDS', '137,80002,63')
     .split(',')
@@ -278,6 +292,9 @@ export function loadConfig(env = process.env, opts = {}) {
   }
 
   return {
+    // Tenant this process serves (spec 072). null = the shared/default estate.
+    tenantId: tenantScoped ? tenantId : null,
+    deploymentsDir,
     enabledChainIds,
     chains,
     port: int(env, 'PORT', 8788),

--- a/services/relay-gateway/test/tenant.test.js
+++ b/services/relay-gateway/test/tenant.test.js
@@ -1,0 +1,88 @@
+/**
+ * Tenant scoping of the gateway (spec 072, T023 / US2.5).
+ *
+ * One gateway process serves one tenant: TENANT_ID resolves the records dir to
+ * deployments/tenants/<id>/ and the existing FR-025 startup allowlist becomes
+ * the tenant boundary — another tenant's contract addresses simply do not
+ * exist in this process's config, so intents targeting them are refused by the
+ * same path that refuses any unknown target.
+ */
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { loadConfig } from '../src/config/index.js'
+import { DEPLOYMENTS_DIR } from './helpers.js'
+
+const TENANT = 'acme-test'
+let tmpRoot
+
+beforeAll(() => {
+  // Fabricate a tenant estate: a records tree with deployments/tenants/<id>/
+  // holding a valid record for chain 137 with DIFFERENT addresses than the
+  // shared estate.
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tenant-gateway-'))
+  const tenantDir = path.join(tmpRoot, 'tenants', TENANT)
+  fs.mkdirSync(tenantDir, { recursive: true })
+  const shared = JSON.parse(
+    fs.readFileSync(path.join(DEPLOYMENTS_DIR, 'polygon-chain137-v2.json'), 'utf8')
+  )
+  const tenantRecord = JSON.parse(JSON.stringify(shared))
+  tenantRecord.contracts.wagerRegistry = '0x1111111111111111111111111111111111111111'
+  tenantRecord.contracts.membershipManager = '0x2222222222222222222222222222222222222222'
+  fs.writeFileSync(path.join(tenantDir, 'polygon-chain137-v2.json'), JSON.stringify(tenantRecord))
+})
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+describe('gateway tenant scoping (spec 072)', () => {
+  it('TENANT_ID resolves records from the tenant estate, not the shared one', () => {
+    const config = loadConfig({
+      ENABLED_CHAIN_IDS: '137',
+      TENANT_ID: TENANT,
+      DEPLOYMENTS_DIR: path.join(tmpRoot, 'tenants', TENANT),
+    })
+    expect(config.tenantId).toBe(TENANT)
+    expect(config.chains[137].targetsByKey.wagerRegistry).toBe('0x1111111111111111111111111111111111111111')
+  })
+
+  it("the shared estate's addresses are NOT in a tenant-scoped allowlist (US2.5)", () => {
+    const config = loadConfig({
+      ENABLED_CHAIN_IDS: '137',
+      TENANT_ID: TENANT,
+      DEPLOYMENTS_DIR: path.join(tmpRoot, 'tenants', TENANT),
+    })
+    const shared = JSON.parse(
+      fs.readFileSync(path.join(DEPLOYMENTS_DIR, 'polygon-chain137-v2.json'), 'utf8')
+    )
+    const allowlisted = Object.keys(config.chains[137].targets)
+    expect(allowlisted).not.toContain(shared.contracts.wagerRegistry.toLowerCase())
+  })
+
+  it('a tenant with no records refuses to start (FR-025 unchanged)', () => {
+    expect(() =>
+      loadConfig({
+        ENABLED_CHAIN_IDS: '137',
+        TENANT_ID: 'ghost-tenant',
+        DEPLOYMENTS_DIR: path.join(tmpRoot, 'tenants', 'ghost-tenant'),
+      })
+    ).toThrow(/cannot read deployments dir|no deployment record/)
+  })
+
+  it('invalid TENANT_ID fails loudly', () => {
+    expect(() => loadConfig({ ENABLED_CHAIN_IDS: '137', TENANT_ID: 'Not Valid!' })).toThrow(
+      /invalid TENANT_ID/
+    )
+  })
+
+  it('unset TENANT_ID keeps the shared estate (default behavior unchanged)', () => {
+    const config = loadConfig(
+      { ENABLED_CHAIN_IDS: '137,80002,63', ENGINE_URL: 'http://engine.test.invalid' },
+      { deploymentsDir: DEPLOYMENTS_DIR }
+    )
+    expect(config.tenantId).toBe(null)
+    expect(config.chains[137].targetsByKey.wagerRegistry).toBeTruthy()
+  })
+})

--- a/tenants/fairwins/manifest.json
+++ b/tenants/fairwins/manifest.json
@@ -10,8 +10,14 @@
     "metaDescription": "FairWins - Open prediction markets where anyone can create, join, and resolve markets. Fair participation, transparent resolution, and privacy-preserving mechanisms for collective wisdom.",
     "domains": ["fairwins.app"],
     "appUrl": "https://fairwins.app",
+    "docsUrl": "https://docs.FairWins.app",
+    "copyrightNotice": "ChipprRobotics LLC. Apache License 2.0",
     "support": { "email": "Howdy@FairWins.App" },
-    "social": { "x": "https://x.com/fairwins_app" },
+    "social": {
+      "x": "https://x.com/fairwins_app",
+      "discord": "https://discord.gg/rkYvPFdRRr",
+      "github": "https://github.com/chippr-robotics/prediction-dao-research"
+    },
     "legal": { "termsPath": "/terms", "privacyPath": "/privacy", "riskPath": "/risk" }
   },
 

--- a/tenants/fairwins/manifest.json
+++ b/tenants/fairwins/manifest.json
@@ -6,8 +6,8 @@
   "identity": {
     "displayName": "FairWins",
     "legalName": "FairWins",
-    "tagline": "Prediction Markets for Friends",
-    "metaDescription": "FairWins - Open prediction markets where anyone can create, join, and resolve markets. Fair participation, transparent resolution, and privacy-preserving mechanisms for collective wisdom.",
+    "tagline": "Your multi-chain financial control plane — your money, your keys, every chain.",
+    "metaDescription": "FairWins is a self-custody, multi-chain financial platform: payments, peer-to-peer wagers, prediction markets, collectibles, earning, swaps, bridging, Bitcoin, and multisig custody — one control plane, and you hold the keys.",
     "domains": ["fairwins.app"],
     "appUrl": "https://fairwins.app",
     "docsUrl": "https://docs.FairWins.app",
@@ -16,7 +16,8 @@
     "social": {
       "x": "https://x.com/fairwins_app",
       "discord": "https://discord.gg/rkYvPFdRRr",
-      "github": "https://github.com/chippr-robotics/prediction-dao-research"
+      "github": "https://github.com/chippr-robotics/prediction-dao-research",
+      "instagram": "https://instagram.com/fairwinsapp"
     },
     "legal": { "termsPath": "/terms", "privacyPath": "/privacy", "riskPath": "/risk" }
   },
@@ -26,7 +27,7 @@
     "logoMark": "/assets/fairwins_no-text_logo.svg",
     "favicon": "/assets/logo_fairwins.svg",
     "appleTouchIcon": "/assets/fairwins_no-text_logo.svg",
-    "htmlTitle": "FairWins - Prediction Markets for Friends",
+    "htmlTitle": "FairWins - Multi-Chain Financial Platform",
     "pwa": {
       "name": "🍀FairWins",
       "shortName": "FairWins",

--- a/tenants/manifest.schema.json
+++ b/tenants/manifest.schema.json
@@ -30,6 +30,8 @@
           "description": "Globally unique across all manifests (validator-enforced)."
         },
         "appUrl": { "type": "string", "pattern": "^https://" },
+        "docsUrl": { "type": "string", "pattern": "^https://" },
+        "copyrightNotice": { "type": "string" },
         "support": {
           "type": "object",
           "additionalProperties": false,


### PR DESCRIPTION
## Summary

Follow-up to #994 (merged): completes the remaining spec-072 white-label tasks and repositions the app's messaging from "wager app" to its current reality — a **self-custody, multi-chain financial platform control plane**.

## Multi-tenant completion (spec 072 T017/T019/T020/T023/T030/T032)

**Tenant-driven brand surfaces (T017)**
- `wagmi.js` WalletConnect metadata (name/description/icon/fallback URL), `Footer` (logo, tagline, docs/community columns, copyright), `EntryGate`, `ShareModal`/`AddressQRModal` QR frames, and `metadataGenerator` external URLs now resolve from `tenantBrand()`/`tenantLinks()` instead of hardcoded FairWins values.
- Manifest schema gains `identity.docsUrl` + `identity.copyrightNotice`; the fairwins manifest carries today's docs/discord/github/instagram links.

**Feature-gated navigation (T019)**
- `appNav.js` filters `NAV_GROUPS` to the active tenant's feature set at module level (`isNavItemEnabledForTenant`); chain-based visibility via `visibleNavGroups` is unchanged, and the default tenant's nav is identical.

**Instance pipeline (T020)**
- `Dockerfile` copies `tenants/` beside the frontend and takes `VITE_TENANT_ID` (one image = one tenant); `cloudbuild.yaml` pins the default instance to `VITE_TENANT_ID=fairwins` explicitly.
- The tenant-branding plugin locates `tenants/` by upward search (`TENANTS_DIR` override) so containerized layouts build — a missing directory fails the build loudly.

**Gateway tenant scoping (T023)**
- relay-gateway: `TENANT_ID` resolves its records dir to `deployments/tenants/<id>/`, making the existing FR-025 startup allowlist the tenant boundary; per-process quotas/killswitch/paymaster are therefore per-tenant. 5 new tests; full gateway suite (226) green.

**Ops docs (T030/T032)**
- `docs/runbooks/tenant-operations.md`: launch (shared + dedicated), suspend/resume (never traps value, direct-claim path), graduation, retirement.
- `infra/cloudflare/README.md`: per-tenant domain rules — one domain, one tenant, one origin; unknown domains never reach a tenant instance.

## Platform repositioning

- **Landing page**: new hero ("Every Chain. One Platform. Your Keys.") and platform copy; brand name, support email, and social links resolve from the tenant manifest; feature cards (Wager/Predict/Collect/Earn/Swap + new **Bridge**/**Bitcoin**) are gated by `isFeatureEnabled` so white-label tenants get an honest landing page.
- **README** rewritten: platform surface table, white-label section, updated architecture/contracts tables, design principles — wager mechanics, tiers, and lifecycle docs preserved as the core layer.
- **docs/index.md + mkdocs**: repositioned intro, real multi-chain network table (EVM mainnets, ETC, Bitcoin, testnets), white-label pointer.
- **Metadata**: fairwins manifest tagline/metaDescription/htmlTitle updated with `index.html` + `manifest.webmanifest` in lockstep (static files remain the default tenant's byte source).

## Testing

- Gateway: 226 tests green (5 new tenant-scoping tests).
- Frontend: 48 tests across affected suites (tenant config/theme/branding, Footer, EntryGate, Landing, AppNavDrawer) + 246-test regression slice (admin suite, HomeScreen, Dashboard) green; ESLint clean.
- `npm run tenants:validate` green; production build verified carrying the new metadata; default-tenant behavior otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqtmZu8A2dxqyt9prZPRWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqtmZu8A2dxqyt9prZPRWT)_