### PR TITLE
perf(infra): right-size the gasless Cloud Run services (-$98.55/mo)

### DIFF
--- a/services/alto-bundler/deploy/service.yaml
+++ b/services/alto-bundler/deploy/service.yaml
@@ -23,8 +23,16 @@ spec:
     metadata:
       annotations:
         run.googleapis.com/container-dependencies: '{"nginx":["alto"]}'  # start alto before nginx
-        autoscaling.knative.dev/minScale: "1"      # keep one warm (executor nonce continuity)
-        autoscaling.knative.dev/maxScale: "2"
+        # minScale 1 keeps one instance warm so a member's first UserOp does not wait on alto's
+        # ~8-13s boot. It is NOT what preserves executor nonce continuity (the earlier comment here
+        # said so and was wrong): alto re-reads the executor nonce from chain on every boot, and the
+        # instance is in fact replaced ~194x/30d by min-instance churn and redeploys.
+        autoscaling.knative.dev/minScale: "1"
+        # PINNED TO 1 — SAFETY, NOT COST. ALTO_EXECUTOR_PRIVATE_KEYS and ALTO_UTILITY_PRIVATE_KEY
+        # both resolve to the SAME secret (alto-executor-key-137), so a second instance would run a
+        # second executor against the same EOA and collide on nonces. Do not raise this without
+        # giving each instance its own executor key.
+        autoscaling.knative.dev/maxScale: "1"
         run.googleapis.com/cpu-throttling: "false"     # bundler must keep processing between requests
         run.googleapis.com/startup-cpu-boost: "true"
     spec:
@@ -46,10 +54,13 @@ spec:
                 secretKeyRef:
                   name: origin-lock-secret
                   key: latest
+          # Right-sized 2026-08-02. nginx only validates one header and proxies to localhost at a
+          # measured 13 req/day median; 1 full vCPU was ~10x the p99. Instance CPU total must be a
+          # supported Cloud Run value (1/2/4/6/8) -> 150m + 850m = exactly 1.
           resources:
             limits:
-              cpu: "1"
-              memory: 256Mi
+              cpu: "150m"
+              memory: 128Mi
           startupProbe:
             httpGet:
               path: /healthz
@@ -107,10 +118,14 @@ spec:
                 secretKeyRef:
                   name: alto-executor-key-137
                   key: latest
+          # Right-sized 2026-08-02: measured 30d p99 was 0.358 vCPU / 0.261 GiB across the whole
+          # instance, so 850m + 896Mi keeps ~2.4x CPU and ~3.4x memory headroom. cpu-throttling
+          # stays "false" — alto returns userOpHash immediately and broadcasts the bundle AFTER the
+          # response, so it must keep CPU between requests. Revert to "1" if p99 exceeds 0.8 vCPU.
           resources:
             limits:
-              cpu: "1"
-              memory: 1Gi
+              cpu: "850m"
+              memory: 896Mi
           # Required by Cloud Run because nginx `depends_on` alto (container-dependencies): the
           # dependency ordering gates nginx startup on alto's port being live. TCP probe on alto's
           # ALTO_PORT (3000); no HTTP health route exists on alto (GET / 404s).

--- a/services/oz-relayer/deploy/production/service.yaml
+++ b/services/oz-relayer/deploy/production/service.yaml
@@ -100,7 +100,10 @@ spec:
             - name: POLYMARKET_BUILDER_MAKER_FEE_BPS
               value: "0"
           resources:
-            limits: { cpu: "1", memory: 512Mi }
+          # Right-sized 2026-08-02: measured 30d p99 for the whole instance was 0.196 vCPU /
+          # 0.31 GiB against 2 vCPU + 1.25 GiB allocated. Container CPU must sum to a supported
+          # Cloud Run value (1/2/4/6/8) -> gateway 500m + engine 350m + redis 150m = exactly 1.
+            limits: { cpu: "500m", memory: 320Mi }
         # ---- sidecar: OZ Relayer engine (localhost:8080) ----
         - name: engine
           image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-engine:multichain-v1.5.0
@@ -133,7 +136,10 @@ spec:
           # ~25s boot would slow every cold start to ~26s. The engine still boots after redis;
           # gasless intents self-submit until it is up (never-stranded). Cold start: ~26s -> ~2s.
           resources:
-            limits: { cpu: 800m, memory: 512Mi }
+          # Right-sized 2026-08-02 (see the gateway container). cpu-throttling stays "false": the
+          # engine tracks inclusion and bumps gas between the SPA's 4s polls, so it needs CPU
+          # outside of requests. Revert to 800m if instance p99 exceeds 0.8 vCPU.
+            limits: { cpu: 350m, memory: 320Mi }
         # ---- sidecar: ephemeral redis (localhost:6379) ----
         - name: redis
           image: redis:7-alpine
