### PR TITLE
fix(test): the AEAD tamper test sometimes did not tamper (1 in 4,500)

### DIFF
--- a/frontend/src/test/addressBook/addressBookCrypto.test.js
+++ b/frontend/src/test/addressBook/addressBookCrypto.test.js
@@ -45,7 +45,16 @@ describe('addressBookCrypto', () => {
 
   it('rejects a tampered envelope (AEAD)', async () => {
     const envelope = JSON.parse(await exportAddressBook(sampleBook(), signerA))
-    envelope.ciphertext = envelope.ciphertext.slice(0, -2) + '00'
+    /*
+     * The replacement is CONDITIONAL, matching backupCrypto.test.js:34 and claimCode.test.js:126.
+     * It used to append a constant '00', which is a no-op whenever the ciphertext already ends in
+     * '00' — nothing was tampered, the import legitimately succeeded, and the test failed with
+     * "promise resolved instead of rejecting". Measured rate over 200k random ciphertexts: 0.022%,
+     * about 1 run in 4,500 — rare enough to look like a mystery flake in a crypto test and read as
+     * "AEAD did not detect tampering", which is alarming and was never true.
+     */
+    const tail = envelope.ciphertext.slice(-2)
+    envelope.ciphertext = envelope.ciphertext.slice(0, -2) + (tail === '00' ? 'ff' : '00')
     await expect(importAddressBook(JSON.stringify(envelope), signerA)).rejects.toThrow()
   })
 })


### PR DESCRIPTION
Failed CI on `075-monorepo-workspaces-complete` with `promise resolved instead of rejecting` — which reads as AEAD failing to detect tampering. It is not that.

The tamper appended a **constant**:

```js
envelope.ciphertext = envelope.ciphertext.slice(0, -2) + '00'
```

so whenever the ciphertext already ended in `00`, nothing was tampered, the import legitimately succeeded, and the assertion failed. **Measured: 0.022% of ciphertexts — about 1 run in 4,500.**

Its two siblings already get this right by choosing a replacement that differs from what is there:

| file | idiom | safe? |
|---|---|---|
| `backupCrypto.test.js:34` | `slice(0,-1) + (last === 'a' ? 'b' : 'a')` | yes |
| `claimCode.test.js:126` | `slice(0,-2) + (… === 'ff' ? '00' : 'ff')` | yes |
| `addressBookCrypto.test.js:48` | `slice(0,-2) + '00'` | **no** |

Same drifted-duplicate shape as the E2E findings in #1019 — one copy carries the fix, a twin does not.

Also verified the replacement changes the **decoded bytes**, not merely the base64 string (trailing base64 bits can be insignificant under padding): **0 no-op tampers across 12 payload lengths x 20k samples**. `src/test/addressBook/` is 73/73 over three consecutive runs.