### PR TITLE
Default to Portfolio on larger displays, Home on mobile

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -5,14 +5,18 @@ import ThemeToggle from './ui/ThemeToggle'
 import NotificationBell from './notifications/NotificationBell'
 import NetworkCrawler from './fairwins/NetworkCrawler'
 import { useNavDrawer } from '../contexts/NavDrawerContext.js'
+import { useIsMobile } from '../hooks/useMediaQuery'
+import { resolveLandingPath } from '../utils/landingViewPreference'
 import './Header.css'
 
 function Header({ hideWalletButton = false, appMode = false }) {
   const navigate = useNavigate()
   const location = useLocation()
   const { open: openNavDrawer, isOpen: navDrawerOpen, available: navDrawerAvailable } = useNavDrawer()
+  const isMobile = useIsMobile()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [logoError, setLogoError] = useState(false)
+  const launchApp = () => navigate(resolveLandingPath(isMobile))
 
   // In app mode the clover logo is the site menu button — it opens the global
   // navigation drawer ("us"). On the landing pages (no drawer provider) it keeps
@@ -96,7 +100,7 @@ function Header({ hideWalletButton = false, appMode = false }) {
               Use Cases
             </button>
             <button
-              onClick={() => navigate('/app')}
+              onClick={launchApp}
               className="nav-link nav-button"
             >
               Launch App
@@ -157,7 +161,7 @@ function Header({ hideWalletButton = false, appMode = false }) {
           </button>
           <button
             onClick={() => {
-              navigate('/app')
+              launchApp()
               closeMenu()
             }}
             className="mobile-nav-link"

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom'
 import Header from './Header'
 import Footer from './Footer'
 import { tenantBrand, tenantLinks, isFeatureEnabled } from '../config/tenant'
+import { useIsMobile } from '../hooks/useMediaQuery'
+import { resolveLandingPath } from '../utils/landingViewPreference'
 import './LandingPage.css'
 
 // Hero social icons by manifest social key (spec 072 — links come from the
@@ -32,12 +34,13 @@ const SOCIAL_ICONS = {
 
 function LandingPage() {
   const navigate = useNavigate()
+  const isMobile = useIsMobile()
   const [visibleSections, setVisibleSections] = useState(new Set())
   const brand = tenantBrand()
   const { support, social } = tenantLinks()
 
   const handleGetStarted = () => {
-    navigate('/app')
+    navigate(resolveLandingPath(isMobile))
   }
 
   // Intersection observer for scroll-triggered animations

--- a/frontend/src/components/LandingRoute.jsx
+++ b/frontend/src/components/LandingRoute.jsx
@@ -4,7 +4,10 @@
  * First-time visitors get the marketing page. Anyone this browser has already
  * attached an account for goes straight to the app, where the unlock prompt
  * meets them — "Launch App" is a step with no decision in it for a returning
- * member, and nothing in FairWins works until an account is connected.
+ * member, and nothing in FairWins works until an account is connected. Which
+ * screen they land on (Home or Portfolio) follows landingViewPreference —
+ * device-based by default (mobile → Home, larger screens → Portfolio) but
+ * overridable from Preferences.
  *
  * Escape hatches, both honoured for the rest of the tab session: "Leave" on the
  * entry gate, and /?stay=1.
@@ -13,12 +16,15 @@
 import { useEffect } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import { useWallet } from '../hooks/useWalletManagement'
+import { useIsMobile } from '../hooks/useMediaQuery'
 import LandingPage from './LandingPage'
 import { hasAcknowledged } from '../utils/entryGateAck'
 import { hasWalletHistory, keepOnLanding, shouldStayOnLanding } from '../utils/appEntry'
+import { resolveLandingPath } from '../utils/landingViewPreference'
 
 export default function LandingRoute() {
   const { isConnected, connectionStatus } = useWallet()
+  const isMobile = useIsMobile()
   const { search } = useLocation()
   const askedToStay = new URLSearchParams(search).get('stay') === '1'
 
@@ -34,7 +40,7 @@ export default function LandingRoute() {
 
   // Never forward past the eligibility gate: a visitor who has not entered yet
   // has to see it, and "Leave" must land somewhere that stays put.
-  if (!stay && returning && hasAcknowledged()) return <Navigate to="/app" replace />
+  if (!stay && returning && hasAcknowledged()) return <Navigate to={resolveLandingPath(isMobile)} replace />
 
   return <LandingPage />
 }

--- a/frontend/src/components/account/HomePreferencesPanel.jsx
+++ b/frontend/src/components/account/HomePreferencesPanel.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useChainTokens } from '../../hooks/useChainTokens'
+import { useIsMobile } from '../../hooks/useMediaQuery'
 import {
   HOME_MODES,
   getDefaultHomeMode,
@@ -7,28 +8,42 @@ import {
   getDefaultCurrencyKind,
   setDefaultCurrencyKind,
 } from '../../utils/homePreference'
+import {
+  LANDING_VIEWS,
+  getLandingViewPreference,
+  setLandingViewPreference,
+  resolveLandingView,
+} from '../../utils/landingViewPreference'
 import './HomePreferencesPanel.css'
 
 /**
- * HomePreferencesPanel (spec 058 US4) — choose which mode the home surface
- * opens in (Pay / Request / Wager) and which currency the amount hero starts
- * on. Device-scoped, no wallet required (the choice must apply on first paint
- * at /app, before any connect). Currency options are rendered with the ACTIVE
- * network's real symbols but stored as a network-agnostic kind, so the
- * setting follows the user honestly across networks.
+ * HomePreferencesPanel (spec 058 US4 + landing-view preference) — choose
+ * which screen the app opens on (Home vs Portfolio), which mode the Home
+ * surface itself opens in (Pay / Request / Wager), and which currency the
+ * amount hero starts on. Device-scoped, no wallet required (the choice must
+ * apply on first paint, before any connect). Currency options are rendered
+ * with the ACTIVE network's real symbols but stored as a network-agnostic
+ * kind, so the setting follows the user honestly across networks.
  */
 
 const MODE_LABELS = { pay: 'Pay', request: 'Request', wager: 'Wager' }
+const LANDING_VIEW_LABELS = { auto: 'Auto', home: 'Home', portfolio: 'Portfolio' }
 
 function HomePreferencesPanel() {
   // Setters persist synchronously; a local bump re-reads storage so the
   // checked states are always current.
   const [, forceRender] = useState(0)
   const tokens = useChainTokens()
+  const isMobile = useIsMobile()
 
+  const landingView = getLandingViewPreference()
   const mode = getDefaultHomeMode()
   const kind = getDefaultCurrencyKind()
 
+  const pickLandingView = (next) => {
+    setLandingViewPreference(next)
+    forceRender((n) => n + 1)
+  }
   const pickMode = (next) => {
     setDefaultHomeMode(next)
     forceRender((n) => n + 1)
@@ -47,8 +62,31 @@ function HomePreferencesPanel() {
     <div className="home-preferences-panel">
       <h3 className="home-preferences-panel-title">Home screen</h3>
       <p className="home-preferences-panel-hint">
-        Choose what the app opens on and which currency the amount starts in.
+        Choose which screen the app opens on, what the Home screen starts on, and which currency
+        the amount starts in.
       </p>
+
+      <fieldset className="home-preferences-group">
+        <legend className="home-preferences-legend">Opens on</legend>
+        <div className="home-preferences-options" role="radiogroup" aria-label="Opens on">
+          {LANDING_VIEWS.map((v) => (
+            <label key={v} className={`home-preferences-option ${landingView === v ? 'active' : ''}`}>
+              <input
+                type="radio"
+                name="landing-default-view"
+                value={v}
+                checked={landingView === v}
+                onChange={() => pickLandingView(v)}
+              />
+              <span>{LANDING_VIEW_LABELS[v]}</span>
+            </label>
+          ))}
+        </div>
+        <p className="home-preferences-note">
+          Auto follows this device&apos;s screen size — Home on a phone, Portfolio on a larger
+          display (currently {LANDING_VIEW_LABELS[resolveLandingView(isMobile)]} on this device).
+        </p>
+      </fieldset>
 
       <fieldset className="home-preferences-group">
         <legend className="home-preferences-legend">Default view</legend>

--- a/frontend/src/components/account/__tests__/HomePreferencesPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/HomePreferencesPanel.test.jsx
@@ -2,23 +2,39 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 
 const tokensHolder = {}
+const mockIsMobile = { current: false }
 vi.mock('../../../hooks/useChainTokens', () => ({ useChainTokens: () => tokensHolder }))
+vi.mock('../../../hooks/useMediaQuery', () => ({ useIsMobile: () => mockIsMobile.current }))
 
 import HomePreferencesPanel from '../HomePreferencesPanel'
 import { getDefaultHomeMode, getDefaultCurrencyKind } from '../../../utils/homePreference'
+import { getLandingViewPreference } from '../../../utils/landingViewPreference'
 
 describe('HomePreferencesPanel (spec 058 US4)', () => {
   beforeEach(() => {
     localStorage.clear()
+    mockIsMobile.current = false
     Object.assign(tokensHolder, { networkName: 'Polygon', stable: 'USDC', native: 'POL' })
   })
 
-  it('renders both settings with the built-in presets checked (Pay / USDC)', () => {
+  it('renders all three settings with the built-in presets checked (Auto / Pay / USDC)', () => {
     render(<HomePreferencesPanel />)
+    expect(screen.getByRole('radiogroup', { name: /opens on/i })).toBeInTheDocument()
     expect(screen.getByRole('radiogroup', { name: /default home view/i })).toBeInTheDocument()
     expect(screen.getByRole('radiogroup', { name: /default currency/i })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Auto' })).toBeChecked()
     expect(screen.getByRole('radio', { name: 'Pay' })).toBeChecked()
     expect(screen.getByRole('radio', { name: 'USDC' })).toBeChecked()
+  })
+
+  it('offers Auto/Home/Portfolio and persists a pinned landing view', () => {
+    render(<HomePreferencesPanel />)
+    for (const name of ['Auto', 'Home', 'Portfolio']) {
+      expect(screen.getByRole('radio', { name })).toBeInTheDocument()
+    }
+    fireEvent.click(screen.getByRole('radio', { name: 'Portfolio' }))
+    expect(screen.getByRole('radio', { name: 'Portfolio' })).toBeChecked()
+    expect(getLandingViewPreference()).toBe('portfolio')
   })
 
   it('offers all three modes and persists a new default view', () => {

--- a/frontend/src/test/LandingRoute.test.jsx
+++ b/frontend/src/test/LandingRoute.test.jsx
@@ -1,18 +1,22 @@
 /**
  * LandingRoute — a returning visitor is not made to walk the marketing page
  * before they can sign in, and a visitor who asked for it still gets it.
+ * Which screen they land on (Home or Portfolio) follows landingViewPreference.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 
 const mockWallet = { isConnected: false, connectionStatus: 'disconnected' }
+const mockIsMobile = { current: false }
 vi.mock('../hooks/useWalletManagement', () => ({ useWallet: () => mockWallet }))
+vi.mock('../hooks/useMediaQuery', () => ({ useIsMobile: () => mockIsMobile.current }))
 vi.mock('../components/LandingPage', () => ({ default: () => <div>Marketing page</div> }))
 
 import LandingRoute from '../components/LandingRoute'
 import { ENTRY_GATE_ACK_KEY } from '../utils/entryGateAck'
 import { keepOnLanding } from '../utils/appEntry'
+import { setLandingViewPreference } from '../utils/landingViewPreference'
 
 const PK = { x: `0x${'1'.repeat(64)}`, y: `0x${'1'.repeat(64)}` }
 
@@ -29,6 +33,7 @@ function renderAt(path = '/') {
       <Routes>
         <Route path="/" element={<LandingRoute />} />
         <Route path="/app" element={<div>App home</div>} />
+        <Route path="/wallet" element={<div>Portfolio view</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -39,6 +44,7 @@ beforeEach(() => {
   sessionStorage.clear()
   mockWallet.isConnected = false
   mockWallet.connectionStatus = 'disconnected'
+  mockIsMobile.current = false
 })
 
 describe('LandingRoute', () => {
@@ -47,16 +53,38 @@ describe('LandingRoute', () => {
     expect(screen.getByText('Marketing page')).toBeInTheDocument()
   })
 
-  it('forwards a returning member with a recorded passkey straight into the app', () => {
+  it('forwards a returning member on a larger display to Portfolio by default', () => {
     acknowledge()
     rememberPasskey()
     renderAt()
+    expect(screen.getByText('Portfolio view')).toBeInTheDocument()
+  })
+
+  it('forwards a returning member on mobile to Home by default', () => {
+    acknowledge()
+    rememberPasskey()
+    mockIsMobile.current = true
+    renderAt()
     expect(screen.getByText('App home')).toBeInTheDocument()
+  })
+
+  it('honours a pinned landing-view preference over the device default', () => {
+    acknowledge()
+    rememberPasskey()
+    setLandingViewPreference('home')
+    renderAt()
+    expect(screen.getByText('App home')).toBeInTheDocument()
+
+    setLandingViewPreference('portfolio')
+    mockIsMobile.current = true
+    renderAt()
+    expect(screen.getByText('Portfolio view')).toBeInTheDocument()
   })
 
   it('forwards on a previously used wallet connector too', () => {
     acknowledge()
     localStorage.setItem('wagmi.recentConnectorId', '"injected"')
+    mockIsMobile.current = true
     renderAt()
     expect(screen.getByText('App home')).toBeInTheDocument()
   })
@@ -64,6 +92,7 @@ describe('LandingRoute', () => {
   it('forwards while a stored session is still restoring', () => {
     acknowledge()
     mockWallet.connectionStatus = 'reconnecting'
+    mockIsMobile.current = true
     renderAt()
     expect(screen.getByText('App home')).toBeInTheDocument()
   })

--- a/frontend/src/utils/__tests__/landingViewPreference.test.js
+++ b/frontend/src/utils/__tests__/landingViewPreference.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  LANDING_VIEWS,
+  getLandingViewPreference,
+  setLandingViewPreference,
+  resolveLandingView,
+  resolveLandingPath,
+} from '../landingViewPreference'
+import { HOME_ITEM, PORTFOLIO_PATH } from '../../config/appNav'
+
+const KEY = 'fairwins_landing_view_v1'
+
+describe('landingViewPreference', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('exposes the canonical view order', () => {
+    expect(LANDING_VIEWS).toEqual(['auto', 'home', 'portfolio'])
+  })
+
+  it('defaults to auto when nothing is saved', () => {
+    expect(getLandingViewPreference()).toBe('auto')
+  })
+
+  it('persists and reads back a valid value', () => {
+    setLandingViewPreference('portfolio')
+    expect(getLandingViewPreference()).toBe('portfolio')
+    expect(localStorage.getItem(KEY)).toBe('portfolio')
+  })
+
+  it('ignores invalid values in the setter', () => {
+    setLandingViewPreference('nope')
+    expect(getLandingViewPreference()).toBe('auto')
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('falls back to auto on a corrupt stored value', () => {
+    localStorage.setItem(KEY, 'lottery')
+    expect(getLandingViewPreference()).toBe('auto')
+  })
+
+  it('never throws when storage is unavailable', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => { throw new Error('denied') })
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('denied') })
+    expect(getLandingViewPreference()).toBe('auto')
+    expect(() => setLandingViewPreference('home')).not.toThrow()
+  })
+
+  describe('resolveLandingView', () => {
+    it('follows the viewport when auto (the default)', () => {
+      expect(resolveLandingView(true)).toBe('home')
+      expect(resolveLandingView(false)).toBe('portfolio')
+    })
+
+    it('honours an explicit pin regardless of viewport', () => {
+      setLandingViewPreference('portfolio')
+      expect(resolveLandingView(true)).toBe('portfolio')
+
+      setLandingViewPreference('home')
+      expect(resolveLandingView(false)).toBe('home')
+    })
+  })
+
+  describe('resolveLandingPath', () => {
+    it('maps the resolved view to its route', () => {
+      expect(resolveLandingPath(true)).toBe(HOME_ITEM.to)
+      expect(resolveLandingPath(false)).toBe(PORTFOLIO_PATH)
+    })
+
+    it('maps an explicit pin to its route regardless of viewport', () => {
+      setLandingViewPreference('home')
+      expect(resolveLandingPath(false)).toBe(HOME_ITEM.to)
+
+      setLandingViewPreference('portfolio')
+      expect(resolveLandingPath(true)).toBe(PORTFOLIO_PATH)
+    })
+  })
+})

--- a/frontend/src/utils/landingViewPreference.js
+++ b/frontend/src/utils/landingViewPreference.js
@@ -1,0 +1,52 @@
+/**
+ * Device-scoped preference for which screen the app opens on: the Home
+ * surface (pay/request/wager, spec 053/058) or the Portfolio view (spec 074).
+ *
+ * Left unset ('auto'), the choice follows the viewport — mobile opens on
+ * Home, larger screens open on Portfolio, since a member on a bigger display
+ * wants to see their balance and assets first rather than a create-a-wager
+ * form. A member can still pin either view regardless of device. Follows the
+ * homePreference.js pattern: plain localStorage, graceful fallbacks, never
+ * throws — the choice must apply on first paint, including while disconnected.
+ */
+
+import { HOME_ITEM, PORTFOLIO_PATH } from '../config/appNav'
+
+const LANDING_VIEW_KEY = 'fairwins_landing_view_v1'
+
+export const LANDING_VIEWS = ['auto', 'home', 'portfolio']
+const DEFAULT_LANDING_VIEW = 'auto'
+
+/** Raw stored preference; 'auto' on missing/corrupt/unavailable storage. */
+export function getLandingViewPreference() {
+  try {
+    const saved = localStorage.getItem(LANDING_VIEW_KEY)
+    return LANDING_VIEWS.includes(saved) ? saved : DEFAULT_LANDING_VIEW
+  } catch (error) {
+    console.warn('Error reading landing view preference:', error)
+    return DEFAULT_LANDING_VIEW
+  }
+}
+
+/** Persist the landing view preference; invalid values are ignored. */
+export function setLandingViewPreference(view) {
+  if (!LANDING_VIEWS.includes(view)) return
+  try {
+    localStorage.setItem(LANDING_VIEW_KEY, view)
+  } catch (error) {
+    // Private browsing / quota: degrade to session-only default.
+    console.warn('Error saving landing view preference:', error)
+  }
+}
+
+/** Resolve the preference to an actual view, with 'auto' following the viewport. */
+export function resolveLandingView(isMobile) {
+  const pref = getLandingViewPreference()
+  if (pref === 'home' || pref === 'portfolio') return pref
+  return isMobile ? 'home' : 'portfolio'
+}
+
+/** Resolve the preference straight to the route the app should open on. */
+export function resolveLandingPath(isMobile) {
+  return resolveLandingView(isMobile) === 'portfolio' ? PORTFOLIO_PATH : HOME_ITEM.to
+}


### PR DESCRIPTION
## Summary
- Returning members previously always landed on the Home screen (pay/request/wager), which fits mobile but buries balances/assets on larger displays. The app entry point now opens **Portfolio** by default on non-mobile viewports and **Home** on mobile.
- Added a device-scoped `landingViewPreference` (`fairwins_landing_view_v1`, following the existing `homePreference.js` pattern) so a member can pin either screen (`auto` / `home` / `portfolio`) regardless of device, exposed via a new "Opens on" control in **Preferences ▸ Home screen**.
- Applied consistently at the three places the app forwards a visitor into the product: `LandingRoute` (returning-member auto-forward from `/`), and the marketing page's "Launch App" (`Header`) and "Get Started" (`LandingPage`) buttons.

## Test plan
- [x] `npx vitest run src/utils/__tests__/landingViewPreference.test.js src/test/LandingRoute.test.jsx src/components/account/__tests__/HomePreferencesPanel.test.jsx src/utils/__tests__/homePreference.test.js src/config/__tests__/appNav.test.js src/test/LandingPage.oracle.test.jsx` — 53/53 passing
- [x] `npx eslint` on all changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01H3SngnjPwB2xBgHp2r2Ei7)_