### PR TITLE
fix(build): both shipped container images were broken by the workspace conversion

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -82,13 +82,41 @@ jobs:
         run: docker build -f services/relay-gateway/Dockerfile -t fairwins-relay-gateway:ci .
 
       # Building is NOT enough — this image built green for the entire life of the workspace
-      # branch and exited instantly at runtime. Resolve the workspace package the way node will.
-      - name: Assert the workspace package resolves at runtime
+      # branch and exited instantly at runtime.
+      #
+      # An import probe is not enough EITHER. Checking only that @fairwins/intent-types resolves
+      # would leave this job's name ("builds and boots") broader than what it asserts, and would
+      # ship green through any other boot regression: loadConfig() throwing, a missing
+      # deployments/ record failing the FR-025 startup check, or any runtime ESM error outside
+      # that one import. Reported in review on #1034. So: start the real entrypoint and require
+      # the server to actually answer.
+      - name: Boot the container and require /healthz to answer
         run: |
           set -o pipefail
-          docker run --rm --entrypoint node fairwins-relay-gateway:ci \
-            -e "import('@fairwins/intent-types').then(m => {
-                  const n = Object.keys(m.INTENT_TYPES || {}).length;
-                  if (!n) { console.error('resolved but empty'); process.exit(1); }
-                  console.log('intent-types resolved, structs:', n);
-                }).catch(e => { console.error(e.message); process.exit(1); })"
+          docker run -d --name gw -p 8788:8788 fairwins-relay-gateway:ci
+
+          for i in $(seq 1 30); do
+            if ! docker ps --filter name=gw --filter status=running -q | grep -q .; then
+              echo "::error::the container exited during startup"
+              docker logs gw
+              exit 1
+            fi
+            if curl -fsS --max-time 2 http://127.0.0.1:8788/healthz >/dev/null 2>&1; then
+              echo "healthz answered after ${i}s"
+              docker logs gw
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "::error::container stayed up but /healthz never answered within 30s"
+          docker logs gw
+          exit 1
+
+      - name: Container logs (on failure)
+        if: failure()
+        run: docker logs gw || true
+
+      - name: Stop the container
+        if: always()
+        run: docker rm -f gw || true

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -90,33 +90,39 @@ jobs:
       # deployments/ record failing the FR-025 startup check, or any runtime ESM error outside
       # that one import. Reported in review on #1034. So: start the real entrypoint and require
       # the server to actually answer.
+      #
+      # Written WITHOUT `exit 0` and without `|| true`, because CiGates rejects both — correctly:
+      # a bare `exit 0` is exactly how a step forces success, and the guard cannot distinguish my
+      # "early return on success" from that. Restructuring costs nothing and keeps the guard
+      # strict; an exemption would have spent the guard's credibility on my own convenience.
       - name: Boot the container and require /healthz to answer
         run: |
-          set -o pipefail
+          set -euo pipefail
           docker run -d --name gw -p 8788:8788 fairwins-relay-gateway:ci
 
+          healthy=0
           for i in $(seq 1 30); do
             if ! docker ps --filter name=gw --filter status=running -q | grep -q .; then
               echo "::error::the container exited during startup"
-              docker logs gw
-              exit 1
+              break
             fi
             if curl -fsS --max-time 2 http://127.0.0.1:8788/healthz >/dev/null 2>&1; then
+              healthy=1
               echo "healthz answered after ${i}s"
-              docker logs gw
-              exit 0
+              break
             fi
             sleep 1
           done
 
-          echo "::error::container stayed up but /healthz never answered within 30s"
+          if [ "$healthy" != 1 ]; then
+            echo "::error::the gateway never served /healthz — see the container logs below"
+          fi
           docker logs gw
-          exit 1
+          # Last command, so its status IS the step's. No `exit`, nothing to swallow.
+          test "$healthy" = 1
 
-      - name: Container logs (on failure)
-        if: failure()
-        run: docker logs gw || true
-
+      # `xargs -r` runs nothing when there is no match, so this exits 0 on its own rather than
+      # needing `|| true` — including when the boot step failed before the container existed.
       - name: Stop the container
         if: always()
