### PR TITLE
fix(ci): two more workflows skipped PRs targeting a feature branch

### DIFF
--- a/.github/workflows/frontend-testing.yml
+++ b/.github/workflows/frontend-testing.yml
@@ -1,10 +1,11 @@
 name: Frontend Testing and Accessibility Audits
 
 on:
+  # No `branches:` filter — see subgraph-build.yml. This workflow runs the FULL frontend suite,
+  # which is a superset of ci-manager's; restricting it to main/develop meant a PR into a feature
+  # branch was reviewed against the smaller set. That is how the addressBookCrypto AEAD flake
+  # (#1032) reached 075: the PR fixing it could not run the workflow that caught it.
   pull_request:
-    branches:
-      - main
-      - develop
     paths:
       - 'frontend/**'
   push:

--- a/.github/workflows/subgraph-build.yml
+++ b/.github/workflows/subgraph-build.yml
@@ -4,10 +4,11 @@ name: Subgraph Build and Tests
 # as a failing gate. No continue-on-error on these steps (constitution IV).
 
 on:
+  # No `branches:` filter. A base-branch filter is not a decision about whether code needs
+  # testing: a PR into a feature branch would skip this gate entirely, and stacked PRs (a
+  # feature branch collecting fixes before one merge to main) are the normal shape of work
+  # here. The `paths:` filter below is what scopes this workflow; the base branch is not.
   pull_request:
-    branches:
-      - main
-      - develop
     paths:
       - 'subgraph/**'
       - 'packages/abi/**'

--- a/test/config/CiGates.test.js
+++ b/test/config/CiGates.test.js
@@ -291,7 +291,14 @@ describe("CI gates cannot be silently disabled (spec 075)", function () {
      * `paths:` is the right way to scope a workflow. The base branch is not: it encodes an
      * assumption that code merging somewhere other than main deserves less checking, and stacked
      * PRs are the normal shape of work in this repo.
+     *
+     * BOTH filter keys are checked. GitHub accepts `branches` and `branches-ignore` (mutually
+     * exclusive per event), and `branches-ignore: ['075-*']` skips stacked PRs exactly as
+     * `branches: [main]` does. Checking only the first would leave this test's NAME — no base
+     * branch filtering — broader than what it asserts, which is the same over-claiming shape the
+     * rest of this file exists to catch. Reported by review on #1033.
      */
+    const BASE_FILTER_KEYS = ["branches", "branches-ignore"];
     const offenders = [];
     for (const file of workflowFiles()) {
       const wf = readWorkflow(file);
@@ -299,12 +306,15 @@ describe("CI gates cannot be silently disabled (spec 075)", function () {
       if (!triggers || typeof triggers !== "object") continue;
       const pr = triggers.pull_request;
       if (pr == null || typeof pr !== "object") continue; // absent, or the unrestricted `pull_request:` form
-      if (pr.branches) offenders.push(`${file} (branches=${JSON.stringify(pr.branches)})`);
+      for (const key of BASE_FILTER_KEYS) {
+        if (pr[key]) offenders.push(`${file} (${key}=${JSON.stringify(pr[key])})`);
+      }
     }
     expect(
       offenders,
       "These workflows skip PRs that target a feature branch, so stacked work is gated more " +
-        `weakly than a direct PR to main. Scope with \`paths:\`, not \`branches:\`:\n  ${offenders.join("\n  ")}`,
+        "weakly than a direct PR to main. Scope with `paths:`, not `branches:`/`branches-ignore:`:" +
+        `\n  ${offenders.join("\n  ")}`,
     ).to.deep.equal([]);
   });
 });

--- a/test/config/CiGates.test.js
+++ b/test/config/CiGates.test.js
@@ -278,6 +278,35 @@ describe("CI gates cannot be silently disabled (spec 075)", function () {
         `run zero jobs and merge on Release Drafter alone (found branches=${JSON.stringify(branches)})`,
     ).to.equal(undefined);
   });
+
+  it("NO workflow filters its pull_request trigger by base branch", function () {
+    /*
+     * The test above pinned ci-manager alone, which closed one instance and left the class open:
+     * frontend-testing.yml and subgraph-build.yml kept `branches: [main, develop]`, so a PR into a
+     * feature branch was reviewed against strictly less than a PR into main. That is not
+     * hypothetical — the AEAD tamper flake (#1032) failed on the 075 branch in the FULL frontend
+     * suite, and the PR fixing it could not run the workflow that caught it, because that PR
+     * targeted 075 rather than main.
+     *
+     * `paths:` is the right way to scope a workflow. The base branch is not: it encodes an
+     * assumption that code merging somewhere other than main deserves less checking, and stacked
+     * PRs are the normal shape of work in this repo.
+     */
+    const offenders = [];
+    for (const file of workflowFiles()) {
+      const wf = readWorkflow(file);
+      const triggers = wf.on ?? wf[true] ?? {};
+      if (!triggers || typeof triggers !== "object") continue;
+      const pr = triggers.pull_request;
+      if (pr == null || typeof pr !== "object") continue; // absent, or the unrestricted `pull_request:` form
+      if (pr.branches) offenders.push(`${file} (branches=${JSON.stringify(pr.branches)})`);
+    }
+    expect(
+      offenders,
+      "These workflows skip PRs that target a feature branch, so stacked work is gated more " +
+        `weakly than a direct PR to main. Scope with \`paths:\`, not \`branches:\`:\n  ${offenders.join("\n  ")}`,
+    ).to.deep.equal([]);
+  });
 });
 
 describe("contracts/ remains a single compilation unit (spec 075, FR-048)", function () {


### PR DESCRIPTION
The dispatcher fix earlier in this branch closed **one instance** of this and left the class open. `frontend-testing.yml` and `subgraph-build.yml` still carried `branches: [main, develop]` on their `pull_request` trigger.

**Not hypothetical.** The addressBookCrypto AEAD flake failed on `075-monorepo-workspaces-complete` inside frontend-testing's **full** frontend suite — a superset of ci-manager's — and #1032, the PR that fixed it, **could not run the workflow that caught it**, because it targeted 075 rather than `main`. The only reason that workflow ran on 075 at all is that pushing there updates #1015, whose base *is* `main`.

| workflow | before | after |
|---|---|---|
| `ci-manager.yml` | any base (fixed earlier) | unchanged |
| `frontend-testing.yml` | `[main, develop]` | **any base** |
| `subgraph-build.yml` | `[main, develop]` | **any base** |
| `oracle-fork-tests.yml`, `release-drafter.yml` | any base | unchanged |

`paths:` is the right way to scope a workflow — both keep theirs. A base-branch filter encodes an assumption that code merging somewhere other than `main` deserves less checking, and stacked PRs are the normal shape of work in this repo.

The `CiGates` test now asserts this across **every** workflow instead of pinning `ci-manager` by name, so a third one cannot reintroduce it. Mutation-tested — with the restriction re-added it fails and names the offending file:

```
AssertionError: These workflows skip PRs that target a feature branch...
  subgraph-build.yml (branches=["main","develop"])
```

13 passing.