### PR TITLE
CI: whole directories had no path filter — services/packages/tenants/scripts PRs ran zero jobs

### DIFF
--- a/.github/workflows/ci-manager.yml
+++ b/.github/workflows/ci-manager.yml
@@ -33,6 +33,12 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       security: ${{ steps.filter.outputs.security }}
       core: ${{ steps.filter.outputs.core }}
+      services: ${{ steps.filter.outputs.services }}
+      packages: ${{ steps.filter.outputs.packages }}
+      tenants: ${{ steps.filter.outputs.tenants }}
+      tooling: ${{ steps.filter.outputs.tooling }}
+      subgraph: ${{ steps.filter.outputs.subgraph }}
+      ops: ${{ steps.filter.outputs.ops }}
       any_code_changed: ${{ steps.check.outputs.any_code_changed }}
     
     steps:
@@ -49,7 +55,9 @@ jobs:
             contracts:
               - 'contracts/**'
               - 'hardhat.config.js'
-              - 'scripts/deploy*.js'
+              # `scripts/deploy*.js` did NOT match scripts/deploy/lib/upgradeable.js (the in-place
+              # upgrade path) or scripts/deploy/check-storage-layout.js (the gate itself).
+              - 'scripts/deploy/**'
               - 'test/*.test.js'
               - 'test/integration/**'
               - 'medusa.json'
@@ -73,6 +81,29 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - '.github/workflows/**'
+              - '.github/actions/**'
+              - 'turbo.json'
+            # Directories below matched NO filter at all before spec 075. A PR touching only one of
+            # them ran zero jobs and merged green — and now that these checks are REQUIRED, they
+            # would report `skipped`, which SATISFIES a required check. Requiring checks made that
+            # hole quieter, not smaller.
+            services:
+              - 'services/**'
+            packages:
+              - 'packages/**'
+              - 'tools/**'
+            tenants:
+              - 'tenants/**'
+            tooling:
+              - 'scripts/**'
+              - 'test/**'
+            subgraph:
+              - 'subgraph/**'
+            ops:
+              - 'deployments/**'
+              - 'infra/**'
+              - 'ops/**'
+              - '.openzeppelin/**'
 
       - name: Check if any code changed
         id: check
@@ -165,7 +196,20 @@ jobs:
   smart-contract-tests:
     name: Smart Contract Tests
     needs: detect-changes
-    if: needs.detect-changes.outputs.contracts == 'true' || needs.detect-changes.outputs.core == 'true'
+    # test.yml is the workhorse: it owns Dependency Hygiene, Relay Gateway Tests, Tenant Manifest
+    # Validation, Frontend Lint/Unit/Build and Cypress Fast E2E — i.e. most of the REQUIRED checks.
+    # Gating it on contracts||core meant a services-, packages-, tenants-, scripts- or
+    # subgraph-only PR skipped every one of them.
+    if: |
+      needs.detect-changes.outputs.contracts == 'true' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.frontend == 'true' ||
+      needs.detect-changes.outputs.services == 'true' ||
+      needs.detect-changes.outputs.packages == 'true' ||
+      needs.detect-changes.outputs.tenants == 'true' ||
+      needs.detect-changes.outputs.tooling == 'true' ||
+      needs.detect-changes.outputs.subgraph == 'true' ||
+      needs.detect-changes.outputs.ops == 'true'
     uses: ./.github/workflows/test.yml
 
   frontend-tests:

--- a/.github/workflows/deploy-contracts.yml
+++ b/.github/workflows/deploy-contracts.yml
@@ -58,9 +58,14 @@ jobs:
           echo "Factory Address: 0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7"
           echo ""
 
-          npx hardhat run scripts/deploy/archive/deploy-deterministic.js --network amoy | tee deployment.log
+          # A pipeline reports the LAST command's status, so `hardhat run ... | tee` exits with
+          # TEE's status — always 0. `$?` below was therefore always 0 and a deploy that reverted,
+          # ran out of gas, or could not reach the RPC was reported as a SUCCESSFUL deployment.
+          # Testing the pipeline as the `if` condition keeps errexit from aborting the step before
+          # the diagnostic prints, while pipefail makes the condition reflect hardhat's own status.
+          set -o pipefail
 
-          if [ $? -eq 0 ]; then
+          if npx hardhat run scripts/deploy/archive/deploy-deterministic.js --network amoy | tee deployment.log; then
             echo "✅ Deployment completed successfully!"
           else
             echo "❌ Deployment failed!"

--- a/test/config/CiGates.test.js
+++ b/test/config/CiGates.test.js
@@ -161,3 +161,62 @@ describe("archived code is never referenced by active code (spec 075)", function
     ).to.deep.equal([]);
   });
 });
