### PR TITLE
Add group-by control to the activity feed

### DIFF
--- a/frontend/src/components/account/RecentActivityFeed.css
+++ b/frontend/src/components/account/RecentActivityFeed.css
@@ -130,6 +130,23 @@
   flex-direction: column;
 }
 
+/* Date-group header (spec 074 follow-up, default "by day"): deliberately
+   understated — small, muted, uppercase — with extra breathing room above it
+   so a new bucket reads as a soft line break rather than a loud section. */
+.account-feed-group-header {
+  padding: 14px 2px 4px;
+  margin: 0;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted, var(--text-secondary));
+}
+
+.account-feed-group-header:first-child {
+  padding-top: 0;
+}
+
 .account-feed-row {
   display: flex;
   align-items: center;

--- a/frontend/src/components/account/RecentActivityFeed.jsx
+++ b/frontend/src/components/account/RecentActivityFeed.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { getNetwork } from '../../config/networks'
-import { formatUsd, formatRelativeTime } from '../../lib/account/format'
+import { formatUsd, formatRelativeTime, dayGroupLabel, weekGroupLabel } from '../../lib/account/format'
 import SensitiveValue from '../common/SensitiveValue'
 import NavIcon from '../nav/NavIcon'
 import EmptyState from './EmptyState'
@@ -29,6 +29,13 @@ const CLASS_FILTERS = [
   { key: 'earn', label: 'Earn' },
   { key: 'pool', label: 'Pools' },
   { key: 'membership', label: 'Membership' },
+]
+
+/** Group-by options for the activity list (spec 074 follow-up). 'day' is the default. */
+const GROUP_OPTIONS = [
+  { key: 'day', label: 'By day' },
+  { key: 'week', label: 'By week' },
+  { key: 'none', label: 'No grouping' },
 ]
 
 function explorerTxUrl(chainId, txHash) {
@@ -76,24 +83,33 @@ function entryMatchesQuery(e, meta, query) {
  *
  * Spec 074 follow-up: the class-filter chip row moved behind a Filter button
  * (dropdown), and a search field lives behind a Search icon — the feed leads
- * with the transactions themselves, and the tools appear on demand.
+ * with the transactions themselves, and the tools appear on demand. A Group
+ * button (dropdown, default "By day") interleaves subtle date-bucket headers
+ * ahead of the rows they cover.
  */
 function RecentActivityFeed({ entries = [], chainId, staleClasses = [], prunedBefore = null }) {
   const [classFilter, setClassFilter] = useState(null)
   const [filterOpen, setFilterOpen] = useState(false)
+  const [groupBy, setGroupBy] = useState('day')
+  const [groupOpen, setGroupOpen] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
   const [query, setQuery] = useState('')
   const filterRef = useRef(null)
+  const groupRef = useRef(null)
   const searchInputRef = useRef(null)
 
-  // Close the filter dropdown on outside click / Escape.
+  // Close the filter/group dropdowns on outside click / Escape.
   useEffect(() => {
-    if (!filterOpen) return undefined
+    if (!filterOpen && !groupOpen) return undefined
     const onDown = (event) => {
-      if (filterRef.current && !filterRef.current.contains(event.target)) setFilterOpen(false)
+      if (filterOpen && filterRef.current && !filterRef.current.contains(event.target)) setFilterOpen(false)
+      if (groupOpen && groupRef.current && !groupRef.current.contains(event.target)) setGroupOpen(false)
     }
     const onKey = (event) => {
-      if (event.key === 'Escape') setFilterOpen(false)
+      if (event.key === 'Escape') {
+        setFilterOpen(false)
+        setGroupOpen(false)
+      }
     }
     document.addEventListener('mousedown', onDown)
     document.addEventListener('keydown', onKey)
@@ -101,7 +117,7 @@ function RecentActivityFeed({ entries = [], chainId, staleClasses = [], prunedBe
       document.removeEventListener('mousedown', onDown)
       document.removeEventListener('keydown', onKey)
     }
-  }, [filterOpen])
+  }, [filterOpen, groupOpen])
 
   // Opening search focuses the field so "icon → type" is one motion.
   useEffect(() => {
@@ -117,7 +133,27 @@ function RecentActivityFeed({ entries = [], chainId, staleClasses = [], prunedBe
   }, [entries, classFilter, query])
 
   const activeFilter = CLASS_FILTERS.find((f) => f.key === classFilter) || CLASS_FILTERS[0]
+  const activeGroup = GROUP_OPTIONS.find((g) => g.key === groupBy) || GROUP_OPTIONS[0]
   const isFiltering = classFilter != null || query.trim() !== ''
+
+  // Interleave date-group headers (default: by day) ahead of the rows they
+  // cover. Entries arrive newest-first, so same-bucket rows are always
+  // contiguous and a header only needs to print when the bucket changes.
+  const groupedRows = useMemo(() => {
+    if (groupBy === 'none') return rows.map((entry) => ({ type: 'entry', entry }))
+    const labelFor = groupBy === 'week' ? weekGroupLabel : dayGroupLabel
+    const items = []
+    let lastLabel = null
+    for (const entry of rows) {
+      const label = labelFor(entry.timestamp)
+      if (label !== lastLabel) {
+        items.push({ type: 'header', label })
+        lastLabel = label
+      }
+      items.push({ type: 'entry', entry })
+    }
+    return items
+  }, [rows, groupBy])
 
   return (
     <section className="account-feed" aria-label="Recent activity">
@@ -176,6 +212,44 @@ function RecentActivityFeed({ entries = [], chainId, staleClasses = [], prunedBe
               </ul>
             )}
           </div>
+          <div className="account-feed-filter-wrap" ref={groupRef}>
+            <button
+              type="button"
+              className={`account-feed-tool${groupBy !== 'day' ? ' active' : ''}`}
+              aria-label="Group activity"
+              aria-haspopup="menu"
+              aria-expanded={groupOpen}
+              onClick={() => setGroupOpen((o) => !o)}
+            >
+              <NavIcon name="layers" size={16} />
+              {groupBy !== 'day' && (
+                <span className="account-feed-tool-badge">{activeGroup.label}</span>
+              )}
+            </button>
+            {groupOpen && (
+              <ul className="account-feed-filter-menu" role="menu" aria-label="Group activity by">
+                {GROUP_OPTIONS.map((g) => (
+                  <li key={g.key} role="none">
+                    <button
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={groupBy === g.key}
+                      className={`account-feed-filter-option${groupBy === g.key ? ' active' : ''}`}
+                      onClick={() => {
+                        setGroupBy(g.key)
+                        setGroupOpen(false)
+                      }}
+                    >
+                      <span className="account-feed-filter-check" aria-hidden="true">
+                        {groupBy === g.key ? <NavIcon name="check" size={14} /> : null}
+                      </span>
+                      {g.label}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </div>
       </div>
 
@@ -214,7 +288,15 @@ function RecentActivityFeed({ entries = [], chainId, staleClasses = [], prunedBe
         )
       ) : (
         <ul className="account-feed-list">
-          {rows.map((e) => {
+          {groupedRows.map((item, idx) => {
+            if (item.type === 'header') {
+              return (
+                <li key={`group-${idx}`} className="account-feed-group-header" role="presentation">
+                  {item.label}
+                </li>
+              )
+            }
+            const e = item.entry
             const meta = KIND_META[e.kind] || { icon: '•', label: e.kind, tone: 'out' }
             const url = explorerTxUrl(e.chainId ?? chainId, e.txHash)
             const relative = e.timestamp != null ? formatRelativeTime(e.timestamp) : null

--- a/frontend/src/lib/account/format.js
+++ b/frontend/src/lib/account/format.js
@@ -66,3 +66,52 @@ export function signGlyph(n) {
   if (num < 0) return '▼'
   return '—'
 }
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function startOfDay(date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+}
+
+/**
+ * Calendar-day bucket label for the activity feed's "group by day" view
+ * (spec 074 follow-up). Mirrors `formatRelativeTime`'s honesty rule: a
+ * missing/invalid timestamp never gets a fabricated date, it gets its own
+ * named bucket instead.
+ */
+export function dayGroupLabel(ts, now = Date.now()) {
+  const t = Number(ts)
+  if (!Number.isFinite(t) || t <= 0) return 'Undated'
+  const d = new Date(t)
+  const diffDays = Math.round((startOfDay(new Date(now)) - startOfDay(d)) / DAY_MS)
+  if (diffDays === 0) return 'Today'
+  if (diffDays === 1) return 'Yesterday'
+  const sameYear = d.getFullYear() === new Date(now).getFullYear()
+  return d.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    year: sameYear ? undefined : 'numeric',
+  })
+}
+
+function startOfWeek(date) {
+  const offset = (date.getDay() + 6) % 7 // days since Monday
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() - offset).getTime()
+}
+
+/** Calendar-week bucket label ("This week" / "Last week" / "Week of ...") for the activity feed. */
+export function weekGroupLabel(ts, now = Date.now()) {
+  const t = Number(ts)
+  if (!Number.isFinite(t) || t <= 0) return 'Undated'
+  const start = startOfWeek(new Date(t))
+  const diffWeeks = Math.round((startOfWeek(new Date(now)) - start) / (7 * DAY_MS))
+  if (diffWeeks === 0) return 'This week'
+  if (diffWeeks === 1) return 'Last week'
+  const sameYear = new Date(start).getFullYear() === new Date(now).getFullYear()
+  return `Week of ${new Date(start).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: sameYear ? undefined : 'numeric',
+  })}`
+}

--- a/frontend/src/test/account/RecentActivityFeed.test.jsx
+++ b/frontend/src/test/account/RecentActivityFeed.test.jsx
@@ -145,6 +145,33 @@ describe('RecentActivityFeed (spec 051 US1)', () => {
     expect(within(rows[0]).getByText('Payout')).toBeInTheDocument()
   })
 
+  it('groups activity by day by default, with an "Undated" bucket for missing timestamps', () => {
+    render(<RecentActivityFeed entries={entries} chainId={80002} />)
+    // Default grouping shouldn't badge the button — "By day" is the baseline.
+    expect(screen.queryByText('By day')).not.toBeInTheDocument()
+    expect(screen.getByText('Today')).toBeInTheDocument()
+    expect(screen.getByText('Undated')).toBeInTheDocument()
+    // Group headers are presentational, not list rows — order-of-rows checks stay unaffected.
+    const rows = screen.getAllByRole('listitem')
+    expect(within(rows[0]).getByText('Payout')).toBeInTheDocument()
+  })
+
+  it('switches grouping via the Group control (spec 074 follow-up)', async () => {
+    const user = userEvent.setup()
+    render(<RecentActivityFeed entries={entries} chainId={80002} />)
+    await user.click(screen.getByRole('button', { name: /group activity/i }))
+    expect(screen.getByRole('menuitemradio', { name: 'By day' })).toHaveAttribute('aria-checked', 'true')
+    await user.click(screen.getByRole('menuitemradio', { name: 'No grouping' }))
+    expect(screen.queryByText('Today')).not.toBeInTheDocument()
+    expect(screen.queryByText('Undated')).not.toBeInTheDocument()
+    expect(screen.getByText('No grouping')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /group activity/i }))
+    await user.click(screen.getByRole('menuitemradio', { name: 'By week' }))
+    expect(screen.getByText('This week')).toBeInTheDocument()
+    expect(screen.getByText('Undated')).toBeInTheDocument()
+  })
+
   it('discloses stale classes and the pruning marker', () => {
     render(
       <RecentActivityFeed

--- a/frontend/src/test/account/format.test.js
+++ b/frontend/src/test/account/format.test.js
@@ -4,7 +4,7 @@
  * ("20645d ago"); callers show an explicit "date unavailable" state on null.
  */
 import { describe, it, expect } from 'vitest'
-import { formatRelativeTime } from '../../lib/account/format'
+import { formatRelativeTime, dayGroupLabel, weekGroupLabel } from '../../lib/account/format'
 
 const NOW = Date.UTC(2026, 6, 11)
 
@@ -28,5 +28,51 @@ describe('formatRelativeTime (FR-006)', () => {
 
   it('clamps future timestamps to "0s ago" rather than negative time', () => {
     expect(formatRelativeTime(NOW + 60_000, NOW)).toBe('0s ago')
+  })
+})
+
+/**
+ * Spec 074 follow-up — the activity feed's Group control (default "By day").
+ * Uses local-time constructors (not Date.UTC) to match dayGroupLabel/
+ * weekGroupLabel's local calendar-day math, and noon anchors to stay clear
+ * of day/week boundary edge cases regardless of the test runner's timezone.
+ */
+const NOW_LOCAL = new Date(2026, 6, 11, 12, 0, 0).getTime() // Saturday, Jul 11 2026
+
+describe('dayGroupLabel (spec 074 follow-up)', () => {
+  it('labels missing/invalid timestamps as "Undated" without fabricating a date', () => {
+    for (const bad of [0, -1, null, undefined, NaN]) {
+      expect(dayGroupLabel(bad, NOW_LOCAL)).toBe('Undated')
+    }
+  })
+
+  it('labels the current calendar day "Today" and the prior day "Yesterday"', () => {
+    expect(dayGroupLabel(NOW_LOCAL, NOW_LOCAL)).toBe('Today')
+    expect(dayGroupLabel(NOW_LOCAL - 24 * 60 * 60 * 1000, NOW_LOCAL)).toBe('Yesterday')
+  })
+
+  it('formats older same-year dates without a year, and cross-year dates with one', () => {
+    const sameYear = new Date(2026, 0, 2, 12).getTime()
+    expect(dayGroupLabel(sameYear, NOW_LOCAL)).not.toMatch(/2026/)
+    const lastYear = new Date(2025, 5, 2, 12).getTime()
+    expect(dayGroupLabel(lastYear, NOW_LOCAL)).toMatch(/2025/)
+  })
+})
+
+describe('weekGroupLabel (spec 074 follow-up)', () => {
+  it('labels missing/invalid timestamps as "Undated"', () => {
+    for (const bad of [0, -1, null, undefined, NaN]) {
+      expect(weekGroupLabel(bad, NOW_LOCAL)).toBe('Undated')
+    }
+  })
+
+  it('labels the current calendar week "This week" and the prior week "Last week"', () => {
+    expect(weekGroupLabel(NOW_LOCAL, NOW_LOCAL)).toBe('This week')
+    expect(weekGroupLabel(NOW_LOCAL - 7 * 24 * 60 * 60 * 1000, NOW_LOCAL)).toBe('Last week')
+  })
+
+  it('formats older weeks as "Week of <date>"', () => {
+    const older = new Date(2026, 0, 5, 12).getTime()
+    expect(weekGroupLabel(older, NOW_LOCAL)).toMatch(/^Week of /)
   })
 })


### PR DESCRIPTION
## Summary
- Adds a "Group activity" control (dropdown: By day / By week / No grouping) to the Account tab's Recent activity view, next to the existing Search and Filter tools.
- Grouping defaults to **by day** as requested.
- Groups render as subtle date-bucket headers ahead of the rows they cover — small, uppercase, muted text with extra spacing above each new bucket — so the grouping reads as a soft visual break rather than a loud divider.
- Entries with no valid timestamp bucket under "Undated" rather than fabricating a date (consistent with the feed's existing "date unavailable" honesty rule).
- Adds `dayGroupLabel`/`weekGroupLabel` helpers to `frontend/src/lib/account/format.js`.

## Test plan
- [x] `npx vitest run src/test/account/RecentActivityFeed.test.jsx` — 12/12 passing (2 new tests for the group control)
- [x] `npx vitest run src/test/account/format.test.js` — 10/10 passing (new unit tests for the grouping label helpers)
- [x] `npx eslint` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Yec9PVDWtALDK3GbHzQVW)_