### PR TITLE
Recovery tab: collapsed accordion sections + sheet-based actions

### DIFF
--- a/docs/developer-guide/frontend.md
+++ b/docs/developer-guide/frontend.md
@@ -147,6 +147,30 @@ counterparty public keys in `KeyRegistry`, and envelope-encrypts wager terms
 before pinning to IPFS. Decryption is lazy — triggered when the user opens a
 wager's details. See [Encryption Architecture](encryption-architecture.md).
 
+### Settings surfaces: collapsed sections + sheets
+
+The **Recovery** tab (`?tab=security`) hosts several independent, high-stakes
+features (data backup, controllers, wallet-based recovery, legacy keys, the
+encryption key, recovery codes). Each panel renders itself as an
+`AccordionSection` inside the tab's `AccordionGroup`
+(`components/account/AccordionSection.jsx`, `AccordionGroup.jsx`):
+
+- **Collapsed by default**, with a one-line `summary` of the panel's current
+  state and an optional `badge` when it needs attention — the tab opens as a
+  scannable list, not a wall of controls.
+- **One section open at a time** (`exclusive`, the group default). Group state
+  is in memory, so returning to the tab always starts tidy.
+- Children stay **mounted** while collapsed (that is what the
+  `grid-template-rows: 0fr → 1fr` animation needs) but the region is `inert`, so
+  nothing inside is focusable or announced until it opens.
+- Panels keep their own `return null` gating: wrap the accordion **inside** the
+  panel, and render `ActionSheet`s as **siblings** of the section, never inside
+  the collapsible region (an inert ancestor would disable the sheet).
+- Consequential or destructive actions — restore, remove a backup, link a
+  wallet, remove a controller, delete a recovered key — confirm in an
+  `ActionSheet` (centered card on desktop, bottom sheet on mobile) that states
+  the consequence first.
+
 ### Network handling
 
 `config/wagmi.js` defines the default chain (Polygon 137, overridable via

--- a/frontend/src/components/account/AccordionGroup.jsx
+++ b/frontend/src/components/account/AccordionGroup.jsx
@@ -1,0 +1,48 @@
+/**
+ * Groups AccordionSections so a whole settings tab opens/collapses as one surface.
+ *
+ * Default is "one open at a time" (`exclusive`): a long settings page reads as a
+ * short list of headings, and opening a section tidies the previous one away
+ * instead of pushing it off-screen. Pass `exclusive={false}` for independent
+ * sections. State lives here (not in storage) so returning to the tab always
+ * starts from the tidy, collapsed view.
+ */
+
+import { useCallback, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
+import { AccordionGroupContext } from './accordionContext'
+
+export default function AccordionGroup({ children, defaultOpenId = null, exclusive = true, className = '' }) {
+  const [openIds, setOpenIds] = useState(() => (defaultOpenId ? [defaultOpenId] : []))
+
+  const toggle = useCallback(
+    (id) => {
+      setOpenIds((prev) => {
+        const isOpen = prev.includes(id)
+        if (exclusive) return isOpen ? [] : [id]
+        return isOpen ? prev.filter((x) => x !== id) : [...prev, id]
+      })
+    },
+    [exclusive]
+  )
+
+  const value = useMemo(
+    () => ({ isOpen: (id) => openIds.includes(id), toggle }),
+    [openIds, toggle]
+  )
+
+  return (
+    <AccordionGroupContext.Provider value={value}>
+      <div className={`accordion-group ${className}`.trim()}>{children}</div>
+    </AccordionGroupContext.Provider>
+  )
+}
+
+AccordionGroup.propTypes = {
+  children: PropTypes.node,
+  /** Section id to start expanded (default: everything collapsed). */
+  defaultOpenId: PropTypes.string,
+  /** Only one section open at a time (default true). */
+  exclusive: PropTypes.bool,
+  className: PropTypes.string,
+}

--- a/frontend/src/components/account/AccordionSection.css
+++ b/frontend/src/components/account/AccordionSection.css
@@ -1,0 +1,203 @@
+/* Collapsible settings section (Recovery tab).
+
+   Colors use the FairWins theme tokens from src/theme.css so text stays
+   high-contrast in BOTH light and dark themes. Fallbacks are the light-mode
+   values (light is the default theme) — never dark literals. */
+
+.accordion-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.acc {
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 14px;
+  background: var(--surface-color, #ffffff);
+  overflow: hidden;
+  transition: border-color var(--transition-fast, 0.15s ease), box-shadow var(--transition-fast, 0.15s ease);
+}
+
+.acc[data-open='true'] {
+  border-color: color-mix(in srgb, var(--brand-primary, #36b37e) 45%, var(--border-color, #e3e7eb));
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.05));
+}
+
+/* --- Header --- */
+.acc__heading {
+  margin: 0;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.acc__trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 56px;
+  padding: 12px 14px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: var(--text-primary, #1f2933);
+  font: inherit;
+  border-radius: 14px;
+  transition: background-color var(--transition-fast, 0.15s ease);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.acc__trigger:hover {
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 6%, transparent);
+}
+
+.acc__trigger:focus-visible {
+  outline: 2px solid var(--brand-primary, #36b37e);
+  outline-offset: -2px;
+}
+
+.acc__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 12%, transparent);
+  color: var(--brand-primary, #36b37e);
+}
+
+.acc__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.acc__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary, #1f2933);
+  line-height: 1.3;
+}
+
+.acc__summary {
+  font-size: 12.5px;
+  color: var(--text-secondary, #5a6772);
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.acc__badge {
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+/* Badge ink is the tone darkened for the light theme — the raw brand/semantic
+   hues are ~2.5:1 against a white surface, well under AA for 11px bold text.
+   Dark mode restores the full hue, which is high-contrast on a dark surface. */
+.acc__badge--info {
+  color: color-mix(in srgb, var(--brand-secondary, #4c9aff) 55%, #000);
+  background: color-mix(in srgb, var(--brand-secondary, #4c9aff) 14%, transparent);
+}
+
+.acc__badge--warn {
+  color: color-mix(in srgb, var(--semantic-warning, #f5a623) 55%, #000);
+  background: color-mix(in srgb, var(--semantic-warning, #f5a623) 18%, transparent);
+}
+
+.acc__badge--ok {
+  color: color-mix(in srgb, var(--brand-primary, #36b37e) 60%, #000);
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 14%, transparent);
+}
+
+:root.theme-dark .acc__badge--info {
+  color: var(--brand-secondary, #4c9aff);
+}
+
+:root.theme-dark .acc__badge--warn {
+  color: var(--semantic-warning, #f5a623);
+}
+
+:root.theme-dark .acc__badge--ok {
+  color: var(--brand-primary, #36b37e);
+}
+
+.acc__chevron {
+  flex: 0 0 auto;
+  color: var(--text-secondary, #5a6772);
+  transition: transform 240ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.acc[data-open='true'] .acc__chevron {
+  transform: rotate(180deg);
+}
+
+/* --- Collapsible region ---
+   grid-template-rows 0fr → 1fr animates to the content's natural height with no
+   JS measuring and no max-height guesswork. The inner element carries the
+   overflow clip and min-height:0 the animation needs. */
+.acc__region {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition:
+    grid-template-rows 260ms cubic-bezier(0.2, 0, 0, 1),
+    opacity 180ms ease;
+}
+
+.acc[data-open='true'] .acc__region {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.acc__region-inner {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.acc__body {
+  padding: 2px 14px 16px;
+  border-top: 1px solid var(--border-color, #e3e7eb);
+  margin-top: 2px;
+  padding-top: 14px;
+}
+
+/* Panels inside a section supply their own heading via the trigger — drop the
+   legacy in-body heading spacing so the body starts flush. */
+.acc__body > .section,
+.acc__body > section {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+@media (max-width: 640px) {
+  .acc__trigger {
+    padding: 12px;
+  }
+
+  .acc__body {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .acc__region,
+  .acc__chevron,
+  .acc,
+  .acc__trigger {
+    transition: none;
+  }
+}

--- a/frontend/src/components/account/AccordionSection.jsx
+++ b/frontend/src/components/account/AccordionSection.jsx
@@ -1,0 +1,105 @@
+/**
+ * Collapsible settings section — the building block of the Recovery tab.
+ *
+ * A settings surface with six stacked panels is unreadable when every panel is
+ * expanded at once. Each panel wraps itself in one of these instead: collapsed
+ * by default, showing a heading, a one-line `summary` of its current state, and
+ * an optional `badge` when something needs attention — so the member can scan
+ * the whole tab in one screen and open only what they came for.
+ *
+ * Behaviour notes:
+ * - Uses the AccordionGroup above it when there is one; otherwise keeps its own
+ *   open state (so a section still works rendered on its own, e.g. in tests).
+ * - Children stay MOUNTED while collapsed (that is what makes the open/close
+ *   animation possible) but the region is `inert`, so nothing inside is
+ *   focusable or reachable by assistive tech until it is open.
+ * - The height animation is CSS-only (`grid-template-rows: 0fr → 1fr`), so it is
+ *   compositor-friendly and needs no measuring; it is disabled under
+ *   `prefers-reduced-motion`.
+ */
+
+import { useId, useState } from 'react'
+import PropTypes from 'prop-types'
+import { useAccordionGroup } from './accordionContext'
+import './AccordionSection.css'
+
+export default function AccordionSection({
+  id,
+  title,
+  summary = null,
+  badge = null,
+  badgeTone = 'info',
+  icon = null,
+  defaultOpen = false,
+  children,
+  className = '',
+  'data-testid': dataTestId,
+}) {
+  const reactId = useId()
+  const sectionId = id || reactId
+  const group = useAccordionGroup()
+  const [localOpen, setLocalOpen] = useState(defaultOpen)
+
+  const open = group ? group.isOpen(sectionId) : localOpen
+  const toggle = () => (group ? group.toggle(sectionId) : setLocalOpen((v) => !v))
+
+  const headerId = `${sectionId}-header`
+  const regionId = `${sectionId}-region`
+
+  return (
+    <section
+      className={`acc ${className}`.trim()}
+      data-open={open ? 'true' : 'false'}
+      data-testid={dataTestId}
+    >
+      <h3 className="acc__heading">
+        <button
+          type="button"
+          id={headerId}
+          className="acc__trigger"
+          aria-expanded={open}
+          aria-controls={regionId}
+          onClick={toggle}
+        >
+          {icon && <span className="acc__icon" aria-hidden="true">{icon}</span>}
+          <span className="acc__text">
+            <span className="acc__title">{title}</span>
+            {summary && !open && <span className="acc__summary">{summary}</span>}
+          </span>
+          {badge && <span className={`acc__badge acc__badge--${badgeTone}`}>{badge}</span>}
+          <svg className="acc__chevron" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+            <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      </h3>
+
+      <div
+        className="acc__region"
+        id={regionId}
+        role="region"
+        aria-labelledby={headerId}
+        inert={!open}
+      >
+        <div className="acc__region-inner">
+          <div className="acc__body">{children}</div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+AccordionSection.propTypes = {
+  /** Stable id — required when inside an AccordionGroup so open state survives re-renders. */
+  id: PropTypes.string,
+  title: PropTypes.node.isRequired,
+  /** One-line state summary shown while collapsed (e.g. "Last backup: never"). */
+  summary: PropTypes.node,
+  /** Short chip shown in the header, typically when the section needs attention. */
+  badge: PropTypes.node,
+  badgeTone: PropTypes.oneOf(['info', 'warn', 'ok']),
+  icon: PropTypes.node,
+  defaultOpen: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  'data-testid': PropTypes.string,
+}

--- a/frontend/src/components/account/ActionSheet.css
+++ b/frontend/src/components/account/ActionSheet.css
@@ -18,6 +18,7 @@
   justify-content: center;
   z-index: 1500;
   padding: 16px;
+  animation: action-sheet-fade 160ms ease-out;
 }
 
 .action-sheet {
@@ -31,6 +32,24 @@
   border-radius: 16px;
   box-shadow: var(--shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
   outline: none;
+  animation: action-sheet-pop 200ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+@keyframes action-sheet-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Desktop: a card that settles in. Mobile overrides this with a rise from the
+   bottom edge (see the media query below). */
+@keyframes action-sheet-pop {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to { opacity: 1; transform: none; }
+}
+
+@keyframes action-sheet-rise {
+  from { transform: translateY(100%); }
+  to { transform: none; }
 }
 
 .action-sheet__handle {
@@ -158,6 +177,52 @@
   flex: 1;
 }
 
+/* There is no global `.btn` rule in this app — only scoped ones — so the sheet
+   paints its own three tones. Without this, the global `button {}` fills them
+   with --bg-secondary (darker than the sheet surface) and primary/destructive
+   look identical to cancel. */
+.action-sheet .btn {
+  padding: 0.55rem 0.9rem;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--text-primary, #1f2933) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 26%, transparent);
+  color: var(--text-primary, #1f2933);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color var(--transition-fast, 0.15s ease), border-color var(--transition-fast, 0.15s ease);
+}
+
+.action-sheet .btn:hover:not(:disabled) {
+  border-color: var(--brand-primary, #36b37e);
+}
+
+.action-sheet .btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.action-sheet .btn-primary {
+  background: var(--brand-primary, #36b37e);
+  border-color: var(--brand-primary, #36b37e);
+  color: #fff;
+}
+
+.action-sheet .btn-primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 88%, #000);
+  border-color: color-mix(in srgb, var(--brand-primary, #36b37e) 88%, #000);
+}
+
+.action-sheet .btn-danger {
+  background: var(--semantic-loss, #e5533d);
+  border-color: var(--semantic-loss, #e5533d);
+  color: #fff;
+}
+
+.action-sheet .btn-danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--semantic-loss, #e5533d) 88%, #000);
+  border-color: color-mix(in srgb, var(--semantic-loss, #e5533d) 88%, #000);
+}
+
 /* Bottom sheet on mobile, like the connect surface. */
 @media (max-width: 640px) {
   .action-sheet__backdrop {
@@ -169,6 +234,7 @@
     max-width: 100%;
     max-height: calc(85vh - 64px);
     border-radius: 20px 20px 0 0;
+    animation: action-sheet-rise 260ms cubic-bezier(0.2, 0, 0, 1);
     /* Reserve room so the last actions clear the fixed icon nav (z-index 1200)
        and stay visible/tappable (#938). */
     padding-bottom: calc(64px + env(safe-area-inset-bottom, 0px));
@@ -181,5 +247,12 @@
     border-radius: 999px;
     background: var(--border-color, #e3e7eb);
     margin: 8px auto 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .action-sheet__backdrop,
+  .action-sheet {
+    animation: none;
   }
 }

--- a/frontend/src/components/account/BackupPanel.css
+++ b/frontend/src/components/account/BackupPanel.css
@@ -1,6 +1,7 @@
-/* Spec 032 — Data backup panel. Theme-variable driven (light/dark) — no hardcoded palette. */
+/* Spec 032 — Data backup panel. Theme-variable driven (light/dark) — no hardcoded palette.
+   The panel renders as a collapsible AccordionSection; the restore choice and the
+   destructive remove confirmation live in ActionSheets. */
 .backup-panel { color: var(--text-primary); }
-.backup-title { margin: 0 0 0.5rem; font-weight: 600; }
 .backup-intro { color: var(--text-secondary); margin: 0 0 1rem; font-size: 0.9rem; line-height: 1.5; }
 
 .backup-notice {
@@ -31,10 +32,6 @@
 
 .backup-cost { color: var(--text-muted, var(--text-secondary)); font-size: 0.78rem; margin: 0.3rem 0 0; }
 
-.backup-restore {
-  margin-top: 0.8rem; border: 1px solid var(--border-color); border-radius: 8px;
-  background: var(--bg-secondary); padding: 0.8rem;
-}
 .backup-restore-q { margin: 0 0 0.5rem; font-weight: 600; font-size: 0.88rem; }
 .backup-radio { display: flex; gap: 0.5rem; align-items: flex-start; margin: 0.35rem 0; font-size: 0.85rem; line-height: 1.4; }
 .backup-radio input { margin-top: 0.2rem; }

--- a/frontend/src/components/account/BackupPanel.jsx
+++ b/frontend/src/components/account/BackupPanel.jsx
@@ -1,112 +1,165 @@
 import { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
 import { useDataBackup } from '../../hooks/useDataBackup'
+import AccordionSection from './AccordionSection'
+import ActionSheet from './ActionSheet'
 import './BackupPanel.css'
 
 /**
  * Account Center → Data backup (spec 032). Explicit, member-initiated encrypted backup & restore: the
  * member's data is encrypted with a wallet-derived key, stored on IPFS, and located trustlessly via an
  * on-chain pointer. Back up / restore (merge or replace) / remove, with honest status. No backend.
+ *
+ * The panel is a collapsible section on the Recovery tab: collapsed it reports when the last backup
+ * happened, so the member can see the state of every recovery feature in one screen. Restore (a choice
+ * between merge and replace) and remove (destructive) each take over a bottom sheet, so the decision is
+ * made in one focused surface instead of unfolding more controls into the page.
  */
-function BackupPanel() {
+function BackupPanel({ defaultOpen = false }) {
   const { available, isConnected, onCanonical, canonicalChainId, canonicalName, status, lastBackupAt, hasRemote, refreshStatus, backup, restore, remove } = useDataBackup()
   const [restoreOpen, setRestoreOpen] = useState(false)
+  const [removeOpen, setRemoveOpen] = useState(false)
   const [mode, setMode] = useState('merge')
 
   useEffect(() => { refreshStatus() }, [refreshStatus])
 
   const busy = status === 'backing-up' || status === 'restoring'
 
-  // Close the restore region and reset to the safe default — so reopening never lands on destructive Replace.
+  // Close the restore sheet and reset to the safe default — so reopening never lands on destructive Replace.
   const closeRestore = () => { setRestoreOpen(false); setMode('merge') }
   const onRestoreConfirm = async () => {
     const res = await restore(mode)
     if (res?.restored) closeRestore()
   }
+  const onRemoveConfirm = async () => {
+    await remove()
+    setRemoveOpen(false)
+  }
+
+  // Collapsed-state summary: the one fact a member opens this section to check.
+  const summary = !available
+    ? 'Not available on this network'
+    : lastBackupAt
+      ? `Last backup ${new Date(lastBackupAt).toLocaleDateString()}`
+      : hasRemote
+        ? 'A backup exists for this account'
+        : 'No backup yet'
 
   return (
-    <section className="backup-panel" aria-labelledby="backup-heading">
-      <h3 id="backup-heading" className="backup-title">Data backup</h3>
-      <p className="backup-intro">
-        Back up your address book, preferences, and activity history as a single <strong>encrypted</strong> file
-        on IPFS, located by a trustless on-chain pointer. Only your account can read it — restore on any device
-        where you sign in to the same account (wallet or passkey). This is an explicit step; nothing leaves your
-        device until you back up.
-      </p>
+    <>
+      <AccordionSection
+        id="backup"
+        title="Data backup"
+        summary={summary}
+        badge={available && !hasRemote ? 'Not backed up' : null}
+        badgeTone="warn"
+        defaultOpen={defaultOpen}
+        className="backup-panel"
+      >
+        <p className="backup-intro">
+          Back up your address book, preferences, and activity history as a single <strong>encrypted</strong> file
+          on IPFS, located by a trustless on-chain pointer. Only your account can read it — restore on any device
+          where you sign in to the same account (wallet or passkey). This is an explicit step; nothing leaves your
+          device until you back up.
+        </p>
 
-      {!available ? (
-        <div className="backup-notice" role="status">
-          Backup isn’t available on this network yet. You can still export/import your address book from the
-          Address Book tab as an offline fallback.
-        </div>
-      ) : (
-        <>
-          <dl className="backup-status">
-            <div className="backup-status-row">
-              <dt>Last backup</dt>
-              <dd>{lastBackupAt ? new Date(lastBackupAt).toLocaleString() : 'Never'}</dd>
-            </div>
-            <div className="backup-status-row">
-              <dt>Stored backup</dt>
-              <dd>{hasRemote ? 'Yes — a backup exists for this wallet' : 'None found'}</dd>
-            </div>
-          </dl>
-
-          {!hasRemote && (
-            <p className="backup-notice" role="status">
-              Without a backup, device-local activity history — sent transfers, failed operations, and earn
-              actions — cannot be recovered if this device’s data is cleared. On-chain activity (wagers, pools,
-              memberships) always rebuilds automatically.
-            </p>
-          )}
-
-          {!onCanonical && (
-            <p className="backup-notice" role="status">
-              Backing up records a pointer on {canonicalName} (chain {canonicalChainId}). You’ll be asked to
-              switch networks; restoring works from any network.
-            </p>
-          )}
-
-          <div className="backup-actions">
-            <button type="button" className="backup-btn backup-btn-primary" onClick={backup} disabled={!isConnected || busy} aria-disabled={!isConnected || busy}>
-              {status === 'backing-up' ? 'Backing up…' : 'Back up my data'}
-            </button>
-            <button type="button" className="backup-btn" onClick={() => (restoreOpen ? closeRestore() : setRestoreOpen(true))} disabled={!isConnected || busy} aria-expanded={restoreOpen}>
-              Restore my data
-            </button>
-            {hasRemote && (
-              <button type="button" className="backup-btn backup-btn-danger" onClick={remove} disabled={!isConnected || busy}>
-                Remove stored backup
-              </button>
-            )}
+        {!available ? (
+          <div className="backup-notice" role="status">
+            Backup isn’t available on this network yet. You can still export/import your address book from the
+            Address Book tab as an offline fallback.
           </div>
-          <p className="backup-cost">A backup includes a small on-chain transaction (gas) to record the pointer.</p>
-
-          {restoreOpen && (
-            <div className="backup-restore" role="group" aria-labelledby="backup-restore-q">
-              <p id="backup-restore-q" className="backup-restore-q">How should the backup be applied to your current data?</p>
-              <label className="backup-radio">
-                <input type="radio" name="restore-mode" value="merge" checked={mode === 'merge'} onChange={() => setMode('merge')} />
-                <span><strong>Merge</strong> — keep both your current data and the backup (recommended; nothing is lost).</span>
-              </label>
-              <label className="backup-radio">
-                <input type="radio" name="restore-mode" value="replace" checked={mode === 'replace'} onChange={() => setMode('replace')} />
-                <span><strong>Replace</strong> — overwrite your current data with the backup.</span>
-              </label>
-              {mode === 'replace' && (
-                <p className="backup-warn" role="alert">Replace will overwrite your current address book and preferences with the backup.</p>
-              )}
-              <div className="backup-actions">
-                <button type="button" className="backup-btn backup-btn-primary" onClick={onRestoreConfirm} disabled={busy}>
-                  {status === 'restoring' ? 'Restoring…' : mode === 'replace' ? 'Confirm replace' : 'Confirm merge'}
-                </button>
-                <button type="button" className="backup-btn" onClick={closeRestore} disabled={busy}>Cancel</button>
+        ) : (
+          <>
+            <dl className="backup-status">
+              <div className="backup-status-row">
+                <dt>Last backup</dt>
+                <dd>{lastBackupAt ? new Date(lastBackupAt).toLocaleString() : 'Never'}</dd>
               </div>
+              <div className="backup-status-row">
+                <dt>Stored backup</dt>
+                <dd>{hasRemote ? 'Yes — a backup exists for this wallet' : 'None found'}</dd>
+              </div>
+            </dl>
+
+            {!hasRemote && (
+              <p className="backup-notice" role="status">
+                Without a backup, device-local activity history — sent transfers, failed operations, and earn
+                actions — cannot be recovered if this device’s data is cleared. On-chain activity (wagers, pools,
+                memberships) always rebuilds automatically.
+              </p>
+            )}
+
+            {!onCanonical && (
+              <p className="backup-notice" role="status">
+                Backing up records a pointer on {canonicalName} (chain {canonicalChainId}). You’ll be asked to
+                switch networks; restoring works from any network.
+              </p>
+            )}
+
+            <div className="backup-actions">
+              <button type="button" className="backup-btn backup-btn-primary" onClick={backup} disabled={!isConnected || busy} aria-disabled={!isConnected || busy}>
+                {status === 'backing-up' ? 'Backing up…' : 'Back up my data'}
+              </button>
+              <button type="button" className="backup-btn" onClick={() => setRestoreOpen(true)} disabled={!isConnected || busy} aria-haspopup="dialog">
+                Restore my data
+              </button>
+              {hasRemote && (
+                <button type="button" className="backup-btn backup-btn-danger" onClick={() => setRemoveOpen(true)} disabled={!isConnected || busy} aria-haspopup="dialog">
+                  Remove stored backup
+                </button>
+              )}
             </div>
-          )}
-        </>
-      )}
-    </section>
+            <p className="backup-cost">A backup includes a small on-chain transaction (gas) to record the pointer.</p>
+          </>
+        )}
+      </AccordionSection>
+
+      {/* Restore: the merge/replace choice gets its own focused surface — a centered card on
+          desktop, a bottom sheet on mobile. Rendered outside the collapsible region so it is
+          never inside an inert subtree. */}
+      <ActionSheet open={restoreOpen} onClose={closeRestore} title="Restore my data" closeDisabled={busy}>
+        <p id="backup-restore-q" className="backup-restore-q">How should the backup be applied to your current data?</p>
+        <div role="radiogroup" aria-labelledby="backup-restore-q">
+          <label className="backup-radio">
+            <input type="radio" name="restore-mode" value="merge" checked={mode === 'merge'} onChange={() => setMode('merge')} />
+            <span><strong>Merge</strong> — keep both your current data and the backup (recommended; nothing is lost).</span>
+          </label>
+          <label className="backup-radio">
+            <input type="radio" name="restore-mode" value="replace" checked={mode === 'replace'} onChange={() => setMode('replace')} />
+            <span><strong>Replace</strong> — overwrite your current data with the backup.</span>
+          </label>
+        </div>
+        {mode === 'replace' && (
+          <p className="backup-warn" role="alert">Replace will overwrite your current address book and preferences with the backup.</p>
+        )}
+        <div className="action-sheet__actions">
+          <button type="button" className="backup-btn" onClick={closeRestore} disabled={busy}>Cancel</button>
+          <button type="button" className="backup-btn backup-btn-primary" onClick={onRestoreConfirm} disabled={busy}>
+            {status === 'restoring' ? 'Restoring…' : mode === 'replace' ? 'Confirm replace' : 'Confirm merge'}
+          </button>
+        </div>
+      </ActionSheet>
+
+      {/* Remove is destructive and was previously one unguarded click. */}
+      <ActionSheet open={removeOpen} onClose={() => setRemoveOpen(false)} title="Remove stored backup?" closeDisabled={busy}>
+        <p className="action-sheet__text">
+          This deletes the on-chain pointer to your encrypted backup. Your data on this device is untouched, but
+          you won’t be able to restore it on another device until you back up again.
+        </p>
+        <div className="action-sheet__actions">
+          <button type="button" className="backup-btn" onClick={() => setRemoveOpen(false)} disabled={busy}>Keep it</button>
+          <button type="button" className="backup-btn backup-btn-danger" onClick={onRemoveConfirm} disabled={busy}>
+            Remove backup
+          </button>
+        </div>
+      </ActionSheet>
+    </>
   )
+}
+
+BackupPanel.propTypes = {
+  /** Start expanded (the Recovery tab keeps every section collapsed by default). */
+  defaultOpen: PropTypes.bool,
 }
 
 export default BackupPanel

--- a/frontend/src/components/account/ControllersPanel.jsx
+++ b/frontend/src/components/account/ControllersPanel.jsx
@@ -7,6 +7,13 @@
  * controller refusal client-side; the contract enforces it regardless).
  * Every mutation routes through sendCalls as an account self-call — one
  * ceremony each, on-chain enforced.
+ *
+ * The panel is a collapsible section on the Recovery tab: collapsed it reports
+ * how many controllers the account has (and flags a single-controller account),
+ * so the list of keys is one tap away rather than a wall of controls. Every
+ * mutation — add a passkey, link a wallet, remove a controller — happens in a
+ * bottom sheet that states the consequence before it acts; the wallet address
+ * entry lives in the link sheet, so the panel itself is just the list.
  */
 
 import { useState, useCallback } from 'react'
@@ -27,13 +34,14 @@ import AddressBookButton from '../ui/AddressBookButton'
 import QRScanner from '../ui/QRScanner'
 import { extractAddressFromScan } from '../../lib/addressBook/scanAddress'
 import ActionSheet from './ActionSheet'
+import AccordionSection from './AccordionSection'
 
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
 
 // User-facing guide for how losing/replacing passkeys and recovery via a linked wallet work.
 const RECOVERY_DOCS_URL = 'https://docs.FairWins.app/user-guide/account-recovery/'
 
-function ControllersPanel({ deps = {} }) {
+function ControllersPanel({ deps = {}, defaultOpen = false }) {
   const { address, sendCalls, provider, chainId } = useWallet()
   const account = usePasskeyAccount(deps)
   const [busy, setBusy] = useState(false)
@@ -43,6 +51,8 @@ function ControllersPanel({ deps = {} }) {
   const [scanOpen, setScanOpen] = useState(false)
   // Informed-consent bottom sheet before a full-controller action: null | 'add' | 'link'.
   const [sheet, setSheet] = useState(null)
+  // Controller queued for removal — removal is irreversible, so it confirms in a sheet.
+  const [pendingRemoval, setPendingRemoval] = useState(null)
 
   const applyLinkAddress = useCallback((addr) => {
     setLinkAddress(addr)
@@ -156,134 +166,125 @@ function ControllersPanel({ deps = {} }) {
     if (await linkWallet()) setSheet(null)
   }, [linkWallet])
 
+  const confirmRemoval = useCallback(async () => {
+    if (pendingRemoval && (await removeController(pendingRemoval))) setPendingRemoval(null)
+  }, [pendingRemoval, removeController])
+
+  const closeLinkSheet = useCallback(() => {
+    setSheet(null)
+    setLinkAddress('')
+    setLinkAddressResolved('')
+  }, [])
+
   const linkTarget = (linkAddressResolved || linkAddress).trim()
 
   if (!account.isPasskeySession) return null
 
+  // Collapsed-state summary + attention badge: how many keys can reach this
+  // account, and whether that number is dangerously low.
+  const summary = !account.deployed
+    ? 'Activates on-chain with your first action'
+    : `${account.controllerCount} ${account.controllerCount === 1 ? 'controller' : 'controllers'}`
+
   return (
-    <section className="controllers-panel" aria-label="Account controllers">
-      <h3>Devices &amp; controllers</h3>
-      <p className="controllers-panel__intro">
-        Passkeys and linked wallets that can control this account. Keep at least two so losing one device never
-        locks you out.{' '}
-        <a href={RECOVERY_DOCS_URL} target="_blank" rel="noopener noreferrer">
-          Learn how account recovery works →
-        </a>
-      </p>
-      {!account.deployed && (
-        <p className="controllers-panel__counterfactual" role="note">
-          Your account is ready to receive funds and activates on-chain with your first action.
-          Controller changes become available after that.
+    <>
+      <AccordionSection
+        id="controllers"
+        title="Devices & controllers"
+        summary={summary}
+        badge={account.singleControllerRisk ? 'Add a backup key' : null}
+        badgeTone="warn"
+        defaultOpen={defaultOpen}
+        className="controllers-panel"
+      >
+        <p className="controllers-panel__intro">
+          Passkeys and linked wallets that can control this account. Keep at least two so losing one device never
+          locks you out.{' '}
+          <a href={RECOVERY_DOCS_URL} target="_blank" rel="noopener noreferrer">
+            Learn how account recovery works →
+          </a>
         </p>
-      )}
-
-      {account.singleControllerRisk && (
-        <p className="controllers-panel__risk" role="alert" data-testid="single-controller-warning">
-          Only one passkey controls this account. Add a second passkey or link a wallet so losing this
-          device never means losing your funds.
-        </p>
-      )}
-
-      <ul className="controllers-panel__list">
-        {account.controllers.map((c) => (
-          <li key={String(c.index)} data-testid={`controller-${c.index}`} className="controllers-panel__item">
-            <div className="controllers-panel__item-info">
-              <div className="controllers-panel__item-head">
-                <span className="controllers-panel__label">{c.label}</span>
-                <span className="controllers-panel__kind" data-kind={c.kind}>
-                  {c.kind === 'wallet' ? 'Wallet' : 'Passkey'}
-                </span>
-                {c.isThisDevice && <span className="controllers-panel__badge">(this device)</span>}
-              </div>
-              {c.kind === 'wallet' && c.address && (
-                <code className="controllers-panel__address">{c.address}</code>
-              )}
-            </div>
-            <button
-              type="button"
-              className="btn btn-small controllers-panel__remove"
-              disabled={busy || account.controllerCount <= 1}
-              onClick={() => removeController(c)}
-              aria-label={`Remove ${c.label}`}
-            >
-              Remove
-            </button>
-          </li>
-        ))}
-      </ul>
-
-      <div className="controllers-panel__actions">
-        <button
-          type="button"
-          className="btn"
-          disabled={busy || !account.deployed}
-          onClick={() => {
-            setNotice(null)
-            setSheet('add')
-          }}
-        >
-          Add a passkey
-        </button>
-        <div className="controllers-panel__link">
-          {/* FR-011: linking is granting FULL control — say so before the act. */}
-          <p className="controllers-panel__link-warning">
-            A linked wallet becomes a full controller: it can move funds, manage controllers, and
-            recover this account if you lose your passkeys. Link only a wallet you exclusively control.
+        {!account.deployed && (
+          <p className="controllers-panel__counterfactual" role="note">
+            Your account is ready to receive funds and activates on-chain with your first action.
+            Controller changes become available after that.
           </p>
-          {/* Standard address entry (ENS resolution + address book + QR scan) used across the app */}
-          <div className="controllers-panel__link-row">
-            <div className="controllers-panel__address-wrap">
-              <AddressInput
-                id="controllers-link-address"
-                value={linkAddress}
-                onChange={(e) => setLinkAddress(e.target.value)}
-                onResolvedChange={(addr) => setLinkAddressResolved(addr || '')}
-                chainId={chainId}
-                placeholder="0x… wallet to link"
-                disabled={busy || !account.deployed}
-                aria-label="Wallet address to link"
-              />
-            </div>
-            <AddressBookButton
-              chainId={chainId}
-              disabled={busy || !account.deployed}
-              onSelect={(entry) => applyLinkAddress(entry.address)}
-            />
-            <button
-              type="button"
-              className="controllers-panel__scan-btn"
-              onClick={() => setScanOpen(true)}
-              disabled={busy || !account.deployed}
-              title="Scan QR code"
-              aria-label="Scan QR code"
-            >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm10-2h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm2 2h2v2h-2v-2zm2-2h2v2h-2v-2zm0 4h2v2h-2v-2z" />
-              </svg>
-            </button>
-          </div>
-          <QRScanner isOpen={scanOpen} onClose={() => setScanOpen(false)} onScanSuccess={handleScan} />
+        )}
+
+        {account.singleControllerRisk && (
+          <p className="controllers-panel__risk" role="alert" data-testid="single-controller-warning">
+            Only one passkey controls this account. Add a second passkey or link a wallet so losing this
+            device never means losing your funds.
+          </p>
+        )}
+
+        <ul className="controllers-panel__list">
+          {account.controllers.map((c) => (
+            <li key={String(c.index)} data-testid={`controller-${c.index}`} className="controllers-panel__item">
+              <div className="controllers-panel__item-info">
+                <div className="controllers-panel__item-head">
+                  <span className="controllers-panel__label">{c.label}</span>
+                  <span className="controllers-panel__kind" data-kind={c.kind}>
+                    {c.kind === 'wallet' ? 'Wallet' : 'Passkey'}
+                  </span>
+                  {c.isThisDevice && <span className="controllers-panel__badge">(this device)</span>}
+                </div>
+                {c.kind === 'wallet' && c.address && (
+                  <code className="controllers-panel__address">{c.address}</code>
+                )}
+              </div>
+              <button
+                type="button"
+                className="btn btn-small controllers-panel__remove"
+                disabled={busy || account.controllerCount <= 1}
+                onClick={() => {
+                  setNotice(null)
+                  setPendingRemoval(c)
+                }}
+                aria-haspopup="dialog"
+                aria-label={`Remove ${c.label}`}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <div className="controllers-panel__actions">
           <button
             type="button"
             className="btn"
-            disabled={busy || !account.deployed || !ADDRESS_RE.test(linkTarget)}
+            disabled={busy || !account.deployed}
+            aria-haspopup="dialog"
+            onClick={() => {
+              setNotice(null)
+              setSheet('add')
+            }}
+          >
+            Add a passkey
+          </button>
+          <button
+            type="button"
+            className="btn"
+            disabled={busy || !account.deployed}
+            aria-haspopup="dialog"
             onClick={() => {
               setNotice(null)
               setSheet('link')
             }}
           >
-            Link wallet
+            Link a wallet
           </button>
         </div>
-      </div>
 
-      {/* Panel-level notice only when no sheet is up (the sheet shows its own). */}
-      {!sheet && notice && (
-        <p role={notice.kind === 'error' ? 'alert' : 'status'} className={`controllers-panel__${notice.kind}`}>
-          {notice.text}
-        </p>
-      )}
-      {account.error && <p role="alert">{account.error}</p>}
+        {/* Panel-level notice only when no sheet is up (the sheet shows its own). */}
+        {!sheet && !pendingRemoval && notice && (
+          <p role={notice.kind === 'error' ? 'alert' : 'status'} className={`controllers-panel__${notice.kind}`}>
+            {notice.text}
+          </p>
+        )}
+        {account.error && <p role="alert">{account.error}</p>}
+      </AccordionSection>
 
       {/* Add-a-passkey: full-controller consequences before the ceremony. */}
       <ActionSheet
@@ -321,20 +322,53 @@ function ControllersPanel({ deps = {} }) {
         </div>
       </ActionSheet>
 
-      {/* Link-wallet: linking grants FULL control — say so plainly before the act (FR-011). */}
+      {/* Link-wallet: the address entry AND the consequence live in one sheet, so the panel
+          stays a list and the member reads what linking means while typing the address.
+          Linking grants FULL control — say so plainly before the act (FR-011). */}
       <ActionSheet
         open={sheet === 'link'}
-        onClose={() => setSheet(null)}
-        title="Link this wallet?"
+        onClose={closeLinkSheet}
+        title="Link a wallet"
         closeDisabled={busy}
       >
-        <p className="action-sheet__text">You&apos;re about to link this wallet as a controller:</p>
-        <code className="action-sheet__addr">{linkTarget}</code>
         <p className="action-sheet__warn">
           A linked wallet becomes a <strong>full controller</strong> of your account. It can move your
           funds, add or remove controllers, and recover the account if you lose your passkeys. Only link a
           wallet you exclusively control.
         </p>
+        {/* Standard address entry (ENS resolution + address book + QR scan) used across the app */}
+        <div className="controllers-panel__link-row">
+          <div className="controllers-panel__address-wrap">
+            <AddressInput
+              id="controllers-link-address"
+              value={linkAddress}
+              onChange={(e) => setLinkAddress(e.target.value)}
+              onResolvedChange={(addr) => setLinkAddressResolved(addr || '')}
+              chainId={chainId}
+              placeholder="0x… wallet to link"
+              disabled={busy}
+              aria-label="Wallet address to link"
+            />
+          </div>
+          <AddressBookButton
+            chainId={chainId}
+            disabled={busy}
+            onSelect={(entry) => applyLinkAddress(entry.address)}
+          />
+          <button
+            type="button"
+            className="controllers-panel__scan-btn"
+            onClick={() => setScanOpen(true)}
+            disabled={busy}
+            title="Scan QR code"
+            aria-label="Scan QR code"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm10-2h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm2 2h2v2h-2v-2zm2-2h2v2h-2v-2zm0 4h2v2h-2v-2z" />
+            </svg>
+          </button>
+        </div>
+        {ADDRESS_RE.test(linkTarget) && <code className="action-sheet__addr">{linkTarget}</code>}
         <ol className="action-sheet__list">
           <li>We screen the address first (linking is blocked if screening flags it or can&apos;t run).</li>
           <li>One on-chain transaction links it to your account.</li>
@@ -346,20 +380,63 @@ function ControllersPanel({ deps = {} }) {
           </p>
         )}
         <div className="action-sheet__actions">
-          <button type="button" className="btn" onClick={() => setSheet(null)} disabled={busy}>
+          <button type="button" className="btn" onClick={closeLinkSheet} disabled={busy}>
             Cancel
           </button>
-          <button type="button" className="btn btn-primary" onClick={confirmLinkWallet} disabled={busy}>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={confirmLinkWallet}
+            disabled={busy || !account.deployed || !ADDRESS_RE.test(linkTarget)}
+          >
             {busy ? 'Linking…' : 'Link wallet'}
           </button>
         </div>
       </ActionSheet>
-    </section>
+
+      {/* Removing a controller is irreversible and can strand an account — confirm it. */}
+      <ActionSheet
+        open={Boolean(pendingRemoval)}
+        onClose={() => setPendingRemoval(null)}
+        title="Remove this controller?"
+        closeDisabled={busy}
+      >
+        <p className="action-sheet__text">
+          <strong>{pendingRemoval?.label}</strong> will no longer be able to approve actions or recover this
+          account.
+        </p>
+        {pendingRemoval?.address && <code className="action-sheet__addr">{pendingRemoval.address}</code>}
+        <p className="action-sheet__warn">
+          {pendingRemoval?.isThisDevice
+            ? 'This is the key on the device you are using now — after removing it you will need another passkey or linked wallet to sign in.'
+            : 'This cannot be undone from here; you would have to add the key back as a new controller.'}
+        </p>
+        {busy && <p className="action-sheet__progress">Removing… confirm any prompts.</p>}
+        {notice && (
+          <p role="alert" className={`action-sheet__notice action-sheet__notice--${notice.kind}`}>
+            {notice.text}
+          </p>
+        )}
+        <div className="action-sheet__actions">
+          <button type="button" className="btn" onClick={() => setPendingRemoval(null)} disabled={busy}>
+            Keep it
+          </button>
+          <button type="button" className="btn btn-danger" onClick={confirmRemoval} disabled={busy}>
+            {busy ? 'Removing…' : 'Remove controller'}
+          </button>
+        </div>
+      </ActionSheet>
+
+      {/* Outside the sheets: the scanner is its own full-screen surface (z-index above them). */}
+      <QRScanner isOpen={scanOpen} onClose={() => setScanOpen(false)} onScanSuccess={handleScan} />
+    </>
   )
 }
 
 ControllersPanel.propTypes = {
   deps: PropTypes.object,
+  /** Start expanded (the Recovery tab keeps every section collapsed by default). */
+  defaultOpen: PropTypes.bool,
 }
 
 export { LastControllerError }

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
@@ -26,6 +26,7 @@ import { captureLegacyRecovery } from '../../data/ledger/sources/legacyRecoveryS
 import AddressInput from '../ui/AddressInput'
 import AddressBookButton from '../ui/AddressBookButton'
 import ActionSheet from './ActionSheet'
+import AccordionSection from './AccordionSection'
 import CrossChainRecoveryPanel from './CrossChainRecoveryPanel'
 import {
   classifySecret,
@@ -55,7 +56,7 @@ const STEP_TITLES = {
   done: 'Funds moved',
 }
 
-function LegacyKeyRecoveryPanel({ deps = {} }) {
+function LegacyKeyRecoveryPanel({ deps = {}, defaultOpen = false }) {
   const { address: sessionAddress, provider, loginMethod, chainId, isConnected } = useWallet()
   const { findByAddress, addContact, updateContact } = useAddressBook()
   // Stable module import ⇒ the memo is preservable and re-derives only when the
@@ -69,6 +70,8 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
   const [stored, setStored] = useState(() => vault.list())
   // Spec 063: which stored account (if any) has its cross-chain "Other chains" scan expanded.
   const [scanAddr, setScanAddr] = useState(null)
+  // Stored key queued for deletion — removal drops the only on-device copy, so it confirms in a sheet.
+  const [pendingRemoval, setPendingRemoval] = useState(null)
 
   // Import working state.
   const [rawSecret, setRawSecret] = useState('')
@@ -330,6 +333,7 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
   const removeStored = useCallback((address) => {
     vault.delete(address)
     refreshStored()
+    setPendingRemoval(null)
   }, [vault, refreshStored])
 
   if (!isConnected) return null
@@ -356,58 +360,70 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
     )
 
   return (
-    <section className="legacy-recovery section" aria-label="Recover a legacy key or word list">
-      <h3>Legacy key &amp; word-list recovery</h3>
-      <p className="section-description">
-        Moving from an older wallet? Bring in a legacy <strong>private key</strong> or <strong>word list</strong>{' '}
-        (recovery phrase). FairWins stores it encrypted on this device; you can then optionally move its funds to
-        a smart account and save it to your address book.
-      </p>
-      <button type="button" className="btn btn-primary legacy-recovery__start" onClick={openWizard}>
-        Recover a legacy key
-      </button>
+    <>
+      <AccordionSection
+        id="legacy-recovery"
+        title="Legacy key & word-list recovery"
+        summary={
+          stored.length > 0
+            ? `${stored.length} recovered ${stored.length === 1 ? 'account' : 'accounts'} on this device`
+            : 'Bring in an old private key or word list'
+        }
+        defaultOpen={defaultOpen}
+        className="legacy-recovery"
+      >
+        <p className="section-description">
+          Moving from an older wallet? Bring in a legacy <strong>private key</strong> or <strong>word list</strong>{' '}
+          (recovery phrase). FairWins stores it encrypted on this device; you can then optionally move its funds to
+          a smart account and save it to your address book.
+        </p>
+        <button type="button" className="btn btn-primary legacy-recovery__start" onClick={openWizard}>
+          Recover a legacy key
+        </button>
 
-      {stored.length > 0 && (
-        <ul className="lkr-stored" aria-label="Recovered legacy keys stored on this device">
-          {stored.map((e) => (
-            <li key={e.address} className="lkr-stored__item">
-              <div className="lkr-stored__meta">
-                <code className="lkr-stored__addr" title={e.address}>{shortAddr(e.address)}</code>
-                <span className="lkr-stored__sub">
-                  {KIND_LABEL[e.kind] || 'key'}
-                  {e.importedAt ? ` · saved ${new Date(e.importedAt).toLocaleDateString()}` : ''}
-                </span>
-              </div>
-              <div className="lkr-stored__actions">
-                <button type="button" className="btn btn-small" onClick={() => startTransferStored(e)}>
-                  Move funds
-                </button>
-                {e.kind === 'mnemonic' && (
+        {stored.length > 0 && (
+          <ul className="lkr-stored" aria-label="Recovered legacy keys stored on this device">
+            {stored.map((e) => (
+              <li key={e.address} className="lkr-stored__item">
+                <div className="lkr-stored__meta">
+                  <code className="lkr-stored__addr" title={e.address}>{shortAddr(e.address)}</code>
+                  <span className="lkr-stored__sub">
+                    {KIND_LABEL[e.kind] || 'key'}
+                    {e.importedAt ? ` · saved ${new Date(e.importedAt).toLocaleDateString()}` : ''}
+                  </span>
+                </div>
+                <div className="lkr-stored__actions">
+                  <button type="button" className="btn btn-small" onClick={() => startTransferStored(e)}>
+                    Move funds
+                  </button>
+                  {e.kind === 'mnemonic' && (
+                    <button
+                      type="button"
+                      className="btn btn-small"
+                      onClick={() => setScanAddr(scanAddr === e.address ? null : e.address)}
+                      aria-expanded={scanAddr === e.address}
+                    >
+                      Other chains
+                    </button>
+                  )}
                   <button
                     type="button"
-                    className="btn btn-small"
-                    onClick={() => setScanAddr(scanAddr === e.address ? null : e.address)}
-                    aria-expanded={scanAddr === e.address}
+                    className="btn btn-small lkr-stored__remove"
+                    onClick={() => setPendingRemoval(e)}
+                    aria-haspopup="dialog"
+                    aria-label={`Remove stored key ${shortAddr(e.address)}`}
                   >
-                    Other chains
+                    Remove
                   </button>
+                </div>
+                {scanAddr === e.address && e.kind === 'mnemonic' && (
+                  <CrossChainRecoveryPanel entry={e} />
                 )}
-                <button
-                  type="button"
-                  className="btn btn-small lkr-stored__remove"
-                  onClick={() => removeStored(e.address)}
-                  aria-label={`Remove stored key ${shortAddr(e.address)}`}
-                >
-                  Remove
-                </button>
-              </div>
-              {scanAddr === e.address && e.kind === 'mnemonic' && (
-                <CrossChainRecoveryPanel entry={e} />
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </AccordionSection>
 
       <ActionSheet open={open} onClose={closeWizard} title={STEP_TITLES[step]} closeDisabled={busy}>
         {/* Step 1 — what this does + the honest warning. */}
@@ -761,12 +777,38 @@ function LegacyKeyRecoveryPanel({ deps = {} }) {
           </div>
         )}
       </ActionSheet>
-    </section>
+
+      {/* Deleting the on-device copy of a legacy key is irreversible from here — confirm it. */}
+      <ActionSheet
+        open={Boolean(pendingRemoval)}
+        onClose={() => setPendingRemoval(null)}
+        title="Remove this recovered key?"
+        closeDisabled={busy}
+      >
+        <p className="action-sheet__text">
+          The encrypted copy stored on this device is deleted. Anything still held by this account stays where it
+          is — you would need the original private key or word list to reach it again.
+        </p>
+        {pendingRemoval?.address && <code className="action-sheet__addr">{pendingRemoval.address}</code>}
+        <div className="action-sheet__actions">
+          <button type="button" className="btn" onClick={() => setPendingRemoval(null)}>Keep it</button>
+          <button
+            type="button"
+            className="btn btn-danger"
+            onClick={() => removeStored(pendingRemoval.address)}
+          >
+            Remove key
+          </button>
+        </div>
+      </ActionSheet>
+    </>
   )
 }
 
 LegacyKeyRecoveryPanel.propTypes = {
   deps: PropTypes.object,
+  /** Start expanded (the Recovery tab keeps every section collapsed by default). */
+  defaultOpen: PropTypes.bool,
 }
 
 export default LegacyKeyRecoveryPanel

--- a/frontend/src/components/account/RecoverAccountPanel.jsx
+++ b/frontend/src/components/account/RecoverAccountPanel.jsx
@@ -33,6 +33,7 @@ import AddressBookButton from '../ui/AddressBookButton'
 import QRScanner from '../ui/QRScanner'
 import { extractAddressFromScan } from '../../lib/addressBook/scanAddress'
 import ActionSheet from './ActionSheet'
+import AccordionSection from './AccordionSection'
 import './RecoverAccountPanel.css'
 
 // Human-readable fragments for the vendored Coinbase Smart Wallet MultiOwnable
@@ -56,7 +57,7 @@ const STEP_TITLES = {
   done: 'Recovery complete',
 }
 
-function RecoverAccountPanel({ deps = {} }) {
+function RecoverAccountPanel({ deps = {}, defaultOpen = false }) {
   const { address: walletAddress, signer, provider, loginMethod, isConnected, chainId } = useWallet()
 
   const [open, setOpen] = useState(false)
@@ -228,19 +229,27 @@ function RecoverAccountPanel({ deps = {} }) {
   const passkeyBlocked = capability && capability.available === false
 
   return (
-    <section className="recover-account-panel section" aria-label="Recover passkey account">
-      <h3>Recover a passkey account</h3>
-      <p className="section-description">
-        Lost your passkeys? If this wallet was linked to your passkey account as a controller, it can
-        authorize a new passkey — no FairWins involvement required.{' '}
-        <a href={RECOVERY_DOCS_URL} target="_blank" rel="noopener noreferrer">
-          Learn how account recovery works →
-        </a>
-      </p>
-      <button type="button" className="btn btn-primary recover-account-panel__start" onClick={openWizard}>
-        Recover an account
-      </button>
+    <>
+      <AccordionSection
+        id="recover-account"
+        title="Recover a passkey account"
+        summary="Use this wallet to authorize a new passkey"
+        defaultOpen={defaultOpen}
+        className="recover-account-panel"
+      >
+        <p className="section-description">
+          Lost your passkeys? If this wallet was linked to your passkey account as a controller, it can
+          authorize a new passkey — no FairWins involvement required.{' '}
+          <a href={RECOVERY_DOCS_URL} target="_blank" rel="noopener noreferrer">
+            Learn how account recovery works →
+          </a>
+        </p>
+        <button type="button" className="btn btn-primary recover-account-panel__start" onClick={openWizard}>
+          Recover an account
+        </button>
+      </AccordionSection>
 
+      {/* The wizard lives outside the collapsible region so it is never inside an inert subtree. */}
       <ActionSheet open={open} onClose={closeWizard} title={STEP_TITLES[step]} closeDisabled={busy}>
         {/* Step 1 — what this does + prerequisites, checked while it's fresh. */}
         {step === 'intro' && (
@@ -423,12 +432,14 @@ function RecoverAccountPanel({ deps = {} }) {
           </div>
         )}
       </ActionSheet>
-    </section>
+    </>
   )
 }
 
 RecoverAccountPanel.propTypes = {
   deps: PropTypes.object,
+  /** Start expanded (the Recovery tab keeps every section collapsed by default). */
+  defaultOpen: PropTypes.bool,
 }
 
 export default RecoverAccountPanel

--- a/frontend/src/components/account/RecoveryCodesPanel.jsx
+++ b/frontend/src/components/account/RecoveryCodesPanel.jsx
@@ -1,4 +1,6 @@
 import { useState, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import AccordionSection from './AccordionSection'
 import { useOpenChallengeCodeVault } from '../../hooks/useOpenChallengeCodeVault'
 import '../fairwins/FriendMarketsModal.css'
 import '../fairwins/OpenChallengeModal.css'
@@ -11,7 +13,7 @@ import '../fairwins/OpenChallengeModal.css'
  * (useOpenChallengeCodeVault), so codes saved before the move remain accessible with no
  * migration and the existing unlock (one wallet signature) is preserved.
  */
-export default function RecoveryCodesPanel() {
+export default function RecoveryCodesPanel({ defaultOpen = false }) {
   const { canUse, recoverCodes, busy } = useOpenChallengeCodeVault()
   const [entries, setEntries] = useState(null) // null = not unlocked yet
   const [error, setError] = useState(null)
@@ -98,12 +100,25 @@ export default function RecoveryCodesPanel() {
   }
 
   return (
-    <div className="section">
-      <h3>Recovery codes</h3>
+    <AccordionSection
+      id="recovery-codes"
+      title="Recovery codes"
+      summary={
+        entries == null
+          ? 'Open-challenge codes saved on this device'
+          : `${entries.length} saved ${entries.length === 1 ? 'code' : 'codes'}`
+      }
+      defaultOpen={defaultOpen}
+    >
       <p className="section-description">
         Recover the four-word codes for open challenges you created and backed up on this device.
       </p>
       <div className="fm-form">{body}</div>
-    </div>
+    </AccordionSection>
   )
+}
+
+RecoveryCodesPanel.propTypes = {
+  /** Start expanded (the Recovery tab keeps every section collapsed by default). */
+  defaultOpen: PropTypes.bool,
 }

--- a/frontend/src/components/account/__tests__/AccordionSection.test.jsx
+++ b/frontend/src/components/account/__tests__/AccordionSection.test.jsx
@@ -1,0 +1,102 @@
+/**
+ * Collapsible settings section (Recovery tab UX).
+ *
+ * Guards the two properties the tab depends on: sections start collapsed with a
+ * scannable summary, and collapsed content stays mounted but INERT — mounted so
+ * the open/close animation works, inert so nothing inside is focusable or
+ * announced until the member opens it.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import AccordionSection from '../AccordionSection'
+import AccordionGroup from '../AccordionGroup'
+
+describe('AccordionSection', () => {
+  it('starts collapsed, shows the summary, and marks the region inert', () => {
+    render(
+      <AccordionSection id="s1" title="Data backup" summary="Last backup: never">
+        <button type="button">Back up my data</button>
+      </AccordionSection>
+    )
+    const trigger = screen.getByRole('button', { name: /data backup/i })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByText('Last backup: never')).toBeInTheDocument()
+    expect(document.getElementById('s1-region')).toHaveAttribute('inert')
+  })
+
+  it('expands on click, drops inert, and hides the collapsed summary', () => {
+    render(
+      <AccordionSection id="s1" title="Data backup" summary="Last backup: never">
+        <button type="button">Back up my data</button>
+      </AccordionSection>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /data backup/i }))
+    expect(screen.getByRole('button', { name: /data backup/i })).toHaveAttribute('aria-expanded', 'true')
+    expect(document.getElementById('s1-region')).not.toHaveAttribute('inert')
+    expect(screen.queryByText('Last backup: never')).not.toBeInTheDocument()
+  })
+
+  it('opens one section at a time inside a group (and closes on a second click)', () => {
+    render(
+      <AccordionGroup>
+        <AccordionSection id="a" title="Alpha">a-body</AccordionSection>
+        <AccordionSection id="b" title="Beta">b-body</AccordionSection>
+      </AccordionGroup>
+    )
+    const alpha = screen.getByRole('button', { name: /alpha/i })
+    const beta = screen.getByRole('button', { name: /beta/i })
+
+    fireEvent.click(alpha)
+    expect(alpha).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.click(beta)
+    expect(beta).toHaveAttribute('aria-expanded', 'true')
+    expect(alpha).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(beta)
+    expect(beta).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('keeps sections independent when the group is not exclusive', () => {
+    render(
+      <AccordionGroup exclusive={false}>
+        <AccordionSection id="a" title="Alpha">a-body</AccordionSection>
+        <AccordionSection id="b" title="Beta">b-body</AccordionSection>
+      </AccordionGroup>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /alpha/i }))
+    fireEvent.click(screen.getByRole('button', { name: /beta/i }))
+    expect(screen.getByRole('button', { name: /alpha/i })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('button', { name: /beta/i })).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('honours defaultOpenId', () => {
+    render(
+      <AccordionGroup defaultOpenId="b">
+        <AccordionSection id="a" title="Alpha">a-body</AccordionSection>
+        <AccordionSection id="b" title="Beta">b-body</AccordionSection>
+      </AccordionGroup>
+    )
+    expect(screen.getByRole('button', { name: /beta/i })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('button', { name: /alpha/i })).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('has no axe violations collapsed or expanded', async () => {
+    const { container } = render(
+      <AccordionSection id="s1" title="Data backup" summary="Last backup: never" badge="Action needed" badgeTone="warn">
+        <button type="button">Back up my data</button>
+      </AccordionSection>
+    )
+    expect(await axe(container)).toHaveNoViolations()
+    fireEvent.click(screen.getByRole('button', { name: /data backup/i }))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('does not warn about the inert prop (React 19 boolean attribute)', () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(<AccordionSection id="s1" title="Data backup">body</AccordionSection>)
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})

--- a/frontend/src/components/account/__tests__/BackupPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/BackupPanel.test.jsx
@@ -1,0 +1,71 @@
+/**
+ * Data backup panel — Recovery-tab presentation (spec 032 UX).
+ *
+ * The panel is a collapsed accordion section that reports its own state in one
+ * line, and the two consequential actions (restore, remove) happen in a sheet
+ * rather than by unfolding more controls into the page.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+
+let ctx
+vi.mock('../../../hooks/useDataBackup', () => ({ useDataBackup: () => ctx }))
+
+import BackupPanel from '../BackupPanel'
+
+beforeEach(() => {
+  ctx = {
+    available: true, isConnected: true, onCanonical: true, canonicalChainId: 137,
+    status: 'idle', lastBackupAt: null, hasRemote: false,
+    refreshStatus: vi.fn(), backup: vi.fn(), restore: vi.fn(async () => ({ restored: true })), remove: vi.fn(),
+  }
+})
+
+describe('BackupPanel', () => {
+  it('starts collapsed and summarises that nothing is backed up yet', () => {
+    render(<BackupPanel />)
+    const trigger = screen.getByRole('button', { name: /data backup/i })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByText('No backup yet')).toBeInTheDocument()
+    expect(screen.getByText('Not backed up')).toBeInTheDocument()
+  })
+
+  it('summarises the last backup date once one exists, with no attention badge', () => {
+    ctx = { ...ctx, hasRemote: true, lastBackupAt: 1765000000000 }
+    render(<BackupPanel />)
+    expect(screen.getByText(/^Last backup /)).toBeInTheDocument()
+    expect(screen.queryByText('Not backed up')).not.toBeInTheDocument()
+  })
+
+  it('restores from a sheet and closes it on success', async () => {
+    ctx = { ...ctx, hasRemote: true }
+    render(<BackupPanel />)
+    fireEvent.click(screen.getByRole('button', { name: /restore my data/i }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /confirm merge/i }))
+    await waitFor(() => expect(ctx.restore).toHaveBeenCalledWith('merge'))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('confirms before removing the stored backup — the button alone never deletes', async () => {
+    ctx = { ...ctx, hasRemote: true }
+    render(<BackupPanel />)
+    fireEvent.click(screen.getByRole('button', { name: /remove stored backup/i }))
+    const dialog = screen.getByRole('dialog')
+    expect(ctx.remove).not.toHaveBeenCalled()
+    fireEvent.click(within(dialog).getByRole('button', { name: /keep it/i }))
+    expect(ctx.remove).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /remove stored backup/i }))
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^remove backup$/i }))
+    await waitFor(() => expect(ctx.remove).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('says so honestly when backup is unavailable on this network', () => {
+    ctx = { ...ctx, available: false }
+    render(<BackupPanel />)
+    expect(screen.getByText('Not available on this network')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /back up my data/i })).toBeNull()
+  })
+})

--- a/frontend/src/components/account/__tests__/BackupPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/BackupPanel.test.jsx
@@ -21,6 +21,16 @@ beforeEach(() => {
   }
 })
 
+// The panel is a COLLAPSED accordion section on the Recovery tab, so tests that
+// touch an in-body control open the section first — the same order a member does
+// it in. (jsdom does not enforce `inert`, so skipping the expand would pass here
+// and fail in a browser.)
+function renderExpanded() {
+  const utils = render(<BackupPanel />)
+  fireEvent.click(screen.getByRole('button', { name: /data backup/i }))
+  return utils
+}
+
 describe('BackupPanel', () => {
   it('starts collapsed and summarises that nothing is backed up yet', () => {
     render(<BackupPanel />)
@@ -39,7 +49,7 @@ describe('BackupPanel', () => {
 
   it('restores from a sheet and closes it on success', async () => {
     ctx = { ...ctx, hasRemote: true }
-    render(<BackupPanel />)
+    renderExpanded()
     fireEvent.click(screen.getByRole('button', { name: /restore my data/i }))
     const dialog = screen.getByRole('dialog')
     fireEvent.click(within(dialog).getByRole('button', { name: /confirm merge/i }))
@@ -49,7 +59,7 @@ describe('BackupPanel', () => {
 
   it('confirms before removing the stored backup — the button alone never deletes', async () => {
     ctx = { ...ctx, hasRemote: true }
-    render(<BackupPanel />)
+    renderExpanded()
     fireEvent.click(screen.getByRole('button', { name: /remove stored backup/i }))
     const dialog = screen.getByRole('dialog')
     expect(ctx.remove).not.toHaveBeenCalled()
@@ -66,6 +76,8 @@ describe('BackupPanel', () => {
     ctx = { ...ctx, available: false }
     render(<BackupPanel />)
     expect(screen.getByText('Not available on this network')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /data backup/i }))
+    expect(screen.getByRole('status')).toHaveTextContent(/isn’t available on this network yet/i)
     expect(screen.queryByRole('button', { name: /back up my data/i })).toBeNull()
   })
 })

--- a/frontend/src/components/account/__tests__/ControllersPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/ControllersPanel.test.jsx
@@ -24,13 +24,19 @@ import ControllersPanel from '../ControllersPanel'
 const ACCOUNT = '0x00000000000000000000000000000000000A11CE'
 const WALLET = '0x' + 'c'.repeat(40)
 
-// Open the link-wallet consent sheet and click its confirm button. The panel
-// button and the sheet's confirm button share the label "Link wallet", so the
-// confirm is scoped to the dialog.
-function confirmLink() {
-  fireEvent.click(screen.getByRole('button', { name: /link wallet/i })) // panel → opens sheet
+// The address entry lives INSIDE the link sheet: the panel's "Link a wallet"
+// button opens it, the address is typed there, and the sheet's "Link wallet"
+// button confirms. Queries are scoped to the dialog throughout.
+function openLinkSheet(address = WALLET) {
+  fireEvent.click(screen.getByRole('button', { name: /link a wallet/i })) // panel → opens sheet
   const dialog = screen.getByRole('dialog')
-  fireEvent.click(within(dialog).getByRole('button', { name: /link wallet/i })) // confirm
+  fireEvent.change(within(dialog).getByLabelText(/wallet address to link/i), { target: { value: address } })
+  return dialog
+}
+
+function confirmLink() {
+  const dialog = openLinkSheet()
+  fireEvent.click(within(dialog).getByRole('button', { name: /^link wallet$/i })) // confirm
 }
 
 function passkeyRow(i, extra = {}) {
@@ -81,15 +87,13 @@ describe('ControllersPanel', () => {
   it('shows an informed-consent sheet before linking, then links a CLEAR wallet through one sendCalls self-call (FR-019)', async () => {
     const screenController = vi.fn(async () => ({ clear: true, available: true }))
     render(<ControllersPanel deps={{ screenController }} />)
-    fireEvent.change(screen.getByLabelText(/wallet address to link/i), { target: { value: WALLET } })
-    // Opening the sheet alone must NOT act — the member has to confirm first.
-    fireEvent.click(screen.getByRole('button', { name: /link wallet/i }))
-    const dialog = screen.getByRole('dialog')
+    // Opening the sheet and typing an address must NOT act — the member has to confirm first.
+    const dialog = openLinkSheet()
     expect(dialog).toHaveTextContent(/full controller/i)
     expect(dialog).toHaveTextContent(WALLET)
     expect(screenController).not.toHaveBeenCalled()
     // Confirm inside the sheet performs the action.
-    fireEvent.click(within(dialog).getByRole('button', { name: /link wallet/i }))
+    fireEvent.click(within(dialog).getByRole('button', { name: /^link wallet$/i }))
     await waitFor(() => expect(walletState.sendCalls).toHaveBeenCalledTimes(1))
     expect(screenController).toHaveBeenCalledWith(WALLET, walletState.provider)
     expect(walletState.sendCalls.mock.calls[0][0][0].target).toBe(ACCOUNT) // self-call
@@ -98,7 +102,6 @@ describe('ControllersPanel', () => {
   it('REFUSES a flagged wallet before any on-chain op (clarification Q2)', async () => {
     const screenController = vi.fn(async () => ({ clear: false, available: true }))
     render(<ControllersPanel deps={{ screenController }} />)
-    fireEvent.change(screen.getByLabelText(/wallet address to link/i), { target: { value: WALLET } })
     confirmLink()
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/flagged/i))
     expect(walletState.sendCalls).not.toHaveBeenCalled()
@@ -111,7 +114,6 @@ describe('ControllersPanel', () => {
       controllers: [passkeyRow(0), { index: 1n, ownerBytes: '0x' + '0'.repeat(24) + 'c'.repeat(40), kind: 'wallet', address: WALLET, label: 'Wallet', credentialId: null, isThisDevice: false }],
     }
     render(<ControllersPanel deps={{ screenController }} />)
-    fireEvent.change(screen.getByLabelText(/wallet address to link/i), { target: { value: WALLET } })
     confirmLink()
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/already a controller/i))
     expect(screenController).not.toHaveBeenCalled()
@@ -121,7 +123,6 @@ describe('ControllersPanel', () => {
   it('REFUSES when screening is unavailable — fail-closed', async () => {
     const screenController = vi.fn(async () => ({ clear: false, available: false }))
     render(<ControllersPanel deps={{ screenController }} />)
-    fireEvent.change(screen.getByLabelText(/wallet address to link/i), { target: { value: WALLET } })
     confirmLink()
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/fail-closed/i))
     expect(walletState.sendCalls).not.toHaveBeenCalled()
@@ -142,6 +143,35 @@ describe('ControllersPanel', () => {
     await waitFor(() => expect(walletState.sendCalls).toHaveBeenCalledTimes(1))
     expect(createCredential).toHaveBeenCalled()
     expect(accountState.refresh).toHaveBeenCalled()
+  })
+
+  it('confirms in a sheet before removing a controller — the Remove button alone never acts', async () => {
+    render(<ControllersPanel />)
+    fireEvent.click(screen.getAllByRole('button', { name: /remove key 1/i })[0])
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveTextContent(/no longer be able to approve actions/i)
+    expect(walletState.sendCalls).not.toHaveBeenCalled()
+    // Backing out leaves the controller alone.
+    fireEvent.click(within(dialog).getByRole('button', { name: /keep it/i }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(walletState.sendCalls).not.toHaveBeenCalled()
+    // Confirming performs the self-call.
+    fireEvent.click(screen.getAllByRole('button', { name: /remove key 1/i })[0])
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /remove controller/i }))
+    await waitFor(() => expect(walletState.sendCalls).toHaveBeenCalledTimes(1))
+    expect(walletState.sendCalls.mock.calls[0][0][0].target).toBe(ACCOUNT) // self-call
+  })
+
+  it('summarises the controller count while collapsed, and flags a single-controller account', () => {
+    const { unmount } = render(<ControllersPanel />)
+    expect(screen.getByRole('button', { name: /devices & controllers/i })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByText('2 controllers')).toBeInTheDocument()
+    unmount()
+
+    accountState = { ...accountState, controllers: [passkeyRow(0)], controllerCount: 1, singleControllerRisk: true }
+    render(<ControllersPanel />)
+    expect(screen.getByText('1 controller')).toBeInTheDocument()
+    expect(screen.getByText('Add a backup key')).toBeInTheDocument()
   })
 
   it('gates mutations until the account is on-chain (counterfactual honesty, FR-007)', () => {

--- a/frontend/src/components/account/__tests__/ControllersPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/ControllersPanel.test.jsx
@@ -24,6 +24,16 @@ import ControllersPanel from '../ControllersPanel'
 const ACCOUNT = '0x00000000000000000000000000000000000A11CE'
 const WALLET = '0x' + 'c'.repeat(40)
 
+// The panel is a COLLAPSED accordion section on the Recovery tab, so every test
+// that touches an in-body control opens the section first — the same order a
+// member does it in. (jsdom does not enforce `inert`, so a test that skipped the
+// expand would pass here and fail in a browser.)
+function renderPanel(props = {}) {
+  const utils = render(<ControllersPanel {...props} />)
+  fireEvent.click(screen.getByRole('button', { name: /devices & controllers/i }))
+  return utils
+}
+
 // The address entry lives INSIDE the link sheet: the panel's "Link a wallet"
 // button opens it, the address is typed there, and the sheet's "Link wallet"
 // button confirms. Queries are scoped to the dialog throughout.
@@ -71,7 +81,7 @@ beforeEach(() => {
 
 describe('ControllersPanel', () => {
   it('lists controllers and enables removal when more than one exists (FR-018/FR-020)', () => {
-    render(<ControllersPanel />)
+    renderPanel()
     expect(screen.getByTestId('controller-0')).toHaveTextContent('Key 0')
     expect(screen.getByTestId('controller-0')).toHaveTextContent('(this device)')
     expect(screen.getAllByRole('button', { name: /remove/i })[0]).toBeEnabled()
@@ -79,14 +89,14 @@ describe('ControllersPanel', () => {
 
   it('refuses last-controller removal in the UI (FR-020 client half)', () => {
     accountState = { ...accountState, controllers: [passkeyRow(0)], controllerCount: 1, singleControllerRisk: true }
-    render(<ControllersPanel />)
+    renderPanel()
     expect(screen.getByTestId('single-controller-warning')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /remove/i })).toBeDisabled()
   })
 
   it('shows an informed-consent sheet before linking, then links a CLEAR wallet through one sendCalls self-call (FR-019)', async () => {
     const screenController = vi.fn(async () => ({ clear: true, available: true }))
-    render(<ControllersPanel deps={{ screenController }} />)
+    renderPanel({ deps: { screenController } })
     // Opening the sheet and typing an address must NOT act — the member has to confirm first.
     const dialog = openLinkSheet()
     expect(dialog).toHaveTextContent(/full controller/i)
@@ -101,7 +111,7 @@ describe('ControllersPanel', () => {
 
   it('REFUSES a flagged wallet before any on-chain op (clarification Q2)', async () => {
     const screenController = vi.fn(async () => ({ clear: false, available: true }))
-    render(<ControllersPanel deps={{ screenController }} />)
+    renderPanel({ deps: { screenController } })
     confirmLink()
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/flagged/i))
     expect(walletState.sendCalls).not.toHaveBeenCalled()
@@ -113,7 +123,7 @@ describe('ControllersPanel', () => {
       ...accountState,
       controllers: [passkeyRow(0), { index: 1n, ownerBytes: '0x' + '0'.repeat(24) + 'c'.repeat(40), kind: 'wallet', address: WALLET, label: 'Wallet', credentialId: null, isThisDevice: false }],
     }
-    render(<ControllersPanel deps={{ screenController }} />)
+    renderPanel({ deps: { screenController } })
     confirmLink()
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/already a controller/i))
     expect(screenController).not.toHaveBeenCalled()
@@ -122,7 +132,7 @@ describe('ControllersPanel', () => {
 
   it('REFUSES when screening is unavailable — fail-closed', async () => {
     const screenController = vi.fn(async () => ({ clear: false, available: false }))
-    render(<ControllersPanel deps={{ screenController }} />)
+    renderPanel({ deps: { screenController } })
     confirmLink()
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/fail-closed/i))
     expect(walletState.sendCalls).not.toHaveBeenCalled()
@@ -134,7 +144,7 @@ describe('ControllersPanel', () => {
       publicKey: { x: '0x' + '3'.repeat(64), y: '0x' + '4'.repeat(64) },
       prfCapable: true,
     }))
-    render(<ControllersPanel deps={{ createCredential }} />)
+    renderPanel({ deps: { createCredential } })
     fireEvent.click(screen.getByRole('button', { name: /add a passkey/i }))
     const dialog = screen.getByRole('dialog')
     expect(dialog).toHaveTextContent(/full controller/i)
@@ -146,7 +156,7 @@ describe('ControllersPanel', () => {
   })
 
   it('confirms in a sheet before removing a controller — the Remove button alone never acts', async () => {
-    render(<ControllersPanel />)
+    renderPanel()
     fireEvent.click(screen.getAllByRole('button', { name: /remove key 1/i })[0])
     const dialog = screen.getByRole('dialog')
     expect(dialog).toHaveTextContent(/no longer be able to approve actions/i)
@@ -176,7 +186,7 @@ describe('ControllersPanel', () => {
 
   it('gates mutations until the account is on-chain (counterfactual honesty, FR-007)', () => {
     accountState = { ...accountState, deployed: false, controllers: [], controllerCount: 0, singleControllerRisk: true }
-    render(<ControllersPanel />)
+    renderPanel()
     expect(screen.getByRole('note')).toHaveTextContent(/activates on-chain with your first action/i)
     expect(screen.getByRole('button', { name: /add a passkey/i })).toBeDisabled()
   })

--- a/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
@@ -9,7 +9,7 @@
  * component's orchestration; their internals are covered in their own suites.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'vitest-axe'
 
@@ -90,6 +90,15 @@ async function importToSaved(user, kind = 'privateKey') {
   await screen.findByTestId('lkr-saved')
 }
 
+// The panel is a COLLAPSED accordion section on the Recovery tab, so tests open
+// the section first — the same order a member does it in. (jsdom does not
+// enforce `inert`, so skipping the expand would pass here and fail in a browser.)
+function renderPanel(props = {}) {
+  const utils = render(<LegacyKeyRecoveryPanel {...props} />)
+  fireEvent.click(screen.getByRole('button', { name: /legacy key & word-list recovery/i }))
+  return utils
+}
+
 describe('LegacyKeyRecoveryPanel', () => {
   it('renders nothing when disconnected', () => {
     mockWallet.isConnected = false
@@ -101,7 +110,7 @@ describe('LegacyKeyRecoveryPanel', () => {
   it('completes recovery at SAVED without any transfer, and writes the audit record', async () => {
     const user = userEvent.setup()
     lib.encryptLegacySecret.mockResolvedValue({ v: 1, kind: 'privateKey', address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     await importToSaved(user)
 
     // Recovery is complete on its own — the SAVED screen, no transfer required.
@@ -153,7 +162,7 @@ describe('LegacyKeyRecoveryPanel', () => {
     lib.decryptLegacySecretWithPasskey.mockResolvedValue('0xkey')
     lib.quoteAllAssets.mockResolvedValue({ from: LEGACY_ADDR, holdings: [], nativeGasReserve: 1n, hasNative: false })
     const user = userEvent.setup()
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     await user.click(screen.getByRole('button', { name: 'Move funds' }))
     // No passphrase field — biometric unlock button instead.
     expect(screen.queryByLabelText('Passphrase')).not.toBeInTheDocument()
@@ -164,7 +173,7 @@ describe('LegacyKeyRecoveryPanel', () => {
 
   it('suggests BIP-39 completions while typing a word list', async () => {
     const user = userEvent.setup()
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     await user.click(screen.getByRole('button', { name: 'Recover a legacy key' }))
     await user.click(screen.getByRole('button', { name: 'Get started' }))
     lib.classifySecret.mockReturnValue({ kind: 'invalid' })
@@ -177,7 +186,7 @@ describe('LegacyKeyRecoveryPanel', () => {
 
   it('blocks continuing when passphrases do not match', async () => {
     const user = userEvent.setup()
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     await user.click(screen.getByRole('button', { name: 'Recover a legacy key' }))
     await user.click(screen.getByRole('button', { name: 'Get started' }))
     lib.classifySecret.mockReturnValue({ kind: 'mnemonic', address: LEGACY_ADDR, secret: 'a b c' })
@@ -193,7 +202,7 @@ describe('LegacyKeyRecoveryPanel', () => {
     const user = userEvent.setup()
     lib.encryptLegacySecret.mockResolvedValue({ v: 1, address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
     book.findByAddress.mockReturnValue(null) // not yet in book → addContact
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     await importToSaved(user)
 
     await user.click(screen.getByRole('button', { name: 'Save to address book' }))
@@ -219,7 +228,7 @@ describe('LegacyKeyRecoveryPanel', () => {
       { asset: { symbol: 'USDC' }, status: 'sent', txHash: '0x1' },
       { asset: { symbol: 'MATIC' }, status: 'sent', txHash: '0x2' },
     ])
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     await importToSaved(user)
 
     await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move funds' }))
@@ -248,7 +257,7 @@ describe('LegacyKeyRecoveryPanel', () => {
       { asset: { symbol: 'USDC' }, status: 'failed', error: 'reverted' },
       { asset: { symbol: 'MATIC' }, status: 'sent', txHash: '0x2' },
     ])
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     await importToSaved(user)
     await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move funds' }))
     await user.click(screen.getByRole('button', { name: 'Check balances' }))
@@ -269,7 +278,7 @@ describe('LegacyKeyRecoveryPanel', () => {
       nativeGasReserve: 0n,
       hasNative: false,
     })
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     await importToSaved(user)
     await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move funds' }))
     await user.click(screen.getByRole('button', { name: 'Check balances' }))
@@ -289,7 +298,7 @@ describe('LegacyKeyRecoveryPanel', () => {
       nativeGasLimit: 25200n,
       hasNative: true,
     })
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     await importToSaved(user)
     await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move funds' }))
     await user.click(screen.getByRole('button', { name: 'Check balances' }))
@@ -302,7 +311,7 @@ describe('LegacyKeyRecoveryPanel', () => {
     lib.decryptLegacySecret.mockResolvedValue('word list secret')
     lib.quoteAllAssets.mockResolvedValue({ from: LEGACY_ADDR, holdings: [], nativeGasReserve: 1n, hasNative: false })
     const user = userEvent.setup()
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
 
     const item = screen.getByRole('listitem')
     expect(within(item).getByText(/word list/i)).toBeInTheDocument()
@@ -316,7 +325,7 @@ describe('LegacyKeyRecoveryPanel', () => {
   it('removes a stored key only after the confirmation sheet is confirmed', async () => {
     lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'privateKey', address: LEGACY_ADDR, importedAt: 42, ct: 'x' })
     const user = userEvent.setup()
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     expect(screen.getByRole('listitem')).toBeInTheDocument()
 
     // Backing out of the confirmation keeps the key.
@@ -332,7 +341,7 @@ describe('LegacyKeyRecoveryPanel', () => {
   it('has no accessibility violations on the entry and SAVED screens', async () => {
     const user = userEvent.setup()
     lib.encryptLegacySecret.mockResolvedValue({ v: 1, address: LEGACY_ADDR, importedAt: 1, ct: 'x' })
-    const { container } = render(<LegacyKeyRecoveryPanel />)
+    const { container } = renderPanel()
     expect(await axe(container)).toHaveNoViolations()
     await importToSaved(user)
     expect(await axe(container)).toHaveNoViolations()
@@ -342,7 +351,7 @@ describe('LegacyKeyRecoveryPanel', () => {
     lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'privateKey', address: LEGACY_ADDR, importedAt: 42, ct: 'x' })
     lib.decryptLegacySecret.mockRejectedValue(new Error('That passphrase did not unlock this key.'))
     const user = userEvent.setup()
-    render(<LegacyKeyRecoveryPanel />)
+    renderPanel()
     await user.click(screen.getByRole('button', { name: 'Move funds' }))
     await user.type(screen.getByLabelText('Passphrase'), 'wrongpass1')
     await user.click(screen.getByRole('button', { name: 'Unlock' }))

--- a/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx
@@ -313,12 +313,19 @@ describe('LegacyKeyRecoveryPanel', () => {
     expect(await screen.findByLabelText('Destination smart account')).toBeInTheDocument()
   })
 
-  it('removes a stored key', async () => {
+  it('removes a stored key only after the confirmation sheet is confirmed', async () => {
     lib.store.set(LEGACY_ADDR.toLowerCase(), { kind: 'privateKey', address: LEGACY_ADDR, importedAt: 42, ct: 'x' })
     const user = userEvent.setup()
     render(<LegacyKeyRecoveryPanel />)
     expect(screen.getByRole('listitem')).toBeInTheDocument()
+
+    // Backing out of the confirmation keeps the key.
     await user.click(screen.getByRole('button', { name: /Remove stored key/i }))
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: /keep it/i }))
+    expect(screen.getByRole('listitem')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Remove stored key/i }))
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: /remove key/i }))
     await waitFor(() => expect(screen.queryByRole('listitem')).not.toBeInTheDocument())
   })
 

--- a/frontend/src/components/account/__tests__/RecoverAccountPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/RecoverAccountPanel.test.jsx
@@ -8,7 +8,7 @@
  * standard address entry (browser-known hint chips).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 const mockWallet = {
@@ -87,6 +87,15 @@ beforeEach(() => {
   addOwnerPublicKey.mockResolvedValue({ wait: txWait })
 })
 
+// The panel is a COLLAPSED accordion section on the Recovery tab, so tests open
+// the section first — the same order a member does it in. (jsdom does not
+// enforce `inert`, so skipping the expand would pass here and fail in a browser.)
+function renderPanel(props) {
+  const utils = render(<RecoverAccountPanel {...props} />)
+  fireEvent.click(screen.getByRole('button', { name: /recover a passkey account/i }))
+  return utils
+}
+
 describe('RecoverAccountPanel', () => {
   it('renders nothing for passkey sessions (they use the Controllers panel)', () => {
     mockWallet.loginMethod = 'passkey'
@@ -102,7 +111,7 @@ describe('RecoverAccountPanel', () => {
 
   it('walks the wizard: intro → account entry → verified confirm step', async () => {
     const user = userEvent.setup()
-    render(<RecoverAccountPanel deps={baseDeps()} />)
+    renderPanel({ deps: baseDeps() })
     // Sheet is closed until the member starts recovery.
     expect(screen.queryByLabelText('Passkey account address')).not.toBeInTheDocument()
     await enterAndVerify(user)
@@ -112,7 +121,7 @@ describe('RecoverAccountPanel', () => {
   it('refuses recovery when the wallet is not a controller and never reaches the ceremony', async () => {
     isOwnerAddress.mockResolvedValue(false)
     const user = userEvent.setup()
-    render(<RecoverAccountPanel deps={baseDeps()} />)
+    renderPanel({ deps: baseDeps() })
     await enterAndVerify(user)
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/not a controller/i))
     // Stays on the account step — the confirm/ceremony button is not rendered.
@@ -125,7 +134,7 @@ describe('RecoverAccountPanel', () => {
       Object.assign(new Error('could not decode result data (value="0x")'), { code: 'BAD_DATA' })
     )
     const user = userEvent.setup()
-    render(<RecoverAccountPanel deps={baseDeps()} />)
+    renderPanel({ deps: baseDeps() })
     await enterAndVerify(user)
     await waitFor(() =>
       expect(screen.getByRole('alert')).toHaveTextContent(/doesn't respond like a FairWins passkey account/i)
@@ -138,7 +147,7 @@ describe('RecoverAccountPanel', () => {
   it('flags an undeployed / wrong-network account before hitting the contract', async () => {
     mockWallet.provider = { getCode: vi.fn().mockResolvedValue('0x') }
     const user = userEvent.setup()
-    render(<RecoverAccountPanel deps={baseDeps()} />)
+    renderPanel({ deps: baseDeps() })
     await enterAndVerify(user)
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/No passkey account is deployed/i))
     expect(isOwnerAddress).not.toHaveBeenCalled()
@@ -147,7 +156,7 @@ describe('RecoverAccountPanel', () => {
 
   it('recovers end-to-end: verify → new passkey → wallet tx → receipt → book record → done', async () => {
     const user = userEvent.setup()
-    render(<RecoverAccountPanel deps={baseDeps()} />)
+    renderPanel({ deps: baseDeps() })
     await enterAndVerify(user)
     await waitFor(() => expect(screen.getByTestId('recover-verified')).toBeInTheDocument())
 
@@ -165,7 +174,7 @@ describe('RecoverAccountPanel', () => {
   it('reports a reverted authorization honestly and does NOT record the credential', async () => {
     txWait.mockResolvedValue({ status: 0 })
     const user = userEvent.setup()
-    render(<RecoverAccountPanel deps={baseDeps()} />)
+    renderPanel({ deps: baseDeps() })
     await enterAndVerify(user)
     await waitFor(() => expect(screen.getByTestId('recover-verified')).toBeInTheDocument())
 

--- a/frontend/src/components/account/__tests__/RecoveryCodesPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/RecoveryCodesPanel.test.jsx
@@ -11,6 +11,15 @@ vi.mock('../../../hooks/useOpenChallengeCodeVault', () => ({
 
 import RecoveryCodesPanel from '../RecoveryCodesPanel'
 
+// The panel is a COLLAPSED accordion section on the Recovery tab, so tests open
+// the section first — the same order a member does it in. (jsdom does not
+// enforce `inert`, so skipping the expand would pass here and fail in a browser.)
+function renderPanel() {
+  const utils = render(<RecoveryCodesPanel />)
+  fireEvent.click(screen.getByRole('button', { name: /recovery codes/i }))
+  return utils
+}
+
 describe('RecoveryCodesPanel (recovery codes in Security)', () => {
   beforeEach(() => {
     recoverCodes.mockReset()
@@ -24,7 +33,7 @@ describe('RecoveryCodesPanel (recovery codes in Security)', () => {
 
   it('prompts to sign in when the vault is unavailable', () => {
     vault = { ...vault, canUse: false }
-    render(<RecoveryCodesPanel />)
+    renderPanel()
     expect(screen.getByText(/sign in to recover/i)).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /unlock/i })).toBeNull()
   })
@@ -33,7 +42,7 @@ describe('RecoveryCodesPanel (recovery codes in Security)', () => {
     recoverCodes.mockResolvedValue([
       { code: 'river amber tiger kite', wagerId: 9, description: 'Rain in Denver', savedAt: 1735689600000 },
     ])
-    render(<RecoveryCodesPanel />)
+    renderPanel()
     fireEvent.click(screen.getByRole('button', { name: /unlock my saved codes/i }))
     await waitFor(() => expect(screen.getByText('river amber tiger kite')).toBeInTheDocument())
     expect(recoverCodes).toHaveBeenCalledTimes(1)
@@ -43,14 +52,14 @@ describe('RecoveryCodesPanel (recovery codes in Security)', () => {
 
   it('shows an empty state when no codes are backed up on this device', async () => {
     recoverCodes.mockResolvedValue([])
-    render(<RecoveryCodesPanel />)
+    renderPanel()
     fireEvent.click(screen.getByRole('button', { name: /unlock my saved codes/i }))
     await waitFor(() => expect(screen.getByText(/no saved codes on this device yet/i)).toBeInTheDocument())
   })
 
   it('surfaces an unlock error without crashing', async () => {
     recoverCodes.mockRejectedValue(new Error('User rejected signature'))
-    render(<RecoveryCodesPanel />)
+    renderPanel()
     fireEvent.click(screen.getByRole('button', { name: /unlock my saved codes/i }))
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/user rejected signature/i))
   })

--- a/frontend/src/components/account/accordionContext.js
+++ b/frontend/src/components/account/accordionContext.js
@@ -1,0 +1,15 @@
+/**
+ * Shared state for a group of AccordionSections (Recovery tab, spec 062 UX).
+ *
+ * Kept in its own module (no components) so Vite fast-refresh stays happy and so
+ * a section can work standalone: `useAccordionGroup()` returns null when there is
+ * no provider above, and the section falls back to its own local open state.
+ */
+
+import { createContext, useContext } from 'react'
+
+export const AccordionGroupContext = createContext(null)
+
+export function useAccordionGroup() {
+  return useContext(AccordionGroupContext)
+}

--- a/frontend/src/components/ui/QRScanner.css
+++ b/frontend/src/components/ui/QRScanner.css
@@ -8,7 +8,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1001;
+  /* Above the account ActionSheet (1500) and every modal that can host an
+     address field, since the scanner is almost always opened from inside one. */
+  z-index: 1600;
   backdrop-filter: blur(4px);
   animation: fadeIn 0.2s ease-out;
 }

--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -749,11 +749,39 @@
   gap: 6px;
 }
 
-/* Security Section */
+/* Security Section (Recovery tab).
+   Every panel here is a collapsible AccordionSection, so the tab opens as a
+   scannable list of headings; the styles below apply to what each section shows
+   once it is expanded. */
+.security-section__intro {
+  margin: 0 0 14px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-secondary, #5a6772);
+}
+
+/* Section headings come from the accordion trigger — in-body headings (nested
+   sub-panels) stay smaller so they never compete with it. */
 .security-section h3 {
   margin: 0 0 8px;
   font-size: 18px;
   color: var(--color-text);
+}
+
+.security-section .acc h3 {
+  margin: 0;
+  font-size: inherit;
+}
+
+.security-section .acc__body h3,
+.security-section .acc__body h4 {
+  font-size: 15px;
+  margin: 16px 0 8px;
+}
+
+.security-section .acc__body > .section-description:first-child,
+.security-section .acc__body > p:first-child {
+  margin-top: 0;
 }
 
 .security-section .section-description {
@@ -855,17 +883,12 @@
   flex-shrink: 0;
 }
 
-.controllers-panel__link {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 12px;
-}
-
+/* Address entry inside the link-wallet sheet (input + address book + QR scan). */
 .controllers-panel__link-row {
   display: flex;
   gap: 8px;
   align-items: flex-start;
+  margin-bottom: 12px;
 }
 
 .controllers-panel__address-wrap {
@@ -882,15 +905,15 @@
   min-width: 42px;
   height: 42px;
   border-radius: 8px;
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-secondary);
-  color: var(--color-text);
+  border: 1px solid var(--border-color, #e3e7eb);
+  background: var(--bg-primary, #f7f9fa);
+  color: var(--text-primary, #1f2933);
   cursor: pointer;
 }
 
 .controllers-panel__scan-btn:hover:not(:disabled) {
-  border-color: var(--color-primary, #36B37E);
-  color: var(--color-primary, #36B37E);
+  border-color: var(--brand-primary, #36b37e);
+  color: var(--brand-primary, #36b37e);
 }
 
 .controllers-panel__scan-btn:disabled {

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -29,6 +29,8 @@ import PrivacyPreferencesPanel from '../components/account/PrivacyPreferencesPan
 import AddressBookPanel from '../components/account/AddressBookPanel'
 import CallsignPanel from '../components/account/CallsignPanel'
 import BackupPanel from '../components/account/BackupPanel'
+import AccordionGroup from '../components/account/AccordionGroup'
+import AccordionSection from '../components/account/AccordionSection'
 import NetworkPanel from '../components/account/NetworkPanel'
 import RecoveryCodesPanel from '../components/account/RecoveryCodesPanel'
 import TaxReportsPanel from '../components/wallet/TaxReportsPanel'
@@ -423,70 +425,90 @@ function WalletPage() {
 
                 {activeTab === 'security' && (
                   <div className="security-section" role="tabpanel">
-                    {/* Backup + Security combined into one panel: the data-backup
-                        controls sit above the account-security controls. */}
-                    <BackupPanel />
-                    {/* Spec 045 US5/US6 — account controllers & recovery.
-                        ControllersPanel renders for passkey sessions (add a
-                        passkey / link a wallet as recovery); the recovery
-                        panel renders for wallet sessions (regain passkey
-                        access using a linked wallet). Each self-gates. */}
-                    <ControllersPanel />
-                    <RecoverAccountPanel />
-                    {/* Recover an account from a legacy private key or word
-                        list, store it encrypted on-device, and move its funds
-                        to a smart account. Self-gates to connected sessions. */}
-                    <LegacyKeyRecoveryPanel />
-                    <div className="section">
-                      <h3>Encryption Key</h3>
-                      <p className="section-description">
-                        Your encryption key allows you to send and receive encrypted wagers. It is derived from
-                        {isPasskey ? ' your passkey' : ' your wallet signature'} and registered on-chain.
-                      </p>
+                    {/* Recovery collects several independent, high-stakes features. Each one
+                        renders as a COLLAPSED AccordionSection that states its own status in a
+                        line, so the tab opens as a scannable list rather than a stack of fully
+                        expanded panels; one section is open at a time, and every consequential
+                        or destructive action confirms in a bottom sheet. */}
+                    <p className="security-section__intro">
+                      Everything that protects your access to this account. Open a section to see or change it.
+                    </p>
+                    <AccordionGroup>
+                      {/* Data backup — encrypted backup/restore of device-local data (spec 032). */}
+                      <BackupPanel />
+                      {/* Spec 045 US5/US6 — account controllers & recovery.
+                          ControllersPanel renders for passkey sessions (add a
+                          passkey / link a wallet as recovery); the recovery
+                          panel renders for wallet sessions (regain passkey
+                          access using a linked wallet). Each self-gates. */}
+                      <ControllersPanel />
+                      <RecoverAccountPanel />
+                      {/* Recover an account from a legacy private key or word
+                          list, store it encrypted on-device, and move its funds
+                          to a smart account. Self-gates to connected sessions. */}
+                      <LegacyKeyRecoveryPanel />
+                      <AccordionSection
+                        id="encryption-key"
+                        title="Encryption key"
+                        summary={
+                          keyRegistered
+                            ? 'Registered on-chain'
+                            : isInitialized
+                              ? 'Derived on this device'
+                              : 'Not initialized'
+                        }
+                        badge={keyRegistered === false ? 'Not registered' : null}
+                        badgeTone="warn"
+                      >
+                        <p className="section-description">
+                          Your encryption key allows you to send and receive encrypted wagers. It is derived from
+                          {isPasskey ? ' your passkey' : ' your wallet signature'} and registered on-chain.
+                        </p>
 
-                      <div className="key-status-card">
-                        <div className="key-status-row">
-                          <span className="key-status-label">Local Keys:</span>
-                          <span className={`key-status-value ${isInitialized ? 'active' : 'inactive'}`}>
-                            {isInitializing ? 'Initializing...' : isInitialized ? 'Derived' : 'Not initialized'}
-                          </span>
+                        <div className="key-status-card">
+                          <div className="key-status-row">
+                            <span className="key-status-label">Local Keys:</span>
+                            <span className={`key-status-value ${isInitialized ? 'active' : 'inactive'}`}>
+                              {isInitializing ? 'Initializing...' : isInitialized ? 'Derived' : 'Not initialized'}
+                            </span>
+                          </div>
+                          <div className="key-status-row">
+                            <span className="key-status-label">On-chain Registration:</span>
+                            <span className={`key-status-value ${keyRegistered ? 'active' : keyRegistered === false ? 'inactive' : ''}`}>
+                              {keyCheckLoading ? 'Checking...' : keyRegistered === null ? 'Not checked' : keyRegistered ? 'Registered' : 'Not registered'}
+                            </span>
+                          </div>
                         </div>
-                        <div className="key-status-row">
-                          <span className="key-status-label">On-chain Registration:</span>
-                          <span className={`key-status-value ${keyRegistered ? 'active' : keyRegistered === false ? 'inactive' : ''}`}>
-                            {keyCheckLoading ? 'Checking...' : keyRegistered === null ? 'Not checked' : keyRegistered ? 'Registered' : 'Not registered'}
-                          </span>
-                        </div>
-                      </div>
 
-                      {keyError && (
-                        <div className="key-error" role="alert">
-                          {keyError}
-                        </div>
-                      )}
-
-                      <div className="key-actions">
-                        <button
-                          onClick={handleCheckKeyStatus}
-                          className="key-action-btn secondary"
-                          disabled={keyCheckLoading}
-                        >
-                          {keyCheckLoading ? 'Checking...' : 'Check Status'}
-                        </button>
-
-                        {!keyRegistered && (
-                          <button
-                            onClick={handleRegisterKey}
-                            className="key-action-btn primary"
-                            disabled={keyRegisterLoading}
-                          >
-                            {keyRegisterLoading ? 'Registering...' : 'Register Encryption Key'}
-                          </button>
+                        {keyError && (
+                          <div className="key-error" role="alert">
+                            {keyError}
+                          </div>
                         )}
-                      </div>
-                    </div>
 
-                    <RecoveryCodesPanel />
+                        <div className="key-actions">
+                          <button
+                            onClick={handleCheckKeyStatus}
+                            className="key-action-btn secondary"
+                            disabled={keyCheckLoading}
+                          >
+                            {keyCheckLoading ? 'Checking...' : 'Check Status'}
+                          </button>
+
+                          {!keyRegistered && (
+                            <button
+                              onClick={handleRegisterKey}
+                              className="key-action-btn primary"
+                              disabled={keyRegisterLoading}
+                            >
+                              {keyRegisterLoading ? 'Registering...' : 'Register Encryption Key'}
+                            </button>
+                          )}
+                        </div>
+                      </AccordionSection>
+
+                      <RecoveryCodesPanel />
+                    </AccordionGroup>
                   </div>
                 )}
 

--- a/frontend/src/test/backup/BackupPanel.accessibility.test.jsx
+++ b/frontend/src/test/backup/BackupPanel.accessibility.test.jsx
@@ -13,15 +13,25 @@ vi.mock('../../hooks/useDataBackup', () => ({ useDataBackup: () => ctx }))
 
 import BackupPanel from '../../components/account/BackupPanel'
 
+// The panel is a COLLAPSED accordion section — open it the way a member does
+// before reaching the controls inside (jsdom does not enforce `inert`).
+function renderExpanded() {
+  const utils = render(<BackupPanel />)
+  fireEvent.click(screen.getByRole('button', { name: /data backup/i }))
+  return utils
+}
+
 describe('BackupPanel accessibility', () => {
-  it('has no axe violations (default view)', async () => {
+  it('has no axe violations collapsed, or expanded on the default view', async () => {
     const { container } = render(<BackupPanel />)
+    expect(await axe(container)).toHaveNoViolations()
+    fireEvent.click(screen.getByRole('button', { name: /data backup/i }))
     expect(screen.getByRole('button', { name: /back up my data/i })).toBeInTheDocument()
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('has no axe violations with the restore merge/replace region open (replace warning shown)', async () => {
-    const { container } = render(<BackupPanel />)
+    const { container } = renderExpanded()
     fireEvent.click(screen.getByRole('button', { name: /restore my data/i }))
     fireEvent.click(screen.getByRole('radio', { name: /replace/i }))
     expect(screen.getByRole('alert')).toBeInTheDocument() // replace warning
@@ -29,7 +39,7 @@ describe('BackupPanel accessibility', () => {
   })
 
   it('resets to the safe default (merge) after selecting Replace then cancelling/reopening', () => {
-    render(<BackupPanel />)
+    renderExpanded()
     fireEvent.click(screen.getByRole('button', { name: /restore my data/i }))
     fireEvent.click(screen.getByRole('radio', { name: /replace/i }))
     expect(screen.getByRole('radio', { name: /replace/i }).checked).toBe(true)


### PR DESCRIPTION
## What

The Recovery tab (`?tab=security`, formerly "Backup & Security") stacked six fully expanded panels, so it opened as a wall of prose and controls before the member could see what was there.

Each panel now renders itself as a **collapsed** `AccordionSection` inside one `AccordionGroup`: a heading, a one-line summary of that panel's current state, and an attention badge where one is warranted (no backup yet, single controller, unregistered encryption key). One section is open at a time, so opening a section tidies the previous one away. The whole tab fits on one screen.

Consequential and destructive actions moved out of the page and into the existing `ActionSheet` (centered card on desktop, bottom sheet on mobile), each stating its consequence before it acts:

| Action | Before | Now |
| --- | --- | --- |
| Restore (merge vs replace) | inline region that unfolded below the buttons | sheet |
| Remove stored backup | one unguarded click | confirm sheet |
| Link a wallet | address input + warning paragraph always on the page | address entry lives in the sheet beside the full-controller warning; the panel is just the controller list |
| Remove a controller | one unguarded click | confirm sheet (names the key, warns when it's this device) |
| Delete a recovered legacy key | one unguarded click | confirm sheet |

## New components

`components/account/AccordionSection.jsx` + `AccordionGroup.jsx` + `accordionContext.js`

- Height animates with `grid-template-rows: 0fr → 1fr` — no measuring, compositor-friendly, and disabled under `prefers-reduced-motion`.
- Collapsed children stay **mounted** (that's what the animation needs) but the region is `inert`, so nothing inside is focusable or announced until it opens.
- Panels keep their own `return null` gating: the accordion wraps *inside* the panel, and sheets render as **siblings** of the section — never inside the collapsible region, where an inert ancestor would disable them.
- A section works standalone (its own open state) when no group is above it.

## Supporting fixes found along the way

- **`ActionSheet` button tones.** The app has no global `.btn` rule — only scoped ones — so sheet actions were painted by the global `button {}` and primary/destructive looked identical to cancel. Added `.btn` / `.btn-primary` / `.btn-danger` scoped to the sheet, plus an entrance animation (rise on mobile, settle on desktop) with a reduced-motion opt-out.
- **Badge contrast.** Raw brand/semantic hues sit around 2.5:1 on a white surface — under AA for 11px bold text. Badge ink is darkened for the light theme and restored to the full hue in dark.
- **`QRScanner` z-index.** The scanner (1001) is opened from inside an `ActionSheet` (1500) in both recovery panels and was painting *behind* it; raised above the sheet layer.
- Dropped the dead `--color-*` variables from the scan-button styles (they are defined nowhere in the repo, so the button had no border or background) and removed the now-unused `.controllers-panel__link` block.

## Testing

- New: `AccordionSection.test.jsx` (collapsed default, inert region, exclusive group behaviour, `defaultOpenId`, axe clean collapsed *and* expanded, no React `inert` warning) and `BackupPanel.test.jsx` (summary states, restore sheet, remove confirmation, unavailable-network honesty).
- Updated: `ControllersPanel.test.jsx` for the sheet-hosted address entry, plus new coverage for the removal confirmation and the collapsed summary/badge; `LegacyKeyRecoveryPanel.test.jsx` for the delete confirmation.
- `npx vitest run src/components/account/__tests__ src/test/backup src/test/WalletPage.test.jsx src/test/claimCode/OpenChallengeCodeBackup.test.jsx` → 21 files, 135 tests passing. `npx eslint src` clean for every touched file. `npx vite build` succeeds.
- Rendered the collapsed/expanded states in Chromium in both themes to check spacing and contrast.

## Docs

Added a "Settings surfaces: collapsed sections + sheets" section to `docs/developer-guide/frontend.md` recording the pattern and the two easy mistakes (wrapping a self-gating panel from the outside; rendering a sheet inside the inert region).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVWHxqgLEWcDcHWrmmpMDE)_