### PR TITLE
Reposition landing page, README, and docs as digital asset infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,250 +1,129 @@
-# FairWins — Multi-Chain Financial Platform
+# FairWins — Digital Asset Infrastructure
 
-> A self-custody **financial control plane**: payments, peer-to-peer wagers,
-> prediction markets, collectibles, earning, swaps, bridging, Bitcoin, and
-> multisig custody — one app, many chains, and the member holds the keys the
-> whole time. Live at [fairwins.app](https://fairwins.app).
+> Self-custody digital asset infrastructure for modern financial products:
+> embedded wallets, policy-governed custody, payments and settlement, markets
+> connectivity, and built-in compliance — across major networks, available
+> **white-label** under your own brand. Live at [fairwins.app](https://fairwins.app).
 
-FairWins began as a peer-to-peer wager management layer. It has grown into a
-multi-chain platform where the wager escrow sits beside a full financial
-surface — while keeping the property it started with: **the platform never
-takes custody of member funds.** Every value-bearing action is signed by the
-member's own wallet (passkey smart account, browser/mobile wallet, or Safe
-multisig vault) against audited, deterministic-deployed contracts.
+FairWins is the platform layer a digital asset business would otherwise
+assemble from multiple vendors. One stack provides the wallet, custody,
+payment, trading, and compliance components — behind one interface, on
+audited, deterministically deployed smart contracts — with a property no
+aggregation of vendors gives you: **the platform never takes custody.** Every
+value-bearing action is signed by the end user's own keys (passkey smart
+account, external wallet, or multisig vault).
 
 📖 **Full documentation:** [docs/](docs/index.md) (MkDocs site — user guide,
 architecture, contract reference, runbooks)
 
-## The platform
+## Platform capabilities
 
-| Surface | What it does | Where |
-|---------|--------------|-------|
-| **Transfer** | Pay/request USDC like a payments app — QR codes, address book, gasless sends (EIP-3009 + relayer, spec 035/036) | All EVM networks |
-| **Wagers** | 1v1 wagers, open challenges, and group pools with smart-contract escrow and oracle/participant resolution | Polygon, Mordor/ETC |
-| **Predict** | Trade real Polymarket prediction markets, member wallet signs every order (spec 057) | Polygon |
-| **Collect** | NFT portfolio with live floors; list/sell via OpenSea (specs 055/056) | EVM mainnets |
-| **Earn** | Third-party lending vaults, liquid staking, supplied liquidity (specs 050/065/067) | Per-network |
-| **Swap** | DEX trading through the right venue per chain — Uniswap / ETCswap (spec 033) | Per-network |
-| **Bridge** | Cross-chain transfers via Across; unfilled deposits refund to the member (spec 067) | EVM mainnets |
-| **Bitcoin** | Native BTC wallet beside the EVM accounts — client-side keys, rotating addresses (spec 061) | Bitcoin |
-| **Protect** | Safe multisig custody vaults with an on-chain policy engine (specs 043/049/068) | Multi-chain |
-| **Recovery** | Encrypted backup/sync, legacy key recovery, asset sweeps (specs 032/062) | Client-side |
-| **ClearPath / Token Mint** | External DAO connections and token issuance (specs 028/030) | Per-network |
+| Capability | What it provides |
+|-----------|------------------|
+| **Embedded wallets** | Passkey (WebAuthn) ERC-4337 smart accounts — no seed phrases, optional sponsored gas — plus external wallets and hardware signers via WalletConnect |
+| **Custody & policy** | Safe multisig vaults with an on-chain policy engine: ordered rules, approver requirements, and thresholds enforced by contract, multi-chain |
+| **Payments & settlement** | Stablecoin transfer/request rails with QR flows, address book, and gasless (EIP-3009 + relayer) settlement |
+| **Portfolio & reporting** | Unified multi-chain portfolio (tokens, positions, NFTs) with a complete activity ledger and tax reporting |
+| **Markets connectivity** | Direct order flow into Polymarket prediction markets, plus escrowed peer-to-peer settlement with oracle resolution (Polymarket, Chainlink, UMA) |
+| **Trading & liquidity** | Per-network DEX execution (Uniswap, ETCswap), cross-chain bridging via Across (no-custody routers), supplied liquidity |
+| **Yield** | Third-party lending vaults, liquid staking, and reward claims — positions stay withdrawable |
+| **Bitcoin** | Native BTC wallet beside the EVM accounts: client-side key derivation, rotating addresses, hard fee ceilings |
+| **Collectibles** | NFT portfolio with live floors and OpenSea sell-side integration |
+| **Compliance** | Chainalysis sanctions screening enforced at the contract layer, jurisdiction gating at the edge, immutable audit records |
+| **Operations console** | Estate-wide reads across every network — balances, fees, roles, pauses — with honest `read / not-deployed / unreadable` state |
+| **Recovery** | End-to-end encrypted backup/sync, cross-device account recovery, legacy key import and asset sweeps |
 
-An **operations console** (spec 071) gives operators estate-wide reads across
-every chain — membership, fees, treasury, pauses — with honest
-`read / not-deployed / unreadable` states and single-chain writes.
+Every fee on the platform has one source of truth (an on-chain `FeeRouter`
+with per-service hard caps) and is disclosed to the user before signature.
 
-## White-label multi-tenant (spec 072)
+## White-label, multi-tenant
 
-FairWins is one tenant of its own platform. A **tenant manifest**
-(`tenants/<id>/manifest.json`) defines an instance's identity (brand, theme,
-domains), settings (features, chains, tiers, fees), and contract set:
+FairWins is delivered as **tenant instances**. A validated configuration
+manifest (`tenants/<id>/manifest.json`) defines an instance's identity (brand,
+theme, domains), settings (features, networks, membership tiers, fees), and
+contract set:
 
-- **Branding-only tenants** front the shared contract estate under their own
-  domain and brand.
-- **Dedicated tenants** get an isolated on-chain estate: tenant-salted CREATE2
-  deployments of the same audited contracts, recorded under
-  `deployments/tenants/<id>/`, with their own membership base, fee router,
-  treasury, and admin keys. Isolation is enforced by separate contract
-  instances — never by a frontend filter.
+- **Branding-only instances** front the shared contract estate under your
+  domain and brand — live in days.
+- **Dedicated instances** get an isolated on-chain estate: deterministic,
+  tenant-salted deployments of the same audited contracts, with your own
+  membership base, fee configuration, treasury, and admin keys. Isolation is
+  enforced by separate contract instances — never by an application filter.
 
-See `docs/developer-guide/white-label-tenants.md` and
-`docs/runbooks/tenant-operations.md`.
+One origin serves one tenant; an instance physically contains no other
+tenant's identity or addresses. See
+[White-Label Tenants](docs/developer-guide/white-label-tenants.md) and the
+[Tenant Operations runbook](docs/runbooks/tenant-operations.md).
 
-## The wager layer
+## Network coverage
 
-The original core, still central: private 1-v-1 wagers whose stakes are locked
-in escrow and settled by whoever the parties agreed to trust — themselves, a
-neutral arbitrator, or external oracles (Polymarket, Chainlink, UMA).
+| Network | Chain ID | Coverage |
+|---------|----------|----------|
+| Polygon | 137 | Full platform (primary network) |
+| Ethereum | 1 | Portfolio, custody, routers, bridge liquidity |
+| Optimism / Base / Arbitrum | 10 / 8453 / 42161 | Portfolio, custody, routers |
+| Ethereum Classic | 61 | Custody + DEX trading |
+| Bitcoin | — | Native wallet (portfolio / send / receive) |
+| Polygon Amoy / Mordor | 80002 / 63 | Test networks |
 
-### Eight resolution types
+## Security model
 
