### PR TITLE
App Store: filter behind a button, category grouping, favorites in Quick Access

### DIFF
--- a/frontend/src/components/miniapps/CatalogPanel.jsx
+++ b/frontend/src/components/miniapps/CatalogPanel.jsx
@@ -30,12 +30,18 @@
  * Search and the six operational-category filters (FR-008) are plain buttons and a plain search
  * input — keyboard operable by construction — with a polite live region announcing the result count
  * so a screen-reader user learns that a filter changed the list rather than having to go find out.
+ * The category chips sit behind a disclosure button inline with the search box rather than always
+ * on screen — the button's own label carries the active count, so collapsing them never hides
+ * *that* a filter is applied, only the chips used to change it. The visible list is then grouped
+ * under a heading per category (FR-007's category is otherwise readable only per-card), in the
+ * same on-chain enum order the chip row already uses, so browsing and filtering agree on one order.
  */
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import './miniapps.css'
 import SubmitAppPanel from './SubmitAppPanel'
 import EmptyState from '../account/EmptyState'
+import NavIcon from '../nav/NavIcon'
 import { APP_CATEGORY_LABELS } from '../../abis/miniAppRegistry'
 import { networkName } from '../../lib/chains/estate'
 import {
@@ -44,6 +50,7 @@ import {
   appSlug,
   fetchCatalog,
 } from '../../lib/miniapps/registryClient'
+import { loadFavoriteApps, subscribeFavoriteApps, toggleFavoriteApp } from '../../lib/miniapps/favorites'
 
 /**
  * Where a developer goes to submit an app or a version update (FR-021).
@@ -94,7 +101,7 @@ function formatAge(ms) {
 /**
  * One catalog entry: name, vendor, version, category (FR-007) plus its launch affordance.
  *
- * Two independent things can withhold that affordance, and each says which one it was:
+ * Two independent things can withhold the launch affordance, and each says which one it was:
  *
  *   - `launchable` is about the LISTING's provenance, not the app's — false only when this card came
  *     from an unverified snapshot, in which case no launch link is rendered at all. A disabled button
@@ -104,20 +111,40 @@ function formatAge(ms) {
  *     lossy best effort there on purpose (two distinct on-chain listings must never collapse onto one
  *     address), so the app is genuinely unreachable by URL. Rendering `/apps/null` would be a link
  *     the catalog knows lands nowhere.
+ *
+ * The favorite star shares the second condition: a shortcut into the nav drawer's Quick Access
+ * group is a link like any other, so it needs the same working slug the Launch button does. It is
+ * withheld silently rather than shown disabled, for the same reason Launch is.
  */
-function AppCard({ app, launchable }) {
+function AppCard({ app, launchable, isFavorite, onToggleFavorite }) {
   const nameId = `miniapp-${app.id}-name`
   const descriptionId = `miniapp-${app.id}-description`
   // An on-chain enum may gain values ahead of this build's label map. Naming the raw ordinal is
   // honest; folding an unknown category into a familiar label would misfile the app.
   const categoryLabel = APP_CATEGORY_LABELS[app.category] ?? `Category ${app.category}`
   const slug = appSlug(app.name)
+  const canFavorite = launchable && Boolean(slug)
 
   return (
     <li className="miniapp-card">
-      <h4 className="miniapp-card-name" id={nameId}>
-        {app.name}
-      </h4>
+      <div className="miniapp-card-head">
+        <h5 className="miniapp-card-name" id={nameId}>
+          {app.name}
+        </h5>
+        {canFavorite && (
+          <button
+            type="button"
+            className={`miniapp-card-favorite${isFavorite ? ' is-active' : ''}`}
+            aria-pressed={isFavorite}
+            aria-label={
+              isFavorite ? `Remove ${app.name} from Quick Access` : `Add ${app.name} to Quick Access`
+            }
+            onClick={() => onToggleFavorite(app, slug)}
+          >
+            <NavIcon name="star" size={16} />
+          </button>
+        )}
+      </div>
       <p className="miniapp-card-category">{categoryLabel}</p>
       {app.description && (
         <p className="miniapp-card-description" id={descriptionId}>
@@ -175,9 +202,23 @@ function CatalogView() {
   const [reloadKey, setReloadKey] = useState(0)
   const [query, setQuery] = useState('')
   const [selectedCategories, setSelectedCategories] = useState(() => new Set())
+  // The category chip row starts collapsed behind the Filter button — see the module header.
+  const [filtersOpen, setFiltersOpen] = useState(false)
+  const [favoriteIds, setFavoriteIds] = useState(() => new Set(loadFavoriteApps().map((fav) => fav.id)))
 
   const outcome = catalogRead.outcome
   const refreshing = catalogRead.key !== reloadKey
+
+  // Reflects changes made from either surface that touches favorites (this panel, or a removal from
+  // the nav drawer's Quick Access group) without threading state between them.
+  useEffect(
+    () => subscribeFavoriteApps(() => setFavoriteIds(new Set(loadFavoriteApps().map((fav) => fav.id)))),
+    [],
+  )
+
+  function handleToggleFavorite(app, slug) {
+    toggleFavoriteApp({ id: app.id, slug, name: app.name })
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -249,6 +290,32 @@ function CatalogView() {
       )
     })
   }, [listing, query, selectedCategories])
+
+  /**
+   * `visible`, grouped under a heading per category (FR-007) in the chip row's own order.
+   *
+   * A category ordinal ahead of this build's label map (see `AppCard`'s fallback) still gets a
+   * group — under its raw ordinal — rather than being dropped: grouping must never quietly shrink
+   * the list `visible` already promised via the result count above it.
+   */
+  const groupedVisible = useMemo(() => {
+    const byCategory = new Map()
+    for (const app of visible) {
+      const bucket = byCategory.get(app.category)
+      if (bucket) bucket.push(app)
+      else byCategory.set(app.category, [app])
+    }
+    const groups = []
+    for (const category of CATEGORY_FILTERS) {
+      const apps = byCategory.get(category.value)
+      if (apps?.length) groups.push({ key: category.value, label: category.label, apps })
+      byCategory.delete(category.value)
+    }
+    for (const [value, apps] of byCategory) {
+      groups.push({ key: value, label: `Category ${value}`, apps })
+    }
+    return groups
+  }, [visible])
 
   function toggleCategory(value) {
     setSelectedCategories((current) => {
@@ -346,37 +413,60 @@ function CatalogView() {
 
       {showControls && (
         <div className="miniapp-catalog-controls">
-          <label className="miniapp-catalog-search">
-            <span className="sr-only">Search apps by name or description</span>
-            <input
-              type="search"
-              placeholder="Search apps…"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-            />
-          </label>
+          <div className="miniapp-catalog-searchrow">
+            <label className="miniapp-catalog-search">
+              <span className="sr-only">Search apps by name or description</span>
+              <input
+                type="search"
+                placeholder="Search apps…"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+              />
+            </label>
 
-          <div className="miniapp-catalog-filters" role="group" aria-label="Filter by operational category">
+            {/* The chip row itself is the state; this button only shows/hides it, so its own
+                pressed state is the disclosure — the active count stays on the label so closing
+                the panel never hides THAT a filter is applied, only the chips that set it. */}
             <button
               type="button"
-              className={`miniapp-catalog-filter${selectedCategories.size === 0 ? ' is-active' : ''}`}
-              aria-pressed={selectedCategories.size === 0}
-              onClick={() => setSelectedCategories(new Set())}
+              className={`miniapp-catalog-filter-toggle${selectedCategories.size > 0 ? ' is-active' : ''}`}
+              aria-expanded={filtersOpen}
+              aria-controls={filtersOpen ? 'miniapp-catalog-filters' : undefined}
+              onClick={() => setFiltersOpen((open) => !open)}
             >
-              All categories
+              <NavIcon name="sliders" size={16} />
+              Filter{selectedCategories.size > 0 ? ` (${selectedCategories.size})` : ''}
             </button>
-            {CATEGORY_FILTERS.map((category) => (
-              <button
-                key={category.value}
-                type="button"
-                className={`miniapp-catalog-filter${selectedCategories.has(category.value) ? ' is-active' : ''}`}
-                aria-pressed={selectedCategories.has(category.value)}
-                onClick={() => toggleCategory(category.value)}
-              >
-                {category.label}
-              </button>
-            ))}
           </div>
+
+          {filtersOpen && (
+            <div
+              className="miniapp-catalog-filters"
+              id="miniapp-catalog-filters"
+              role="group"
+              aria-label="Filter by operational category"
+            >
+              <button
+                type="button"
+                className={`miniapp-catalog-filter${selectedCategories.size === 0 ? ' is-active' : ''}`}
+                aria-pressed={selectedCategories.size === 0}
+                onClick={() => setSelectedCategories(new Set())}
+              >
+                All categories
+              </button>
+              {CATEGORY_FILTERS.map((category) => (
+                <button
+                  key={category.value}
+                  type="button"
+                  className={`miniapp-catalog-filter${selectedCategories.has(category.value) ? ' is-active' : ''}`}
+                  aria-pressed={selectedCategories.has(category.value)}
+                  onClick={() => toggleCategory(category.value)}
+                >
+                  {category.label}
+                </button>
+              ))}
+            </div>
+          )}
 
           {/* Polite live region: a filter or search term changes the grid silently for a screen-reader
               user, so the resulting count is announced rather than left to be discovered. */}
@@ -404,13 +494,28 @@ function CatalogView() {
         />
       )}
 
-      {visible.length > 0 && (
-        <ul className="miniapp-catalog-grid">
-          {visible.map((app) => (
-            <AppCard key={app.id} app={app} launchable={listing.verified} />
-          ))}
-        </ul>
-      )}
+      {groupedVisible.map((group) => (
+        <section
+          key={group.key}
+          className="miniapp-catalog-group"
+          aria-labelledby={`miniapp-catalog-group-${group.key}`}
+        >
+          <h4 className="miniapp-catalog-group-title" id={`miniapp-catalog-group-${group.key}`}>
+            {group.label}
+          </h4>
+          <ul className="miniapp-catalog-grid">
+            {group.apps.map((app) => (
+              <AppCard
+                key={app.id}
+                app={app}
+                launchable={listing.verified}
+                isFavorite={favoriteIds.has(app.id)}
+                onToggleFavorite={handleToggleFavorite}
+              />
+            ))}
+          </ul>
+        </section>
+      ))}
     </section>
   )
 }

--- a/frontend/src/components/miniapps/miniapps.css
+++ b/frontend/src/components/miniapps/miniapps.css
@@ -141,6 +141,17 @@
   flex-direction: column;
   gap: 0.6rem;
 }
+/* Search box and the Filter disclosure sit on one row (the request this satisfies: category
+   chips move behind a Filter button inline with search, rather than always on screen). */
+.miniapp-catalog-searchrow {
+  align-items: stretch;
+  display: flex;
+  gap: 0.5rem;
+}
+.miniapp-catalog-search {
+  flex: 1 1 auto;
+  min-width: 0;
+}
 .miniapp-catalog-search input {
   background: var(--surface-color, #fff);
   border: 1px solid var(--border-color, #e3e7eb);
@@ -153,6 +164,35 @@
 .miniapp-catalog-search input:focus-visible {
   outline: 2px solid var(--brand-primary, #36b37e);
   outline-offset: 1px;
+}
+
+.miniapp-catalog-filter-toggle {
+  align-items: center;
+  background: transparent;
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 10px;
+  color: var(--text-primary, #1f2933);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 0.85rem;
+  gap: 0.35rem;
+  padding: 0 0.85rem;
+  white-space: nowrap;
+}
+.miniapp-catalog-filter-toggle:hover {
+  border-color: var(--brand-primary, #36b37e);
+}
+.miniapp-catalog-filter-toggle:focus-visible {
+  outline: 2px solid var(--brand-primary, #36b37e);
+  outline-offset: 2px;
+}
+/* A category is selected: marked by weight + a tinted background, not colour alone — the label's
+   own "(N)" count is the third, text-based signal. */
+.miniapp-catalog-filter-toggle.is-active {
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 14%, transparent);
+  border-color: var(--brand-primary, #36b37e);
+  font-weight: 600;
 }
 
 .miniapp-catalog-filters {
@@ -191,6 +231,22 @@
   margin: 0;
 }
 
+/* ---- Category groups ---------------------------------------------------- */
+
+.miniapp-catalog-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.miniapp-catalog-group-title {
+  color: var(--text-secondary, #5a6772);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
 /* ---- Catalog grid ------------------------------------------------------ */
 
 .miniapp-catalog-grid {
@@ -211,11 +267,42 @@
   gap: 0.4rem;
   padding: 0.85rem 0.9rem;
 }
+.miniapp-card-head {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
 .miniapp-card-name {
   color: var(--text-primary, #1f2933);
   font-size: 0.98rem;
   line-height: 1.3;
   margin: 0;
+}
+/* Star toggle for Quick Access (nav drawer). Filled + brand colour when favorited — a shape
+   change, not just a colour change, so the state reads without relying on hue (WCAG 1.4.1). */
+.miniapp-card-favorite {
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-secondary, #5a6772);
+  cursor: pointer;
+  flex: 0 0 auto;
+  line-height: 0;
+  padding: 0.2rem;
+}
+.miniapp-card-favorite:hover {
+  color: var(--brand-primary, #36b37e);
+}
+.miniapp-card-favorite:focus-visible {
+  outline: 2px solid var(--brand-primary, #36b37e);
+  outline-offset: 2px;
+}
+.miniapp-card-favorite.is-active {
+  color: var(--brand-primary, #36b37e);
+}
+.miniapp-card-favorite.is-active .nav-icon {
+  fill: currentColor;
 }
 .miniapp-card-category {
   color: var(--text-secondary, #5a6772);

--- a/frontend/src/components/nav/AppNavDrawer.jsx
+++ b/frontend/src/components/nav/AppNavDrawer.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useNavDrawer } from '../../contexts/NavDrawerContext.js'
 import { useIsMobile } from '../../hooks/useMediaQuery'
@@ -12,10 +12,12 @@ import {
   NAV_GROUPS,
   pathForNavItem,
   visibleNavGroups,
+  isNavItemEnabledForTenant,
 } from '../../config/appNav'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { collectiblesGatewayUrl } from '../../lib/collectibles/gatewayClient'
 import { predictGatewayUrl } from '../../lib/predict/predictClient'
+import { loadFavoriteApps, subscribeFavoriteApps } from '../../lib/miniapps/favorites'
 import './AppNavDrawer.css'
 
 // Deep-link alias parity with WalletPage (the Swap tab is now "Trade"; the
@@ -41,24 +43,32 @@ const TAB_ALIASES = { swap: 'trade', backup: 'security' }
  */
 const TAB_TO_MINIAPP = { tokens: 'apps', clearpath: 'apps' }
 
-// The drawer list = a top "Quick Access" group (Home, Portfolio) + the section groups. Built per
-// render because item visibility is chain-aware (spec 055: Collectibles hides entirely on networks
-// OpenSea doesn't serve or with no gateway configured).
+// The drawer list = a top "Quick Access" group (Home, Portfolio, favorited mini-apps) + the
+// section groups. Built per render because item visibility is chain-aware (spec 055: Collectibles
+// hides entirely on networks OpenSea doesn't serve or with no gateway configured).
 //
 // Wagers used to be spliced into the Apps group here, because it was an absolute `/wagers` route
 // rather than a `/wallet?tab=` section and so was not carried by NAV_GROUPS' tenant filter. That
 // splice is gone: Wagers is now a view inside Finance ▸ Transfer (spec 073), reached through the
 // Transfer entry NAV_GROUPS already carries, and gated by PayTransferPanel on the same `wagers`
 // tenant feature. One fewer place for the menu and the routes to disagree.
-function buildDrawerGroups(visibility) {
+function buildDrawerGroups(visibility, favoriteItems) {
   return [
-    { label: 'Quick Access', items: [HOME_ITEM, PORTFOLIO_ITEM] },
+    { label: 'Quick Access', items: [HOME_ITEM, PORTFOLIO_ITEM, ...favoriteItems] },
     ...visibleNavGroups(visibility, NAV_GROUPS),
   ]
 }
 
+// `favorites.js` entries -> drawer items. `showIcon` opts into PortalNav's initial-letter fallback
+// (the on-chain registry carries no app icon, so the first letter of its name stands in for one,
+// same as any other icon-less drawer entry would in the collapsed rail) so a favorited app is
+// recognisable at a glance in the EXPANDED menu too, not just the icon-only gutter.
+function favoriteToNavItem(favorite) {
+  return { id: `favorite-${favorite.id}`, label: favorite.name, to: `/apps/${favorite.slug}`, showIcon: true }
+}
+
 // Which drawer entry reflects the current route, so the open menu highlights it.
-function resolveActiveId(location) {
+function resolveActiveId(location, favoriteItems) {
   const { pathname, search } = location
   if (pathname === '/wallet') {
     const requested = new URLSearchParams(search).get('tab')
@@ -75,12 +85,15 @@ function resolveActiveId(location) {
     return WAGERS_VIEW.tab
   }
   // A mounted mini-app (`/apps/<slug>`, spec 073) IS the Apps section — the workspace is
-  // where a catalog launch lands. Highlighting the catalog entry keeps the menu pointing at
-  // where the member actually is, instead of showing nothing selected for the entire time an
-  // app is open. The trailing slash is part of the match so a future top-level route that
-  // merely starts with those letters cannot borrow the highlight.
+  // where a catalog launch lands. A favorited app highlights its OWN Quick Access shortcut
+  // instead, so the member sees exactly which shortcut brought them here; everything else
+  // falls back to the catalog entry, so nothing is left unselected for the entire time an app
+  // is open. The trailing slash is part of the match so a future top-level route that merely
+  // starts with those letters cannot borrow the highlight.
   if (pathname === '/apps' || pathname.startsWith('/apps/')) {
-    return 'apps'
+    const slug = pathname === '/apps' ? '' : pathname.slice('/apps/'.length)
+    const favoriteMatch = favoriteItems.find((item) => item.to === `/apps/${slug}`)
+    return favoriteMatch ? favoriteMatch.id : 'apps'
   }
   return null
 }
@@ -98,17 +111,31 @@ export default function AppNavDrawer() {
   const { isOpen, close, toggle } = useNavDrawer()
   const navigate = useNavigate()
   const location = useLocation()
-  const activeId = resolveActiveId(location)
   const { capabilities } = useChainTokens()
   const isMobile = useIsMobile()
   const drawerRef = useRef(null)
+
+  // Favorited mini-apps (App Store quick-access). Gated on the `apps` tenant feature so a build
+  // that has disabled the mini-app platform never surfaces a shortcut into it, even if a favorite
+  // was saved on this device before the tenant config changed.
+  const [favorites, setFavorites] = useState(() => loadFavoriteApps())
+  useEffect(() => subscribeFavoriteApps(() => setFavorites(loadFavoriteApps())), [])
+  const favoriteItems = useMemo(
+    () => (isNavItemEnabledForTenant('apps') ? favorites.map(favoriteToNavItem) : []),
+    [favorites],
+  )
+
+  const activeId = resolveActiveId(location, favoriteItems)
   const drawerGroups = useMemo(
     () =>
-      buildDrawerGroups({
-        collectibles: Boolean(capabilities?.collectibles) && collectiblesGatewayUrl() !== '',
-        predict: Boolean(capabilities?.predict) && predictGatewayUrl() !== '',
-      }),
-    [capabilities],
+      buildDrawerGroups(
+        {
+          collectibles: Boolean(capabilities?.collectibles) && collectiblesGatewayUrl() !== '',
+          predict: Boolean(capabilities?.predict) && predictGatewayUrl() !== '',
+        },
+        favoriteItems,
+      ),
+    [capabilities, favoriteItems],
   )
 
   // Desktop never fully closes: `collapsed` is the icon gutter, `isOpen` is the
@@ -139,7 +166,8 @@ export default function AppNavDrawer() {
   }, [isOpen, isMobile, close])
 
   const handleSelect = (id) => {
-    navigate(pathForNavItem(id))
+    const favorite = favoriteItems.find((item) => item.id === id)
+    navigate(favorite ? favorite.to : pathForNavItem(id))
     close()
   }
 

--- a/frontend/src/components/ui/PortalNav.jsx
+++ b/frontend/src/components/ui/PortalNav.jsx
@@ -20,6 +20,11 @@
  * than dropped — the button keeps its accessible name, so screen readers and
  * `getByRole('tab', { name })` see the same rail collapsed or expanded. Group
  * headings become hairline rules (a 200px-wide word cannot survive a 64px rail).
+ *
+ * An item with no `icon` renders no icon tile when expanded (text only) unless it
+ * opts in with `showIcon: true`, in which case it gets the same initial-letter
+ * fallback the collapsed rail always shows — for entries whose glyph IS their
+ * name, like a favorited mini-app's Quick Access shortcut.
  */
 import { Fragment } from 'react'
 import NavIcon from '../nav/NavIcon'
@@ -52,8 +57,9 @@ export default function PortalNav({
     >
       {/* Collapsed, an icon-less item would be an unreadable blank row, so the
           rail falls back to its initial. Expanded, it keeps rendering exactly
-          what it did before: nothing at all. */}
-      {(item.icon || collapsed) && (
+          what it did before — nothing at all — unless the item opted into the
+          fallback via `showIcon`. */}
+      {(item.icon || item.showIcon || collapsed) && (
         <span className="portal-nav-item-icon" aria-hidden="true">
           {item.icon ? <NavIcon name={item.icon} /> : <span className="portal-nav-item-initial">{item.label?.[0]}</span>}
         </span>

--- a/frontend/src/lib/miniapps/favorites.js
+++ b/frontend/src/lib/miniapps/favorites.js
@@ -1,0 +1,118 @@
+/**
+ * Favorited mini-apps — Quick Access shortcuts (App Store UI, follow-up to spec 073).
+ *
+ * Mirrors `lib/network/endpointStore.js`: a device-scoped entry in the global preference blob
+ * (`utils/userStorage#saveGlobalPreference`), a lazily-loaded in-memory snapshot, and a revision
+ * counter so React consumers (the catalog panel and the nav drawer) can react to a change made in
+ * either surface without prop-drilling.
+ *
+ * Device-scoped rather than synced (spec 032 backup): a favorite is a per-device shortcut to a
+ * spot in the nav, not account data worth exporting, and this keeps it out of the plaintext-at-rest
+ * backup blob for the same reason `network_endpoints` stays out of it.
+ *
+ * An entry stores the registry id (immutable, the true identity — see `appNamespaceKey` in
+ * `registryClient.js`) alongside the slug and name captured at favorite-time, so the drawer can
+ * render a link and a label without re-reading the registry. A vendor rename after the fact leaves
+ * a stale label/slug until the member re-favorites; that is an acceptable staleness for a shortcut,
+ * not a trust boundary the way the catalog listing itself is.
+ */
+import { getGlobalPreference, saveGlobalPreference } from '../../utils/userStorage'
+
+/** Global-preference key holding the favorited app list. */
+export const FAVORITES_PREF_KEY = 'miniapp_favorites'
+
+function normalizeEntry(raw) {
+  const id = Number(raw?.id)
+  const slug = typeof raw?.slug === 'string' ? raw.slug : ''
+  const name = typeof raw?.name === 'string' ? raw.name : ''
+  if (!Number.isInteger(id) || id <= 0 || !slug || !name) return null
+  return { id, slug, name }
+}
+
+function readFromStorage() {
+  const raw = getGlobalPreference(FAVORITES_PREF_KEY, [])
+  if (!Array.isArray(raw)) return []
+  const seen = new Set()
+  const out = []
+  for (const rawEntry of raw) {
+    const entry = normalizeEntry(rawEntry)
+    if (!entry || seen.has(entry.id)) continue
+    seen.add(entry.id)
+    out.push(entry)
+  }
+  return out
+}
+
+/** @type {Array<{id:number, slug:string, name:string}>|null} lazily loaded snapshot */
+let snapshot = null
+/** Bumped on every change so React consumers can re-derive their lists. */
+let revision = 0
+const listeners = new Set()
+
+/** The full favorites list, newest last. Never returns null. */
+export function loadFavoriteApps() {
+  if (snapshot === null) snapshot = readFromStorage()
+  return snapshot
+}
+
+export function isFavoriteApp(id) {
+  const numericId = Number(id)
+  return loadFavoriteApps().some((fav) => fav.id === numericId)
+}
+
+/** Monotonic counter that changes whenever the favorites list changes. */
+export function favoritesRevision() {
+  return revision
+}
+
+/** Subscribe to favorites changes. Returns an unsubscribe function. */
+export function subscribeFavoriteApps(listener) {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function commit(next) {
+  snapshot = next
+  revision += 1
+  saveGlobalPreference(FAVORITES_PREF_KEY, next)
+  for (const listener of listeners) {
+    try {
+      listener(revision)
+    } catch {
+      // A bad subscriber must not break the save.
+    }
+  }
+}
+
+/**
+ * Add an app to Quick Access. A no-op when the app can't be identified (no registry id, slug or
+ * name — the three things a shortcut needs) or is already favorited.
+ */
+export function addFavoriteApp({ id, slug, name } = {}) {
+  const entry = normalizeEntry({ id, slug, name })
+  if (!entry) return
+  const current = loadFavoriteApps()
+  if (current.some((fav) => fav.id === entry.id)) return
+  commit([...current, entry])
+}
+
+/** Drop an app from Quick Access. A no-op when it wasn't favorited. */
+export function removeFavoriteApp(id) {
+  const numericId = Number(id)
+  const current = loadFavoriteApps()
+  const next = current.filter((fav) => fav.id !== numericId)
+  if (next.length === current.length) return
+  commit(next)
+}
+
+export function toggleFavoriteApp(app) {
+  if (isFavoriteApp(app?.id)) removeFavoriteApp(app.id)
+  else addFavoriteApp(app)
+}
+
+/** Test seam: forget the in-memory snapshot so the next read hits storage again. */
+export function __resetFavoriteAppsForTests() {
+  snapshot = null
+  revision = 0
+  listeners.clear()
+}

--- a/frontend/src/test/AppNavDrawer.test.jsx
+++ b/frontend/src/test/AppNavDrawer.test.jsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react'
-import { describe, it, expect, afterEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 import AppNavDrawer from '../components/nav/AppNavDrawer'
 import { NavDrawerProvider } from '../contexts/NavDrawerContext.jsx'
 import { useNavDrawer } from '../contexts/NavDrawerContext.js'
+import { addFavoriteApp, __resetFavoriteAppsForTests } from '../lib/miniapps/favorites'
 
 // useIsMobile() reads window.matchMedia('(max-width: 768px)'). setup.js mocks
 // matches: false for every query, i.e. desktop — which these tests rely on
@@ -54,6 +55,11 @@ function renderDrawer(route = '/app') {
 }
 
 describe('AppNavDrawer (global nav drawer)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    __resetFavoriteAppsForTests()
+  })
+
   it('lists Home plus the Finance / Tools / Apps sections', () => {
     const { container } = renderDrawer()
 
@@ -188,5 +194,50 @@ describe('AppNavDrawer (desktop icon gutter)', () => {
     const aside = document.getElementById('app-nav-drawer')
     expect(aside).toHaveAttribute('aria-hidden', 'true')
     expect(aside.className).not.toContain('collapsed')
+  })
+})
+
+// Favorited mini-apps (App Store Quick Access). A favorite is a device-scoped shortcut
+// (lib/miniapps/favorites.js) into `/apps/<slug>`, surfaced alongside Home/Portfolio.
+describe('AppNavDrawer (favorited mini-apps / Quick Access)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    __resetFavoriteAppsForTests()
+  })
+
+  it('lists a favorited app under Quick Access and routes it to its workspace', () => {
+    addFavoriteApp({ id: 12, slug: 'token-mint', name: 'Token Mint' })
+
+    const { container } = renderDrawer()
+
+    expect(screen.getByRole('button', { name: 'Token Mint' })).toBeInTheDocument()
+    const labels = Array.from(
+      container.querySelectorAll('.portal-nav-group-label, .portal-nav-item-label')
+    ).map((el) => el.textContent)
+    const quickAccessIdx = labels.indexOf('Quick Access')
+    const financeIdx = labels.indexOf('Finance')
+    const favoriteIdx = labels.indexOf('Token Mint')
+    expect(favoriteIdx).toBeGreaterThan(quickAccessIdx)
+    expect(favoriteIdx).toBeLessThan(financeIdx)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Token Mint' }))
+    expect(screen.getByTestId('loc')).toHaveTextContent('/apps/token-mint')
+  })
+
+  it('lists only Home and Portfolio under Quick Access when nothing is favorited', () => {
+    const { container } = renderDrawer()
+    const labels = Array.from(
+      container.querySelectorAll('.portal-nav-group-label, .portal-nav-item-label')
+    ).map((el) => el.textContent)
+    const quickAccessIdx = labels.indexOf('Quick Access')
+    const financeIdx = labels.indexOf('Finance')
+    expect(labels.slice(quickAccessIdx + 1, financeIdx)).toEqual(['Home', 'Portfolio'])
+  })
+
+  it('highlights the favorited shortcut itself, not just the Apps entry, when it is the open app', () => {
+    addFavoriteApp({ id: 12, slug: 'token-mint', name: 'Token Mint' })
+    renderDrawer('/apps/token-mint')
+    expect(screen.getByRole('button', { name: 'Token Mint' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('button', { name: 'Apps' })).not.toHaveAttribute('aria-current')
   })
 })

--- a/frontend/src/test/PortalNav.test.jsx
+++ b/frontend/src/test/PortalNav.test.jsx
@@ -177,6 +177,20 @@ describe('PortalNav (collapsed icon rail)', () => {
     expect(screen.getByRole('tab', { name: 'Account' })).not.toHaveAttribute('title')
   })
 
+  it('an icon-less item opted into showIcon gets the initial-letter fallback even expanded', () => {
+    const { container } = render(
+      <PortalNav
+        items={[{ id: 'favorite-1', label: 'Token Mint', showIcon: true }]}
+        activeId="favorite-1"
+        onSelect={vi.fn()}
+        ariaLabel="Sections"
+      />
+    )
+    expect(container.querySelector('.portal-nav')).not.toHaveClass('portal-nav--collapsed')
+    expect(container.querySelectorAll('.portal-nav-item-icon')).toHaveLength(1)
+    expect(screen.getByText('T')).toBeInTheDocument()
+  })
+
   it('still selects when a collapsed item is clicked', () => {
     const onSelect = vi.fn()
     render(<PortalNav groups={ICON_GROUPS} activeId="overview" onSelect={onSelect} collapsed ariaLabel="Sections" />)

--- a/frontend/src/test/miniapps/CatalogPanel.test.jsx
+++ b/frontend/src/test/miniapps/CatalogPanel.test.jsx
@@ -40,7 +40,13 @@ vi.mock('../../lib/miniapps/registryClient', async (importOriginal) => {
 
 import { AppCategory, AppStatus, APP_CATEGORY_LABELS } from '../../abis/miniAppRegistry'
 import { REGISTRY_STATUS, UNREACHABLE_REASON, appSlug } from '../../lib/miniapps/registryClient'
+import { loadFavoriteApps, __resetFavoriteAppsForTests } from '../../lib/miniapps/favorites'
 import CatalogPanel from '../../components/miniapps/CatalogPanel'
+
+beforeEach(() => {
+  localStorage.clear()
+  __resetFavoriteAppsForTests()
+})
 
 const CHAIN = 137
 const REGISTRY = '0x5a168Cc9FeFaf40e7BC536C8C61669e6d547A0A2'
@@ -140,9 +146,24 @@ async function renderSettled() {
   return result
 }
 
-/** The apps currently on screen, by card heading — the member's-eye view of the catalog. */
+/**
+ * The apps currently on screen, by card heading — the member's-eye view of the catalog.
+ *
+ * Level 5: the catalog groups apps under a level-4 category heading (`h3 Apps > h4 category >
+ * h5 app name`), so the app names themselves sit one level deeper than they did before grouping.
+ */
 function listedApps() {
+  return screen.queryAllByRole('heading', { level: 5 }).map((node) => node.textContent)
+}
+
+/** The category group headings currently on screen, in render order. */
+function listedGroups() {
   return screen.queryAllByRole('heading', { level: 4 }).map((node) => node.textContent)
+}
+
+/** Opens the category filter chips, which sit behind the Filter disclosure inline with search. */
+async function openFilters(user) {
+  await user.click(screen.getByRole('button', { name: /^Filter/ }))
 }
 
 describe('CatalogPanel — listing (spec 073 FR-003/FR-007)', () => {
@@ -189,7 +210,7 @@ describe('CatalogPanel — listing (spec 073 FR-003/FR-007)', () => {
 
     await renderSettled()
 
-    const card = screen.getByRole('heading', { level: 4, name: 'Treasury Sweep' }).closest('li')
+    const card = screen.getByRole('heading', { level: 5, name: 'Treasury Sweep' }).closest('li')
     expect(within(card).getByText(APP_CATEGORY_LABELS[AppCategory.TREASURY_LIQUIDITY])).toBeInTheDocument()
     expect(within(card).getByText('v4')).toBeInTheDocument()
     expect(within(card).getByText('0x1234…5678')).toBeInTheDocument()
@@ -295,6 +316,7 @@ describe('CatalogPanel — search and category filters (FR-008)', () => {
 
     await renderSettled()
     expect(listedApps()).toHaveLength(6)
+    await openFilters(user)
 
     for (const category of Object.values(AppCategory)) {
       const label = APP_CATEGORY_LABELS[category]
@@ -321,6 +343,7 @@ describe('CatalogPanel — search and category filters (FR-008)', () => {
     )
     state.fetchCatalog = vi.fn(async () => okOutcome(perCategory))
     await renderSettled()
+    await openFilters(user)
 
     await user.click(screen.getByRole('button', { name: APP_CATEGORY_LABELS[AppCategory.RECONCILIATION] }))
     await user.click(screen.getByRole('button', { name: APP_CATEGORY_LABELS[AppCategory.REPORTING_AUDIT] }))
@@ -333,6 +356,130 @@ describe('CatalogPanel — search and category filters (FR-008)', () => {
     await user.click(screen.getByRole('button', { name: 'All categories' }))
     expect(listedApps()).toHaveLength(6)
     expect(screen.getByRole('button', { name: 'All categories' })).toHaveAttribute('aria-pressed', 'true')
+  })
+})
+
+describe('CatalogPanel — category chips sit behind a Filter disclosure', () => {
+  beforeEach(() => {
+    state.fetchCatalog = vi.fn(async () =>
+      okOutcome([
+        appRecord({ id: 1, name: 'Settle Desk', category: AppCategory.TRADE_SETTLEMENT }),
+        appRecord({ id: 2, name: 'Ledger Match', category: AppCategory.RECONCILIATION }),
+      ]),
+    )
+  })
+
+  it('hides the category chips until Filter is pressed', async () => {
+    await renderSettled()
+
+    expect(screen.getByRole('button', { name: 'Filter' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'All categories' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Filter' })).toHaveAttribute('aria-expanded', 'false')
+
+    const user = userEvent.setup()
+    await openFilters(user)
+
+    expect(screen.getByRole('button', { name: 'All categories' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Filter' })).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('keeps the active-filter count on the toggle label even while the chips are collapsed', async () => {
+    const user = userEvent.setup()
+    await renderSettled()
+    await openFilters(user)
+
+    await user.click(screen.getByRole('button', { name: APP_CATEGORY_LABELS[AppCategory.RECONCILIATION] }))
+    await openFilters(user) // collapse
+
+    expect(screen.queryByRole('button', { name: 'All categories' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Filter (1)' })).toBeInTheDocument()
+    // The narrowing itself survives collapsing the chip row — only the chips hide.
+    expect(listedApps()).toEqual(['Ledger Match'])
+  })
+})
+
+describe('CatalogPanel — apps grouped by category', () => {
+  it('renders a heading per category, in the on-chain enum order, over only the categories present', async () => {
+    state.fetchCatalog = vi.fn(async () =>
+      okOutcome([
+        appRecord({ id: 1, name: 'Ledger Match', category: AppCategory.RECONCILIATION }),
+        appRecord({ id: 2, name: 'Settle Desk', category: AppCategory.TRADE_SETTLEMENT }),
+        appRecord({ id: 3, name: 'Second Settle Desk', category: AppCategory.TRADE_SETTLEMENT }),
+      ]),
+    )
+    await renderSettled()
+
+    // Trade Settlement is ordinal 0, Reconciliation is ordinal 1 — the group order follows the
+    // enum, not discovery order, and only categories that actually have an app appear at all.
+    expect(listedGroups()).toEqual([
+      APP_CATEGORY_LABELS[AppCategory.TRADE_SETTLEMENT],
+      APP_CATEGORY_LABELS[AppCategory.RECONCILIATION],
+    ])
+
+    const tradeGroup = screen.getByRole('heading', {
+      level: 4,
+      name: APP_CATEGORY_LABELS[AppCategory.TRADE_SETTLEMENT],
+    }).closest('section')
+    expect(within(tradeGroup).getAllByRole('heading', { level: 5 }).map((n) => n.textContent)).toEqual([
+      'Settle Desk',
+      'Second Settle Desk',
+    ])
+  })
+
+  it('narrowing to one category leaves exactly one group heading', async () => {
+    const user = userEvent.setup()
+    state.fetchCatalog = vi.fn(async () =>
+      okOutcome([
+        appRecord({ id: 1, name: 'Settle Desk', category: AppCategory.TRADE_SETTLEMENT }),
+        appRecord({ id: 2, name: 'Ledger Match', category: AppCategory.RECONCILIATION }),
+      ]),
+    )
+    await renderSettled()
+
+    await user.type(screen.getByRole('searchbox', { name: /search apps/i }), 'ledger')
+
+    expect(listedGroups()).toEqual([APP_CATEGORY_LABELS[AppCategory.RECONCILIATION]])
+  })
+})
+
+describe('CatalogPanel — Quick Access favorites', () => {
+  it('offers no favorite star for a card that cannot be launched by URL', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 1, name: 'Ünïcode Desk' })]))
+    await renderSettled()
+
+    expect(screen.queryByRole('button', { name: /Quick Access/ })).toBeNull()
+  })
+
+  it('offers no favorite star on an unverified stale snapshot', async () => {
+    state.fetchCatalog = vi.fn(async () =>
+      unreachableOutcome({ stale: staleSnapshot([appRecord({ id: 1, name: 'Settle Desk' })], 60_000) }),
+    )
+    await renderSettled()
+
+    expect(screen.queryByRole('button', { name: /Quick Access/ })).toBeNull()
+  })
+
+  it('adds a launchable app to Quick Access and persists it, then removes it on a second press', async () => {
+    const user = userEvent.setup()
+    state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 9, name: 'Settle Desk' })]))
+    await renderSettled()
+
+    const star = screen.getByRole('button', { name: 'Add Settle Desk to Quick Access' })
+    expect(star).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(star)
+
+    const active = screen.getByRole('button', { name: 'Remove Settle Desk from Quick Access' })
+    expect(active).toHaveAttribute('aria-pressed', 'true')
+    expect(loadFavoriteApps()).toEqual([{ id: 9, slug: appSlug('Settle Desk'), name: 'Settle Desk' }])
+
+    await user.click(active)
+
+    expect(screen.getByRole('button', { name: 'Add Settle Desk to Quick Access' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+    expect(loadFavoriteApps()).toEqual([])
   })
 })
 

--- a/frontend/src/test/miniapps/favorites.test.js
+++ b/frontend/src/test/miniapps/favorites.test.js
@@ -1,0 +1,117 @@
+// App Store favorites (Quick Access shortcuts) — device-scoped store, same shape as
+// `lib/network/endpointStore.js`. This file guards persistence, normalization of garbage
+// input, and the revision/subscriber contract the catalog panel and nav drawer both rely on.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  FAVORITES_PREF_KEY,
+  addFavoriteApp,
+  favoritesRevision,
+  isFavoriteApp,
+  loadFavoriteApps,
+  removeFavoriteApp,
+  subscribeFavoriteApps,
+  toggleFavoriteApp,
+  __resetFavoriteAppsForTests,
+} from '../../lib/miniapps/favorites'
+
+describe('favorites — persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    __resetFavoriteAppsForTests()
+  })
+
+  it('starts empty', () => {
+    expect(loadFavoriteApps()).toEqual([])
+  })
+
+  it('round-trips a favorite through storage', () => {
+    addFavoriteApp({ id: 7, slug: 'token-mint', name: 'Token Mint' })
+    __resetFavoriteAppsForTests() // force a re-read from storage
+    expect(loadFavoriteApps()).toEqual([{ id: 7, slug: 'token-mint', name: 'Token Mint' }])
+  })
+
+  it('is a no-op when adding a second time', () => {
+    addFavoriteApp({ id: 7, slug: 'token-mint', name: 'Token Mint' })
+    addFavoriteApp({ id: 7, slug: 'token-mint', name: 'Token Mint' })
+    expect(loadFavoriteApps()).toHaveLength(1)
+  })
+
+  it('refuses an entry missing an id, slug or name', () => {
+    addFavoriteApp({ slug: 'token-mint', name: 'Token Mint' })
+    addFavoriteApp({ id: 7, name: 'Token Mint' })
+    addFavoriteApp({ id: 7, slug: 'token-mint' })
+    addFavoriteApp({})
+    expect(loadFavoriteApps()).toEqual([])
+  })
+
+  it('removes a favorite, leaving the others alone', () => {
+    addFavoriteApp({ id: 7, slug: 'token-mint', name: 'Token Mint' })
+    addFavoriteApp({ id: 8, slug: 'clearpath', name: 'ClearPath' })
+    removeFavoriteApp(7)
+    expect(loadFavoriteApps()).toEqual([{ id: 8, slug: 'clearpath', name: 'ClearPath' }])
+  })
+
+  it('removing an id that was never favorited is a no-op', () => {
+    addFavoriteApp({ id: 7, slug: 'token-mint', name: 'Token Mint' })
+    removeFavoriteApp(999)
+    expect(loadFavoriteApps()).toHaveLength(1)
+  })
+
+  it('toggle adds when absent and removes when present', () => {
+    const app = { id: 7, slug: 'token-mint', name: 'Token Mint' }
+    toggleFavoriteApp(app)
+    expect(isFavoriteApp(7)).toBe(true)
+    toggleFavoriteApp(app)
+    expect(isFavoriteApp(7)).toBe(false)
+  })
+
+  it('bumps the revision and notifies subscribers on every change', () => {
+    const seen = []
+    const unsubscribe = subscribeFavoriteApps((rev) => seen.push(rev))
+    const before = favoritesRevision()
+
+    addFavoriteApp({ id: 7, slug: 'token-mint', name: 'Token Mint' })
+    removeFavoriteApp(7)
+
+    expect(seen).toHaveLength(2)
+    expect(favoritesRevision()).toBe(before + 2)
+    unsubscribe()
+    addFavoriteApp({ id: 8, slug: 'clearpath', name: 'ClearPath' })
+    expect(seen).toHaveLength(2) // unsubscribed
+  })
+
+  it('ignores garbage in storage rather than throwing', () => {
+    localStorage.setItem('fw_global_prefs', JSON.stringify({ [FAVORITES_PREF_KEY]: 'not-an-array' }))
+    __resetFavoriteAppsForTests()
+    expect(loadFavoriteApps()).toEqual([])
+  })
+
+  it('drops a malformed entry from a mixed list rather than the whole list', () => {
+    localStorage.setItem(
+      'fw_global_prefs',
+      JSON.stringify({
+        [FAVORITES_PREF_KEY]: [
+          { id: 7, slug: 'token-mint', name: 'Token Mint' },
+          { id: 'nope', slug: 'bad', name: 'Bad' },
+        ],
+      }),
+    )
+    __resetFavoriteAppsForTests()
+    expect(loadFavoriteApps()).toEqual([{ id: 7, slug: 'token-mint', name: 'Token Mint' }])
+  })
+
+  it('de-duplicates by id when storage somehow carries the same id twice', () => {
+    localStorage.setItem(
+      'fw_global_prefs',
+      JSON.stringify({
+        [FAVORITES_PREF_KEY]: [
+          { id: 7, slug: 'token-mint', name: 'Token Mint' },
+          { id: 7, slug: 'token-mint-v2', name: 'Token Mint (renamed)' },
+        ],
+      }),
+    )
+    __resetFavoriteAppsForTests()
+    expect(loadFavoriteApps()).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

- Category chips in the Apps (mini-app catalog) view now sit behind an inline **Filter** disclosure button next to the search box, instead of always being on screen. The toggle's label carries the active-filter count (e.g. `Filter (2)`) so collapsing the chip row never hides *that* a filter is applied.
- The visible catalog is now **grouped under a heading per category**, in on-chain enum order, so browsing and filtering agree on one order. A category ordinal ahead of this build's label map still gets its own group rather than being silently dropped.
- Each launchable app card now has a **star toggle** ("Add/Remove … Quick Access") that saves the app to a new device-scoped favorites store (`frontend/src/lib/miniapps/favorites.js`, mirroring `lib/network/endpointStore.js`'s persistence pattern).
- Favorited apps appear as **Quick Access shortcuts** in the global nav drawer (alongside Home/Portfolio), using the drawer's existing initial-letter icon fallback — opted into via a small, additive `showIcon` flag on `PortalNav` items — since the on-chain registry carries no per-app icon asset.

## Details

- `frontend/src/lib/miniapps/favorites.js` — new store: `loadFavoriteApps`, `addFavoriteApp`, `removeFavoriteApp`, `toggleFavoriteApp`, `isFavoriteApp`, revision + subscribe contract.
- `frontend/src/components/miniapps/CatalogPanel.jsx` — Filter disclosure, category grouping, per-card favorite star (gated on a working launch slug, same as Launch itself).
- `frontend/src/components/nav/AppNavDrawer.jsx` — favorited apps rendered into the "Quick Access" group, routed to `/apps/<slug>`, gated on the `apps` tenant feature, active-highlighting for the specific shortcut when its app is open.
- `frontend/src/components/ui/PortalNav.jsx` — additive `item.showIcon` opt-in so an icon-less item still gets the initial-letter fallback in the expanded rail (previously only the collapsed rail did this); existing consumers are unaffected since none used icon-less items before.
- `frontend/src/components/miniapps/miniapps.css` — styling for the filter toggle, category group headings, and the favorite star.

## Test plan

- [x] `npx vitest run src/test/miniapps/ src/test/PortalNav.test.jsx src/test/AppNavDrawer.test.jsx` — all pass (538 tests across the miniapps + nav suites), including new coverage for the filter disclosure, category grouping, and favorites (persistence store, catalog UI, nav drawer integration).
- [x] `npx eslint` on all touched/added files — clean.
- [ ] Manual click-through in a running dev server (not performed in this environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nxx9WqiX17YTcGu29Dv94x)_