### PR TITLE
Protect: accordion vault cards + account-card visual language

### DIFF
--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.css
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.css
@@ -18,14 +18,32 @@
   gap: 8px;
 }
 
+/* Card identity borrowed from the My Account carousel's account-card (AccountCardsCarousel.css):
+   the same per-kind left accent used for a "legacy" account there, plus a card-level shadow — so a
+   recovered account reads as the same "account" here as it does in the carousel/account switcher. */
 .lkr-stored__item {
   display: flex;
   flex-direction: column;
   gap: 10px;
   padding: 12px;
   border: 1px solid color-mix(in srgb, var(--text-primary, #1f2933) 18%, transparent);
+  border-left: 4px solid var(--semantic-warning, #f5a623);
   border-radius: 10px;
   background: var(--bg-primary, #f7f9fa);
+  box-shadow: var(--shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.1));
+}
+
+.lkr-stored__kind {
+  align-self: flex-start;
+  padding: 2px 8px;
+  border-radius: var(--radius-full, 9999px);
+  background: var(--bg-secondary, #ffffff);
+  border: 1px solid var(--border-color, #e3e7eb);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary, #5a6772);
 }
 
 .lkr-stored__row {

--- a/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
+++ b/frontend/src/components/account/LegacyKeyRecoveryPanel.jsx
@@ -416,6 +416,7 @@ function LegacyKeyRecoveryPanel({ deps = {}, defaultOpen = false }) {
                   <div className="lkr-stored__row">
                     <BlockiesAvatar address={e.address} size={40} className="lkr-stored__avatar" />
                     <div className="lkr-stored__meta">
+                      <span className="lkr-stored__kind">Recovered</span>
                       <span className="lkr-stored__name">{displayName}</span>
                       <code className="lkr-stored__addr" title={e.address}>{shortAddr(e.address)}</code>
                       <span className="lkr-stored__sub">

--- a/frontend/src/components/custody/Custody.css
+++ b/frontend/src/components/custody/Custody.css
@@ -46,18 +46,6 @@
   margin: 0.5rem 0;
 }
 
-.custody-onchain-body {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: minmax(0, 1fr);
-}
-
-@media (min-width: 720px) {
-  .custody-onchain-body {
-    grid-template-columns: minmax(0, 18rem) minmax(0, 1fr);
-  }
-}
-
 .custody-field {
   display: flex;
   flex-direction: column;
@@ -76,55 +64,65 @@
 }
 
 .custody-vault-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
   display: flex;
   flex-direction: column;
+  gap: 10px;
+  margin: 0.5rem 0 0;
+}
+
+/* Protect-accordion-refresh — the vault card borrows the account-card visual language (per-kind
+   accent border, active-state ring) from AccountCardsCarousel.css so a vault reads as the same
+   "account" everywhere it appears, while the collapsible mechanics stay the shared `.acc` ones. */
+.custody-vault-card {
+  border-left: 4px solid var(--brand-secondary, #4c9aff);
+}
+
+.custody-vault-card.is-testnet {
+  border-left-color: var(--semantic-warning, #f5a623);
+}
+
+.custody-vault-card[data-open='true'] {
+  box-shadow: 0 0 0 2px var(--brand-primary, #36b37e);
+}
+
+.custody-vault-card__title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 0.375rem;
+  min-width: 0;
 }
 
-.custody-vault-item {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.125rem;
-  width: 100%;
-  text-align: left;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
-  border-radius: 0.375rem;
-  background: transparent;
-  cursor: pointer;
+.custody-vault-card__kind {
+  padding: 2px 8px;
+  border-radius: var(--radius-full, 9999px);
+  background: var(--bg-primary, #f7f9fa);
+  border: 1px solid var(--border-color, #e3e7eb);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary, #5a6772);
+  flex: none;
 }
 
-.custody-vault-item.is-selected {
-  border-color: var(--accent-color, #4f46e5);
+.custody-vault-card__label {
+  font-weight: 600;
+  color: var(--text-primary, #1f2933);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.custody-vault-addr,
+.custody-vault-card__addr {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.8125rem;
+  color: var(--text-secondary, #5a6772);
+}
+
 .custody-vault-meta {
   font-size: 0.8125rem;
   color: var(--text-muted, #6b7280);
-}
-
-/* Spec 068 (FR-002) — chain identity on every vault row. Testnet vaults are visually distinct so a
-   testnet vault is never mistaken for the mainnet one of the same name. */
-.custody-chain-badge {
-  align-self: flex-start;
-  font-size: 0.75rem;
-  line-height: 1.4;
-  padding: 0.0625rem 0.375rem;
-  border-radius: 0.25rem;
-  border: 1px solid var(--border-subtle, #d1d5db);
-  color: var(--text-muted, #6b7280);
-  background: var(--surface-subtle, #f9fafb);
-}
-
-.custody-chain-badge.is-testnet {
-  border-color: var(--warning-border, #fcd34d);
-  background: var(--warning-bg, #fffbeb);
-  color: var(--warning-text, #92400e);
 }
 
 .custody-owner-name {
@@ -160,12 +158,6 @@
 
 .custody-predicted code {
   word-break: break-all;
-}
-
-.custody-vault-column {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
 }
 
 .custody-proposal-list {

--- a/frontend/src/components/custody/CustodyPanel.jsx
+++ b/frontend/src/components/custody/CustodyPanel.jsx
@@ -15,8 +15,6 @@ import { useVaultProposals } from '../../hooks/useVaultProposals'
 import { isCustodySupported, CUSTODY_SUPPORTED_CHAIN_IDS } from '../../config/safeContracts'
 import { NETWORKS } from '../../config/networks'
 import VaultList from './VaultList'
-import VaultDetail from './VaultDetail'
-import VaultProposalsPanel from './VaultProposalsPanel'
 import CreateVaultWizard from './CreateVaultWizard'
 import LoadVaultForm from './LoadVaultForm'
 import './Custody.css'
@@ -48,7 +46,6 @@ function OnChainSection() {
   // Spec 049 — one shared proposal-queue instance for the active vault, so policy-change proposals
   // (VaultDetail → PolicyPanel) land in the same queue the VaultProposalsPanel renders.
   const proposals = useVaultProposals(activeVault)
-  const onVaultChain = Boolean(activeVault && Number(chainId) === Number(activeVault.chainId))
   const canCreateHere = isCustodySupported(chainId)
   const elsewhere = otherCustodyChains(chainId)
 
@@ -101,23 +98,17 @@ function OnChainSection() {
         </p>
       )}
 
-      <div className="custody-onchain-body">
-        <VaultList vaults={vaults} activeAddress={activeAddress} onSelect={selectVault} />
-        {activeVault && (
-          <div className="custody-vault-column">
-            <VaultDetail
-              vault={activeVault}
-              onForget={forget}
-              isActiveIdentity={active.mode === 'vault' && active.vaultAddress === activeVault.address}
-              onProposePolicy={activeVault.owner && onVaultChain ? proposals.propose : undefined}
-              onSwitchNetwork={switchNetwork}
-              // FR-019 — the policy panel needs the live queue to refuse a second pending change.
-              proposalQueue={proposals.queue}
-            />
-            <VaultProposalsPanel vault={activeVault} proposals={proposals} />
-          </div>
-        )}
-      </div>
+      {/* Spec 074/protect-accordion-refresh — one vault expanded at a time, its detail inline in the
+          card body, the same collapsible pattern as the Recovery tab (AccordionSection). */}
+      <VaultList
+        vaults={vaults}
+        activeAddress={activeAddress}
+        onSelect={selectVault}
+        onForget={forget}
+        onSwitchNetwork={switchNetwork}
+        proposals={proposals}
+        isActiveIdentity={(v) => active.mode === 'vault' && active.vaultAddress === v.address}
+      />
     </div>
   )
 }

--- a/frontend/src/components/custody/VaultDetail.jsx
+++ b/frontend/src/components/custody/VaultDetail.jsx
@@ -27,7 +27,6 @@ export default function VaultDetail({
   if (vault.reachable === false) {
     return (
       <div className="custody-vault-detail" role="region" aria-label="Vault detail">
-        <h4>{vault.label || 'Vault'}</h4>
         <p className="custody-error" role="alert">
           Could not reach {chainLabel} to read this vault. Its details will appear when the network
           responds; nothing about the vault has changed.
@@ -44,7 +43,6 @@ export default function VaultDetail({
   if (vault.isSafe === false) {
     return (
       <div className="custody-vault-detail" role="region" aria-label="Vault detail">
-        <h4>{vault.label || 'Vault'}</h4>
         <p className="custody-error" role="alert">
           Could not read a Safe at <code>{vault.address}</code> on {chainLabel}.
         </p>
@@ -59,7 +57,6 @@ export default function VaultDetail({
 
   return (
     <div className="custody-vault-detail" role="region" aria-label="Vault detail">
-      <h4>{vault.label || 'Vault'}</h4>
       {!onVaultChain && (
         <div className="custody-warning" role="status">
           <p>

--- a/frontend/src/components/custody/VaultList.jsx
+++ b/frontend/src/components/custody/VaultList.jsx
@@ -4,10 +4,41 @@
 // Spec 068 (US1) — the list spans EVERY chain the member has vaults on, so each row states its
 // chain (FR-002) and an unreachable chain degrades to an honest per-row notice rather than
 // disappearing or blanking the list.
+//
+// Protect-accordion-refresh — the list reuses the Recovery tab's AccordionSection (one vault
+// expanded at a time, detail inline in the card body instead of a side column) so the two
+// collapsible surfaces behave identically. The card itself borrows the account-card visual
+// language (avatar, kind pill, per-kind accent border, active-state ring) from the My Account
+// carousel, so a vault reads as the same "account" everywhere it's shown in the app.
 
+import { useMemo } from 'react'
+import AccordionSection from '../account/AccordionSection'
+import { AccordionGroupContext } from '../account/accordionContext'
+import BlockiesAvatar from '../ui/BlockiesAvatar'
 import PolicyBadge from './PolicyBadge'
+import VaultDetail from './VaultDetail'
+import VaultProposalsPanel from './VaultProposalsPanel'
 
-export default function VaultList({ vaults, activeAddress, onSelect }) {
+export default function VaultList({
+  vaults,
+  activeAddress,
+  onSelect,
+  onForget,
+  onSwitchNetwork,
+  proposals,
+  isActiveIdentity = () => false,
+}) {
+  // One vault open at a time, driven by the existing selection state rather than
+  // AccordionGroup's own — selecting a vault IS expanding its card, matching the exclusive
+  // open-one-at-a-time behavior of the Recovery tab's AccordionGroup.
+  const groupValue = useMemo(
+    () => ({
+      isOpen: (id) => id === activeAddress,
+      toggle: (id) => onSelect(id === activeAddress ? null : id),
+    }),
+    [activeAddress, onSelect],
+  )
+
   if (!vaults?.length) {
     return (
       <p className="custody-hint" role="status">
@@ -15,47 +46,60 @@ export default function VaultList({ vaults, activeAddress, onSelect }) {
       </p>
     )
   }
+
   return (
-    <ul className="custody-vault-list" aria-label="Your vaults">
-      {vaults.map((v) => {
-        const selected = v.address === activeAddress
-        const label = v.label || 'Unnamed vault'
-        return (
-          <li key={`${v.chainId}:${v.address}`}>
-            <button
-              type="button"
-              className={`custody-vault-item${selected ? ' is-selected' : ''}`}
-              aria-current={selected ? 'true' : undefined}
-              onClick={() => onSelect(v.address)}
+    <AccordionGroupContext.Provider value={groupValue}>
+      <div className="accordion-group custody-vault-list" aria-label="Your vaults">
+        {vaults.map((v) => {
+          const open = v.address === activeAddress
+          const label = v.label || 'Unnamed vault'
+          const summary = [
+            v.isSafe && v.threshold != null
+              ? `${v.threshold}-of-${v.owners.length}${v.owner ? ' · owner' : ' · view-only'}`
+              : null,
+            v.reachable === false
+              ? `${v.chainName || `chain ${v.chainId}`} unreachable`
+              : v.isSafe === false
+                ? 'unreadable'
+                : null,
+          ]
+            .filter(Boolean)
+            .join(' · ')
+
+          return (
+            <AccordionSection
+              key={`${v.chainId}:${v.address}`}
+              id={v.address}
+              className={`custody-vault-card${v.isTestnet ? ' is-testnet' : ''}`}
+              icon={<BlockiesAvatar address={v.address} size={28} />}
+              title={
+                <span className="custody-vault-card__title">
+                  <span className="custody-vault-card__kind">Multisig</span>
+                  <span className="custody-vault-card__label">{label}</span>
+                  <span className="custody-vault-card__addr">{shorten(v.address)}</span>
+                  <PolicyBadge status={v.policyStatus} summary={v.policySummary} />
+                </span>
+              }
+              summary={summary}
+              badge={`${v.chainName || `Chain ${v.chainId}`}${v.isTestnet ? ' · testnet' : ''}`}
+              badgeTone={v.isTestnet ? 'warn' : 'info'}
             >
-              <span className="custody-vault-label">{label}</span>
-              <span className="custody-vault-addr">{shorten(v.address)}</span>
-              {/* Chain identity is never optional on a custody surface (FR-002): approving on the
-                  wrong network is the mistake this whole feature exists to prevent. */}
-              <span className={`custody-chain-badge${v.isTestnet ? ' is-testnet' : ''}`}>
-                {v.chainName || `Chain ${v.chainId}`}
-                {v.isTestnet ? ' · testnet' : ''}
-              </span>
-              {v.isSafe && (
-                <span className="custody-vault-meta">
-                  {v.threshold}-of-{v.owners.length}
-                  {v.owner ? ' · owner' : ' · view-only'}
-                </span>
-              )}
-              {v.reachable === false && (
-                <span className="custody-vault-meta custody-error">
-                  {v.chainName || `chain ${v.chainId}`} unreachable
-                </span>
-              )}
-              {v.reachable !== false && v.isSafe === false && (
-                <span className="custody-vault-meta custody-error">unreadable</span>
-              )}
-              <PolicyBadge status={v.policyStatus} summary={v.policySummary} />
-            </button>
-          </li>
-        )
-      })}
-    </ul>
+              <VaultDetail
+                vault={v}
+                onForget={onForget}
+                isActiveIdentity={isActiveIdentity(v)}
+                onProposePolicy={open && v.owner && v.onVaultChain ? proposals?.propose : undefined}
+                onSwitchNetwork={onSwitchNetwork}
+                // FR-019 — the policy panel needs the live queue to refuse a second pending change;
+                // only the open vault's own queue applies (the shared instance tracks activeVault).
+                proposalQueue={open ? (proposals?.queue ?? []) : []}
+              />
+              {open && <VaultProposalsPanel vault={v} proposals={proposals} />}
+            </AccordionSection>
+          )
+        })}
+      </div>
+    </AccordionGroupContext.Provider>
   )
 }
 

--- a/frontend/src/test/custody/VaultDetail.test.jsx
+++ b/frontend/src/test/custody/VaultDetail.test.jsx
@@ -6,6 +6,10 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { axe } from 'vitest-axe'
 
+// Protect-accordion-refresh — VaultList now embeds VaultProposalsPanel inline for the open vault,
+// so opening a card in these unit tests reaches useWallet() even without a proposals prop.
+vi.mock('../../hooks', () => ({ useWallet: () => ({ chainId: 63, address: undefined, switchNetwork: vi.fn() }) }))
+
 vi.mock('../../lib/custody/policy', () => ({
   getPolicyStatus: vi.fn(async () => 'unsupported'),
   readPolicy: vi.fn(async () => null),
@@ -119,12 +123,17 @@ describe('VaultDetail', () => {
 })
 
 describe('VaultList', () => {
-  it('marks the active vault and calls onSelect', () => {
+  // Protect-accordion-refresh — the active vault's card is the one expanded (AccordionSection's
+  // aria-expanded), and re-clicking its trigger collapses it by selecting nothing, matching the
+  // Recovery tab's exclusive open-one-at-a-time accordion behavior.
+  it('expands the active vault as an accordion card and toggles via onSelect', () => {
     const onSelect = vi.fn()
     const vaults = [{ chainId: 63, address: A, label: 'One', isSafe: true, owners: [A], threshold: 1, owner: true }]
     render(<VaultList vaults={vaults} activeAddress={A} onSelect={onSelect} />)
-    const item = screen.getByRole('button', { name: /One/i })
-    expect(item).toHaveAttribute('aria-current', 'true')
+    const trigger = screen.getByRole('button', { name: /One/i })
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(trigger)
+    expect(onSelect).toHaveBeenCalledWith(null)
   })
 
   it('renders an empty state with no vaults', () => {


### PR DESCRIPTION
## Summary

- The Protect (Custody) On-chain vault list now uses the same collapsible `AccordionSection`/`AccordionGroup` pattern already used on the Recovery tab: one vault card expands at a time, with its detail (`VaultDetail` + `VaultProposalsPanel`) rendered inline in the card body instead of in a separate side column.
- Both the Protect vault cards and the Recovery tab's "recovered accounts" rows (`LegacyKeyRecoveryPanel`) now borrow the account-card visual language from the My Account carousel (`AccountCardsCarousel`): avatar, uppercase kind pill, per-kind accent border, and an active-state ring — so an account/vault reads consistently wherever it's shown across the app.
- Removed the now-redundant `<h4>{vault.label}</h4>` heading inside `VaultDetail`, since the accordion header already displays the vault's label.

## Test plan

- [x] `npx vitest run src/test/custody` — 272 tests pass (updated `VaultList` interaction tests to assert `aria-expanded` instead of the old `aria-current` selection model)
- [x] `npx vitest run src/components/account/__tests__/LegacyKeyRecoveryPanel.test.jsx` — 16 tests pass, including the axe accessibility check
- [x] `npx vitest run src/test/account` — passes except one pre-existing, unrelated axe failure in `MyAccountView.axe.test.jsx` (Activity view list markup), confirmed present on `main` before this change via `git stash`
- [x] Visual check: rendered `CustodyPanel` and `LegacyKeyRecoveryPanel` with sample data and screenshotted collapsed/expanded states to confirm the accordion behavior and account-card styling render correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_016tYF9AM7Lxje4d97HNRz2j)_