-        run: docker rm -f gw || true
+        run: docker ps -aq --filter "name=^gw$" | xargs -r docker rm -f

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,94 @@
+name: Container Images Build
+
+# Spec 075 fallout. The workspace conversion broke BOTH shipped images and CI reported green,
+# because no workflow has ever built either one:
+#
+#   · the SPA image ran `npm ci` inside frontend/ after this repo dropped to a single root
+#     lockfile — `npm ci` cannot install without a lockfile, so the image failed outright;
+#   · the relay-gateway image BUILT SUCCESSFULLY and then died at boot on
+#     ERR_MODULE_NOT_FOUND, because `npm ci` writes a workspace symlink whether or not its
+#     target directory exists, and packages/intent-types was never copied in.
+#
+# CI missed both because its jobs run `npm ci --workspace <name>` against a FULL CHECKOUT, where
+# packages/ is present. The Docker build context is a different, narrower world, and it was the
+# only world nothing tested. This workflow tests that world.
+#
+# No `branches:` filter — a PR into a feature branch needs this as much as one into main, and
+# scoping by base branch is the defect fixed in #1033. `paths:` is the scoping tool.
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'services/**/Dockerfile'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'frontend/package.json'
+      - 'services/relay-gateway/package.json'
+      - 'packages/**'
+      - 'tools/miniapp-build/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'services/**/Dockerfile'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'packages/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  spa-image:
+    name: SPA image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # `--target build` stops before nginx: the build stage is where the workspace install and
+      # the Vite build happen, which is the whole risk surface. Building the runtime stage too
+      # would only copy an already-produced dist/.
+      - name: Build the frontend image build stage
+        run: docker build -f Dockerfile --target build -t fairwins-spa:ci .
+
+      # A build that exits 0 having produced nothing is the failure mode this repo keeps hitting,
+      # so assert the artefact rather than the exit code.
+      - name: Assert the bundle actually exists
+        run: |
+          set -o pipefail
+          docker run --rm --entrypoint sh fairwins-spa:ci -c '
+            test -s dist/index.html || { echo "::error::dist/index.html missing or empty"; exit 1; }
+            n=$(ls dist/assets 2>/dev/null | wc -l)
+            [ "$n" -gt 0 ] || { echo "::error::dist/assets is empty"; exit 1; }
+            echo "bundle OK: $n asset(s)"
+          '
+
+  gateway-image:
+    name: Relay gateway image builds and boots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the relay-gateway image
+        run: docker build -f services/relay-gateway/Dockerfile -t fairwins-relay-gateway:ci .
+
+      # Building is NOT enough — this image built green for the entire life of the workspace
+      # branch and exited instantly at runtime. Resolve the workspace package the way node will.
+      - name: Assert the workspace package resolves at runtime
+        run: |
+          set -o pipefail
+          docker run --rm --entrypoint node fairwins-relay-gateway:ci \
+            -e "import('@fairwins/intent-types').then(m => {
+                  const n = Object.keys(m.INTENT_TYPES || {}).length;
+                  if (!n) { console.error('resolved but empty'); process.exit(1); }
+                  console.log('intent-types resolved, structs:', n);
+                }).catch(e => { console.error(e.message); process.exit(1); })"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,33 @@
 # Stage 1: Build the React application
 FROM node:22-alpine AS build
 
+# Build from the REPO ROOT, not frontend/ (spec 075). There is one root lockfile now, so
+# `COPY frontend/package*.json` matched only package.json and `npm ci` failed outright with
+# "can only install with an existing package-lock.json". Restoring a child lockfile is not the
+# fix either: frontend/package.json declares @fairwins/intent-types and @fairwins/miniapp-build,
+# which are `private: true` workspace packages that can never resolve from the registry.
+WORKDIR /app
+
+# Manifests first, so a source-only change does not invalidate the install layer.
+COPY package.json package-lock.json ./
+COPY frontend/package.json ./frontend/
+COPY packages/intent-types/package.json ./packages/intent-types/
+COPY tools/miniapp-build/package.json ./tools/miniapp-build/
+
+RUN npm ci --workspace frontend --include-workspace-root=false
+
+# The linked workspace SOURCES. `npm ci` writes a workspace link whether or not the target
+# directory exists — a missing one yields a DANGLING symlink and an install that looks clean,
+# which is exactly how the relay-gateway image built successfully and then crashed on boot.
+COPY packages/intent-types/ ./packages/intent-types/
+COPY tools/miniapp-build/ ./tools/miniapp-build/
+
+# Source + tenant manifests (spec 072 — the tenant-branding plugin resolves tenants/ as a
+# sibling of the frontend tree; the build fails loudly if the directory is missing).
+COPY frontend/ ./frontend/
+COPY tenants/ ./tenants/
+
 WORKDIR /app/frontend
-
-# Copy package files
-COPY frontend/package*.json ./
-
-# Install dependencies
-RUN npm ci
-
-# Copy source code + tenant manifests (spec 072 — the tenant-branding plugin
-# resolves tenants/ as a sibling of the frontend tree; the build fails loudly
-# if the directory is missing)
-COPY frontend/ .
-COPY tenants/ ../tenants/
 
 # Build arguments for environment variables (baked into JS bundle at build time)
 # Note: VITE_PINATA_JWT is NOT included here - it's handled at runtime via nginx proxy

