### PR TITLE
fix(ci): the two byte-reproducibility gates were never wired into CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,19 @@ jobs:
       - name: Check generated ABIs are current
         run: npm run check:abis
 
+      # Gate (spec 075, FR-005). plan.md describes this feature as "gated on a byte-for-byte
+      # bytecode diff that BLOCKS the change on any difference" — but the script was referenced
+      # nowhere except a comment in dependabot.yml, so it blocked nothing and was a tool someone
+      # had to remember to run. This is the step that makes the sentence true.
+      #
+      # It is the only automated defence against the incident that motivated the pin: a floating
+      # @chainlink/contracts (1.3.0 -> 1.5.0) silently changed ChainlinkFunctionsOracleAdapter's
+      # deployed bytecode with every other gate green, because CompilerTargets only checks the
+      # SHAPE of a version range, not the bytes that come out. Runs directly after Compile so the
+      # artifacts it hashes are this run's.
+      - name: Bytecode is byte-identical to the recorded baseline
+        run: node scripts/codegen/bytecode-digest.js --compare specs/075-monorepo-workspaces/baseline-bytecode.json
+
       # spec 075 FR-041: exercise the task graph with caching DISABLED. Turborepo does not sandbox,
       # so an undeclared input yields a wrong cache hit rather than an error; the cache is not
       # trusted in CI until the graph has been observed to reproduce this pipeline's outcomes.
@@ -166,6 +179,45 @@ jobs:
           # what exhausted it and failed every job on upload. Coverage numbers land in
           # the step summary above; the HTML is only read same-day, if ever.
           retention-days: 7
+
+  # Gate (spec 075, FR-019/FR-020/B2). Mini-app output bytes are keccak-committed on-chain in
+  # MiniAppRegistry, and the chain of custody is:
+  #   npm hoisting -> module resolution -> host shim text -> entry.js -> manifest hash -> on-chain
+  # A change to installation layout can therefore invalidate an immutable, curated, on-chain record
+  # with no error raised anywhere. This gate existed as a script but appeared in NO workflow — it
+  # was a manual checklist item, for the one guarantee in this repo that cannot be re-checked after
+  # the fact.
+  miniapp-bytes:
+    name: Mini-app Output Bytes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # `--since` stamped BEFORE the build, and `&&` so a failed build can never reach the
+      # compare. Both matter: the compare used to accept any dist/ younger than 10 minutes, so a
+      # build that FAILED left the previous successful output in place and the gate printed
+      # "output bytes unchanged" — the exact false pass its own source comment describes, which
+      # happened once already when rollup's native binary went missing during this conversion.
+      - name: Build mini-apps and compare output bytes
+        run: |
+          set -o pipefail
+          STAMP=$(($(date +%s) * 1000))
+          npm run build:miniapps
+          node scripts/miniapps/record-build-digests.js \
+            --compare specs/075-monorepo-workspaces/baseline-miniapp-builds.json \
+            --since "$STAMP"
 
   frontend-lint:
     name: Frontend Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,10 +212,18 @@ jobs:
       # happened once already when rollup's native binary went missing during this conversion.
       - name: Build mini-apps and compare output bytes
         run: |
-          set -o pipefail
+          set -euo pipefail
           STAMP=$(($(date +%s) * 1000))
-          npm run build:miniapps
-          node scripts/miniapps/record-build-digests.js \
+          # Explicit `&&`, and explicit `-e`. The comment above claims the compare cannot be
+          # reached by a failed build, so the code must say that rather than lean on the runner's
+          # default `bash -e {0}` — a `shell:` override, or someone copying this block elsewhere,
+          # would silently turn the claim false. Relying on implicit shell behaviour for a gate's
+          # blocking property is how the tee'd steps in this repo lost their exit codes.
+          #
+          # KEEP THIS COMPOUND LAST. `set -e` deliberately does NOT fire on a failing left-hand
+          # side of `&&`, so the build's failure reaches the step only as the compound's own exit
+          # status. Verified: with a trailing command after it, a failed build yields step exit 0.
+          npm run build:miniapps && node scripts/miniapps/record-build-digests.js \
             --compare specs/075-monorepo-workspaces/baseline-miniapp-builds.json \
             --since "$STAMP"
 

--- a/scripts/miniapps/record-build-digests.js
+++ b/scripts/miniapps/record-build-digests.js
@@ -50,6 +50,7 @@ const args = process.argv.slice(2);
 const outIdx = args.indexOf("--out");
 const cmpIdx = args.indexOf("--compare");
 const maxAgeIdx = args.indexOf("--max-age-seconds");
+const sinceIdx = args.indexOf("--since");
 const now = digests();
 
 /**
@@ -64,24 +65,59 @@ const now = digests();
  * a build pass a small window; the default is off only for `--out`, where recording whatever is
  * on disk is the intent.
  */