@@ -145,7 +151,10 @@ spec:
             timeoutSeconds: 2
             failureThreshold: 20
           resources:
-            limits: { cpu: 200m, memory: 256Mi }
+          # Right-sized 2026-08-02. Ephemeral by design (no persistence flags above), holds only
+          # in-flight engine state; 128Mi is ample. Legal below 512Mi because this service has no
+          # run.googleapis.com/execution-environment annotation (gen1). Adding gen2 invalidates it.
+            limits: { cpu: 150m, memory: 128Mi }
   traffic:
     - percent: 100
       latestRevision: true


### PR DESCRIPTION
Cuts the always-on gasless infra bill roughly in half, and fixes a latent dual-executor hazard on the bundler.

## Why

`fairwins-alto-bundler` and `fairwins-relay-gateway` each ran **2 vCPU + 1.25 GiB** with `minScale: 1` + `cpu-throttling: "false"` (instance-based billing) = one instance pinned 24/7 at **$101.18/mo each, $202.36/mo total ($2,428/yr)**.

Measured over 30 days (Cloud Monitoring):

| | allocated | p99 CPU | requests | median/day |
|---|---|---|---|---|
| bundler | 2 vCPU | **0.358 vCPU** | 2,855 | 13 |
| gateway | 2 vCPU | **0.196 vCPU** | 10,522 | 57 |

~10x over-provisioned; ~99% of the bill was idle.

## What

Both instances right-sized to **exactly 1.0 vCPU** (Cloud Run requires the sum of container CPU to be a supported value: 1/2/4/6/8).

| service | container | CPU | memory |
|---|---|---|---|
| bundler | nginx | 1 -> **150m** | 256Mi -> **128Mi** |
| bundler | alto | 1 -> **850m** | 1Gi -> **896Mi** |
| gateway | gateway | 1 -> **500m** | 512Mi -> **320Mi** |
| gateway | engine | 800m -> **350m** | 512Mi -> **320Mi** |
| gateway | redis | 200m -> **150m** | 256Mi -> **128Mi** |

**$202.36/mo -> $103.81/mo (-$98.55/mo, -$1,183/yr).** Prices are live Cloud Billing Catalog list prices for us-central1 instance-based billing ($0.000018/vCPU-s, $0.0000020/GiB-s).

Sub-512Mi containers are legal because neither service sets `run.googleapis.com/execution-environment` (gen1). **Adding gen2 later invalidates those limits.**

## What is deliberately NOT changed

`cpu-throttling` stays `"false"` on both. alto returns `userOpHash` immediately and broadcasts the bundle *after* the response; the OZ engine tracks inclusion and bumps gas between the SPA's 4s polls. Request-based billing gives CPU only during a request and would starve both loops — reproducing the 2026-07-12 "transactions mine but the UI never learns" incident. The 9.6x cheaper min-instance idle CPU SKU exists **only** under request-based billing, so it is unreachable without breaking correctness.

## Security fix carried along

Bundler pinned to `maxScale: 1` (was `2`). `ALTO_EXECUTOR_PRIVATE_KEYS` and `ALTO_UTILITY_PRIVATE_KEY` both resolve to the **same** secret `alto-executor-key-137`, so a second instance would run a second executor against the same EOA (~46 POL) and collide on nonces. Idle traffic was hiding this.

Also corrects the stale `minScale` comment: it does **not** preserve executor nonce continuity — alto re-reads the nonce from chain every boot, and the instance was replaced ~194x in 30 days. It buys first-request latency only.

## Verification

Already applied live (the gateway is excluded from CI by `cloudbuild.yaml`, so `services replace` is its durable path):

```
bundler  eth_supportedEntryPoints -> ["0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"]
bundler  eth_chainId              -> "0x89"   (RPC round-trip + listener bind OK)
gateway  /status                  -> {"status":"ok","chains":{"63":{"rpc":"up"},"137":{"rpc":"up"}},"killSwitch":false}
```

**Rollback:** revert this commit and re-run `gcloud run services replace` on both files. Under 5 minutes, no data migration, no key movement — redis is already ephemeral and gateway quota/dedup state is in-process and documented as safe to lose.

## Follow-ups (not in this PR)

- `minScale: 0` — a further ~$87/mo, gated on 5 prerequisites (bundler probe budget vs boot time, `ALTO_RPC_URL` has no fallback, gateway health budget, spend-cap persistence across cold starts, and the fact that the project has **0 uptime checks and 0 alert policies**).
- Soak `container/cpu/utilizations` at p99 for 7 days. **Revert trigger: p99 > 0.8 vCPU.**
- `ALTO_LOG_LEVEL` is unset — alto emits 1,025 MB/mo, 75% of the project's entire log volume, at 13 req/day.
- Path-filter the bundler build trigger (`cloudbuild.yaml:90-91` already flags it): it redeploys on every main merge, defeating the warmth `minScale: 1` pays for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)