+
+/**
+ * Spec 075: every top-level directory containing executable code must be matched by at least one
+ * ci-manager path filter.
+ *
+ * Before this, `services/**`, `packages/**`, `tenants/**`, `tools/**`, `subgraph/**`,
+ * `deployments/**` and most of `scripts/**` matched NO filter, so a PR touching only one of them
+ * ran zero jobs. With required status checks now in force that is worse, not better: the jobs
+ * report `skipped`, and a skipped check SATISFIES a required check — so such a PR merges with a
+ * green tick and no tests run.
+ *
+ * The list was never the defect; the mechanism was. This fails when a new top-level code directory
+ * appears with nothing matching it.
+ */
+describe("every code directory is covered by a ci-manager path filter (spec 075)", function () {
+  const IGNORED = new Set([
+    "node_modules", "artifacts", "cache", "coverage", "dist", "build",
+    "docs", "specs", "blockscout", "contracts-archive", "test-archive", ".github", ".specify",
+    ".claude", ".openzeppelin", ".git",
+  ]);
+  const CODE = /\.(js|jsx|mjs|cjs|ts|tsx|sol|sh|py)$/;
+
+  const hasCode = (dir) => {
+    const stack = [dir];
+    while (stack.length) {
+      const d = stack.pop();
+      for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+        if (e.name === "node_modules" || e.name.startsWith(".")) continue;
+        const p = path.join(d, e.name);
+        if (e.isDirectory()) stack.push(p);
+        else if (CODE.test(e.name)) return true;
+      }
+    }
+    return false;
+  };
+
+  it("matches every top-level directory that contains executable code", function () {
+    const wf = yaml.load(fs.readFileSync(path.join(WF_DIR, "ci-manager.yml"), "utf8"));
+    const step = wf.jobs["detect-changes"].steps.find((s) => (s.uses || "").includes("paths-filter"));
+    expect(step, "ci-manager no longer uses dorny/paths-filter — this guard needs updating").to.exist;
+    const filters = yaml.load(step.with.filters);
+    const globs = Object.values(filters).flat().map(String);
+
+    const uncovered = [];
+    for (const e of fs.readdirSync(ROOT, { withFileTypes: true })) {
+      if (!e.isDirectory() || IGNORED.has(e.name) || e.name.startsWith(".")) continue;
+      if (!hasCode(path.join(ROOT, e.name))) continue;
+      // A directory is covered if some glob is rooted at it.
+      if (!globs.some((g) => g.replace(/^!/, "").startsWith(`${e.name}/`))) uncovered.push(e.name);
+    }
+
+    expect(
+      uncovered,
+      "These top-level directories contain executable code but match no ci-manager filter, so a PR " +
+        "touching only them runs no jobs — and with required checks in force, `skipped` counts as " +
+        `success:\n  ${uncovered.join("\n  ")}`,
+    ).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
Stacked on #1015 (base `075-monorepo-workspaces-complete`); retarget to `main` once that merges.

Found by the spec-075 coverage audit, verified against the workflow before acting.

## The hole

`services/**`, `packages/**`, `tenants/**`, `tools/**`, `subgraph/**`, `deployments/**`, `infra/**`, `ops/**` and most of `scripts/**` matched **no ci-manager filter**. A PR touching only one of them ran zero jobs and merged green.

**Adding required status checks made this worse, not better.** Those jobs now report `skipped` — and a skipped check *satisfies* a required check. So a relay-gateway-only PR (sanctions screening, quotas, killswitch, paymaster authorization) would merge with a full row of green ticks and nothing run.

## Also fixed

`scripts/deploy*.js` does not match `scripts/deploy/lib/upgradeable.js` — the in-place upgrade path — or `scripts/deploy/check-storage-layout.js`, the storage gate itself. Verified with picomatch. `turbo.json` already declares `scripts/deploy/lib/**` as a test input, so the repo contradicted itself. Now `scripts/deploy/**`.

## The regating that matters

`smart-contract-tests` invokes **all of `test.yml`** — which owns Dependency Hygiene, Relay Gateway Tests, Tenant Manifest Validation, Frontend Lint/Unit/Build and Cypress Fast E2E, i.e. most of the required checks — yet gated only on `contracts || core`. It now runs for any code change.

## The list was never the defect; the mechanism was

`test/config/CiGates.test.js` now asserts that every top-level directory containing executable code is matched by at least one filter, so the next directory cannot be born un-gated.

It earned its place immediately: **on its first run it failed on `ops/`** — a directory I had missed while writing this very fix. Mutation-tested by removing `services/**` and confirming it goes red.

## Reviewer note

This makes CI run *more* often, deliberately. "Smart test selection" that skips the tests protecting a directory is not a saving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3zsM5EwGkw9MCG76KiFGn