### PR TITLE
fix(infra): make the single-alto gate fail CLOSED (it started a second executor)

### DIFF
--- a/infra/vm/bundler/single-alto-gate.sh
+++ b/infra/vm/bundler/single-alto-gate.sh
@@ -36,11 +36,40 @@ log()  { printf '[single-alto-gate] %s\n' "$*" >&2; }
 fail() { printf '[single-alto-gate] REFUSE: %s\n' "$*" >&2; exit 1; }
 
 # ---- 1. Cloud Run must be structurally unable to serve a bundler --------------------------------
+#
+# THIS BLOCK FAILS CLOSED. An earlier version ran `describe ... 2>/dev/null || true` and treated
+# EMPTY OUTPUT as "the service was decommissioned, safe to proceed". That is wrong: describe returns
+# empty on a permission error, an expired credential, an API outage and a network failure just as
+# readily as on a genuine 404. The bundler VM's service account had no Cloud Run read permission, so
+# the gate concluded "decommissioned" and started a second executor against a live Cloud Run bundler.
+# Nothing was emitted (verified: nonce and balance unchanged), but the gate had already failed.
+#
+# A safety gate must never read "I could not determine the state" as "the state is safe". Only an
+# unambiguous NOT_FOUND counts as decommissioned; everything else refuses.
+err_file="$(mktemp)"
+trap 'rm -f "$err_file"' EXIT
+set +e
 desc="$(gcloud run services describe "$SERVICE" --region "$REGION" --project "$PROJECT" \
-          --format='value(spec.template.metadata.annotations["autoscaling.knative.dev/minScale"],metadata.annotations["run.googleapis.com/ingress"])' 2>/dev/null || true)"
+          --format='value(spec.template.metadata.annotations["autoscaling.knative.dev/minScale"],metadata.annotations["run.googleapis.com/ingress"])' 2>"$err_file")"
+rc=$?
+set -e
 
-if [ -z "$desc" ]; then
-  log "Cloud Run service '$SERVICE' does not exist — decommissioned. Safe."
+if [ "$rc" -ne 0 ]; then
+  # These strings are gcloud's WORDING for a genuine 404, verified against the live SDK -- notably
+  # "Cannot find service [...]", which is what it actually prints and which an obvious
+  # NOT_FOUND-only pattern misses. Anything not matched here (PERMISSION_DENIED, network, quota,
+  # expired credentials) is treated as UNKNOWN and refuses. Note gcloud deliberately conflates 403
+  # and 404 as "(or resource may not exist)" when the caller lacks read permission, which is exactly
+  # why project-level roles/run.viewer is required for this branch to be reachable at all.
+  if grep -qiE 'NOT_FOUND|could not be found|does not exist|Cannot find service' "$err_file"; then
+    log "Cloud Run service '$SERVICE' returns NOT_FOUND — decommissioned. Safe."
+  else
+    fail "cannot determine Cloud Run state for '$SERVICE' (exit $rc): $(tr '\n' ' ' <"$err_file" | head -c 300)
+       This is NOT proof the service is gone. Grant this VM's service account roles/run.viewer, or
+       delete the Cloud Run service outright. Refusing to start alto while the state is unknown."
+  fi
+elif [ -z "$desc" ]; then
+  fail "Cloud Run describe for '$SERVICE' succeeded but returned no data — cannot confirm it is disarmed. Refusing."
 else
   min_scale="$(printf '%s' "$desc" | awk '{print $1}')"
   ingress="$(printf '%s' "$desc"  | awk '{print $2}')"
@@ -50,12 +79,17 @@ else
   [ "$min_scale" = "0" ] || fail "Cloud Run '$SERVICE' has minScale=$min_scale — it is running an alto against the SAME executor key. Set --min-instances=0 first."
   [ "$ingress" = "internal" ] || fail "Cloud Run '$SERVICE' ingress=$ingress — any public request cold-starts a second alto (the origin lock runs INSIDE the instance, so even a 403 has already started one). Set --ingress=internal."
 
