### PR TITLE
My Account polish: portfolio-first, theme-aware cards, feed tools, instant portfolio (spec 074 amendment)

### DIFF
--- a/docs/developer-guide/my-account.md
+++ b/docs/developer-guide/my-account.md
@@ -25,25 +25,46 @@ and every recovered legacy account.
   dots track the nearest card. The card button itself is the
   `role="option"` inside a labelled `role="listbox"` — don't reintroduce an
   interactive wrapper (axe nested-interactive).
-- **Cards show identity only** (avatar, label, kind chip, short address,
-  vault network via strict `NETWORKS[chainId]` lookup). Balances deliberately
-  have one home — the views below. Per-card balances would re-create the
-  split asset view this feature removed, and would need a fake zero or
-  spinner for accounts on unreachable networks.
+- **Theme-aware, and pinned against global button CSS**: cards render on the
+  theme surface tokens with a per-kind accent edge (light + dark). The dots
+  and cards use two-class selectors deliberately — App.css's mobile rule
+  `button:not([role="switch"]) { min-width/min-height: 44px; padding: … }`
+  outranks a single class and once inflated the dots into page-dominating
+  circles. The dot is a 6px visual inside a ~22px `background-clip:
+  content-box` touch target.
+- **Cards show identity plus one number**: avatar, label, kind chip, short
+  address, vault network (strict `NETWORKS[chainId]` lookup) — and on the
+  ACTIVE card only, the portfolio total (`activeTotalUsd`), rendered only
+  when the shared portfolio instance is `ready` (never a fabricated $0 while
+  loading). Full balances still have one home — the views below.
 
 ## The three views
 
 Defined once as `ACCOUNT_VIEWS` in `frontend/src/config/appNav.js`
-(`activity` — default, `portfolio`, `stats`) and driven by `?view=` on the
+(`portfolio` — default, `activity`, `stats`) and driven by `?view=` on the
 Account tab (the PayTransferPanel idiom): `/wallet?tab=account&view=stats` is
-a direct link; unknown values fall back to Activity via
+a direct link; unknown values fall back to Portfolio via
 `accountViewFromParam()`.
 
-- **Activity** — `FreshnessIndicator` + `ActivityBreakdowns` +
-  `RecentActivityFeed` from the unified ledger.
-- **Portfolio** — the existing `PortfolioPanel`, unchanged (own honest
-  states, asset detail sheet, disclosures).
-- **Stats** — `SummaryTiles` + `PnlChart`.
+- **Portfolio** (default) — the existing `PortfolioPanel` (own honest states,
+  asset detail sheet, disclosures), fed MyAccountView's shared portfolio
+  instance via its optional `portfolio` prop (it self-loads without one).
+- **Activity** — `FreshnessIndicator` + `RecentActivityFeed`: a clean feed.
+  Class filters live behind the Filter button (menu of `menuitemradio`
+  options) and search behind the Search icon (matches kind, token, amount,
+  tx hash, failure reason); no matches → an honest "no matching activity"
+  state.
+- **Stats** — `SummaryTiles` + `PnlChart` + `ActivityBreakdowns` (the
+  by-status / by-token / by-resolution groups are stats, not a log).
+
+**Portfolio freshness**: `usePortfolio` keeps a session-memory snapshot cache
+keyed by account + scan scope. A remount hydrates the last real snapshot
+immediately (original `lastUpdated` intact) while a fresh read runs in the
+background — the member never stares at "Loading portfolio…" for data the
+session already has. Snapshots never cross accounts or the testnet-visibility
+boundary, and nothing persists across reloads. MyAccountView mounts ONE
+portfolio instance for the card total and the Portfolio view together, and it
+starts warming as soon as My Account opens, whichever view is showing.
 
 The switcher renders exactly once per width: WalletPage feeds
 `SectionIconNav` (the mobile bottom bar) the `ACCOUNT_VIEWS` items while the

