### PR TITLE
Remove pill background behind bottom nav icons, sharpen active contrast

### DIFF
--- a/frontend/src/components/nav/SectionIconNav.css
+++ b/frontend/src/components/nav/SectionIconNav.css
@@ -29,7 +29,7 @@
   border: none;
   border-radius: 8px;
   background: transparent;
-  color: var(--text-secondary, var(--color-text-secondary, #5A6772));
+  color: var(--text-muted, var(--color-text-secondary, #8A959E));
   cursor: pointer;
   transition: color 0.15s ease, background 0.15s ease;
 }
@@ -53,18 +53,7 @@
   justify-content: center;
   width: 40px;
   height: 30px;
-  border-radius: 9px;
   color: inherit;
-  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.08);
-  border: 1px solid rgba(var(--brand-primary-rgb, 54, 179, 126), 0.14);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  transition: background 0.15s ease, border-color 0.15s ease;
-}
-
-.section-icon-nav-item.active .section-icon-nav-icon {
-  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.18);
-  border-color: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.32);
 }
 
 .section-icon-nav-label {
@@ -74,4 +63,8 @@
   max-width: 72px;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.section-icon-nav-item.active .section-icon-nav-label {
+  font-weight: 700;
 }


### PR DESCRIPTION
## Summary
- The mobile `SectionIconNav` bottom bar rendered a translucent green pill (`background`/`border`) behind every icon regardless of active state, making it hard to tell active vs. inactive tabs apart.
- Removed the pill background/border entirely — icons now sit directly on the bar.
- Inactive items now use the more muted `--text-muted` gray (previously `--text-secondary`, which read too close to the active brand-green).
- Active items now also get a bolder label weight (700 vs 600) on top of the existing color swap to brand green, for a clearer active/inactive distinction.

## Test plan
- [x] `npx vitest run src/test/SectionIconNav.test.jsx` — 4/4 passing (behavior unchanged, styling-only diff)
- [x] Verified via screenshot from the user that the affected bar is the mobile bottom icon nav (Earn tab, Lend/Rewards/Stake/Supply screen)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cn534ToKKhmdV3616hcpUr)_