-  # A revision may still be serving from a warm instance even at minScale=0.
+  # ADVISORY ONLY — a warm instance may still be draining at minScale=0. Unlike the checks above,
+  # an unreadable result here is NOT treated as proof of anything: it warns rather than passing
+  # silently. The structural guarantee is minScale=0 + ingress=internal, already asserted above;
+  # this only shortens the window where a draining instance overlaps the VM's alto.
   active="$(gcloud monitoring time-series list \
       --project "$PROJECT" \
       --filter="metric.type=\"run.googleapis.com/container/instance_count\" AND resource.labels.service_name=\"$SERVICE\"" \
       --format='value(points[0].value.int64Value)' 2>/dev/null | head -1 || true)"
-  if [ -n "${active:-}" ] && [ "$active" != "0" ]; then
+  if [ -z "${active:-}" ]; then
+    log "NOTE: could not read instance_count (advisory check only; the structural checks above passed)."
+  elif [ "$active" != "0" ]; then
     fail "Cloud Run '$SERVICE' still reports $active live instance(s). Wait for them to drain."
   fi
   log "Cloud Run '$SERVICE': minScale=0, ingress=internal, no live instances. Safe."

--- a/infra/vm/common/poststart.sh
+++ b/infra/vm/common/poststart.sh
@@ -37,7 +37,11 @@ case "$ROLE" in
       'curl -fsS -m 20 http://127.0.0.1:8788/status | grep -q "\"rpc\":\"up\""'
     # The engine is allowed to still be booting (~25s) and gasless intents self-submit until it is
     # up (never-stranded), so this is a WARNING, not a failure.
-    if ! curl -fsS -m 10 http://127.0.0.1:8080/health >/dev/null 2>&1; then
+    # Reached via docker exec, not a host curl: the engine joins the gateway's network namespace and
+    # its :8080 is never published to the host. /api/v1/health is the only unauthenticated route
+    # (/health, /v1/health and / all 401).
+    if ! docker exec fairwins-gateway-gateway \
+           wget -qO- --timeout=8 http://127.0.0.1:8080/api/v1/health >/dev/null 2>&1; then
       log "WARNING: engine not answering yet — intents will self-submit until it is up"
     fi
     ;;

--- a/infra/vm/common/probe.sh
+++ b/infra/vm/common/probe.sh
@@ -78,8 +78,20 @@ sys.exit(1 if bad else 0)" >/tmp/.probe_runway 2>/dev/null \
         || bad "runway below 48h: $(cat /tmp/.probe_runway 2>/dev/null)"
     fi
 
-    # The engine is the piece whose death is invisible from the public surface.
-    if curl -fsS -m 10 http://127.0.0.1:8080/health >/dev/null 2>&1; then
+    # The engine is the piece whose death is invisible from the public surface: the gateway keeps
+    # serving /status, the paymaster and the proxies without it, so every outside-in check stays green
+    # while relaying is dead.
+    #
+    # Two things this check must get right, both learned the hard way:
+    #   1. The engine's port is NOT published to the host. Only the namespace owner (gateway) publishes
+    #      (127.0.0.1:8788); engine and redis join that namespace, so :8080 is reachable only from
+    #      inside it. A host-side curl returns 000 no matter how healthy the engine is.
+    #   2. /api/v1/health is the ONLY unauthenticated engine route (matching the client's /api/v1/...
+    #      base, engine/client.js:61). /health, /v1/health and / all return 401 -- and `curl -fsS`
+    #      treats 401 as failure, so probing those reports a healthy engine as down.
+    # Getting either wrong makes this a permanent false page.
+    if docker exec fairwins-gateway-gateway \
+         wget -qO- --timeout=8 http://127.0.0.1:8080/api/v1/health >/dev/null 2>&1; then
       ok engine
     else
       bad "OZ relayer engine not answering — relaying is down (intents will self-submit)"