--- a/services/relay-gateway/Dockerfile
+++ b/services/relay-gateway/Dockerfile
@@ -14,6 +14,11 @@ WORKDIR /app
 # whatever the registry served that day.
 COPY package.json package-lock.json ./
 COPY services/relay-gateway/package.json ./services/relay-gateway/
+# The linked workspace package's manifest must be present too. This service depends on
+# @fairwins/intent-types (spec 075, FR-024), and `npm ci` writes the workspace symlink whether
+# or not its target exists — so omitting it produced a DANGLING link, a build that succeeded,
+# and a container that died at boot on ERR_MODULE_NOT_FOUND. The install cannot tell you.
+COPY packages/intent-types/package.json ./packages/intent-types/
 RUN npm ci --omit=dev --no-audit --no-fund \
       --workspace fairwins-relay-gateway --include-workspace-root=false
 
@@ -23,6 +28,12 @@ ENV NODE_ENV=production
 COPY --from=deps /app/node_modules ./node_modules
 COPY services/relay-gateway/package.json ./
 COPY services/relay-gateway/src ./src
+# The symlink copied with node_modules resolves to /app/packages/intent-types, so the RUNTIME
+# stage needs the real files as well — carrying the link alone is what made this image start
+# and immediately exit. src/intent/intentTypes.js imports it at module load, reached from
+# src/server.js at boot, so every gateway surface (035/036 intents, the 050 paymaster endpoint,
+# the 057 Polymarket proxy, 060 fee reads, 061 Bitcoin) fails together.
+COPY packages/intent-types ./packages/intent-types
 # Version-pinned target set (FR-025): the deployments records are baked into the image so the
 # startup consistency check validates against the exact addresses this build was shipped with.
 COPY deployments ./deployments


### PR DESCRIPTION
Found by reviewing #1015 — which **Copilot declined to review** ("exceeds the maximum number of lines (20,000)"), so the 47-commit change heading for `main` had received no automated review at all. Two independent reviewers reproduced both of these by building the actual images.

## 1. The SPA image did not build

`Dockerfile` ran `npm ci` inside `frontend/`, but this branch drops to a single root lockfile, so `COPY frontend/package*.json ./` matched only `package.json`:

```
npm error `npm ci` can only install with an existing package-lock.json
```

This is the image `cloudbuild.yaml` deploys to **fairwins.app**.

Restoring a child lockfile is *not* the fix: `frontend/package.json` declares `@fairwins/intent-types` and `@fairwins/miniapp-build`, both `private: true` workspace packages that can never resolve from the registry. The build now runs from the repo root with `npm ci --workspace frontend`, copying the linked workspace sources.

## 2. The relay-gateway image built green and died at boot

It declares `@fairwins/intent-types` but copied `packages/intent-types` into **neither** stage. `npm ci` writes a workspace symlink whether or not its target exists, so the install exited 0 with a **dangling link**:

```
node_modules/@fairwins/intent-types -> ../../packages/intent-types   (dangling)

$ docker run --rm <image>
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@fairwins/intent-types'
    imported from /app/src/intent/intentTypes.js
```

`src/server.js` reaches that import at boot, so the blast radius is every gateway surface at once — relayed intents (035/036) **and** the spec-050 paymaster endpoint are the same service — plus the Polymarket proxy (057), fee reads (060) and Bitcoin (061).

## Verified by building, not by inspection

| | before | after |
|---|---|---|
| SPA build stage | `npm ci` fails, exit 1 | builds; `dist/index.html` + **18 assets** + `sw.js` |
| gateway image | builds, then exits instantly | `intent-types resolved, structs: 27`, stays up |

## Why CI caught neither

**Nothing builds these images.** CI's `Frontend Build` and `relay-gateway-tests` jobs run `npm ci --workspace <name>` against a **full checkout**, where `packages/` exists — so they are green *precisely because* they never exercise the Docker build context, which is a narrower world.

`container-build.yml` closes that gap, and asserts the **artefact rather than the exit code**, because building was never the part that failed:

- SPA job: requires a non-empty `dist/index.html` and at least one file in `dist/assets`.
- Gateway job: resolves `@fairwins/intent-types` the way node will, and fails if it resolves empty.

No `branches:` filter — scoping a gate by base branch is the defect fixed in #1033.

## Not in this PR

The same review found that **the byte-reproducibility gates are not wired into CI at all** — `bytecode-digest.js` is referenced only in a comment, and `record-build-digests.js` appears in no workflow, despite `plan.md` describing the first as "blocks the change on any difference". The mini-app gate also has a reachable false pass (a *failing* `vite build` followed by `--compare` prints `OK` and exits 0). Those are being tracked separately rather than folded in here.