--- a/frontend/src/components/account/AccountCardsCarousel.css
+++ b/frontend/src/components/account/AccountCardsCarousel.css
@@ -1,7 +1,7 @@
 /* AccountCardsCarousel — the swipeable account cards atop the My Account view.
-   Cards are deliberately fixed-palette (like a physical card) so they read the
-   same in light and dark themes; the surrounding chrome uses theme tokens with
-   light-mode literals as fallbacks (repo convention, see ActionSheet.css). */
+   Theme-aware (post-launch feedback on spec 074): cards render on the theme's
+   surface tokens with a per-kind accent edge, so they read correctly in light
+   AND dark mode. Light-mode literals as fallbacks (repo convention). */
 
 .account-cards {
   position: relative;
@@ -15,7 +15,7 @@
   display: flex;
   gap: 12px;
   margin: 0;
-  padding: 4px 2px 10px;
+  padding: 4px 2px 8px;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;
@@ -27,28 +27,32 @@
 }
 
 /* One card per account — the "bank card" of the reference design. The button
-   itself is the listbox option AND the snap target. */
-.account-card {
+   itself is the listbox option AND the snap target. Two-class selector so the
+   16px padding survives App.css's mobile `button:not([role="switch"])`
+   tap-target padding (the card is far beyond 44px already). */
+.account-cards-track .account-card {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
   flex: 0 0 auto;
   width: min(78%, 320px);
   scroll-snap-align: center;
   min-height: 150px;
   padding: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-left: 4px solid var(--brand-primary, #36b37e);
   border-radius: var(--radius-lg, 12px);
-  background: linear-gradient(135deg, #1c2733 0%, #0e141b 100%);
-  color: #e6edf3;
+  background: var(--bg-secondary, #ffffff);
+  color: var(--text-primary, #1f2933);
   text-align: left;
   cursor: pointer;
   transition: transform var(--transition-fast, 0.15s), box-shadow var(--transition-fast, 0.15s);
-  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+  box-shadow: var(--shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.1));
 }
 
 .account-card:hover {
   transform: translateY(-2px);
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
 }
 
 .account-card:focus-visible {
@@ -56,17 +60,26 @@
   outline-offset: 2px;
 }
 
+/* Per-kind accent edge — identity color without abandoning the theme. */
 .account-card--vault {
-  background: linear-gradient(135deg, #16283f 0%, #0d1622 100%);
+  border-left-color: var(--brand-secondary, #4c9aff);
 }
 
 .account-card--legacy {
-  background: linear-gradient(135deg, #33291c 0%, #171008 100%);
+  border-left-color: var(--semantic-warning, #f5a623);
 }
 
 .account-card.is-active {
   border-color: var(--brand-primary, #36b37e);
-  box-shadow: 0 0 0 2px var(--brand-primary, #36b37e), var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+  box-shadow: 0 0 0 2px var(--brand-primary, #36b37e), var(--shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.1));
+}
+
+.account-card--vault.is-active {
+  border-left-color: var(--brand-primary, #36b37e);
+}
+
+.account-card--legacy.is-active {
+  border-left-color: var(--brand-primary, #36b37e);
 }
 
 .account-card-top {
@@ -83,20 +96,42 @@
 .account-card-kind {
   padding: 2px 8px;
   border-radius: var(--radius-full, 9999px);
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--bg-primary, #f7f9fa);
+  border: 1px solid var(--border-color, #e3e7eb);
   font-size: 0.7rem;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: #cfd9e3;
+  color: var(--text-secondary, #5a6772);
 }
 
 .account-card-label {
   font-size: 1.05rem;
   font-weight: 600;
+  color: var(--text-primary, #1f2933);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Quick-access portfolio total on the ACTIVE card (post-launch feedback). */
+.account-card-balance {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.account-card-balance-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary, #5a6772);
+}
+
+.account-card-balance-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary, #1f2933);
 }
 
 .account-card-bottom {
@@ -109,12 +144,12 @@
 .account-card-address {
   font-family: monospace;
   font-size: 0.85rem;
-  color: #aab6c2;
+  color: var(--text-secondary, #5a6772);
 }
 
 .account-card-network {
   font-size: 0.75rem;
-  color: #8b98a5;
+  color: var(--text-muted, #8b98a5);
 }
 
 .account-card-state {
@@ -123,11 +158,11 @@
   gap: 4px;
   margin-top: auto;
   font-size: 0.75rem;
-  color: #8b98a5;
+  color: var(--text-muted, #8b98a5);
 }
 
 .account-card-state.is-active {
-  color: var(--brand-accent, #7bdcb5);
+  color: var(--brand-primary, #36b37e);
   font-weight: 600;
 }
 
@@ -139,6 +174,7 @@
   transform: translateY(-50%);
   width: 32px;
   height: 32px;
+  padding: 0;
   border: 1px solid var(--border-color, #e3e7eb);
   border-radius: var(--radius-full, 9999px);
   background: var(--bg-secondary, #ffffff);
@@ -168,25 +204,42 @@
   }
 }
 
+/* Position dots — deliberately minimal (post-launch feedback: they must not
+   dominate the page). App.css's mobile tap-target rule
+   (`button:not([role="switch"]) { min-width/min-height: 44px; padding: … }`)
+   outranks a single class, so the two-class selector pins every inflating
+   property. The dot LOOKS 6px (background clipped to the content box) while
+   the transparent padding keeps a ~22px touch target. */
 .account-cards-dots {
   display: flex;
   justify-content: center;
-  gap: 6px;
-  padding: 2px 0 0;
+  align-items: center;
+  gap: 2px;
+  padding: 0;
 }
 
-.account-cards-dot {
-  width: 8px;
-  height: 8px;
-  padding: 0;
+.account-cards-dots .account-cards-dot {
+  width: 22px;
+  height: 22px;
+  min-width: 0;
+  min-height: 0;
+  padding: 8px;
   border: none;
   border-radius: 50%;
   background: var(--border-color, #e3e7eb);
+  background-clip: content-box;
+  font-size: 0;
+  line-height: 0;
   cursor: pointer;
-  transition: background var(--transition-fast, 0.15s), transform var(--transition-fast, 0.15s);
+  transition: background-color var(--transition-fast, 0.15s);
 }
 
-.account-cards-dot.is-current {
+.account-cards-dots .account-cards-dot:hover {
+  border: none;
+}
+
+.account-cards-dots .account-cards-dot.is-current {
   background: var(--brand-primary, #36b37e);
-  transform: scale(1.2);
+  background-clip: content-box;
+  padding: 7px;
 }

--- a/frontend/src/components/account/AccountCardsCarousel.jsx
+++ b/frontend/src/components/account/AccountCardsCarousel.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import BlockiesAvatar from '../ui/BlockiesAvatar'
 import NavIcon from '../nav/NavIcon'
 import LegacyUnlockDialog from './LegacyUnlockDialog'
+import SensitiveValue from '../common/SensitiveValue'
 import { useAccountSwitcher, ACCOUNT_KIND_TAG, shortAccountAddr } from '../../hooks/useAccountSwitcher'
 import { NETWORKS } from '../../config/networks'
 import './AccountCardsCarousel.css'
@@ -32,7 +33,20 @@ function chainLabel(chainId) {
 
 const KIND_LABEL = { personal: 'Personal', vault: 'Multisig', legacy: 'Recovered' }
 
-function AccountCardsCarousel() {
+// Full-precision USD, matching the Portfolio view's own total formatting.
+function formatUsdFull(n) {
+  return `$${Number(n || 0).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`
+}
+
+/**
+ * @param {number|null} activeTotalUsd — the ACTIVE account's portfolio total,
+ * shown on its card for quick access. Null hides the line (still loading /
+ * unavailable) — a card must never show a fabricated $0 while data loads.
+ */
+function AccountCardsCarousel({ activeTotalUsd = null }) {
   const { accounts, currentId, choose, unlockEntry, setUnlockEntry, onUnlocked } = useAccountSwitcher()
   const trackRef = useRef(null)
   const [scrollIndex, setScrollIndex] = useState(0)
@@ -120,6 +134,14 @@ function AccountCardsCarousel() {
                   <span className="account-card-kind">{KIND_LABEL[acc.kind] || acc.kind}</span>
                 </span>
                 <span className="account-card-label">{acc.label || shortAccountAddr(acc.address)}</span>
+                {isActive && activeTotalUsd != null && (
+                  <span className="account-card-balance">
+                    <span className="account-card-balance-label">Total balance</span>
+                    <SensitiveValue className="account-card-balance-value">
+                      {formatUsdFull(activeTotalUsd)}
+                    </SensitiveValue>
+                  </span>
+                )}
                 <span className="account-card-bottom">
                   <span className="account-card-address">{shortAccountAddr(acc.address)}</span>
                   {network && <span className="account-card-network">{network}</span>}

--- a/frontend/src/components/account/MyAccountView.jsx
+++ b/frontend/src/components/account/MyAccountView.jsx
@@ -1,5 +1,6 @@
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAccountStats } from '../../hooks/useAccountStats'
+import usePortfolio from '../../hooks/usePortfolio'
 import { useWalletConnection } from '../../hooks/useWalletManagement'
 import { useEffectiveAccount } from '../../hooks/useEffectiveAccount'
 import { ACCOUNT_VIEWS, ACCOUNT_DEFAULT_VIEW, accountViewFromParam } from '../../config/appNav'
@@ -18,11 +19,12 @@ import './MyAccountView.css'
  * MyAccountView — the unified Account tab body (spec 074, replacing the
  * spec-020 AccountDashboard's role). Top half: the account card carousel
  * (personal / multisig / recovered — selecting a card switches the app-wide
- * acting account). Bottom half: ONE of three views of the selected account —
- * Activity (ledger feed + breakdowns), Portfolio, or Stats (tiles + P&L
- * chart) — driven by `?view=` so each is deep-linkable (the PayTransferPanel
- * idiom). The switcher is WalletPage's bottom icon bar on mobile and the tab
- * strip here on desktop; exactly one is visible at any width (the strip hides
+ * acting account; the active card carries the portfolio total). Bottom half:
+ * ONE of three views of the selected account — Portfolio (the default),
+ * Activity (the ledger feed), or Stats (tiles + P&L chart + breakdowns) —
+ * driven by `?view=` so each is deep-linkable (the PayTransferPanel idiom).
+ * The switcher is WalletPage's bottom icon bar on mobile and the tab strip
+ * here on desktop; exactly one is visible at any width (the strip hides
  * ≤768px in CSS, SectionIconNav renders only ≤768px).
  *
  * Stats and Activity follow the ACTING account (spec 063 pattern): the acting
@@ -47,6 +49,12 @@ function MyAccountView() {
   // nothing → identical to the pre-074 behavior.
   const { address: actingAddress, isActingAccount } = useEffectiveAccount()
   const stats = useAccountStats(isActingAccount ? { accountAddress: actingAddress } : undefined)
+  // ONE portfolio instance for the whole view (post-launch feedback): it backs
+  // the Portfolio view AND the active card's quick-access total, and because
+  // it lives here (not inside the view panel) the scan starts — and the
+  // snapshot cache warms — the moment My Account opens, whichever view shows.
+  const portfolio = usePortfolio(isActingAccount ? { accountAddress: actingAddress } : undefined)
+  const activeTotalUsd = portfolio.status === 'ready' ? portfolio.totalUsd : null
   const {
     summary, series, setRange, breakdowns, activity, staleClasses, prunedBefore,
     isSupportedNetwork, chainId, isLoading, isEmpty, freshness, refresh,
@@ -87,7 +95,7 @@ function MyAccountView() {
 
   return (
     <div className="my-account">
-      <AccountCardsCarousel />
+      <AccountCardsCarousel activeTotalUsd={activeTotalUsd} />
 
       {/* Desktop view switcher (the pt-tabs idiom); hidden ≤768px where
           WalletPage's bottom icon bar carries the same three views. */}
@@ -106,28 +114,25 @@ function MyAccountView() {
         ))}
       </div>
 
+      {view === 'portfolio' && (
+        <div role="tabpanel" aria-label="Portfolio" className="my-account-panel">
+          <PortfolioPanel portfolio={portfolio} />
+        </div>
+      )}
+
       {view === 'activity' && (
         <div role="tabpanel" aria-label="Activity" className="my-account-panel">
           <div className="my-account-freshness">
             <FreshnessIndicator state={freshness?.summary} onRefresh={refresh} />
           </div>
           {honestState || (
-            <>
-              <ActivityBreakdowns breakdowns={breakdowns} />
-              <RecentActivityFeed
-                entries={activity}
-                chainId={chainId}
-                staleClasses={staleClasses}
-                prunedBefore={prunedBefore}
-              />
-            </>
+            <RecentActivityFeed
+              entries={activity}
+              chainId={chainId}
+              staleClasses={staleClasses}
+              prunedBefore={prunedBefore}
+            />
           )}
-        </div>
-      )}
-
-      {view === 'portfolio' && (
-        <div role="tabpanel" aria-label="Portfolio" className="my-account-panel">
-          <PortfolioPanel />
         </div>
       )}
 
@@ -140,6 +145,10 @@ function MyAccountView() {
             <>
               <SummaryTiles summary={summary} isEmpty={isLoading && !summary} />
               <PnlChart series={series} onRangeChange={setRange} onCreateWager={goCreate} />
+              {/* The by-status / by-token / by-resolution breakdowns are stats,
+                  not a transaction log — they live here beside the tiles and
+                  chart (post-launch feedback), keeping Activity a clean feed. */}
+              <ActivityBreakdowns breakdowns={breakdowns} />
             </>
           )}
         </div>

--- a/frontend/src/components/account/RecentActivityFeed.css
+++ b/frontend/src/components/account/RecentActivityFeed.css
@@ -6,9 +6,120 @@
 }
 
 .account-feed-title {
-  margin: 0 0 10px;
+  margin: 0;
   font-size: 1rem;
   color: var(--text-primary);
+}
+
+/* Header row: title left, on-demand tools (search / filter) right. */
+.account-feed-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 0 0 10px;
+}
+
+.account-feed-tools {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Icon tool buttons — sized explicitly (two-class selector) so App.css's
+   mobile tap-target rule pads them consistently rather than unpredictably. */
+.account-feed-tools .account-feed-tool {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 32px;
+  min-height: 32px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-full, 9999px);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.account-feed-tools .account-feed-tool.active {
+  border-color: var(--brand-secondary, #4c9aff);
+  color: var(--brand-secondary, #4c9aff);
+}
+
+.account-feed-tool-badge {
+  font-weight: 600;
+}
+
+.account-feed-filter-wrap {
+  position: relative;
+}
+
+.account-feed-filter-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 20;
+  min-width: 160px;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  background: var(--bg-secondary, #ffffff);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: var(--radius-md, 8px);
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+}
+
+.account-feed-filter-menu .account-feed-filter-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 36px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: var(--radius-sm, 4px);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.account-feed-filter-menu .account-feed-filter-option:hover {
+  background: var(--bg-primary, #f7f9fa);
+}
+
+.account-feed-filter-menu .account-feed-filter-option.active {
+  color: var(--brand-secondary, #4c9aff);
+  font-weight: 600;
+}
+
+.account-feed-filter-check {
+  display: inline-flex;
+  width: 16px;
+  justify-content: center;
+}
+
+.account-feed-search {
+  margin: 0 0 10px;
+}
+
+.account-feed-search-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-primary, #f7f9fa);
+  color: var(--text-primary, #1f2933);
+  font-size: 0.9rem;
+}
+
+.account-feed-search-input:focus-visible {
+  outline: 2px solid var(--brand-primary, #36b37e);
+  outline-offset: 1px;
 }
 
 .account-feed-list {
@@ -94,29 +205,6 @@
 }
 
 /* --- spec 051: unified ledger feed --- */
-
-.account-feed-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin: 0 0 10px;
-}
-
-.account-feed-filter {
-  border: 1px solid var(--border-color);
-  background: transparent;
-  color: var(--text-secondary);
-  border-radius: var(--radius-full, 9999px);
-  padding: 4px 10px;
-  font-size: 0.75rem;
-  cursor: pointer;
-}
-
-.account-feed-filter.active {
-  background: var(--brand-secondary, #4C9AFF);
-  border-color: var(--brand-secondary, #4C9AFF);
-  color: #fff;
-}
 
 .account-feed-icon.tone-failed {
   background: rgba(229, 83, 61, 0.18);

--- a/frontend/src/components/account/RecentActivityFeed.jsx
+++ b/frontend/src/components/account/RecentActivityFeed.jsx
@@ -1,7 +1,8 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { getNetwork } from '../../config/networks'
 import { formatUsd, formatRelativeTime } from '../../lib/account/format'
 import SensitiveValue from '../common/SensitiveValue'
+import NavIcon from '../nav/NavIcon'
 import EmptyState from './EmptyState'
 import './RecentActivityFeed.css'
 
@@ -46,50 +47,171 @@ function amountLine(e) {
 }
 
 /**
+ * Case-insensitive search across everything a member might remember about a
+ * transaction: what it was (label/kind/class), the token, the amounts (raw and
+ * USD-formatted), the tx hash, and a failure reason.
+ */
+function entryMatchesQuery(e, meta, query) {
+  const q = query.trim().toLowerCase()
+  if (!q) return true
+  const haystack = [
+    meta.label,
+    e.kind,
+    e.class,
+    e.tokenSymbol,
+    e.amount != null ? String(e.amount) : null,
+    e.valueUsd != null ? formatUsd(e.valueUsd) : null,
+    e.txHash,
+    e.failureReason,
+    e.status,
+  ]
+  return haystack.some((v) => v != null && String(v).toLowerCase().includes(q))
+}
+
+/**
  * RecentActivityFeed — the Account tab's canonical activity record
- * (spec 051 US1): every ledger class, newest first, with class filters,
- * honest failed states, and an explicit "date unavailable" state instead of
- * a fabricated relative time (FR-006).
+ * (spec 051 US1): every ledger class, newest first, with honest failed states
+ * and an explicit "date unavailable" state instead of a fabricated relative
+ * time (FR-006).
+ *
+ * Spec 074 follow-up: the class-filter chip row moved behind a Filter button
+ * (dropdown), and a search field lives behind a Search icon — the feed leads
+ * with the transactions themselves, and the tools appear on demand.
  */
 function RecentActivityFeed({ entries = [], chainId, staleClasses = [], prunedBefore = null }) {
   const [classFilter, setClassFilter] = useState(null)
+  const [filterOpen, setFilterOpen] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const filterRef = useRef(null)
+  const searchInputRef = useRef(null)
 
-  const rows = useMemo(
-    () => (classFilter ? entries.filter((e) => e.class === classFilter) : entries),
-    [entries, classFilter],
-  )
+  // Close the filter dropdown on outside click / Escape.
+  useEffect(() => {
+    if (!filterOpen) return undefined
+    const onDown = (event) => {
+      if (filterRef.current && !filterRef.current.contains(event.target)) setFilterOpen(false)
+    }
+    const onKey = (event) => {
+      if (event.key === 'Escape') setFilterOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [filterOpen])
 
-  const filterChips = (
-    <div className="account-feed-filters" role="group" aria-label="Filter activity by type">
-      {CLASS_FILTERS.map((f) => (
-        <button
-          key={f.label}
-          type="button"
-          className={`account-feed-filter${classFilter === f.key ? ' active' : ''}`}
-          aria-pressed={classFilter === f.key}
-          onClick={() => setClassFilter(f.key)}
-        >
-          {f.label}
-        </button>
-      ))}
-    </div>
-  )
+  // Opening search focuses the field so "icon → type" is one motion.
+  useEffect(() => {
+    if (searchOpen) searchInputRef.current?.focus()
+  }, [searchOpen])
+
+  const rows = useMemo(() => {
+    const byClass = classFilter ? entries.filter((e) => e.class === classFilter) : entries
+    if (!query.trim()) return byClass
+    return byClass.filter((e) =>
+      entryMatchesQuery(e, KIND_META[e.kind] || { label: e.kind }, query),
+    )
+  }, [entries, classFilter, query])
+
+  const activeFilter = CLASS_FILTERS.find((f) => f.key === classFilter) || CLASS_FILTERS[0]
+  const isFiltering = classFilter != null || query.trim() !== ''
 
   return (
     <section className="account-feed" aria-label="Recent activity">
-      <h3 className="account-feed-title">Recent activity</h3>
-      {filterChips}
+      <div className="account-feed-header">
+        <h3 className="account-feed-title">Recent activity</h3>
+        <div className="account-feed-tools">
+          <button
+            type="button"
+            className={`account-feed-tool${searchOpen || query ? ' active' : ''}`}
+            aria-label={searchOpen ? 'Hide activity search' : 'Search activity'}
+            aria-expanded={searchOpen}
+            onClick={() => {
+              setSearchOpen((open) => {
+                if (open) setQuery('')
+                return !open
+              })
+            }}
+          >
+            <NavIcon name="search" size={16} />
+          </button>
+          <div className="account-feed-filter-wrap" ref={filterRef}>
+            <button
+              type="button"
+              className={`account-feed-tool${classFilter != null ? ' active' : ''}`}
+              aria-label="Filter activity by type"
+              aria-haspopup="menu"
+              aria-expanded={filterOpen}
+              onClick={() => setFilterOpen((o) => !o)}
+            >
+              <NavIcon name="sliders" size={16} />
+              {classFilter != null && (
+                <span className="account-feed-tool-badge">{activeFilter.label}</span>
+              )}
+            </button>
+            {filterOpen && (
+              <ul className="account-feed-filter-menu" role="menu" aria-label="Filter activity by type">
+                {CLASS_FILTERS.map((f) => (
+                  <li key={f.label} role="none">
+                    <button
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={classFilter === f.key}
+                      className={`account-feed-filter-option${classFilter === f.key ? ' active' : ''}`}
+                      onClick={() => {
+                        setClassFilter(f.key)
+                        setFilterOpen(false)
+                      }}
+                    >
+                      <span className="account-feed-filter-check" aria-hidden="true">
+                        {classFilter === f.key ? <NavIcon name="check" size={14} /> : null}
+                      </span>
+                      {f.label}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {searchOpen && (
+        <div className="account-feed-search">
+          <input
+            ref={searchInputRef}
+            type="search"
+            className="account-feed-search-input"
+            placeholder="Search by type, token, amount, or tx hash"
+            aria-label="Search activity"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </div>
+      )}
+
       {staleClasses.length > 0 && (
         <p className="account-feed-stale" role="status">
           Some activity may be out of date: {staleClasses.join(', ')} could not be refreshed.
         </p>
       )}
       {rows.length === 0 ? (
-        <EmptyState
-          compact
-          title="No recent activity"
-          message="Your wagers, transfers, earn, pool, and membership activity will appear here."
-        />
+        isFiltering ? (
+          <EmptyState
+            compact
+            title="No matching activity"
+            message="Nothing matches the current filter or search. Clear them to see all activity."
+          />
+        ) : (
+          <EmptyState
+            compact
+            title="No recent activity"
+            message="Your wagers, transfers, earn, pool, and membership activity will appear here."
+          />
+        )
       ) : (
         <ul className="account-feed-list">
           {rows.map((e) => {

--- a/frontend/src/components/nav/NavIcon.jsx
+++ b/frontend/src/components/nav/NavIcon.jsx
@@ -44,6 +44,8 @@ const ICON_PATHS = {
   user: <><circle cx="12" cy="8" r="3.5" /><path d="M5.5 20c.8-4.2 12.2-4.2 13 0" /></>,
   // My Account bottom nav — Activity: a clock face, "what happened recently".
   clock: <><circle cx="12" cy="12" r="8.5" /><path d="M12 7.5V12l3 2" /></>,
+  // Activity feed toolbar — search: the universal magnifier.
+  search: <><circle cx="11" cy="11" r="6.5" /><path d="m15.8 15.8 4.7 4.7" /></>,
   trending: <><path d="M4 15.5 9.5 10l3.5 3.5L20 6" /><path d="M15.5 6H20v4.5" /></>,
   // Collectibles (spec 055) — a faceted gem: unique, collectible, display-worthy.
   gem: <><path d="M7 4h10l4 6-9 10L3 10l4-6Z" /><path d="M3 10h18" /><path d="M9.5 10 12 4l2.5 6L12 20l-2.5-10Z" /></>,

--- a/frontend/src/components/wallet/PortfolioPanel.jsx
+++ b/frontend/src/components/wallet/PortfolioPanel.jsx
@@ -180,12 +180,27 @@ function CollectiblesEstimateRow({ valuationState, priceMap }) {
  * the asset detail sheet (instances + actions). Category explainers live in
  * InfoTip bubbles; testnet and zero-balance visibility follow the
  * Preferences → Portfolio settings.
+ *
+ * Spec 074 follow-up: the panel can be handed an externally-owned `portfolio`
+ * (MyAccountView mounts ONE usePortfolio so the account card's quick-access
+ * total and this panel read the same snapshot — no duplicate scans). Without
+ * the prop it self-loads exactly as before. Split into a self-loading wrapper
+ * and a body so the hook is never called conditionally.
  */
-export default function PortfolioPanel() {
+export default function PortfolioPanel({ portfolio = null }) {
+  if (portfolio) return <PortfolioBody portfolio={portfolio} />
+  return <SelfLoadingPortfolioPanel />
+}
+
+function SelfLoadingPortfolioPanel() {
   // Spec 063 (US1): the portfolio shows the account the member is acting as (a vault or recovered
   // account), not always the connected wallet. Personal mode passes its own address → unchanged.
   const { address: actingAddress, isActingAccount } = useEffectiveAccount()
   const portfolio = usePortfolio(isActingAccount ? { accountAddress: actingAddress } : undefined)
+  return <PortfolioBody portfolio={portfolio} />
+}
+
+function PortfolioBody({ portfolio }) {
   // Decided HERE (not inside the row) so the Digital Collectibles section keeps
   // its honest "No assets in this category." message when the row is absent.
   const collectiblesValuation = useCollectiblesValuation()

--- a/frontend/src/config/appNav.js
+++ b/frontend/src/config/appNav.js
@@ -34,14 +34,14 @@ export const PORTFOLIO_ITEM = { id: 'portfolio', label: 'Portfolio', icon: 'tren
  * `icon` is a NavIcon name.
  */
 export const ACCOUNT_VIEWS = [
-  // Activity first — the default view: the ledger feed + breakdowns, mirroring
-  // the "recent transactions under your cards" shape of the reference design.
-  { id: 'activity', label: 'Activity', icon: 'clock' },
+  // Portfolio first — the default view (post-launch feedback on spec 074):
+  // what a member owns is the first thing they look for under their cards.
   { id: 'portfolio', label: 'Portfolio', icon: 'trending' },
+  { id: 'activity', label: 'Activity', icon: 'clock' },
   { id: 'stats', label: 'Stats', icon: 'reports' },
 ]
 
-export const ACCOUNT_DEFAULT_VIEW = 'activity'
+export const ACCOUNT_DEFAULT_VIEW = 'portfolio'
 
 /** Resolve a raw `?view=` param to a known account view (unknown/missing → default). */
 export function accountViewFromParam(param) {

--- a/frontend/src/hooks/usePortfolio.js
+++ b/frontend/src/hooks/usePortfolio.js
@@ -40,6 +40,28 @@ import { createBitcoinGatewayClient, bitcoinGatewayUrl } from '../lib/bitcoin/ga
 
 const POLL_MS = 60_000
 
+/**
+ * Session-scoped snapshot cache (post-launch feedback on spec 074): the
+ * portfolio view unmounts on every tab switch, and a cold multi-chain scan
+ * left the member staring at "Loading portfolio…" each time. Remounting for
+ * an account we've already read hydrates the LAST REAL snapshot immediately
+ * (its lastUpdated timestamp intact — never fabricated data) while a fresh
+ * read runs in the background. Keyed by account + scan scope so a snapshot
+ * can never leak across accounts or across the testnet-visibility boundary.
+ * In-memory only — nothing is persisted, and a reload starts cold.
+ */
+const SNAPSHOT_CACHE_MAX = 8
+const snapshotCache = new Map()
+
+function cacheSnapshot(key, snapshot) {
+  // Refresh insertion order so the eviction below is least-recently-written.
+  snapshotCache.delete(key)
+  snapshotCache.set(key, snapshot)
+  if (snapshotCache.size > SNAPSHOT_CACHE_MAX) {
+    snapshotCache.delete(snapshotCache.keys().next().value)
+  }
+}
+
 // Works for ERC-20 balances and ERC-721 item counts alike.
 const BALANCE_OF_ABI = ['function balanceOf(address) view returns (uint256)']
 
@@ -114,6 +136,12 @@ export function usePortfolio({ accountAddress } = {}) {
     [bitcoinNetworkIds],
   )
 
+  // Cache identity: the account being scanned plus the exact scan scope.
+  const cacheKey = useMemo(
+    () => `${String(address || '').toLowerCase()}|${chainIds.join(',')}|${bitcoinNetworkIds.join(',')}`,
+    [address, chainIds, bitcoinNetworkIds],
+  )
+
   const [reads, setReads] = useState({ balances: null, failedAssets: [], error: null, bitcoinEntries: [] })
   const [priceMap, setPriceMap] = useState(() => new Map())
   const [isLoading, setIsLoading] = useState(false)
@@ -166,16 +194,19 @@ export function usePortfolio({ accountAddress } = {}) {
         // never a $0 portfolio (unchanged pre-bitcoin semantics).
         setReads({ balances: null, failedAssets, error: 'Unable to read balances from the supported networks.', bitcoinEntries: [] })
       } else {
-        setReads({
+        const nextReads = {
           balances,
           // Bitcoin failures ride the same honest-degradation channel the EVM
           // reads use: named in failedAssets, never rendered as zero.
           failedAssets: [...failedAssets, ...bitcoinRes.failed],
           error: null,
           bitcoinEntries: bitcoinRes.holdings,
-        })
+        }
+        const now = Date.now()
+        setReads(nextReads)
         setPriceMap(priced)
-        setLastUpdated(Date.now())
+        setLastUpdated(now)
+        cacheSnapshot(cacheKey, { reads: nextReads, priceMap: priced, lastUpdated: now })
       }
     } catch (err) {
       if (reqId !== reqIdRef.current) return
@@ -183,18 +214,28 @@ export function usePortfolio({ accountAddress } = {}) {
     } finally {
       if (reqId === reqIdRef.current) setIsLoading(false)
     }
-  }, [isConnected, address, providers, registry, bitcoinAssets, bitcoinNetworkIds])
+  }, [isConnected, address, providers, registry, bitcoinAssets, bitcoinNetworkIds, cacheKey])
 
-  // Reset synchronously on account or scan-scope change so a stale snapshot
-  // (e.g. testnet rows after the preference flips off) can never render.
+  // On account or scan-scope change: hydrate the last real snapshot for THIS
+  // key if one exists (instant data on remount, background refresh follows);
+  // otherwise reset synchronously so another key's stale snapshot (e.g.
+  // testnet rows after the preference flips off, or another account's
+  // balances) can never render.
   useEffect(() => {
     reqIdRef.current++
-    setReads({ balances: null, failedAssets: [], error: null, bitcoinEntries: [] })
-    setPriceMap(new Map())
-    setLastUpdated(null)
+    const cached = snapshotCache.get(cacheKey)
+    if (cached) {
+      setReads(cached.reads)
+      setPriceMap(cached.priceMap)
+      setLastUpdated(cached.lastUpdated)
+    } else {
+      setReads({ balances: null, failedAssets: [], error: null, bitcoinEntries: [] })
+      setPriceMap(new Map())
+      setLastUpdated(null)
+    }
     load()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [address, chainIds])
+  }, [cacheKey])
 
   useEffect(() => {
     if (!isConnected || !address) return undefined

--- a/frontend/src/test/WalletPage.test.jsx
+++ b/frontend/src/test/WalletPage.test.jsx
@@ -59,8 +59,30 @@ vi.mock('../utils/keyRegistryService', () => ({
   ensureKeyRegistered: vi.fn(),
 }))
 // Spec 074 — the Account tab body renders the unified view (card carousel +
-// Activity/Portfolio/Stats). Mock the switcher seam so this entry-point test
-// stays free of the custody/legacy async loads behind it.
+// Portfolio/Activity/Stats). Mock the portfolio seams (the default view) and
+// the switcher seam so this entry-point test stays free of the multi-chain
+// scans and custody/legacy async loads behind them.
+vi.mock('../components/wallet/PortfolioPanel', () => ({
+  default: () => <div data-testid="portfolio-panel" />,
+}))
+vi.mock('../hooks/usePortfolio', () => {
+  const usePortfolio = () => ({
+    status: 'ready',
+    isLoading: false,
+    error: null,
+    holdings: [],
+    aggregates: [],
+    categories: [],
+    totalUsd: 0,
+    failedAssets: [],
+    priceMap: new Map(),
+    showTestnetAssets: false,
+    showZeroBalances: false,
+    lastUpdated: null,
+    refresh: vi.fn(),
+  })
+  return { default: usePortfolio, usePortfolio }
+})
 vi.mock('../hooks/useAccountSwitcher', () => {
   const useAccountSwitcher = () => ({
     accounts: [

--- a/frontend/src/test/account/AccountCardsCarousel.test.jsx
+++ b/frontend/src/test/account/AccountCardsCarousel.test.jsx
@@ -127,4 +127,18 @@ describe('AccountCardsCarousel (spec 074 US1)', () => {
     expect(screen.queryByRole('button', { name: 'Previous account' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /^Go to / })).not.toBeInTheDocument()
   })
+
+  it('shows the quick-access total on the ACTIVE card only (post-launch feedback)', () => {
+    render(<AccountCardsCarousel activeTotalUsd={1234.5} />)
+    expect(screen.getAllByText(/total balance/i)).toHaveLength(1)
+    expect(screen.getByText('$1,234.50')).toBeInTheDocument()
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveTextContent('Total balance')
+    expect(options[1]).not.toHaveTextContent('Total balance')
+  })
+
+  it('renders no balance line without a total (loading / unavailable)', () => {
+    render(<AccountCardsCarousel />)
+    expect(screen.queryByText(/total balance/i)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/test/account/MyAccountView.axe.test.jsx
+++ b/frontend/src/test/account/MyAccountView.axe.test.jsx
@@ -43,6 +43,24 @@ vi.mock('../../components/account/LegacyUnlockDialog', () => ({ default: () => n
 vi.mock('../../components/wallet/PortfolioPanel', () => ({
   default: () => <div data-testid="portfolio-panel" />,
 }))
+vi.mock('../../hooks/usePortfolio', () => {
+  const usePortfolio = () => ({
+    status: 'ready',
+    isLoading: false,
+    error: null,
+    holdings: [],
+    aggregates: [],
+    categories: [],
+    totalUsd: 42.5,
+    failedAssets: [],
+    priceMap: new Map(),
+    showTestnetAssets: false,
+    showZeroBalances: false,
+    lastUpdated: Date.now(),
+    refresh: vi.fn(),
+  })
+  return { default: usePortfolio, usePortfolio }
+})
 
 const stats = {
   summary: {
@@ -93,8 +111,14 @@ function renderView(route = '/wallet?tab=account') {
 }
 
 describe('MyAccountView accessibility (spec 074 SC-005, ports the spec 020 FR-018 gate)', () => {
-  it('has no axe violations on the default (Activity) view', async () => {
+  it('has no axe violations on the default (Portfolio) view', async () => {
     const { container } = renderView()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no axe violations on the Activity view', async () => {
+    const { container } = renderView('/wallet?tab=account&view=activity')
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })

--- a/frontend/src/test/account/MyAccountView.test.jsx
+++ b/frontend/src/test/account/MyAccountView.test.jsx
@@ -9,10 +9,15 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 
 const useAccountStatsMock = vi.fn()
+const usePortfolioMock = vi.fn()
 let effectiveAccount
 
 vi.mock('../../hooks/useAccountStats', () => ({
   useAccountStats: (...args) => useAccountStatsMock(...args),
+}))
+vi.mock('../../hooks/usePortfolio', () => ({
+  default: (...args) => usePortfolioMock(...args),
+  usePortfolio: (...args) => usePortfolioMock(...args),
 }))
 vi.mock('../../hooks/useEffectiveAccount', () => ({
   useEffectiveAccount: () => effectiveAccount,
@@ -74,6 +79,22 @@ const baseStats = () => ({
   refresh: vi.fn(),
 })
 
+const readyPortfolio = () => ({
+  status: 'ready',
+  isLoading: false,
+  error: null,
+  holdings: [],
+  aggregates: [],
+  categories: [],
+  totalUsd: 12.34,
+  failedAssets: [],
+  priceMap: new Map(),
+  showTestnetAssets: false,
+  showZeroBalances: false,
+  lastUpdated: Date.now(),
+  refresh: vi.fn(),
+})
+
 const { default: MyAccountView } = await import('../../components/account/MyAccountView')
 
 function LocationProbe() {
@@ -93,6 +114,7 @@ function renderView(route = '/wallet?tab=account') {
 beforeEach(() => {
   vi.clearAllMocks()
   useAccountStatsMock.mockImplementation(() => baseStats())
+  usePortfolioMock.mockImplementation(() => readyPortfolio())
   effectiveAccount = {
     type: 'personal',
     address: '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
@@ -104,41 +126,61 @@ beforeEach(() => {
 })
 
 describe('MyAccountView — unified account experience (spec 074)', () => {
-  it('defaults to the Activity view with the carousel on top (U1, C1, V1)', () => {
+  it('defaults to the Portfolio view with the carousel on top (U1, C1, V2)', () => {
     renderView()
     expect(screen.getByRole('listbox', { name: /select the active account/i })).toBeInTheDocument()
+    expect(screen.getByRole('tabpanel', { name: 'Portfolio' })).toBeInTheDocument()
+    expect(screen.getByTestId('portfolio-panel')).toBeInTheDocument()
+    expect(screen.queryByRole('tabpanel', { name: 'Activity' })).not.toBeInTheDocument()
+  })
+
+  it('shows the portfolio total on the active card once data is ready (post-launch feedback)', () => {
+    renderView()
+    expect(screen.getByText(/total balance/i)).toBeInTheDocument()
+    expect(screen.getByText('$12.34')).toBeInTheDocument()
+  })
+
+  it('never shows a fabricated $0 on the card while the portfolio loads', () => {
+    usePortfolioMock.mockImplementation(() => ({ ...readyPortfolio(), status: 'loading', totalUsd: 0 }))
+    renderView()
+    expect(screen.queryByText(/total balance/i)).not.toBeInTheDocument()
+  })
+
+  it('deep-links to the Activity view (U2, V1)', () => {
+    renderView('/wallet?tab=account&view=activity')
     expect(screen.getByRole('tabpanel', { name: 'Activity' })).toBeInTheDocument()
     expect(screen.getByText(/recent activity/i)).toBeInTheDocument()
     expect(screen.queryByTestId('portfolio-panel')).not.toBeInTheDocument()
   })
 
-  it('deep-links to the Portfolio view (U2, V2)', () => {
-    renderView('/wallet?tab=account&view=portfolio')
-    expect(screen.getByRole('tabpanel', { name: 'Portfolio' })).toBeInTheDocument()
-    expect(screen.getByTestId('portfolio-panel')).toBeInTheDocument()
-  })
-
-  it('deep-links to the Stats view (U3, V3)', () => {
+  it('deep-links to the Stats view, which now hosts the breakdowns (U3, V3)', () => {
     renderView('/wallet?tab=account&view=stats')
     expect(screen.getByRole('tabpanel', { name: 'Stats' })).toBeInTheDocument()
     // Summary tiles render (the wallet balance tile is stats-only chrome)
     expect(screen.getByText(/wallet balance/i)).toBeInTheDocument()
+    // By status / by token / by resolution moved here from Activity.
+    expect(screen.getByText(/by resolution/i)).toBeInTheDocument()
   })
 
-  it('falls back to Activity for an unknown view (U4)', () => {
+  it('keeps the breakdowns out of the Activity view (post-launch feedback)', () => {
+    renderView('/wallet?tab=account&view=activity')
+    expect(screen.queryByText(/by resolution/i)).not.toBeInTheDocument()
+  })
+
+  it('falls back to the default Portfolio view for an unknown view (U4)', () => {
     renderView('/wallet?tab=account&view=nonsense')
-    expect(screen.getByRole('tabpanel', { name: 'Activity' })).toBeInTheDocument()
+    expect(screen.getByRole('tabpanel', { name: 'Portfolio' })).toBeInTheDocument()
   })
 
   it('switches views from the tab strip and rewrites ?view= (U7, V5)', () => {
     renderView()
     const tablist = screen.getByRole('tablist', { name: /account views/i })
-    fireEvent.click(screen.getByRole('tab', { name: 'Portfolio' }))
-    expect(screen.getByTestId('portfolio-panel')).toBeInTheDocument()
-    expect(screen.getByTestId('loc')).toHaveTextContent('view=portfolio')
-    // Back to the default view deletes the param
     fireEvent.click(screen.getByRole('tab', { name: 'Activity' }))
     expect(screen.getByRole('tabpanel', { name: 'Activity' })).toBeInTheDocument()
+    expect(screen.getByTestId('loc')).toHaveTextContent('view=activity')
+    // Back to the default view deletes the param
+    fireEvent.click(screen.getByRole('tab', { name: 'Portfolio' }))
+    expect(screen.getByTestId('portfolio-panel')).toBeInTheDocument()
     expect(screen.getByTestId('loc')).not.toHaveTextContent('view=')
     expect(tablist).toBeInTheDocument()
   })
@@ -164,6 +206,10 @@ describe('MyAccountView — unified account experience (spec 074)', () => {
     expect(useAccountStatsMock).toHaveBeenCalledWith({
       accountAddress: '0x8cc5000000000000000000000000000000000000',
     })
+    // The shared portfolio instance follows the acting account too.
+    expect(usePortfolioMock).toHaveBeenCalledWith({
+      accountAddress: '0x8cc5000000000000000000000000000000000000',
+    })
   })
 
   it('keeps the honest unsupported-network state on Activity and Stats (V1, V3)', () => {
@@ -171,7 +217,7 @@ describe('MyAccountView — unified account experience (spec 074)', () => {
       ...baseStats(),
       isSupportedNetwork: false,
     }))
-    renderView()
+    renderView('/wallet?tab=account&view=activity')
     expect(screen.getByText(/network not supported/i)).toBeInTheDocument()
   })
 
@@ -180,7 +226,7 @@ describe('MyAccountView — unified account experience (spec 074)', () => {
       ...baseStats(),
       isEmpty: true,
     }))
-    renderView()
+    renderView('/wallet?tab=account&view=activity')
     expect(screen.getByText(/no activity yet/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /create a wager/i })).toBeInTheDocument()
   })

--- a/frontend/src/test/account/RecentActivityFeed.test.jsx
+++ b/frontend/src/test/account/RecentActivityFeed.test.jsx
@@ -93,13 +93,44 @@ describe('RecentActivityFeed (spec 051 US1)', () => {
     expect(screen.getByText(/unvalued/i)).toBeInTheDocument()
   })
 
-  it('filters by activity class', async () => {
+  it('filters by activity class from the filter dropdown (spec 074 follow-up)', async () => {
     const user = userEvent.setup()
     render(<RecentActivityFeed entries={entries} chainId={80002} />)
-    await user.click(screen.getByRole('button', { name: 'Transfers' }))
+    // Class options are behind the Filter button, not an always-on chip row.
+    expect(screen.queryByRole('menuitemradio')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /filter activity by type/i }))
+    await user.click(screen.getByRole('menuitemradio', { name: 'Transfers' }))
     expect(screen.queryByText('Payout')).not.toBeInTheDocument()
     expect(screen.getByText('Transfer')).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'All activity' }))
+    // Picking closes the menu; the active class shows on the button badge.
+    expect(screen.queryByRole('menuitemradio')).not.toBeInTheDocument()
+    expect(screen.getByText('Transfers')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /filter activity by type/i }))
+    await user.click(screen.getByRole('menuitemradio', { name: 'All activity' }))
+    expect(screen.getByText('Payout')).toBeInTheDocument()
+  })
+
+  it('searches transactions behind the search icon (spec 074 follow-up)', async () => {
+    const user = userEvent.setup()
+    render(<RecentActivityFeed entries={entries} chainId={80002} />)
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /search activity/i }))
+    const input = screen.getByRole('searchbox', { name: /search activity/i })
+    await user.type(input, 'payout')
+    expect(screen.getByText('Payout')).toBeInTheDocument()
+    expect(screen.queryByText('Deposit')).not.toBeInTheDocument()
+    // A tx-hash fragment locates the transaction too.
+    await user.clear(input)
+    await user.type(input, TX_B.slice(0, 10))
+    expect(screen.getByText('Deposit')).toBeInTheDocument()
+    expect(screen.queryByText('Payout')).not.toBeInTheDocument()
+    // No matches → honest "no matching activity" state, not the generic empty.
+    await user.clear(input)
+    await user.type(input, 'zzz-no-match')
+    expect(screen.getByText(/no matching activity/i)).toBeInTheDocument()
+    // Collapsing search clears the query.
+    await user.click(screen.getByRole('button', { name: /hide activity search/i }))
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument()
     expect(screen.getByText('Payout')).toBeInTheDocument()
   })
 

--- a/frontend/src/test/collectibles/walletPageCollectibles.test.jsx
+++ b/frontend/src/test/collectibles/walletPageCollectibles.test.jsx
@@ -25,8 +25,28 @@ vi.mock('../../components/ui/BlockiesAvatar', () => ({
   default: () => <div data-testid="blockies-avatar" />,
 }))
 // Spec 074 — the Account tab body is the unified view (card carousel +
-// Activity/Portfolio/Stats). Mock the switcher seam so the fallback-to-Account
-// cases stay free of the custody/legacy async loads behind it.
+// Portfolio/Activity/Stats). Mock the portfolio hook (the default view's data
+// seam, also mounted for the card total) and the switcher seam so the
+// fallback-to-Account cases stay free of multi-chain scans and custody/legacy
+// async loads.
+vi.mock('../../hooks/usePortfolio', () => {
+  const usePortfolio = () => ({
+    status: 'ready',
+    isLoading: false,
+    error: null,
+    holdings: [],
+    aggregates: [],
+    categories: [],
+    totalUsd: 0,
+    failedAssets: [],
+    priceMap: new Map(),
+    showTestnetAssets: false,
+    showZeroBalances: false,
+    lastUpdated: null,
+    refresh: vi.fn(),
+  })
+  return { default: usePortfolio, usePortfolio }
+})
 vi.mock('../../hooks/useAccountSwitcher', () => {
   const useAccountSwitcher = () => ({
     accounts: [

--- a/frontend/src/test/portfolio/usePortfolio.test.jsx
+++ b/frontend/src/test/portfolio/usePortfolio.test.jsx
@@ -270,4 +270,24 @@ describe('usePortfolio (aggregated, on-chain priced)', () => {
     })
     expect(calls).toBeGreaterThan(callsAfterLoad)
   })
+
+  it('remounting hydrates the last real snapshot instantly while a refresh runs (spec 074 follow-up)', async () => {
+    // First mount: a real read lands and warms the session snapshot cache.
+    fixtures.nativeBalances.set(137, 2n * 10n ** 18n)
+    fixtures.prices.set('MATIC', { usd: 0.5, source: 'chainlink', chainId: 137 })
+    const first = await renderPortfolio()
+    await waitFor(() => expect(latest.status).toBe('ready'))
+    expect(latest.totalUsd).toBeCloseTo(1)
+    const firstUpdated = latest.lastUpdated
+    first.unmount()
+
+    // Second mount with the background read HANGING: the member still sees the
+    // last real snapshot (status ready, same figures, same honest timestamp)
+    // instead of "Loading portfolio…".
+    fixtures.nativeBalances.set(137, () => new Promise(() => {}))
+    await renderPortfolio()
+    expect(latest.status).toBe('ready')
+    expect(latest.totalUsd).toBeCloseTo(1)
+    expect(latest.lastUpdated).toBe(firstUpdated)
+  })
 })

--- a/specs/074-unified-my-account/contracts/my-account-ui-contract.md
+++ b/specs/074-unified-my-account/contracts/my-account-ui-contract.md
@@ -2,15 +2,18 @@
 
 The externally observable behavior of `/wallet?tab=account`. Consumed by the
 Vitest suites named per item; IDs referenced from tasks.md.
+Amended 2026-08-03 (post-launch feedback): Portfolio is the default view, the
+breakdowns moved to Stats, and the feed grew filter/search tools (F*).
 
 ## URLs
 
-- **U1** `/wallet?tab=account` (and bare `/wallet`) → unified view, Activity
-  view active.
-- **U2** `/wallet?tab=account&view=portfolio` → Portfolio view active.
+- **U1** `/wallet?tab=account` (and bare `/wallet`) → unified view,
+  **Portfolio** view active (amended — was Activity).
+- **U2** `/wallet?tab=account&view=activity` → Activity view active
+  (`&view=portfolio` stays a valid explicit link to the default).
 - **U3** `/wallet?tab=account&view=stats` → Stats view active.
-- **U4** `/wallet?tab=account&view=<unknown>` → Activity view (fallback, no
-  blank panel).
+- **U4** `/wallet?tab=account&view=<unknown>` → Portfolio view (fallback, no
+  blank panel; amended — was Activity).
 - **U5** `/wallet?tab=portfolio` → replaced-history redirect to U2.
 - **U6** Drawer Quick Access "Portfolio" → navigates to U2's URL
   (`pathForNavItem('portfolio') === PORTFOLIO_PATH`).
@@ -36,16 +39,25 @@ Vitest suites named per item; IDs referenced from tasks.md.
   account render; with exactly 1 account neither renders.
 - **C6** The active marker follows `currentId` even when the switch happened
   in the WalletButton dropdown (both read the same hook).
+- **C7** (amended) The ACTIVE card shows the portfolio total (`Total
+  balance`) once the shared portfolio instance is `ready`; no balance line
+  renders while loading (never a fabricated $0), and non-active cards carry
+  none.
+- **C8** (amended) Cards use theme surface tokens with a per-kind accent
+  (light + dark aware); position dots are minimal (≈6px visual) with a padded
+  touch target, pinned against the app-wide button/tap-target CSS.
 
 ## Views (V)
 
-- **V1** Activity view = FreshnessIndicator + ActivityBreakdowns +
-  RecentActivityFeed (ledger entries), preserving the existing
-  unsupported-network and no-activity EmptyStates.
-- **V2** Portfolio view = existing `PortfolioPanel` unchanged (its own
-  loading/error/disconnected states, asset detail sheet, disclosures).
-- **V3** Stats view = FreshnessIndicator + SummaryTiles + PnlChart with the
-  same EmptyStates as V1.
+- **V1** Activity view = FreshnessIndicator + RecentActivityFeed (ledger
+  entries), preserving the existing unsupported-network and no-activity
+  EmptyStates. (Amended: the breakdowns moved to V3.)
+- **V2** Portfolio view = existing `PortfolioPanel` (its own loading/error/
+  disconnected states, asset detail sheet, disclosures), fed the view-owned
+  portfolio instance.
+- **V3** Stats view = FreshnessIndicator + SummaryTiles + PnlChart +
+  ActivityBreakdowns (amended: by-status / by-token / by-resolution live
+  here) with the same EmptyStates as V1.
 - **V4** Wallet utilities (QR / disconnect) render below every view.
 - **V5** Exactly one view switcher is visible at any width: SectionIconNav
   (≤768px, fed `ACCOUNT_VIEWS` while the Account tab is active) or the
@@ -62,6 +74,28 @@ Vitest suites named per item; IDs referenced from tasks.md.
   wallet context's connected-wallet balance.
 - **A4** Changing the effective address clears held balances before the next
   load (no cross-account stale figures).
+
+## Feed tools (F) — amended 2026-08-03
+
+- **F1** The class filters (All activity / Wagers / Transfers / Earn / Pools /
+  Membership) live behind a Filter button: `aria-haspopup="menu"`, options as
+  `role="menuitemradio"` with `aria-checked`; picking one closes the menu and
+  the active class shows on the button.
+- **F2** A Search icon toggles a search field (focused on open) that matches
+  entries by kind/label, class, token symbol, amount (raw or USD-formatted),
+  tx hash, status, or failure reason; collapsing the field clears the query.
+- **F3** A filter/search combination with no matches shows a "no matching
+  activity" state distinct from the no-history empty state.
+
+## Portfolio freshness (P) — amended 2026-08-03
+
+- **P1** A remount for an account+scope already read this session hydrates
+  the last real snapshot immediately (status `ready`, original `lastUpdated`)
+  while a background refresh runs.
+- **P2** Snapshots are keyed by account + scan scope: switching accounts or
+  toggling testnet visibility can never render another key's data.
+- **P3** The cache is session-memory only (bounded, LRU-ish); a reload starts
+  cold.
 
 ## Accessibility (X)
 

--- a/specs/074-unified-my-account/spec.md
+++ b/specs/074-unified-my-account/spec.md
@@ -241,10 +241,39 @@ entries for Portfolio point at the new location.
 - **SC-005**: The unified view introduces no new accessibility violations
   (axe audit passes, as for the surfaces it replaces).
 
+## Amendment — post-launch feedback (2026-08-03)
+
+First-use feedback on the shipped view, superseding the original text where
+they conflict:
+
+- **FR-006a**: Portfolio is the FIRST view — the default lower half and the
+  first entry in the view switcher (supersedes the "Activity is default"
+  assumption below).
+- **FR-006b**: The by-status / by-token / by-resolution breakdowns belong to
+  the **Stats** view, not Activity — Activity is a clean transaction feed.
+- **FR-014**: The activity feed's class filters live behind a **filter
+  button** (dropdown), and a **search** field lives behind a search icon,
+  matching transactions by type, token, amount, tx hash, or failure reason.
+  An active filter/search with no matches shows an honest "no matching
+  activity" state.
+- **FR-015**: The account cards MUST be theme-aware (light + dark), using the
+  app's surface tokens with a per-kind accent rather than a fixed dark
+  palette; the carousel position dots MUST be visually minimal and never
+  dominate the page (while keeping a usable touch target).
+- **FR-016**: Reopening My Account for an account already read this session
+  MUST show the last real portfolio snapshot immediately (with its honest
+  timestamp) while a fresh read runs in the background — never a bare
+  "Loading portfolio…" for data the session already has. Snapshots never
+  cross accounts or the testnet-visibility boundary, and nothing persists
+  beyond the session.
+- **FR-017**: The ACTIVE account's card carries its portfolio total for quick
+  access, appearing only once real data is available (never a fabricated $0
+  while loading).
+
 ## Assumptions
 
-- The Activity view is the default lower-half view (mirrors the reference
-  design, where recent transactions sit directly under the cards).
+- ~~The Activity view is the default lower-half view~~ — superseded by
+  FR-006a above: Portfolio is the default (post-launch feedback).
 - The wallet-button dropdown's account switcher remains in place as a quick
   shortcut; this feature unifies the *viewing* experience without removing
   the dropdown (both drive the same underlying selection).

--- a/specs/074-unified-my-account/tasks.md
+++ b/specs/074-unified-my-account/tasks.md
@@ -160,6 +160,35 @@ Quick Access navigates to the new path.
       override, and the portfolio redirect; note the change in
       `CLAUDE.md` guardrails if reviewers deem it durable.
 
+## Phase 8: Post-launch feedback amendment (2026-08-03)
+
+**Goal**: first-use feedback — Portfolio-first, cleaner Activity, theme-aware
+cards, minimal dots, instant portfolio data, card total (contract U1/U2/U4,
+C7/C8, V1/V3, F1–F3, P1–P3).
+
+- [X] T020 Reorder `ACCOUNT_VIEWS` (Portfolio first) and set
+      `ACCOUNT_DEFAULT_VIEW = 'portfolio'` in `frontend/src/config/appNav.js`.
+- [X] T021 Theme-aware account cards + minimal position dots in
+      `frontend/src/components/account/AccountCardsCarousel.css` (surface
+      tokens + per-kind accent edge; dots pinned against App.css's mobile
+      tap-target rule with a clipped-background 6px visual / 22px hit area).
+- [X] T022 Quick-access total on the active card:
+      `AccountCardsCarousel({ activeTotalUsd })`, rendered only when real
+      data is ready; wired from MyAccountView's shared portfolio instance.
+- [X] T023 Move `ActivityBreakdowns` from the Activity view to the Stats view
+      in `frontend/src/components/account/MyAccountView.jsx`.
+- [X] T024 Rework `frontend/src/components/account/RecentActivityFeed.jsx`:
+      filter chips → Filter-button dropdown (menuitemradio), search behind a
+      Search icon (kind/token/amount/txHash/reason matching), honest
+      "no matching activity" state; `search` glyph added to NavIcon.
+- [X] T025 Portfolio snapshot cache in `frontend/src/hooks/usePortfolio.js`
+      (session-memory, keyed account+scope, hydrate-then-refresh) and ONE
+      shared portfolio instance in MyAccountView handed to `PortfolioPanel`
+      (new optional `portfolio` prop, self-loading wrapper preserved).
+- [X] T026 Update Vitest suites (MyAccountView, axe, carousel, feed,
+      usePortfolio cache, WalletPage/collectibles portfolio mocks) and the
+      spec/contract/docs artifacts for the amendment.
+
 ## Dependencies
 
 ```text


### PR DESCRIPTION
## Summary

First-use feedback on the unified My Account view shipped in #1008, recorded as a 2026-08-03 amendment to `specs/074-unified-my-account/` (spec FR-006a/b + FR-014–017, contract U/C/V/F/P items, tasks Phase 8).

## What changed

**Carousel**
- **Cards are theme-aware**: theme surface tokens + a per-kind accent edge (green personal / blue multisig / amber recovered) replace the fixed black palette, so they read correctly in light and dark mode.
- **Position dots are minimal**: root cause was App.css's mobile tap-target rule (`button:not([role="switch"]) { min-width/min-height: 44px; padding: … }`) outranking the dot class and inflating each dot to ~70px. Dots are now a 6px visual inside a ~22px `background-clip: content-box` touch target, pinned with a higher-specificity selector.
- **Quick-access total**: the active card shows the account's portfolio total — only once real data is ready, never a fabricated $0 while loading.

**Views**
- **Portfolio is the first/default view** (`ACCOUNT_DEFAULT_VIEW`), first in both switchers; unknown `?view=` values fall back to it. `?view=activity` deep-links the feed.
- **Activity is a clean feed**: the by-status / by-token / by-resolution breakdowns moved to **Stats** (beside the tiles and chart). Class filters moved behind a **Filter button** (dropdown of `menuitemradio` options, active class badged on the button) and a **Search icon** toggles a field matching kind, token, amount (raw or USD), tx hash, and failure reason — with an honest "no matching activity" state.

**Portfolio freshness**
- `usePortfolio` gained a session-memory snapshot cache keyed by account + scan scope: remounting hydrates the last real snapshot immediately (original `lastUpdated` intact) while a fresh read runs in the background — no more "Loading portfolio…" for data the session already has. Snapshots never cross accounts or the testnet-visibility boundary; nothing persists across reloads.
- `MyAccountView` mounts ONE shared portfolio instance (starts warming the moment My Account opens, whichever view shows) feeding both the card total and `PortfolioPanel` via a new optional `portfolio` prop (the panel still self-loads without it — no conditional hooks).

## Test plan

- Updated/extended suites: `MyAccountView.test.jsx` (new defaults, breakdown placement, card total, acting pass-through to the shared portfolio), `MyAccountView.axe.test.jsx` (axe on all three views), `AccountCardsCarousel.test.jsx` (active-card total, no-fabricated-$0), `RecentActivityFeed.test.jsx` (filter dropdown, search incl. tx-hash lookup, honest no-match state), `usePortfolio.test.jsx` (snapshot-cache hydrate-then-refresh), plus portfolio-hook mocks in `WalletPage.test.jsx` / `walletPageCollectibles.test.jsx`.
- 30 suites / 250 tests green; frontend ESLint 0 errors (18 pre-existing warnings in untouched files); `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je4L8CUjjvskvXuC2EoFEu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Je4L8CUjjvskvXuC2EoFEu)_