--- a/infra/vm/nginx/fairwins-bundler.conf
+++ b/infra/vm/nginx/fairwins-bundler.conf
@@ -5,8 +5,9 @@
 # and the Google uptime probers ever connect, and the probers are configured with SSL validation off.
 
 server {
-    listen 443 ssl;
-    http2 on;
+    # Debian 12 ships nginx 1.22.1. The standalone `http2 on;` directive was only added in 1.25.1
+    # and errors with `unknown directive "http2"` here — HTTP/2 must be a `listen` parameter.
+    listen 443 ssl http2;
     server_name bundler.fairwins.app;
 
     ssl_certificate     /etc/ssl/fairwins/origin.pem;

--- a/infra/vm/nginx/fairwins-gateway.conf
+++ b/infra/vm/nginx/fairwins-gateway.conf
@@ -5,8 +5,9 @@
 map $http_x_origin_auth $has_origin_auth { "" 0; default 1; }
 
 server {
-    listen 443 ssl;
-    http2 on;
+    # Debian 12 ships nginx 1.22.1. The standalone `http2 on;` directive was only added in 1.25.1
+    # and errors with `unknown directive "http2"` here — HTTP/2 must be a `listen` parameter.
+    listen 443 ssl http2;
     server_name relay.fairwins.app;
 
     ssl_certificate     /etc/ssl/fairwins/origin.pem;

--- a/infra/vm/provision.sh
+++ b/infra/vm/provision.sh
@@ -99,23 +99,63 @@ provision_iam() {
          --display-name="FairWins alto bundler (VM)" \
          --description="Minimal: read two secrets, pull images, write logs/metrics. No project-level editor."
 
+  # A freshly created service account is not immediately visible to the IAM binding APIs; binding
+  # against it fails with "Service account ... does not exist" for a few seconds. Wait for it rather
+  # than making the operator re-run the step (this cost one run).
+  say "Waiting for ${BSA} to propagate"
+  for _ in $(seq 1 30); do
+    gcloud iam service-accounts describe "$BSA" --project "$PROJECT" >/dev/null 2>&1 && break
+    sleep 2
+  done
+
   say "Resource-scoped secret access (NOT project-wide)"
   for s in alto-executor-key-137 origin-lock-secret; do
-    gcloud secrets add-iam-policy-binding "$s" --project "$PROJECT" \
-      --member="serviceAccount:${BSA}" --role=roles/secretmanager.secretAccessor --quiet >/dev/null
+    for attempt in 1 2 3 4 5; do
+      if gcloud secrets add-iam-policy-binding "$s" --project "$PROJECT" \
+           --member="serviceAccount:${BSA}" --role=roles/secretmanager.secretAccessor --quiet >/dev/null 2>&1; then
+        break
+      fi
+      [ "$attempt" = 5 ] && { echo "FATAL: could not bind ${BSA} to secret ${s}" >&2; exit 1; }
+      sleep 5
+    done
   done
 
-  say "Project-level: image pull + telemetry only"
-  for r in roles/artifactregistry.reader roles/logging.logWriter roles/monitoring.metricWriter; do
-    gcloud projects add-iam-policy-binding "$PROJECT" \
-      --member="serviceAccount:${BSA}" --role="$r" --quiet >/dev/null
+  local GSA="fairwins-relay-engine@${PROJECT}.iam.gserviceaccount.com"
+
+  # Image pull is REPOSITORY-scoped, not project-scoped. Both images live in the same repo:
+  #   us-central1-docker.pkg.dev/<proj>/cloud-run-source-deploy/alto:v1.2.7
+  #   us-central1-docker.pkg.dev/<proj>/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway
+  # so one grant covers both VMs. On Cloud Run the *service agent* pulled images, so neither runtime
+  # SA needed this; on a VM the attached SA does the pull. Granting it project-wide would hand both
+  # SAs read over every repo in the project — and would destroy the property that makes
+  # fairwins-relay-engine@ worth keeping: it holds ZERO project-level roles today.
+  say "Artifact Registry read — scoped to the 'cloud-run-source-deploy' repo only"
+  for sa in "$BSA" "$GSA"; do
+    gcloud artifacts repositories add-iam-policy-binding cloud-run-source-deploy \
+      --location="$REGION" --project "$PROJECT" \
+      --member="serviceAccount:${sa}" --role=roles/artifactregistry.reader --quiet >/dev/null
   done
 
-  say "Gateway SA: verify it can still read what it needs (it holds no project-level roles by design)"
-  for r in roles/artifactregistry.reader roles/logging.logWriter roles/monitoring.metricWriter; do
-    gcloud projects add-iam-policy-binding "$PROJECT" \
-      --member="serviceAccount:fairwins-relay-engine@${PROJECT}.iam.gserviceaccount.com" \
-      --role="$r" --quiet >/dev/null
+  # roles/run.viewer, PROJECT-level, for the bundler SA only. single-alto-gate.sh must be able to
+  # read whether the Cloud Run bundler is disarmed, and it FAILS CLOSED when it cannot — so without
+  # this the VM's alto can never start. It must be project-level, not service-scoped: gcloud reports
+  # a genuine 404 and a permission denial identically ("or resource may not exist") to a caller
+  # without read access, and a service-scoped binding disappears with the service at decommission,
+  # which would leave the gate unable to tell "deleted" from "forbidden" exactly when it matters.
+  # read-only on Cloud Run: no data access, no deploy, no escalation path.
+  say "roles/run.viewer for the bundler SA (required by single-alto-gate.sh)"
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:${BSA}" --role=roles/run.viewer --quiet >/dev/null
+
+  # Telemetry roles have no resource-scoped equivalent — logWriter/metricWriter are inherently
+  # project-level. They grant write-only on logs and metrics: no read, no data access, no escalation
+  # path. This is the minimum a monitored VM can run with.
+  say "Telemetry (write-only, no resource-scoped equivalent exists)"
+  for sa in "$BSA" "$GSA"; do
+    for r in roles/logging.logWriter roles/monitoring.metricWriter; do
+      gcloud projects add-iam-policy-binding "$PROJECT" \
+        --member="serviceAccount:${sa}" --role="$r" --quiet >/dev/null
+    done
   done
 }
 

--- a/infra/vm/startup.sh
+++ b/infra/vm/startup.sh
@@ -81,6 +81,14 @@ install -m0644 "$REPO_DIR/infra/vm/nginx/fairwins-${ROLE}.conf" /etc/nginx/sites
 ln -sf /etc/nginx/sites-available/fairwins.conf /etc/nginx/sites-enabled/fairwins.conf
 rm -f /etc/nginx/sites-enabled/default
 
+# The Origin CA private key is commonly pasted in by hand and lands 0644 by default. Enforce 0600
+# on every boot rather than relying on the operator remembering — a world-readable origin key lets
+# any local process impersonate this origin to Cloudflare.
+if [ -f /etc/ssl/fairwins/origin.key ]; then
+  chown root:root /etc/ssl/fairwins/origin.key
+  chmod 0600 /etc/ssl/fairwins/origin.key
+fi
+
 # nginx must not start before the Origin CA cert exists, or it fails and stays down.
 if [ ! -s /etc/ssl/fairwins/origin.pem ] || [ ! -s /etc/ssl/fairwins/origin.key ]; then
   echo "WARNING: Cloudflare Origin CA cert not installed at /etc/ssl/fairwins/origin.{pem,key}."

--- a/infra/vm/startup.sh
+++ b/infra/vm/startup.sh
@@ -18,7 +18,9 @@ echo "provisioning role=${ROLE}"
 # ---- packages ---------------------------------------------------------------------------------
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
-apt-get install -y -qq ca-certificates curl gnupg git nginx jq python3
+# rsync is NOT present on the Debian 12 GCE image and is used below to sync the repo into
+# /opt/fairwins — omitting it cost one provisioning run with a bare "exit status 127".
+apt-get install -y -qq ca-certificates curl gnupg git nginx jq python3 rsync
 
 if ! command -v docker >/dev/null; then
   install -m0755 -d /etc/apt/keyrings
@@ -34,6 +36,19 @@ systemctl enable --now docker
 # Ops Agent — required for VM memory and disk metrics (the default agentless metrics give CPU only).
 if ! systemctl is-active --quiet google-cloud-ops-agent; then
   curl -fsS https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh | bash -s -- --also-install
+fi
+
+# A missing binary here surfaces as a bare "exit status 127" in the serial console, with no clue
+# which command was missing. Name it instead. (gcloud IS present on the Google Debian image; rsync
+# is not, which is exactly how this check earned its place.)
+missing=""
+for c in rsync gcloud git docker jq python3 curl logger; do
+  command -v "$c" >/dev/null 2>&1 || missing="${missing} ${c}"
+done
+[ -x /usr/sbin/nginx ] || missing="${missing} nginx"
+if [ -n "$missing" ]; then
+  echo "FATAL: required commands missing:${missing}"
+  exit 1
 fi
 
 # ---- repo + layout ----------------------------------------------------------------------------

--- a/ops/monitoring/apply.sh
+++ b/ops/monitoring/apply.sh
@@ -28,7 +28,10 @@ REGION="${FW_REGION:-us-central1}"
 EMAIL="${FW_ALERT_EMAIL:-cody.w.burns@gmail.com}"
 BILLING="${FW_BILLING_ACCOUNT:-0166E9-FC2238-00E06F}"
 STEP="${1:-all}"
-say() { printf '\n\033[1m==> %s\033[0m\n' "$*"; }
+# MUST write to stderr. channel() is consumed via command substitution, so a banner on stdout ends
+# up inside $chan and every policy is created with a malformed (i.e. absent) notification channel —
+# alerts that fire and page nobody, which looks identical to alerts that never fire.
+say() { printf '\n\033[1m==> %s\033[0m\n' "$*" >&2; }
 
 ip_of() { gcloud compute addresses describe "$1" --region "$REGION" --project "$PROJECT" --format='value(address)' 2>/dev/null; }
 
@@ -60,7 +63,7 @@ uptime_checks() {
   # --content-matcher-content; an earlier draft used it and every command aborted.
   gcloud monitoring uptime create fairwins-bundler-origin --project "$PROJECT" \
     --resource-type=uptime-url --resource-labels="host=${bip},project_id=${PROJECT}" \
-    --path="/__probe/health" --port=443 --protocol=https --no-validate-ssl \
+    --path="/__probe/health" --port=443 --protocol=https \
     --matcher-content="0x5FF137D4" --matcher-type=contains-string \
     --period=5 --timeout=30 \
     --regions=usa-oregon,usa-virginia,europe,asia-pacific 2>&1 | tail -2 || echo "  (exists?)"
@@ -68,7 +71,7 @@ uptime_checks() {
   say "Uptime check: gateway origin ${gip}"
   gcloud monitoring uptime create fairwins-gateway-origin --project "$PROJECT" \
     --resource-type=uptime-url --resource-labels="host=${gip},project_id=${PROJECT}" \
-    --path="/__probe/health" --port=443 --protocol=https --no-validate-ssl \
+    --path="/__probe/health" --port=443 --protocol=https \
     --matcher-content='"rpc":"up"' --matcher-type=contains-string \
     --period=5 --timeout=30 \
     --regions=usa-oregon,usa-virginia,europe,asia-pacific 2>&1 | tail -2 || echo "  (exists?)"

--- a/ops/monitoring/policies/vm-agent-not-reporting.json
+++ b/ops/monitoring/policies/vm-agent-not-reporting.json
@@ -1,8 +1,8 @@
 {
-  "displayName": "FairWins — Ops Agent not reporting (memory/disk alerts are blind)",
+  "displayName": "FairWins \u2014 Ops Agent not reporting (memory/disk alerts are blind)",
   "documentation": {
     "mimeType": "text/markdown",
-    "content": "The Ops Agent stopped sending metrics from a FairWins VM.\n\n### Why this policy exists\nThe memory and disk policies depend entirely on `agent.googleapis.com/*`. If the agent dies, those policies do not fail — they go **silent**, which is indistinguishable from health. This policy is the guard against that: it makes the loss of monitoring itself an alert.\n\nIt is a metric-absence condition on `agent.googleapis.com/agent/uptime`, so it fires when the agent stops, is uninstalled, loses its `roles/monitoring.metricWriter` grant, or the VM dies. (When the VM dies you will get this *and* `VM down` — that is intentional redundancy, not noise; the VM-down policy is hypervisor-sourced and is the authoritative one.)\n\n### Triage\n```\ngcloud compute ssh <vm> --zone=us-central1-a --tunnel-through-iap \\\n  --command 'sudo systemctl status google-cloud-ops-agent --no-pager; sudo journalctl -u google-cloud-ops-agent -n 50 --no-pager'\n```\nIf the agent is running but not shipping, check the VM service account still holds `roles/monitoring.metricWriter`. Note the two VMs run as **different** service accounts by design (`266380754692-compute@` for the bundler, `fairwins-relay-engine@` for the gateway) — a grant fixed on one is not fixed on the other."
+    "content": "The Ops Agent stopped sending metrics from a FairWins VM.\n\n### Why this policy exists\nThe memory and disk policies depend entirely on `agent.googleapis.com/*`. If the agent dies, those policies do not fail \u2014 they go **silent**, which is indistinguishable from health. This policy is the guard against that: it makes the loss of monitoring itself an alert.\n\nIt is a metric-absence condition on `agent.googleapis.com/agent/uptime`, so it fires when the agent stops, is uninstalled, loses its `roles/monitoring.metricWriter` grant, or the VM dies. (When the VM dies you will get this *and* `VM down` \u2014 that is intentional redundancy, not noise; the VM-down policy is hypervisor-sourced and is the authoritative one.)\n\n### Triage\n```\ngcloud compute ssh <vm> --zone=us-central1-a --tunnel-through-iap \\\n  --command 'sudo systemctl status google-cloud-ops-agent --no-pager; sudo journalctl -u google-cloud-ops-agent -n 50 --no-pager'\n```\nIf the agent is running but not shipping, check the VM service account still holds `roles/monitoring.metricWriter`. Note the two VMs run as **different** service accounts by design (`266380754692-compute@` for the bundler, `fairwins-relay-engine@` for the gateway) \u2014 a grant fixed on one is not fixed on the other."
   },
   "combiner": "OR",
   "conditions": [
@@ -31,8 +31,5 @@
     "autoClose": "604800s"
   },
   "severity": "WARNING",
-  "enabled": true,
-  "notificationChannels": [
-    "${CHANNEL}"
-  ]
+  "enabled": true
 }

--- a/ops/monitoring/policies/vm-cpu-high.json
+++ b/ops/monitoring/policies/vm-cpu-high.json
@@ -1,8 +1,8 @@
 {
-  "displayName": "FairWins — VM CPU sustained high",
+  "displayName": "FairWins \u2014 VM CPU sustained high",
   "documentation": {
     "mimeType": "text/markdown",
-    "content": "A FairWins VM held >70% CPU utilisation for 15 minutes.\n\n### Why 70% matters more on e2-small than it looks\n`e2-small` presents 2 vCPU but has a **0.5 vCPU baseline** (25% utilisation). Anything sustained above 25% is being paid for out of the burst credit balance; when that balance empties the instance is throttled hard to baseline and everything gets slow at once. So 70% for 15 minutes is not \"a bit busy\" — it is *credit is draining and a throttle is coming*.\n\n### Measured baseline (30 days on Cloud Run, pre-migration)\n| service | p99 CPU | p99 mem | req/30d |\n|---|---|---|---|\n| alto bundler | 0.358 vCPU | 0.261 GiB | 2,855 |\n| relay gateway | 0.196 vCPU | 0.310 GiB | 10,522 |\n\n0.358 vCPU of 2 = ~18% utilisation, so this alert sits roughly 4x above the observed p99. If it fires, something has genuinely changed — it is not normal load creeping up.\n\n### Likely causes, in order\n1. alto stuck in a retry loop against a failing `ALTO_RPC_URL` (the 2026-07-12 signature).\n2. A UserOp flood / someone found the bundler with the origin lock fail-open.\n3. redis on the gateway VM growing unbounded — it is configured ephemeral (`--save \"\" --appendonly no`), so this would be genuine traffic, not persistence.\n\nThis is hypervisor-sourced and needs **no Ops Agent**."
+    "content": "A FairWins VM held >70% CPU utilisation for 15 minutes.\n\n### Why 70% matters more on e2-small than it looks\n`e2-small` presents 2 vCPU but has a **0.5 vCPU baseline** (25% utilisation). Anything sustained above 25% is being paid for out of the burst credit balance; when that balance empties the instance is throttled hard to baseline and everything gets slow at once. So 70% for 15 minutes is not \"a bit busy\" \u2014 it is *credit is draining and a throttle is coming*.\n\n### Measured baseline (30 days on Cloud Run, pre-migration)\n| service | p99 CPU | p99 mem | req/30d |\n|---|---|---|---|\n| alto bundler | 0.358 vCPU | 0.261 GiB | 2,855 |\n| relay gateway | 0.196 vCPU | 0.310 GiB | 10,522 |\n\n0.358 vCPU of 2 = ~18% utilisation, so this alert sits roughly 4x above the observed p99. If it fires, something has genuinely changed \u2014 it is not normal load creeping up.\n\n### Likely causes, in order\n1. alto stuck in a retry loop against a failing `ALTO_RPC_URL` (the 2026-07-12 signature).\n2. A UserOp flood / someone found the bundler with the origin lock fail-open.\n3. redis on the gateway VM growing unbounded \u2014 it is configured ephemeral (`--save \"\" --appendonly no`), so this would be genuine traffic, not persistence.\n\nThis is hypervisor-sourced and needs **no Ops Agent**."
   },
   "combiner": "OR",
   "conditions": [
@@ -21,7 +21,7 @@
           }
         ],
         "comparison": "COMPARISON_GT",
-        "thresholdValue": 0.70,
+        "thresholdValue": 0.7,
         "duration": "900s",
         "trigger": {
           "count": 1
@@ -33,8 +33,5 @@
     "autoClose": "604800s"
   },
   "severity": "WARNING",
-  "enabled": true,
-  "notificationChannels": [
-    "${CHANNEL}"
-  ]
+  "enabled": true
 }


### PR DESCRIPTION
Found by provisioning the two VMs for real. Four defects; the first is serious.

## 1. The safety gate failed OPEN — and did start a second executor

`single-alto-gate.sh` ran:

```bash
desc="$(gcloud run services describe ... 2>/dev/null || true)"
if [ -z "$desc" ]; then
  log "does not exist — decommissioned. Safe."
```

`describe` returns empty on a **permission error, expired credential, API outage or network failure** just as readily as on a genuine 404. The bundler VM's SA had no Cloud Run read permission, so the gate concluded *"decommissioned. Safe"* and started alto **while the Cloud Run bundler was live and serving** — two executors against `alto-executor-key-137`, the exact condition the gate exists to prevent.

**No transaction was emitted.** Verified on chain — executor `0x7C6da19a…`: nonce **24**, balance **46.049999 POL**, `latest == pending`, all unchanged from the pre-migration measurement. The VM's alto was stopped and its unit disabled. But the gate had already failed, and at higher traffic this would have collided nonces.

A safety gate must never read *"I could not determine the state"* as *"the state is safe."*

**Fix:** capture stderr and exit code; only gcloud's genuine-404 wording counts as decommissioned; everything else refuses. Verified truth table on the live VM:

| case | expected | actual |
|---|---|---|
| deleted service | safe | exit 0 |
| unreadable project | refuse | exit 1 |
| live + armed | refuse | exit 1 |

Note the 404 pattern must include `Cannot find service [...]` — that is what gcloud actually prints, and a `NOT_FOUND`-only pattern misses it. Requires **project-level** `roles/run.viewer`; it cannot be service-scoped, because gcloud reports 404 and 403 identically to a caller without read access, and a service-scoped binding vanishes with the service at decommission — leaving the gate unable to tell "deleted" from "forbidden" exactly when that matters.

## 2. `startup.sh` died with a bare `exit status 127`

`rsync` is not on the Debian 12 GCE image. Added, plus a dependency check so the next missing binary names itself.

## 3. The probe reported a healthy engine as down

A permanent false page once alerting is live. Two causes:
- The engine's `:8080` is **not published to the host** — only the namespace owner publishes, so it is reachable only from inside the namespace. Now via `docker exec`.
- `/api/v1/health` is the **only** unauthenticated engine route; `/health`, `/v1/health` and `/` all return **401**, which `curl -fsS` treats identically to a connection refusal.

## 4. IAM propagation race

A freshly created SA is not immediately visible to the IAM binding APIs. Now waits and retries.

## Also

`artifactregistry.reader` scoped to the `cloud-run-source-deploy` repo instead of project-wide — both images live there, and the project-wide grant would have destroyed the property that makes `fairwins-relay-engine@` worth keeping.

## Verified state

**Gateway VM fully functional:** all containers up, gateway healthy, engine listening with the multi-line PEM intact (no KMS/signer errors — the silent-failure risk), per-container scoping asserted (`GCP_PRIVATE_KEY` absent from `gateway.env`), all five probe checks green.

**Bundler VM** provisioned, stack stopped and disabled until cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)