### PR TITLE
Remove redundant Dashboard/My Account desktop nav tabs

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -76,46 +76,33 @@ function Header({ hideWalletButton = false, appMode = false }) {
           )}
         </button>
 
-        {/* Desktop Navigation */}
-        <nav className="header-nav desktop-nav" aria-label="Main navigation">
-          {appMode ? (
-            <>
-              <button
-                onClick={() => navigate('/app')}
-                className={`nav-link nav-button ${location.pathname === '/app' || location.pathname === '/main' || location.pathname === '/fairwins' ? 'active' : ''}`}
-              >
-                Dashboard
-              </button>
-              <button
-                onClick={() => navigate('/wallet')}
-                className={`nav-link nav-button ${location.pathname === '/wallet' ? 'active' : ''}`}
-              >
-                My Account
-              </button>
-            </>
-          ) : (
-            <>
-              <button onClick={() => scrollToSection('features')} className="nav-link nav-button">
-                Features
-              </button>
-              <button onClick={() => scrollToSection('how-it-works')} className="nav-link nav-button">
-                How It Works
-              </button>
-              <button onClick={() => scrollToSection('custody')} className="nav-link nav-button">
-                Custody
-              </button>
-              <button onClick={() => scrollToSection('use-cases')} className="nav-link nav-button">
-                Use Cases
-              </button>
-              <button
-                onClick={() => navigate('/app')}
-                className="nav-link nav-button"
-              >
-                Launch App
-              </button>
-            </>
-          )}
-        </nav>
+        {/* Desktop Navigation — landing page only. In app mode, the left nav
+            drawer (opened via the logo button above) is the sole source of
+            navigation; a duplicate "Dashboard"/"My Account" pair here was
+            redundant and its active-state highlighting didn't track the
+            current view correctly. */}
+        {!appMode && (
+          <nav className="header-nav desktop-nav" aria-label="Main navigation">
+            <button onClick={() => scrollToSection('features')} className="nav-link nav-button">
+              Features
+            </button>
+            <button onClick={() => scrollToSection('how-it-works')} className="nav-link nav-button">
+              How It Works
+            </button>
+            <button onClick={() => scrollToSection('custody')} className="nav-link nav-button">
+              Custody
+            </button>
+            <button onClick={() => scrollToSection('use-cases')} className="nav-link nav-button">
+              Use Cases
+            </button>
+            <button
+              onClick={() => navigate('/app')}
+              className="nav-link nav-button"
+            >
+              Launch App
+            </button>
+          </nav>
+        )}
 
         {/* Wallet Connection Section */}
         <div className="header-actions">


### PR DESCRIPTION
## Summary
- In desktop app mode, the header showed "Dashboard" / "My Account" tabs alongside the left side nav drawer, and they were wired incorrectly: "Dashboard" always navigated to `/app` instead of reflecting the current view, and "My Account" showed as active on every route that wasn't `/app` (including `/wallet`'s own sub-tabs, admin, wagers, etc.).
- The side nav drawer (opened via the logo button) already provides full navigation for app mode, making these header tabs redundant.
- Removed the `appMode` branch of the header's desktop nav entirely; the desktop nav (`Features`/`How It Works`/`Custody`/`Use Cases`/`Launch App`) now renders only on the landing page, where it always did.

## Test plan
- [x] Confirmed no test file references the removed "Dashboard"/"My Account" header buttons (`grep` across `frontend/src/test`)
- [ ] Manually verify in a browser that desktop app-mode header no longer shows the two tabs and the side nav drawer still covers navigation (dependencies aren't installed in this sandboxed environment, so this wasn't run locally)


---
_Generated by [Claude Code](https://claude.ai/code/session_017WtWS7hXF33PbrAxzfY3uc)_