### PR TITLE
Fix connected wallets losing their signer, blocking encryption key backup/registration

### DIFF
--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -198,8 +198,16 @@ export function WalletProvider({ children }) {
             name: walletClient.chain?.name || 'Unknown'
           })
 
-          // Get signer for the specific account that wagmi has authorized
-          const ethersSigner = await ethersProvider.getSigner(walletClient.account.address)
+          // Build the signer directly for the account wagmi already authorized, instead
+          // of `ethersProvider.getSigner(address)` — ethers v6's BrowserProvider.getSigner()
+          // issues its own `eth_requestAccounts` round-trip to re-verify authorization. That
+          // round-trip fires every time this effect re-runs (e.g. right after the auto
+          // chain-switch below changes `walletClient`), and MetaMask can surface it as a
+          // fresh permission prompt even though the account is already connected. A tester
+          // rejecting that redundant prompt threw here, which nulled out a signer that was
+          // already valid — breaking every signer-dependent action (encryption key backup/
+          // registration included) while the wallet still showed "connected".
+          const ethersSigner = new ethers.JsonRpcSigner(ethersProvider, walletClient.account.address)
           if (cancelled) return
           setProvider(ethersProvider)
           setSigner(ethersSigner)
@@ -251,7 +259,13 @@ export function WalletProvider({ children }) {
 
     updateProviderAndSigner()
     return () => { cancelled = true }
-  }, [isConnected, address, walletClient, loginMethod])
+    // Keyed on the wallet's own address/chain rather than the `walletClient` object
+    // itself: wagmi hands back a new `walletClient` reference on unrelated refetches
+    // (balance polls, focus revalidation, ...), and re-running this effect for no
+    // semantic change was what made the redundant getSigner() re-authorization above
+    // fire so often in the first place.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isConnected, address, walletClient?.account?.address, walletClient?.chain?.id, loginMethod])
 
   // Auto-switch to Polygon (PRIMARY_CHAIN_ID) when the wallet connects on an
   // unsupported chain. If the switch fails, show a network error instead.


### PR DESCRIPTION
## Summary

Testers reported being unable to back up or register an encryption key for classic (MetaMask-style) wallets. The provided console log pinned it down:

```
[WalletContext] Signer created for: 0x1215185387E70a48b07D73AcB67002A073F18575
MetaMask - RPC Error: User rejected the request. {code: 4001, ...}
  ... at getSigner @ web3-*.js
```

**Root cause**: `WalletContext`'s provider/signer effect (`frontend/src/contexts/WalletContext.jsx`) re-derived the ethers signer via `ethersProvider.getSigner(address)` every time the effect re-ran — which happens on *any* `walletClient` object reference change from wagmi (e.g. immediately after the app's own auto chain-switch-to-Polygon logic runs). ethers v6's `BrowserProvider.getSigner()` issues its own `eth_requestAccounts` round-trip to re-verify authorization on every call. When that redundant permission request surfaced in the wallet extension and got rejected (a tester naturally declining what looked like a duplicate of the connection they'd already approved), the effect's catch block nulled out an otherwise perfectly valid signer.

With `signer` null but `isConnected`/`address` still true, every signer-gated action broke silently — including the "Register Encryption Key" control and the account backup flow — surfacing as "Not connected. Please sign in again." even though the wallet was visibly connected.

## Fix

- Build the signer directly for the account wagmi already authorized via `new ethers.JsonRpcSigner(provider, address)` instead of the async `provider.getSigner(address)` — this is the documented wagmi → ethers v6 adapter pattern, and it never issues a fresh authorization round-trip since wagmi has already verified the account.
- Narrowed the effect's dependency array to the wallet's actual `address`/`chain.id` rather than the whole `walletClient` object, so it no longer re-runs (and re-derives) on incidental reference churn unrelated to a real account/chain change.

## Test plan

- [x] `npx vitest run src/test/wallet-management.test.jsx src/test/UserManagementModal.test.jsx src/test/useEncryption.test.jsx src/test/useEncryption.passkey.test.jsx` — 31 passed
- [x] `npx vitest run src/test/backup src/test/WalletPage.test.jsx src/test/MarketAcceptanceModal.test.jsx src/test/FriendMarketsModal.test.jsx src/test/MyMarketsModal.test.jsx src/test/useRoles.test.jsx` — 224 passed
- [x] `npx eslint src/contexts/WalletContext.jsx` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01YAddwzbBphjFSYmA4ZzdRH)_