-| Type | Settled by |
-|------|-----------|
-| `Either` / `Creator` / `Opponent` | The participants themselves |
-| `ThirdParty` | A neutral arbitrator named at creation |
-| `Polymarket` | A linked Polymarket CTF condition |
-| `ChainlinkDataFeed` | A price feed threshold (GT/GTE/LT/LTE/EQ) |
-| `ChainlinkFunctions` | A custom off-chain computation via the DON |
-| `UMA` | An Optimistic Oracle V3 assertion |
-
-### Wager mechanics
-
-- **1v1 even-money or Make an Offer odds** — equal stakes, or asymmetric stakes
-  at a creator-set multiplier where the settler puts up the majority stake
-- **Open challenges** — post a wager with no named opponent, gated by a
-  four-word claim code; whoever you share the code with can take the other side
-- **Group pools** — multi-party wager pools resolved by a member-approved
-  payout matrix (spec 034)
-- **QR / deep-link sharing** — the opponent scans a code and accepts in-app
-- **Mutual draws** — both parties (or the arbitrator) can settle a push
-- **End-to-end encrypted terms** — envelope encryption (X-Wing post-quantum
-  hybrid KEM) with keys published in an on-chain `KeyRegistry`
-
-### Safety mechanisms
-
-- **Stake escrow** — both stakes locked in `WagerRegistry` until resolution
-- **Refund paths everywhere** — expired offers, declined wagers, and wagers
-  whose resolve deadline passes unresolved all return stakes; funds can never
-  get stuck
-- **Pull-based payouts** — the winner claims the pot; claims can't be redirected
-- **Sanctions screening** — `SanctionsGuard` checks the Chainalysis oracle on
-  every create and accept
-
-### Roles, tiers, and operator powers
-
-Wager participation requires a paid **Wager Participant** membership on
-`MembershipManager` (the default tier is **None** — no participation). The
-four-tier ladder is anchored at **$2 Bronze** in USDC:
-
-| Tier | Price | Wagers / month | Open wagers at once |
-|------|-------|----------------|---------------------|
-| None     | —    | 0         | 0         |
-| Bronze   | $2   | 15        | 5         |
-| Silver   | $8   | 30        | 10        |
-| Gold     | $25  | 100       | 30        |
-| Platinum | $100 | Unlimited | Unlimited |
-
-A membership can be **bought directly** (soulbound) or acquired by **redeeming
-a `MembershipVoucher`** — a transferable ERC-721 that is burned for the
-soulbound membership. Membership lives on one reference chain per environment
-(spec 071) and follows the member across networks.
-
-The operator team retains a narrow set of on-chain powers, each bound to a
-distinct OpenZeppelin AccessControl role (`GUARDIAN_ROLE`,
-`ACCOUNT_MODERATOR_ROLE`, `ROLE_MANAGER_ROLE`, `UPGRADER_ROLE`,
-`DEFAULT_ADMIN_ROLE`). See
-[Roles and Tiers](docs/system-overview/roles-and-tiers.md) for the full
-privilege matrix. **No role can move escrowed stakes.**
+1. **Self-custody, structurally** — no contract role or operator key can move
+   user funds; payouts are pull-based, and refund paths cover every timeout.
+   Policy guards for multisig vaults are deliberately non-upgradeable.
+2. **Deterministic deployments** — salted CREATE2 via the Safe Singleton
+   Factory; every address is recorded in-repo (`deployments/`, per-tenant
+   under `deployments/tenants/<id>/`) and version-pinned by consuming
+   services at startup.
+3. **Defense at every layer** — checks-effects-interactions, Slither/Medusa in
+   CI, storage-layout gates on upgrades, sanctions screening on value flows,
+   origin-locked serving, strict CSP.
+4. **Honest state** — fees disclosed before signature; absence rendered as
+   absence (never a zero); no mocked data in shipped paths. These rules are
+   binding: see `.specify/memory/constitution.md`.
 
 ## Architecture
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│                        WagerRegistry                         │
-│   create · accept · declareWinner · draw · claim · refund    │
-└───────┬──────────────┬───────────────────────┬───────────────┘
-        │              │                       │
-        ▼              ▼                       ▼
-┌───────────────┐ ┌──────────────┐  ┌─────────────────────────┐
-│ Membership    │ │ Sanctions    │  │     Oracle adapters     │
-│ Manager       │ │ Guard        │  │ (IOracleAdapter)        │
-│ tiers, limits │ │ Chainalysis  │  │ Polymarket · Chainlink  │
-└───────────────┘ └──────────────┘  │ DataFeed · Functions ·  │
-                                    │ UMA OOv3                │
-┌───────────────┐  ┌──────────────┐ └─────────────────────────┘
-│ KeyRegistry   │  │ Membership   │  public keys (privacy) +
-│ (privacy)     │  │ Voucher      │  transferable ERC-721 voucher
-└───────────────┘  └──────────────┘  redeemed via MembershipManager
-```
+- **Contracts** (`contracts/`) — UUPS proxies at stable addresses for the
+  value-bearing registries (settlement engine, membership, fee router, token
+  factory, staking/bridge/liquidity routers), immutable clones for bearer
+  assets and per-group instances, non-upgradeable policy guards, ERC-4337
+  account stack, oracle adapters (Polymarket, Chainlink DataFeed/Functions,
+  UMA OOv3).
+- **Frontend** (`frontend/`) — React + Vite SPA, one build per tenant
+  instance, served by nginx on Cloud Run behind Cloudflare. No backend: state
+  lives on-chain, on IPFS, or client-side encrypted.
+- **Services** (`services/`) — optional per-tenant relay-gateway (gasless
+  intents + ERC-7677 paymaster with quotas and killswitch) and ERC-4337
+  bundler; The Graph subgraph for indexing.
+- **Tooling** (`scripts/`) — deterministic deploy scripts, tenant manifest
+  validation, frontend contract-artifact sync, operational runbooks under
+  `docs/runbooks/`.
 
-Around that core sit the platform contracts: `WagerPoolFactory` (group pools),
-`FeeRouter` (the single fee source of truth, spec 060), `CallsignRegistry`
-(optional naming, spec 054), `TokenFactory`, `StakingRouter`, `BridgeRouter` +
-`LiquidityRouter` (no-custody routers, spec 067), Safe policy guards
-(specs 049/068), and the ERC-4337 account stack (spec 041/050).
+Full picture: [Architecture guide](docs/developer-guide/architecture.md).
 
-`WagerRegistry` and `MembershipManager` are UUPS-upgradeable behind stable
-proxy addresses — logic is swappable in place while escrowed state is
-preserved (see [ADR 004](docs/adr/004-upgradeable-registry-uups.md)).
-
-Frontend: React + Vite SPA (no backend) served by nginx on Cloud Run behind
-Cloudflare, one build per tenant instance. Optional services: the
-relay-gateway (gasless intents + paymaster, per-tenant scoped) and subgraph.
-Deployed addresses are recorded in [`deployments/`](deployments/) (shared
-estate) and `deployments/tenants/<id>/` (dedicated tenant estates). Full
-picture: [Architecture guide](docs/developer-guide/architecture.md).
-
-## Quick Start
-
-### Installation
+## Quick start
 
 ```bash
 npm install
-npm run compile
-```
-
-### Run Tests
-
-```bash
-npm test                # contract suite
-npm run test:fork       # fork tests
-npm run test:coverage   # coverage
-npm run test:frontend   # frontend (Vitest)
+npm run compile          # contracts
+npm test                 # contract suite
+npm run test:frontend    # frontend (Vitest)
 npm run tenants:validate # tenant manifest validation
