### PR TITLE
Animate bottom-nav tab selection with a sliding pill indicator

### DIFF
--- a/frontend/src/components/nav/SectionIconNav.css
+++ b/frontend/src/components/nav/SectionIconNav.css
@@ -18,7 +18,25 @@
   overflow-x: auto;
 }
 
+/* The active-tab pill. Absolutely positioned and driven by JS-measured
+   left/top/width/height (see SectionIconNav.jsx), so it can glide from one
+   icon to another instead of snapping. Sits behind the item content
+   (z-index 0 vs. items' z-index 1) so the icon glyph stays legible on top. */
+.section-icon-nav-indicator {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  border-radius: 10px;
+  background: var(--brand-primary, var(--color-primary, #36B37E));
+  box-shadow: 0 4px 10px rgba(var(--brand-primary-rgb, 54, 179, 126), 0.35);
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), width 0.25s ease, height 0.25s ease;
+  pointer-events: none;
+}
+
 .section-icon-nav-item {
+  position: relative;
+  z-index: 1;
   flex: 1 1 0;
   min-width: 56px;
   display: flex;
@@ -31,10 +49,10 @@
   background: transparent;
   color: var(--text-muted, var(--color-text-secondary, #8A959E));
   cursor: pointer;
-  transition: color 0.15s ease, background 0.15s ease;
+  transition: color 0.2s ease, background 0.15s ease;
 }
 
-.section-icon-nav-item:hover {
+.section-icon-nav-item:not(.active):hover {
   background: var(--bg-primary, var(--color-surface-hover, rgba(0, 0, 0, 0.04)));
 }
 
@@ -54,6 +72,17 @@
   width: 40px;
   height: 30px;
   color: inherit;
+  transition: color 0.2s ease;
+}
+
+.section-icon-nav-item.active .section-icon-nav-icon {
+  color: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .section-icon-nav-indicator {
+    transition: none;
+  }
 }
 
 .section-icon-nav-label {

--- a/frontend/src/components/nav/SectionIconNav.jsx
+++ b/frontend/src/components/nav/SectionIconNav.jsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from 'react'
 import { useIsMobile } from '../../hooks/useMediaQuery'
 import NavIcon from './NavIcon'
 import './SectionIconNav.css'
@@ -11,14 +12,56 @@ import './SectionIconNav.css'
  * Presentational: the host passes the sibling `items` (each `{ id, label, icon }`),
  * the `activeId`, and an `onSelect`. Renders nothing on desktop or when there are
  * fewer than two siblings (a single view has nothing to switch between).
+ *
+ * The active tab is marked by a pill that slides beneath the selected icon —
+ * measured against the actual DOM layout so it tracks precisely regardless of
+ * label width or item count, then animated with a spring easing on change.
  */
 export default function SectionIconNav({ items = [], activeId, onSelect, ariaLabel = 'Section navigation' }) {
   const isMobile = useIsMobile()
+  const navRef = useRef(null)
+  const iconRefs = useRef({})
+  const [indicator, setIndicator] = useState(null)
+
+  useLayoutEffect(() => {
+    const navEl = navRef.current
+    const iconEl = iconRefs.current[activeId]
+
+    const measure = () => {
+      if (!navEl || !iconEl) {
+        setIndicator(null)
+        return
+      }
+      const navRect = navEl.getBoundingClientRect()
+      const iconRect = iconEl.getBoundingClientRect()
+      setIndicator({
+        left: iconRect.left - navRect.left,
+        top: iconRect.top - navRect.top,
+        width: iconRect.width,
+        height: iconRect.height,
+      })
+    }
+
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [activeId, items])
 
   if (!isMobile || items.length < 2) return null
 
   return (
-    <nav className="section-icon-nav" aria-label={ariaLabel}>
+    <nav className="section-icon-nav" aria-label={ariaLabel} ref={navRef}>
+      {indicator && (
+        <span
+          className="section-icon-nav-indicator"
+          aria-hidden="true"
+          style={{
+            transform: `translate(${indicator.left}px, ${indicator.top}px)`,
+            width: indicator.width,
+            height: indicator.height,
+          }}
+        />
+      )}
       {items.map((item) => (
         <button
           key={item.id}
@@ -27,7 +70,11 @@ export default function SectionIconNav({ items = [], activeId, onSelect, ariaLab
           aria-current={item.id === activeId ? 'page' : undefined}
           onClick={() => onSelect(item.id)}
         >
-          <span className="section-icon-nav-icon" aria-hidden="true">
+          <span
+            className="section-icon-nav-icon"
+            aria-hidden="true"
+            ref={(el) => { iconRefs.current[item.id] = el }}
+          >
             <NavIcon name={item.icon} size={20} />
           </span>
           <span className="section-icon-nav-label">{item.label}</span>


### PR DESCRIPTION
## Summary
- Follow-up to #1003, which removed the static pill background and sharpened active/inactive contrast on the mobile `SectionIconNav` bottom bar (Pay/Request/Wager, Earn's Lend/Rewards/Stake/Supply, etc.).
- The active tab now gets a single indicator element that measures the active icon's real DOM position (`getBoundingClientRect`) and animates its `transform`/size to it with a spring easing (`cubic-bezier(0.34, 1.56, 0.64, 1)`), so switching tabs reads as one fluid slide-and-reveal of the primary brand color instead of a static box/snap.
- The pill fills solid `--brand-primary` (green in the default FairWins theme) with the icon glyph turning white on top for contrast; inactive icons/labels stay on the existing muted gray.
- Re-measures on window resize; respects `prefers-reduced-motion: reduce` by disabling the transition.
- Verified interactively: served the component through a temporary local harness page in a real browser (not jsdom, since `getBoundingClientRect` is a no-op there) and screenshotted the idle, mid-transition, and settled states to confirm the pill glides smoothly between tabs.

## Test plan
- [x] `npx vitest run src/test/SectionIconNav.test.jsx src/test/HomeScreen.test.jsx` — 20/20 passing (behavior unchanged; aria-current/click semantics untouched)
- [x] `npx eslint src/components/nav/SectionIconNav.jsx` — clean, no warnings
- [x] Manual browser verification (mobile viewport) of the slide animation across tab changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cn534ToKKhmdV3616hcpUr)_