-function assertFresh(maxAgeSeconds) {
+/**
+ * `--since <epoch-ms>` is the CORRECT form and what CI uses: the caller stamps the time before it
+ * starts the build, so "fresh" means "written by THIS run". Absolute age cannot express that. A
+ * build that FAILED, followed by a compare inside the age window, hashed the previous successful
+ * dist/ and printed OK — the very incident the comment above describes, still reachable for ten
+ * minutes, which is exactly the iterate-and-rerun cadence.
+ *
+ * Age remains as a fallback for a human running the sweep by hand.
+ */
+function assertFresh({ maxAgeSeconds, sinceMs }) {
   const stale = [];
-  const cutoff = Number(process.env.SOURCE_DATE_EPOCH ? 0 : maxAgeSeconds);
+  // SOURCE_DATE_EPOCH means "reproducible build, timestamps are pinned" — freshness is then
+  // unknowable and the check must be SKIPPED. It previously set the cutoff to 0, which marked
+  // every file stale the instant it was written: the escape hatch was a permanent hard failure,
+  // and a gate that always fails is a gate someone deletes.
+  if (process.env.SOURCE_DATE_EPOCH) return;
+
   for (const app of APPS) {
     for (const f of FILES) {
       const p = path.join(ROOT, "frontend", "miniapps", app, "dist", f);
-      const ageSec = (Date.now() - fs.statSync(p).mtimeMs) / 1000;
-      if (ageSec > cutoff) stale.push(`${app}/${f} (${Math.round(ageSec)}s old)`);
+      const mtimeMs = fs.statSync(p).mtimeMs;
+      if (sinceMs != null) {
+        if (mtimeMs < sinceMs) {
+          stale.push(`${app}/${f} (written ${Math.round((sinceMs - mtimeMs) / 1000)}s BEFORE this run)`);
+        }
+        continue;
+      }
+      const ageSec = (Date.now() - mtimeMs) / 1000;
+      if (ageSec > maxAgeSeconds) stale.push(`${app}/${f} (${Math.round(ageSec)}s old)`);
     }
   }
   if (stale.length) {
     console.error(
-      `\nFAIL: ${stale.length} built file(s) are older than ${maxAgeSeconds}s — the build did not just run.\n` +
+      `\nFAIL: ${stale.length} built file(s) predate this verification run — the build did not just run.\n` +
         "Refusing to compare a stale dist/: that reports success for a build that never happened.\n" +
         stale.map((s) => `  · ${s}`).join("\n"),
     );
     process.exit(2);
   }
+}
+
+/**
+ * Fail CLOSED on an unusable value. `Number(undefined)` and `Number("abc")` are both NaN, and
+ * `age > NaN` is always false — so `--max-age-seconds` with a missing or non-numeric argument
+ * silently disabled the freshness check entirely and a three-hour-old dist/ reported OK.
+ */
+function numericArg(flag, raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    console.error(`FAIL: ${flag} needs a non-negative number (got ${JSON.stringify(raw)}).`);
+    process.exit(2);
+  }
+  return n;
 }
 
 const missing = Object.entries(now).filter(([, v]) => v === "MISSING");
@@ -99,8 +135,11 @@ if (outIdx !== -1) {
 
 if (cmpIdx !== -1) {
   // Default window: 10 minutes. Long enough for two real builds, short enough that yesterday's
-  // dist cannot masquerade as today's.
-  assertFresh(maxAgeIdx !== -1 ? Number(args[maxAgeIdx + 1]) : 600);
+  // dist cannot masquerade as today's. `--since` supersedes it and is what CI passes.
+  assertFresh({
+    sinceMs: sinceIdx !== -1 ? numericArg("--since", args[sinceIdx + 1]) : null,
+    maxAgeSeconds: maxAgeIdx !== -1 ? numericArg("--max-age-seconds", args[maxAgeIdx + 1]) : 600,
+  });
   const base = JSON.parse(fs.readFileSync(args[cmpIdx + 1], "utf8"));
   const diff = Object.keys(base).filter((k) => base[k] !== now[k]);
   Object.keys(base).forEach((k) => console.log(`${base[k] === now[k] ? "  match " : "  DIFFER"} ${k}`));


### PR DESCRIPTION
Found reviewing #1015. Both gates exist as scripts and appear in **no workflow** — `bytecode-digest.js` is referenced only by a comment in `dependabot.yml`, `record-build-digests.js` by nothing at all. They were manual checklist items, for the two guarantees in this repo that **cannot be re-checked after the fact**.

`plan.md` describes the first as *"gated on a byte-for-byte bytecode diff (FR-005) that **blocks the change on any difference**"*. It blocked nothing.

It is also the only automated defence against the incident that motivated the exact pins: a floating `@chainlink/contracts` 1.3.0→1.5.0 silently changed `ChainlinkFunctionsOracleAdapter`'s deployed bytecode with every other gate green — `CompilerTargets` only checks the **shape** of a version range, never the bytes that come out.

The mini-app gate guards bytes **keccak-committed on-chain** in MiniAppRegistry, along this chain of custody:

```
npm hoisting -> module resolution -> host shim text -> entry.js -> manifest hash -> on-chain record
```

A hoisting change can invalidate an immutable, curated, on-chain commitment with no error raised anywhere. **This PR's parent is a hoisting change.**

## The mini-app gate also had a reachable false pass

Worse than being unwired. Three defects in the freshness guard:

| defect | before | after |
|---|---|---|
| Freshness was **absolute age** — a *failed* build left the previous `dist/` and the compare printed `OK` | exit 0 | `--since` stamped pre-build ⇒ exit 2 |
| `SOURCE_DATE_EPOCH` set cutoff to 0, marking every file stale the instant it was written | exit 2 (always) | exit 0 (check skipped) |
| `--max-age-seconds` with junk ⇒ `NaN`, and `age > NaN` is always false | exit 0 (check disabled) | exit 2 (fails closed) |

The first is the incident the function's **own comment** describes — still reachable for ten minutes, which is exactly the iterate-and-rerun cadence. CI also chains with `&&` so a failed build can never reach the compare.

## Verified

```
junk --max-age-seconds       -> exit 2   (was 0)
--max-age-seconds, no value  -> exit 2   (was 0)
SOURCE_DATE_EPOCH set        -> exit 0   (was 2)
--since in the future        -> exit 2   (the false pass)
--since long ago             -> exit 0   (genuinely fresh)
```

Both gates pass on this tree (`CHANGED: 0  REMOVED: 0  ADDED: 0`). CiGates 12 passing.