+npm run frontend         # run the app locally
 ```
 
-### Run the app locally
+To stand up an instance, see the
+[Tenant quickstart](specs/072-white-label-tenants/quickstart.md); to add
+integrations or contracts, see the
+[developer guide](docs/developer-guide/setup.md).
 
-```bash
-npm run frontend
-```
+## Development
 
-### Wager lifecycle (contract level)
-
-```solidity
-// Creator escrows their stake and defines the wager
-uint256 id = registry.createWager(
-    opponent, arbitrator, usdc,
-    creatorStake, opponentStake,
-    acceptDeadline, resolveDeadline,
-    ResolutionType.Polymarket,
-    polymarketConditionId, /* creatorIsYes */ true,
-    metadataHash, "ipfs://<cid>"
-);
-
-// Opponent escrows their stake
-registry.acceptWager(id);
-
-// After the linked Polymarket market settles, anyone can trigger resolution
-registry.autoResolveFromPolymarket(id);
-
-// Winner pulls the full pot
-registry.claimPayout(id);
-
-// — or, if it never resolved by the deadline, either party gets made whole
-registry.claimRefund(id);
-```
-
-### Adding a new oracle adapter
-
-1. Implement the `IOracleAdapter` interface
-2. Wire it into `WagerRegistry`'s adapter slot for its resolution type
-3. Write tests (unit + fork) and update the docs
-
-## Contracts
-
-| Contract | Location | Description |
-|----------|----------|-------------|
-| `WagerRegistry` | `contracts/wagers/` | Wager lifecycle + stake escrow, incl. open challenges (UUPS proxy) |
-| `WagerPoolFactory` / `WagerPool` | `contracts/pools/` | Group wager pools (factory + immutable clones) |
-| `MembershipManager` | `contracts/access/` | Tiered memberships, rate limits, voucher redemption (UUPS proxy) |
-| `MembershipVoucher` | `contracts/access/` | Transferable ERC-721 voucher → soulbound membership (immutable) |
-| `SanctionsGuard` | `contracts/access/` | Chainalysis screening + deny list |
-| `FeeRouter` | `contracts/fees/` | Single source of truth for platform fees (UUPS proxy) |
-| `KeyRegistry` | `contracts/privacy/` | Encryption public keys |
-| `CallsignRegistry` | `contracts/identity/` | Optional %callsign naming (UUPS proxy) |
-| `BridgeRouter` / `LiquidityRouter` | `contracts/bridge/`, `contracts/liquidity/` | No-custody bridge + liquidity routers |
-| `SafePolicyGuard(V2)` | `contracts/custody/` | Multisig vault policy engines (non-upgradeable by design) |
-| Oracle adapters | `contracts/oracles/` | Polymarket · Chainlink DataFeed/Functions · UMA OOv3 |
-
-`contracts-archive/` holds superseded research — reference only, never deploy.
-
-Details: [Smart Contracts guide](docs/developer-guide/smart-contracts.md).
-
-## Design principles
-
-1. **Self-custody, always** — no contract or operator role can move member
-   funds; escrow is pull-based and refund paths cover every timeout.
-2. **Leverage, don't rebuild** — Polymarket, Chainlink, UMA, Uniswap, Across,
-   OpenSea, and Safe do what they're best at; FairWins is the control plane
-   that composes them under one honest UI.
-3. **Honest state** — fees disclosed before signature, absence shown as
-   absence, no mocked data in shipped paths (constitution III).
-4. **Deterministic operations** — salted CREATE2 deployments, repo-recorded
-   addresses, spec-driven development ([Spec Kit](https://github.com/github/spec-kit),
-   see [CLAUDE.md](CLAUDE.md) and `.specify/memory/constitution.md`).
+This repo uses [Spec Kit](https://github.com/github/spec-kit) for spec-driven
+development — see [CLAUDE.md](CLAUDE.md) and the binding standards in
+`.specify/memory/constitution.md`. Contract changes must follow
+checks-effects-interactions and pass Slither/Medusa in CI.
 
 ## License
 

--- a/docs/developer-guide/white-label-tenants.md
+++ b/docs/developer-guide/white-label-tenants.md
@@ -1,10 +1,9 @@
 # White-Label Tenants
 
-Spec 072 turns the single-brand product into a platform of **tenant instances**: each
-tenant (customer) runs its own branded instance with its own configuration and — for
-tenants that need asset isolation — its own contract deployments. The FairWins product
-is the **default tenant** (`tenants/fairwins/manifest.json`) and behaves exactly as
-before.
+The platform is delivered as **tenant instances** (spec 072): each tenant (customer)
+runs its own branded instance with its own configuration and — for tenants that need
+asset isolation — its own contract deployments. The FairWins instance is the
+**default tenant** (`tenants/fairwins/manifest.json`).
 
 Full design: `specs/072-white-label-tenants/` (spec, plan, research D1–D11, data-model,
 quickstart, tasks).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,103 +1,83 @@
 # Welcome to FairWins
 
-**A self-custody, multi-chain financial platform — one control plane for your
-money, and you hold the keys.**
+**Self-custody digital asset infrastructure — embedded wallets, policy-governed
+custody, payments, markets connectivity, and compliance, available white-label
+under your own brand.**
 
-FairWins began as a peer-to-peer wager management layer and has grown into a
-multi-chain financial control plane. One app now spans payments and requests
-(gasless USDC transfers), peer-to-peer wagers and group pools, Polymarket
-prediction-market trading, an NFT portfolio with OpenSea selling, lending and
-staking, DEX swaps, cross-chain bridging via Across, a native Bitcoin wallet,
-and Safe multisig custody vaults with an on-chain policy engine. The platform
-never takes custody: every value-bearing action is signed by the member's own
-wallet — passkey smart account, browser/mobile wallet, or multisig vault.
+FairWins is the platform layer for digital asset products. One stack provides
+the components a digital asset business otherwise assembles from multiple
+vendors:
 
-The wager layer that started it all is unchanged in spirit: two people agree on
-a bet, both stakes are locked in an audited escrow contract, and the wager is
-resolved by the participants, a neutral arbitrator, or an external oracle
-(Polymarket, Chainlink, UMA). There is no order book, no market making, and no
-house.
+- **Embedded wallets** — passkey (WebAuthn) ERC-4337 smart accounts with no
+  seed phrases and optional sponsored gas, plus external wallets and hardware
+  signers via WalletConnect
+- **Custody & policy** — Safe multisig vaults with an on-chain policy engine:
+  spending rules, approver requirements, and thresholds enforced by contract
+- **Payments & settlement** — stablecoin transfer/request rails with QR flows,
+  address book, and gasless settlement
+- **Portfolio & reporting** — unified multi-chain portfolio with a complete
+  activity ledger and tax reporting
+- **Markets connectivity** — direct order flow into Polymarket prediction
+  markets, plus escrowed peer-to-peer settlement with oracle resolution
+  (Polymarket, Chainlink, UMA)
+- **Trading, bridging & yield** — per-network DEX execution, Across bridging
+  through no-custody routers, lending vaults, and liquid staking
+- **Bitcoin** — a native BTC wallet beside the EVM accounts, keys held
+  client-side
+- **Compliance** — Chainalysis sanctions screening enforced at the contract
+  layer and jurisdiction gating at the edge
 
-FairWins is also **white-label multi-tenant** (spec 072): the product you see
-at fairwins.app is the default tenant of a platform other operators can run
-under their own brand, domain, configuration, and — for full asset isolation —
-their own dedicated contract deployments. See the
-[White-Label Tenants guide](developer-guide/white-label-tenants.md).
+The defining property: **the platform never takes custody.** Every
+value-bearing action is signed by the user's own keys, payouts are pull-based,
+and refund paths cover every timeout — funds cannot be stranded.
 
-> **Important**: Before purchasing a tier or interacting with the protocol,
+> **Important**: Before purchasing a tier or interacting with the platform,
 > please read the [Roles and Tiers](system-overview/roles-and-tiers.md)
 > overview and the [Account Moderation Policy](system-overview/account-moderation.md).
 > The protocol can be paused by a Guardian role holder, and individual
 > accounts can be frozen for cause by an Account Moderator role holder.
 
-## How it works
+## White-label instances
 
-```mermaid
-sequenceDiagram
-    actor C as Creator
-    actor O as Opponent
-    participant W as WagerRegistry (escrow)
-    participant A as Oracle Adapter
-
-    C->>W: createWager (stake locked)
-    C-->>O: share QR code / link
-    O->>W: acceptWager (stake locked)
-    Note over W: Wager active until end time
-    alt Participant-resolved
-        C->>W: declareWinner
-    else Oracle-resolved
-        A->>W: autoResolve (Polymarket / Chainlink / UMA)
-    end
-    W->>O: winner claims full pot
-```
-
-1. **Create** — pick the terms, the stake (USDC), and how the wager resolves
-2. **Share** — send your friend a QR code or deep link
-3. **Lock** — both stakes are held in smart-contract escrow
-4. **Resolve** — a participant, arbitrator, or oracle declares the outcome
-5. **Settle** — the winner claims the combined pot; expired or unresolved wagers are refundable
+FairWins is delivered as **tenant instances**: a validated configuration
+manifest defines an instance's brand, theme, domains, feature set, networks,
+and contract set. Branding-only instances front the shared contract estate;
+dedicated instances get an **isolated on-chain estate** — deterministic,
+tenant-salted deployments of the same audited contracts with their own
+membership base, fee configuration, treasury, and admin keys. Isolation is
+enforced by separate contract instances, never by an application filter.
+See the [White-Label Tenants guide](developer-guide/white-label-tenants.md).
 
 ## Where it runs
 
-| Network | Chain ID | Role |
-|---------|----------|------|
-| Polygon Mainnet | 137 | **Live** — primary network + membership reference chain at [fairwins.app](https://fairwins.app) |
-| Ethereum Mainnet | 1 | Portfolio, custody, routers, bridge-LP |
+| Network | Chain ID | Coverage |
+|---------|----------|----------|
+| Polygon Mainnet | 137 | **Live** — full platform (primary network) at [fairwins.app](https://fairwins.app) |
+| Ethereum Mainnet | 1 | Portfolio, custody, routers, bridge liquidity |
 | Optimism / Base / Arbitrum | 10 / 8453 / 42161 | Portfolio, custody, routers |
-| Ethereum Classic | 61 | Custody + ETCswap trading |
-| Bitcoin | — | Native BTC wallet (portfolio/send/receive, spec 061) |
-| Polygon Amoy / Mordor | 80002 / 63 | Testnets (toggle in the wallet menu) |
+| Ethereum Classic | 61 | Custody + DEX trading |
+| Bitcoin | — | Native wallet (portfolio/send/receive) |
+| Polygon Amoy / Mordor | 80002 / 63 | Test networks (toggle in the wallet menu) |
 
 Recorded contract addresses live in [`deployments/`](https://github.com/chippr-robotics/prediction-dao-research/tree/main/deployments)
 — see the [Architecture guide](developer-guide/architecture.md) for the full map.
 
-## Who settles a wager
-
-| Settler | Who settles it |
-|------|----------------|
-| Me (Creator) | The creator declares the winner |
-| Them (Opponent) | The opponent declares the winner |
-| A Friend (Third Party) | A neutral arbitrator chosen at creation |
-| An Oracle — Polymarket | Auto-settles from a linked Polymarket market |
-| An Oracle — Chainlink Data Feed | Auto-settles from a price-feed threshold |
-| An Oracle — Chainlink Functions | Auto-settles from a custom off-chain computation |
-| An Oracle — UMA | Auto-settles via UMA's Optimistic Oracle V3 |
-
-In the create UI these settlers appear as **Me**, **Them**, **A Friend**, and
-**An Oracle** (the oracle tab covers Polymarket / Chainlink / UMA). The retired
-**Either Party** option is no longer offered for new wagers.
-
 ## Privacy & security
 
-- **End-to-end encrypted terms** — wager descriptions are envelope-encrypted
-  client-side (X-Wing post-quantum hybrid KEM, [ADR-003](adr/003-xwing-post-quantum-encryption.md))
-  and stored on IPFS; only the participants (and arbitrator, if any) can read them
-- **On-chain key registry** — participants publish encryption public keys via `KeyRegistry`
-- **Escrow** — stakes are held by `WagerRegistry` until resolution; refund paths
-  exist for expired offers and unresolved wagers
+- **Self-custody, structurally** — no contract role or operator key can move
+  user funds; multisig policy guards are deliberately non-upgradeable
+- **End-to-end encryption** — private records are envelope-encrypted
+  client-side (X-Wing post-quantum hybrid KEM,
+  [ADR-003](adr/003-xwing-post-quantum-encryption.md)); encrypted backups sync
+  across devices with keys the platform never sees
+- **On-chain key registry** — participants publish encryption public keys via
+  `KeyRegistry`
 - **Sanctions screening** — `SanctionsGuard` checks the Chainalysis sanctions
-  oracle before any wager is created or accepted
-- **No backend** — the app is a static SPA; all state lives on-chain or on IPFS
+  oracle before value flows execute
+- **No backend** — the app is a static SPA; state lives on-chain, on IPFS, or
+  client-side encrypted
+- **Honest fees** — every fee has one on-chain source of truth with hard caps,
+  disclosed before signature
 
 ## Quick Navigation
 
@@ -107,7 +87,7 @@ In the create UI these settlers appear as **Me**, **Them**, **A Friend**, and
 
     ---
 
-    Learn how to create wagers, accept challenges, and claim winnings.
+    Using the platform: accounts, payments, markets, custody, and recovery.
 
     [:octicons-arrow-right-24: Getting Started](user-guide/getting-started.md)
 
@@ -123,7 +103,7 @@ In the create UI these settlers appear as **Me**, **Them**, **A Friend**, and
 
     ---
 
-    Understand the contracts, frontend, oracle integration, and infrastructure.
+    Understand the contracts, frontend, integrations, and infrastructure.
 
     [:octicons-arrow-right-24: Architecture](developer-guide/architecture.md)
 
@@ -141,24 +121,24 @@ In the create UI these settlers appear as **Me**, **Them**, **A Friend**, and
 
 | Contract | Role |
 |----------|------|
-| `WagerRegistry` | Wager lifecycle and stake escrow (create, accept, resolve, claim, refund), including open challenges. **UUPS proxy** — upgradeable at a stable address (spec 025) |
-| `MembershipManager` | Tiered memberships (Bronze → Platinum) with creation rate limits and voucher redemption. **UUPS proxy** (spec 027) |
-| `MembershipVoucher` | Transferable ERC-721 bearer claim on a membership; bought with USDC, redeemed (burned) for a soulbound membership (spec 026). **Immutable** by design |
-| `TokenFactory` | Role-gated, sanctions-screened issuance of open ERC-20/721 and restricted ERC-1404 tokens as immutable clones (spec 028). **UUPS proxy**. See the [Token Mint guide](developer-guide/token-mint.md) |
+| `WagerRegistry` | Escrowed peer-to-peer settlement engine (create, accept, resolve, claim, refund) with oracle resolution. **UUPS proxy** — upgradeable at a stable address |
+| `MembershipManager` | Tiered access (Bronze → Platinum) with rate limits and voucher redemption. **UUPS proxy** |
+| `MembershipVoucher` | Transferable ERC-721 bearer claim on a membership, redeemed for a soulbound membership. **Immutable** by design |
+| `FeeRouter` | Single source of truth for platform fees, per-service hard caps. **UUPS proxy** |
+| `TokenFactory` | Role-gated, sanctions-screened issuance of ERC-20/721 and restricted ERC-1404 tokens as immutable clones. **UUPS proxy** |
+| `SafePolicyGuard` / `SafePolicyGuardV2` | On-chain policy engines for multisig vaults — **non-upgradeable** by design |
+| `BridgeRouter` / `LiquidityRouter` | No-custody routers for Across bridging and Uniswap/HubPool liquidity |
 | `SanctionsGuard` | Non-bypassable sanctions screening (Chainalysis oracle + deny list) |
-| `KeyRegistry` | Public encryption keys for private wager terms |
+| `KeyRegistry` | Public encryption keys for end-to-end encrypted records |
 | Oracle adapters | `PolymarketOracleAdapter`, `ChainlinkDataFeedOracleAdapter`, `ChainlinkFunctionsOracleAdapter`, `UMAOptimisticOracleV3Adapter` |
 
-The two value-bearing core contracts (`WagerRegistry`, `MembershipManager`)
-are **UUPS upgradeable proxies** — logic is swapped in place while state and
-addresses are preserved — so features ship without stranding wagers or
-memberships (see [ADR-004](adr/004-upgradeable-registry-uups.md)).
-
-The earlier futarchy/DAO-governance research (ClearPath, friend-group market
-factories, conditional-token markets) has been superseded by this P2P design;
-its documentation is preserved under
+The value-bearing registries are **UUPS upgradeable proxies** — logic is
+swapped in place while state and addresses are preserved — so features ship
+without stranding funds or memberships (see
+[ADR-004](adr/004-upgradeable-registry-uups.md)). Earlier research materials
+are preserved under
 [`docs/archived/`](https://github.com/chippr-robotics/prediction-dao-research/tree/main/docs/archived)
-and the contracts under `contracts-archive/`.
+and `contracts-archive/` (reference only).
 
 ## License
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
          touch-action: manipulation (no double-tap zoom), a 16px input floor (no iOS
          focus zoom), and text-size-adjust (no auto-inflation) — see src/index.css. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="description" content="FairWins is a self-custody, multi-chain financial platform: payments, peer-to-peer wagers, prediction markets, collectibles, earning, swaps, bridging, Bitcoin, and multisig custody — one control plane, and you hold the keys." />
+    <meta name="description" content="FairWins is self-custody digital asset infrastructure: embedded wallets, policy-governed custody, payments and settlement, markets connectivity, and built-in compliance screening across major networks — available white-label under your own brand." />
 
     <!-- Progressive Web App: manifest + install/standalone metadata -->
     <link rel="manifest" href="/manifest.webmanifest" />
@@ -19,7 +19,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="🍀FairWins" />
     <link rel="apple-touch-icon" href="/assets/fairwins_no-text_logo.svg" />
-    <title>FairWins - Multi-Chain Financial Platform</title>
+    <title>FairWins - Digital Asset Infrastructure</title>
     
     <!-- Preconnect to common external origins for better performance -->
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "🍀FairWins",
   "short_name": "FairWins",
-  "description": "A self-custody, multi-chain financial platform: payments, peer-to-peer wagers, prediction markets, collectibles, earning, swaps, bridging, Bitcoin, and multisig custody — one control plane, and you hold the keys.",
+  "description": "Self-custody digital asset infrastructure: embedded wallets, policy-governed custody, payments and settlement, markets connectivity, and built-in compliance screening across major networks.",
   "id": "/",
   "start_url": "/?source=pwa",
   "scope": "/",

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -52,7 +52,7 @@ export default function Footer({ variant = 'full' }) {
             <p>{brand.tagline}</p>
           </div>
           <div className="footer-section">
-            <h4>Oracles</h4>
+            <h4>Integrations</h4>
             <ul>
               <li><a href="https://polymarket.com" target="_blank" rel="noopener noreferrer">Polymarket</a></li>
               {SHOW_ALL_ORACLE_MODELS && (

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import Header from './Header'
 import Footer from './Footer'
-import { useChainTokens } from '../hooks/useChainTokens'
 import { tenantBrand, tenantLinks, isFeatureEnabled } from '../config/tenant'
 import './LandingPage.css'
 
@@ -34,7 +33,6 @@ const SOCIAL_ICONS = {
 function LandingPage() {
   const navigate = useNavigate()
   const [visibleSections, setVisibleSections] = useState(new Set())
-  const { native: nativeSymbol } = useChainTokens()
   const brand = tenantBrand()
   const { support, social } = tenantLinks()
 
@@ -79,19 +77,20 @@ function LandingPage() {
         <div className="hero-content">
           <div className="hero-badge">
             <span className="hero-badge-dot" />
-            Self-custody · Multi-chain
+            Self-Custody · Multi-Chain · White-Label
           </div>
 
           <h1 className="hero-headline">
-            Every Chain.<br />
-            <span className="hero-headline-accent">One Platform.</span><br />
-            Your Keys.
+            Digital Asset<br />
+            <span className="hero-headline-accent">Infrastructure.</span><br />
+            Your Brand.
           </h1>
 
           <p className="hero-subtitle">
-            Your financial control plane: pay, wager, trade prediction markets,
-            earn, swap, bridge, and manage Bitcoin and multisig vaults — across
-            every chain you use, and you hold the keys the whole time.
+            {brand.displayName} is the platform layer for digital asset products:
+            embedded wallets, policy-governed custody, payments and settlement,
+            markets connectivity, and built-in compliance — across major networks,
+            with keys your users hold.
           </p>
 
           <div className="hero-actions">
@@ -126,18 +125,18 @@ function LandingPage() {
           <div className="preview-card">
             <div className="preview-card-header">
               <div className="preview-status-live" />
-              <span className="preview-label">Live Wager</span>
+              <span className="preview-label">Vault Transfer</span>
             </div>
-            <div className="preview-question">Will BTC close above $150k on New Year&apos;s Eve?</div>
+            <div className="preview-question">Transfer 25,000 USDC · Operations vault</div>
             <div className="preview-stakes">
               <div className="preview-stake">
-                <span className="preview-stake-label">Your stake</span>
-                <span className="preview-stake-value">0.5 {nativeSymbol}</span>
+                <span className="preview-stake-label">Approvals</span>
+                <span className="preview-stake-value">2 of 3</span>
               </div>
-              <div className="preview-vs">VS</div>
+              <div className="preview-vs">→</div>
               <div className="preview-stake">
-                <span className="preview-stake-label">Their stake</span>
-                <span className="preview-stake-value">0.5 {nativeSymbol}</span>
+                <span className="preview-stake-label">Policy check</span>
+                <span className="preview-stake-value">Passed</span>
               </div>
             </div>
             <div className="preview-resolution">
@@ -145,23 +144,23 @@ function LandingPage() {
                 <circle cx="12" cy="12" r="10" />
                 <polyline points="12 6 12 12 16 14" />
               </svg>
-              Escrowed on-chain · resolves with a challenge period
+              Signed by vault owners · settled on-chain
             </div>
           </div>
         </div>
       </section>
 
-      {/* The Platform - Feature Pillars */}
+      {/* The Platform - Capability Pillars */}
       <section className={`value-section ${isVisible('value-props') ? 'visible' : ''}`} id="features">
         <div className="container" id="value-props" data-animate>
           <div className="section-header">
             <span className="section-tag">The Platform</span>
-            <h2 className="section-title">Everything your money can do,<br />in one place</h2>
+            <h2 className="section-title">Everything a digital asset product needs,<br />in one stack</h2>
             <p className="section-subtitle">
-              {brand.displayName} started as peer-to-peer wagering. Today it is a
-              self-custody financial control plane spanning Polygon, Ethereum and its
-              L2s, Ethereum Classic, and Bitcoin — send, bet, trade, collect, earn,
-              swap, and bridge without ever handing over your funds.
+              {brand.displayName} combines the components you would otherwise assemble
+              from multiple vendors — wallets, custody, payments, markets, and
+              compliance — in one self-custody platform spanning Ethereum and its L2s,
+              Polygon, Ethereum Classic, and Bitcoin.
             </p>
           </div>
 
@@ -173,12 +172,12 @@ function LandingPage() {
                   <path d="M7 11V7a5 5 0 0 1 10 0v4" />
                 </svg>
               </div>
-              <h3>Your portfolio, your keys</h3>
+              <h3>Unified custody &amp; portfolio</h3>
               <p>
-                See every asset you actually hold on-chain — tokens, stablecoins, positions,
-                and collectibles — organized and priced in one portfolio, with your full
-                activity in a single ledger. Your wallet signs every action — the platform
-                never takes custody of your funds.
+                Every on-chain asset — tokens, stablecoins, positions, and collectibles —
+                organized and priced in one portfolio view, with a complete activity
+                ledger. Users sign every action with their own keys; the platform never
+                takes custody of funds.
               </p>
             </div>
 
@@ -189,24 +188,22 @@ function LandingPage() {
                   <polygon points="22 2 15 22 11 13 2 9 22 2" />
                 </svg>
               </div>
-              <h3>Transfer</h3>
-              <p>Pay and request money like a payments app — big numpad, QR codes, address book, and USDC by default. Gasless sends mean no gas token required to move your money.</p>
+              <h3>Payments &amp; settlement</h3>
+              <p>Stablecoin transfers and requests with QR codes, address book, and gasless rails — recipients settle in USDC without holding a gas token, and every transfer is screened before it moves.</p>
             </div>
 
-            {isFeatureEnabled('wagers') && (
             <div className="value-card">
               <div className="value-icon">
                 <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                  <path d="M8 6h13M8 12h13M8 18h13" />
-                  <path d="M3 6l1.5 1.5L7 5M3 12l1.5 1.5L7 11M3 18l1.5 1.5L7 17" />
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                  <path d="M9 12l2 2 4-4" />
                 </svg>
               </div>
-              <h3>Wager</h3>
-              <p>Head-to-head bets, open challenges, and group pools. Smart contracts escrow the stakes; outcomes settle by oracle or by the people you choose, with challenge periods to keep it fair.</p>
+              <h3>Embedded wallets</h3>
+              <p>Passkey smart accounts open with a fingerprint or face — no seed phrases, no extensions, optional sponsored gas — alongside support for external wallets and hardware signers via WalletConnect.</p>
             </div>
-            )}
 
-            {isFeatureEnabled('predict') && (
+            {(isFeatureEnabled('predict') || isFeatureEnabled('wagers')) && (
             <div className="value-card">
               <div className="value-icon">
                 <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -214,8 +211,8 @@ function LandingPage() {
                   <polyline points="17 6 23 6 23 12" />
                 </svg>
               </div>
-              <h3>Predict</h3>
-              <p>Browse and trade real Polymarket prediction markets without leaving the app. Your own wallet signs every order, and every fee is disclosed before you commit.</p>
+              <h3>Markets connectivity</h3>
+              <p>Direct order flow into Polymarket prediction markets and escrowed peer-to-peer settlement with oracle resolution (Polymarket, Chainlink, UMA) — user wallets sign every order, and every fee is disclosed before commitment.</p>
             </div>
             )}
 
@@ -228,8 +225,8 @@ function LandingPage() {
                   <polyline points="21 15 16 10 5 21" />
                 </svg>
               </div>
-              <h3>Collect</h3>
-              <p>Your NFTs, alongside the rest of your portfolio — with live floor prices and best offers. List and sell through OpenSea right from your collection.</p>
+              <h3>Digital collectibles</h3>
+              <p>NFT holdings with live floor prices and best offers, listed and sold through OpenSea from inside the platform — valuation and liquidity in the same view as the rest of the portfolio.</p>
             </div>
             )}
 
@@ -243,8 +240,8 @@ function LandingPage() {
                   <path d="M12 12c3 0 5-2 5-5-3 0-5 2-5 5z" />
                 </svg>
               </div>
-              <h3>Earn</h3>
-              <p>Put idle assets to work in audited third-party lending vaults. Watch positions grow, claim rewards, and withdraw whenever you want — explained in plain language.</p>
+              <h3>Yield</h3>
+              <p>Idle assets deployed into audited third-party lending vaults, liquid staking, and supplied liquidity — positions stay withdrawable, rates and fees are disclosed before signature.</p>
             </div>
             )}
 
@@ -258,11 +255,11 @@ function LandingPage() {
                   <path d="M21 13v2a4 4 0 0 1-4 4H3" />
                 </svg>
               </div>
-              <h3>Swap</h3>
-              <p>Exchange tokens through the right DEX for whichever chain you&apos;re on — Uniswap on Polygon and Ethereum networks, ETCswap on Ethereum Classic. Always labeled honestly.</p>
+              <h3>Trading &amp; liquidity</h3>
+              <p>Token execution through the right venue per network — Uniswap on Ethereum, L2s, and Polygon; ETCswap on Ethereum Classic — with honest venue labeling on every quote.</p>
             </div>
             )}
-          
+
             {isFeatureEnabled('bridge') && (
             <div className="value-card">
               <div className="value-icon">
@@ -272,8 +269,8 @@ function LandingPage() {
                   <path d="M8 18v-4M12 18v-6M16 18v-4" />
                 </svg>
               </div>
-              <h3>Bridge</h3>
-              <p>Move assets between chains through Across. Deposits refund straight to you if they can&apos;t be filled — the router never holds your funds, by design.</p>
+              <h3>Cross-chain</h3>
+              <p>Asset bridging via Across with a no-custody router: deposits that cannot be filled refund straight to the sender, and platform contracts never hold funds in flight.</p>
             </div>
             )}
 
@@ -286,19 +283,19 @@ function LandingPage() {
                 </svg>
               </div>
               <h3>Bitcoin</h3>
-              <p>A real Bitcoin wallet beside your EVM accounts — rotating receive addresses, honest fee quotes before you sign, and keys that never leave your device.</p>
+              <p>A native Bitcoin wallet beside the EVM accounts — rotating receive addresses, honest fee quotes before signing, and keys derived and held on the user&apos;s device.</p>
             </div>
             )}
           </div>
         </div>
       </section>
 
-      {/* How It Works - Visual Timeline */}
+      {/* White-label offering - Visual Timeline */}
       <section className={`steps-section ${isVisible('steps-area') ? 'visible' : ''}`} id="how-it-works">
         <div className="container" id="steps-area" data-animate>
           <div className="section-header">
-            <span className="section-tag">How It Works</span>
-            <h2 className="section-title">Three steps. That's it.</h2>
+            <span className="section-tag">White-Label</span>
+            <h2 className="section-title">Your platform, from configuration</h2>
           </div>
 
           <div className="steps-timeline">
@@ -309,11 +306,12 @@ function LandingPage() {
                 <span>1</span>
               </div>
               <div className="step-content">
-                <h3>Connect</h3>
+                <h3>Provision</h3>
                 <p>
-                  Create a passkey account with just your fingerprint or face — no seed
-                  phrase, no gas token needed to start. Already have a wallet? Connect
-                  your browser or mobile wallet instead.
+                  Stand up a branded instance from a validated configuration manifest:
+                  your identity, theme, domain, feature set, and networks — with a
+                  dedicated, isolated contract deployment where assets and
+                  administration must be yours alone.
                 </p>
               </div>
             </div>
@@ -323,11 +321,11 @@ function LandingPage() {
                 <span>2</span>
               </div>
               <div className="step-content">
-                <h3>Make your move</h3>
+                <h3>Onboard</h3>
                 <p>
-                  Pay a friend, lock in a wager, take a position on a prediction market,
-                  lend idle funds, swap tokens, or list a collectible. Every action lives
-                  in the same minimalist app.
+                  Users create passkey wallets in seconds or connect wallets they
+                  already hold. Sanctions screening and jurisdiction gating are built
+                  into every value flow — not bolted on.
                 </p>
               </div>
             </div>
@@ -337,11 +335,11 @@ function LandingPage() {
                 <span>3</span>
               </div>
               <div className="step-content">
-                <h3>Stay in control</h3>
+                <h3>Operate</h3>
                 <p>
-                  Your wallet signs everything, stakes sit in smart-contract escrow, and
-                  winnings, positions, and rewards are yours to claim or withdraw at any
-                  time. No middlemen holding your money.
+                  Payments, trading, custody, and yield run self-custody on audited
+                  contracts, while your operations console reads the whole estate —
+                  every network, every balance, every control — with honest state.
                 </p>
               </div>
             </div>
@@ -354,10 +352,11 @@ function LandingPage() {
         <div className="container" id="resolution-area" data-animate>
           <div className="section-header">
             <span className="section-tag">Custody, Your Way</span>
-            <h2 className="section-title">You hold the keys. Always.</h2>
+            <h2 className="section-title">Keys stay with your users. Always.</h2>
             <p className="section-subtitle">
-              {brand.displayName} never custodies your funds. Choose how you want to
-              control your account — from a simple passkey to a shared multisig vault.
+              {brand.displayName} never custodies funds. Accounts range from a simple
+              passkey to policy-governed multisig vaults — all self-custody, all
+              recoverable.
             </p>
           </div>
 
@@ -371,8 +370,8 @@ function LandingPage() {
                 </svg>
               </div>
               <h3>Passkey Accounts</h3>
-              <p>Your face or fingerprint creates an on-chain smart account — no seed phrase, no extensions. Everyday actions can run gas-free, with fees always disclosed when they&apos;re not.</p>
-              <span className="resolution-use-case">Best for: Getting started in seconds</span>
+              <p>A fingerprint or face creates an on-chain smart account — no seed phrase, no extensions. Everyday actions can run gas-sponsored, with fees always disclosed when they&apos;re not.</p>
+              <span className="resolution-use-case">Best for: Mainstream onboarding</span>
             </div>
 
             <div className="resolution-card resolution-initiator">
@@ -383,8 +382,8 @@ function LandingPage() {
                   <path d="M16 12h.01" />
                 </svg>
               </div>
-              <h3>Your Own Wallet</h3>
-              <p>Bring the wallet you already trust — browser extension or any WalletConnect-compatible mobile wallet. {brand.displayName} is just an interface to your keys.</p>
+              <h3>External Wallets</h3>
+              <p>Browser extensions, mobile wallets, and hardware signers connect over WalletConnect. {brand.displayName} is an interface to keys your users already control.</p>
               <span className="resolution-use-case">Best for: Existing crypto users</span>
             </div>
 
@@ -398,9 +397,9 @@ function LandingPage() {
                   <path d="M16 3.13a4 4 0 0 1 0 7.75" />
                 </svg>
               </div>
-              <h3>Shared Vaults</h3>
-              <p>Hold funds together in a Safe multisig where moving money takes co-owner approval. Wager as the vault, pay from the vault — governed by your group, not by us.</p>
-              <span className="resolution-use-case">Best for: Groups, clubs & treasuries</span>
+              <h3>Policy-Governed Vaults</h3>
+              <p>Safe multisig vaults with an on-chain policy engine: spending rules, approver requirements, and thresholds enforced by contract — moving funds takes the approvals your policy demands.</p>
+              <span className="resolution-use-case">Best for: Treasuries &amp; funds</span>
             </div>
 
             <div className="resolution-card resolution-thirdparty">
@@ -411,9 +410,9 @@ function LandingPage() {
                   <path d="M7 11V7a5 5 0 0 1 10 0v4" />
                 </svg>
               </div>
-              <h3>Encrypted Backup</h3>
-              <p>Your address book, vault references, and settings sync end-to-end encrypted. Recover on any device with your phrase — we couldn&apos;t read your data if we wanted to.</p>
-              <span className="resolution-use-case">Best for: Peace of mind</span>
+              <h3>Encrypted Backup &amp; Recovery</h3>
+              <p>Address books, vault references, and settings sync end-to-end encrypted; accounts recover on any device. Legacy keys can be imported, stored encrypted, and swept — nothing readable ever leaves the client.</p>
+              <span className="resolution-use-case">Best for: Operational resilience</span>
             </div>
           </div>
         </div>
@@ -423,57 +422,57 @@ function LandingPage() {
       <section className={`scenarios-section ${isVisible('scenarios-area') ? 'visible' : ''}`} id="use-cases">
         <div className="container" id="scenarios-area" data-animate>
           <div className="section-header">
-            <span className="section-tag">Use Cases</span>
-            <h2 className="section-title">What will you do first?</h2>
+            <span className="section-tag">Who It&apos;s For</span>
+            <h2 className="section-title">Built for digital asset businesses</h2>
           </div>
 
           <div className="scenario-grid">
             <div className="scenario-card">
-              <div className="scenario-emoji">&#127944;</div>
-              <h3>The Big Game</h3>
-              <p className="scenario-setup">"I bet you $50 the Chiefs win the Super Bowl."</p>
+              <div className="scenario-emoji">&#127970;</div>
+              <h3>Fintechs &amp; Neo-brokers</h3>
+              <p className="scenario-setup">"We want a digital asset offering without building custody from scratch."</p>
               <p className="scenario-resolution">
-                Lock a head-to-head wager. Smart-contract escrow holds both stakes, a challenge period keeps it honest, and the winner claims the pot.
+                Launch a branded instance from configuration — your domain, your theme, your feature set — on a dedicated, isolated contract deployment.
               </p>
             </div>
             <div className="scenario-card">
-              <div className="scenario-emoji">&#128200;</div>
-              <h3>The Market Call</h3>
-              <p className="scenario-setup">"The polls are wrong and I'd stake money on it."</p>
+              <div className="scenario-emoji">&#127974;</div>
+              <h3>Corporate Treasury</h3>
+              <p className="scenario-setup">"No single employee should be able to move funds."</p>
               <p className="scenario-resolution">
-                Trade real prediction markets on elections, sports, and world events through Polymarket — signed by your wallet, fees shown up front.
+                Policy-governed multisig vaults enforce approver sets and spending rules on-chain, with a proposal flow and full audit trail.
               </p>
             </div>
             <div className="scenario-card">
-              <div className="scenario-emoji">&#127829;</div>
-              <h3>The Dinner Debt</h3>
-              <p className="scenario-setup">"Just send me your half whenever."</p>
+              <div className="scenario-emoji">&#128184;</div>
+              <h3>Payments Operations</h3>
+              <p className="scenario-setup">"Settle in stablecoins without teaching anyone about gas."</p>
               <p className="scenario-resolution">
-                Pay or request USDC with a QR code in seconds — payments-app simple, no gas token required, straight between wallets.
+                Gasless USDC transfer rails with QR-based request flows, address books, and sanctions screening on every movement.
               </p>
             </div>
             <div className="scenario-card">
-              <div className="scenario-emoji">&#127942;</div>
-              <h3>The Office Pool</h3>
-              <p className="scenario-setup">"Everyone in for the bracket. Winner takes all."</p>
+              <div className="scenario-emoji">&#128202;</div>
+              <h3>Trading Desks</h3>
+              <p className="scenario-setup">"One venue view across chains, with fees we can defend."</p>
               <p className="scenario-resolution">
-                Spin up a group wager pool. Everyone joins with USDC, the group approves the payout, and claims go straight to the winners' wallets.
+                Market connectivity into Polymarket, per-network DEX execution, and oracle-resolved settlement — every fee disclosed before signature.
               </p>
             </div>
             <div className="scenario-card">
-              <div className="scenario-emoji">&#128444;&#65039;</div>
-              <h3>The Collection</h3>
-              <p className="scenario-setup">"What's my collection actually worth?"</p>
+              <div className="scenario-emoji">&#128737;&#65039;</div>
+              <h3>Compliance Teams</h3>
+              <p className="scenario-setup">"Screening has to be structural, not a checkbox."</p>
               <p className="scenario-resolution">
-                See your NFTs with live floor prices right beside your tokens — and list one for sale on OpenSea without leaving the app.
+                Chainalysis sanctions screening is enforced at the contract layer, jurisdiction gating at the edge, and activity is auditable end to end.
               </p>
             </div>
             <div className="scenario-card">
-              <div className="scenario-emoji">&#127793;</div>
-              <h3>The Idle Stack</h3>
-              <p className="scenario-setup">"My USDC is just sitting there between bets."</p>
+              <div className="scenario-emoji">&#128273;</div>
+              <h3>Product Teams</h3>
+              <p className="scenario-setup">"Onboarding dies at the seed phrase."</p>
               <p className="scenario-resolution">
-                Lend it into an audited vault and watch it earn. Withdraw any time, claim rewards when they land — your position, your call.
+                Embedded passkey wallets open with a fingerprint, run gas-sponsored, and recover across devices — self-custody without the sharp edges.
               </p>
             </div>
           </div>
@@ -487,8 +486,8 @@ function LandingPage() {
           <div className="cta-orb cta-orb-2" />
         </div>
         <div className="final-cta-content">
-          <h2>Ready to take control<br />of your money?</h2>
-          <p>Connect with a passkey and make your first move in under a minute.</p>
+          <h2>Ready to see the platform<br />in action?</h2>
+          <p>Step into the live app, or talk to us about a branded instance of your own.</p>
           <button onClick={handleGetStarted} className="hero-cta-primary cta-large">
             <span>Get Started</span>
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -498,7 +497,7 @@ function LandingPage() {
           </button>
           {support.email && (
             <p className="cta-contact">
-              Questions? <a href={`mailto:${support.email}`}>{support.email}</a>
+              Platform &amp; white-label inquiries: <a href={`mailto:${support.email}`}>{support.email}</a>
             </p>
           )}
         </div>

--- a/frontend/src/components/compliance/EntryGate.jsx
+++ b/frontend/src/components/compliance/EntryGate.jsx
@@ -81,15 +81,15 @@ export default function EntryGate() {
       >
         <h2 id="entry-gate-title">Before you enter {tenantBrand().displayName}</h2>
         <p>
-          {tenantBrand().displayName} is peer-to-peer software. You wager directly against other participants;
-          {' '}{tenantBrand().displayName} is never your counterparty, sets no odds, and takes no share of any wager.
+          {tenantBrand().displayName} is self-custody software. You transact directly on-chain from your
+          own wallet; {tenantBrand().displayName} is never your counterparty and never holds your funds.
         </p>
         <p>By selecting <strong>Enter</strong>, you confirm that:</p>
         <ul>
           <li>You are at least 21 years old.</li>
           <li>You are not accessing {tenantBrand().displayName} from any restricted jurisdiction listed in our Terms.</li>
           <li>You are not subject to sanctions and do not appear on any government restricted-party list.</li>
-          <li>Accessing peer-to-peer wagering is lawful where you are located, and you accept full responsibility for compliance with your local laws.</li>
+          <li>Your use of the platform — including any peer-to-peer settlement features — is lawful where you are located, and you accept full responsibility for compliance with your local laws.</li>
           <li>
             You have read and agree to the{' '}
             <a href="/terms">Terms &amp; Conditions</a> and{' '}

--- a/frontend/src/test/tenantConfig.test.js
+++ b/frontend/src/test/tenantConfig.test.js
@@ -30,7 +30,7 @@ describe('tenant config (spec 072)', () => {
     const brand = tenantBrand()
     expect(brand.displayName).toBe('FairWins')
     expect(brand.appUrl).toBe('https://fairwins.app')
-    expect(brand.htmlTitle).toBe('FairWins - Multi-Chain Financial Platform')
+    expect(brand.htmlTitle).toBe('FairWins - Digital Asset Infrastructure')
     expect(brand.logo).toBe('/assets/logo_fairwins.svg')
     expect(brand.logoMark).toBe('/assets/fairwins_no-text_logo.svg')
     // Values from frontend/public/manifest.webmanifest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: FairWins
-site_description: Self-custody multi-chain financial platform — payments, wagers, prediction markets, earning, bridging, Bitcoin, and multisig custody under your own keys
+site_description: Self-custody digital asset infrastructure — embedded wallets, policy-governed custody, payments, markets connectivity, and compliance across major networks, available white-label
 site_author: Chippr Robotics
 site_url: https://docs.FairWins.app
 

--- a/tenants/fairwins/manifest.json
+++ b/tenants/fairwins/manifest.json
@@ -6,8 +6,8 @@
   "identity": {
     "displayName": "FairWins",
     "legalName": "FairWins",
-    "tagline": "Your multi-chain financial control plane — your money, your keys, every chain.",
-    "metaDescription": "FairWins is a self-custody, multi-chain financial platform: payments, peer-to-peer wagers, prediction markets, collectibles, earning, swaps, bridging, Bitcoin, and multisig custody — one control plane, and you hold the keys.",
+    "tagline": "Enterprise-grade digital asset infrastructure — self-custody, multi-chain, white-label.",
+    "metaDescription": "FairWins is self-custody digital asset infrastructure: embedded wallets, policy-governed custody, payments and settlement, markets connectivity, and built-in compliance screening across major networks — available white-label under your own brand.",
     "domains": ["fairwins.app"],
     "appUrl": "https://fairwins.app",
     "docsUrl": "https://docs.FairWins.app",
@@ -27,7 +27,7 @@
     "logoMark": "/assets/fairwins_no-text_logo.svg",
     "favicon": "/assets/logo_fairwins.svg",
     "appleTouchIcon": "/assets/fairwins_no-text_logo.svg",
-    "htmlTitle": "FairWins - Multi-Chain Financial Platform",
+    "htmlTitle": "FairWins - Digital Asset Infrastructure",
     "pwa": {
       "name": "🍀FairWins",
       "shortName": "FairWins",


### PR DESCRIPTION
## Summary

Repositions all outward-facing copy to present the platform as a standalone **digital asset infrastructure** offering — familiar in look and feel to Zero Hash, Fireblocks, Dfns, and BitGo — with no legacy framing and no evolution narrative. Peer-to-peer settlement appears only as one capability of the markets module, never as the product.

## Landing page (`frontend/src/components/LandingPage.jsx`)

- **Hero**: "Digital Asset Infrastructure. Your Brand." with a Self-Custody · Multi-Chain · White-Label badge; subtitle describes the platform layer (embedded wallets, policy-governed custody, payments and settlement, markets connectivity, built-in compliance). Hero preview card now shows a **policy-checked vault transfer** (approvals 2 of 3, policy passed, signed by vault owners).
- **Capability pillars** (feature-gated per tenant): unified custody & portfolio, payments & settlement, embedded wallets, markets connectivity (Polymarket order flow + escrowed peer-to-peer settlement with oracle resolution), digital collectibles, yield, trading & liquidity, cross-chain, Bitcoin.
- **White-label section**: Provision → Onboard → Operate — branded instance from a validated manifest, dedicated isolated contract deployments, compliance built into every flow, estate-wide operations console.
- **Custody section**: passkey accounts, external wallets, **policy-governed vaults**, encrypted backup & recovery.
- **Use cases** rewritten for a business audience: fintechs/neo-brokers, corporate treasury, payments operations, trading desks, compliance teams, product teams.
- CTA offers the live app plus white-label inquiries via the tenant's support address.

## Identity & metadata

- Tenant manifest tagline/metaDescription/htmlTitle, `index.html`, `manifest.webmanifest`, and the MkDocs site description all repositioned to enterprise infrastructure language ("FairWins - Digital Asset Infrastructure").
- Footer marketing column renamed to **Integrations** (links unchanged).
- EntryGate generalized to self-custody software language; all eligibility affirmations (21+, jurisdictions, sanctions, lawful-use) preserved.

## README + docs

- **README** rewritten as a product-first presentation: capability table, white-label/multi-tenant model, network coverage, security model, architecture, quick start. No historic narrative.
- **docs/index.md** rewritten to match: platform capabilities, white-label instances, network coverage, privacy & security, neutral contract-table descriptions (`WagerRegistry` described as the escrowed peer-to-peer settlement engine).
- White-label developer-guide intro neutralized.

## Testing

- 36 tests across affected suites (tenant config/branding, Landing, Footer, EntryGate) green; ESLint clean; `npm run tenants:validate` green; production build verified carrying the new metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqtmZu8A2dxqyt9prZPRWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqtmZu8A2dxqyt9prZPRWT)_