### PR TITLE
Replace rectangular focus outline on bottom nav with an organic icon ring

### DIFF
--- a/frontend/src/components/nav/SectionIconNav.css
+++ b/frontend/src/components/nav/SectionIconNav.css
@@ -61,8 +61,12 @@
 }
 
 .section-icon-nav-item:focus-visible {
-  outline: 2px solid var(--brand-primary, var(--color-primary, #36B37E));
-  outline-offset: -2px;
+  outline: none;
+}
+
+.section-icon-nav-item:focus-visible .section-icon-nav-icon {
+  border-radius: 10px;
+  box-shadow: 0 0 0 2px var(--bg-secondary, var(--color-surface, #fff)), 0 0 0 4px var(--brand-primary, var(--color-primary, #36B37E));
 }
 
 .section-icon-nav-icon {


### PR DESCRIPTION
## Summary
- Follow-up to #1004 (sliding pill indicator on the mobile `SectionIconNav` bottom bar). After tapping a tab, a rectangular green `:focus-visible` outline was drawn around the *whole* item (icon pill + label), clashing with the rounded sliding pill and reading as a static "selection box" rather than an organic highlight.
- The app's webview appears to apply `:focus-visible` on tap (not just keyboard navigation), so this rectangle showed on every tab selection, not only via keyboard.
- Suppressed the default/custom rectangular outline and replaced it with a soft ring shaped to the icon pill's own border-radius, so the focus indicator now hugs the organic pill shape instead of boxing the whole item.
- Verified in a real browser: confirmed no ring appears after a tap-driven selection, and that keyboard `Tab` focus still shows a clean rounded ring around just the icon (no double/black default-outline artifact — an early version of the fix suppressed only the custom outline and exposed the browser's own default black focus ring underneath it, which is also fixed here).

## Test plan
- [x] `npx vitest run src/test/SectionIconNav.test.jsx src/test/HomeScreen.test.jsx` — 20/20 passing
- [x] `npx eslint src/components/nav/SectionIconNav.jsx` — clean
- [x] Manual browser verification (click-triggered and keyboard-Tab-triggered focus states)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cn534ToKKhmdV3616hcpUr)_