### PR TITLE
fix(turbo): three undeclared inputs that could serve a wrong cache hit (#1036)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -65,7 +65,29 @@
         "src/**",
         "test/**",
         "vite.config.js",
+        "vite-plugins/**"
+      ]
+    },
+    "frontend#test": {
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "src/**",
+        "test/**",
+        "vite.config.js",
         "vite-plugins/**",
+        "$TURBO_ROOT$/tenants/**",
+        "$TURBO_ROOT$/packages/*/src/**"
+      ]
+    },
+    "fairwins-relay-gateway#test": {
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "src/**",
+        "test/**",
         "$TURBO_ROOT$/tenants/**",
         "$TURBO_ROOT$/packages/*/src/**"
       ]

--- a/turbo.json
+++ b/turbo.json
@@ -66,8 +66,8 @@
         "test/**",
         "vite.config.js",
         "vite-plugins/**",
-        "../../tenants/**",
-        "../../packages/*/src/**"
+        "$TURBO_ROOT$/tenants/**",
+        "$TURBO_ROOT$/packages/*/src/**"
       ]
     },
     "build": {
@@ -80,10 +80,35 @@
         "index.html",
         "vite.config.js",
         "vite-plugins/**",
-        "../../tenants/**"
+        "$TURBO_ROOT$/tenants/**"
       ],
       "outputs": [
         "dist/**"
+      ]
+    },
+    "@fairwins/miniapp-build#build": {
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "*.js",
+        "package.json",
+        "$TURBO_ROOT$/tenants/**"
+      ],
+      "outputs": []
+    },
+    "prediction-dao-research-subgraph#build": {
+      "dependsOn": [
+        "codegen"
+      ],
+      "inputs": [
+        "src/**",
+        "subgraph.yaml",
+        "schema.graphql",
+        "$TURBO_ROOT$/packages/abi/json/**"
+      ],
+      "outputs": [
+        "build/**"
       ]
     },
     "codegen": {


### PR DESCRIPTION
Closes the three highest-risk items on #1036. Turborepo does not sandbox, so an undeclared input yields a **wrong cache hit rather than an error** — `turbo.json`'s own header says every `inputs` list is a safety claim. Three of them were false.

## 1. The mini-app build preset was hashed by nothing

`@fairwins/miniapp-build` lives flat at `tools/miniapp-build/*.js` with no `src/`, so the shared `build` globs matched **none of its own source** — it hashed 6 inputs, five of them tenants files, plus `package.json`.

`hostScopePlugin.js` renders shim text that is *literally embedded* in `entry.js`, whose sha256 goes into `manifest.json`, whose raw bytes are **keccak-committed on-chain**.

Editing the preset and then running the **documented** command (`docs/developer-guide/monorepo.md:48`, `quickstart.md:273`) would restore a stale `dist/**` with fresh mtimes — passing the freshness guard and reporting *"output bytes unchanged"* for bytes built by the old preset.

## 2. `subgraph#build` ignored `subgraph.yaml`, `schema.graphql` and the ABIs

It hashed `package.json` plus 7 mapping `.ts` files. Change a contract address or `startBlock`, get a cache hit, deploy a subgraph built from the old manifest. `codegen` declared those inputs; `build` neither declared them nor `dependsOn` codegen. Now it does both.

## 3. `../../tenants/**` resolved outside the repo from `frontend/`

`frontend#build` hashed **1460 inputs, zero of them tenants files** — that glob only resolves for packages exactly two levels deep.

The frontend build was tenant-sensitive **only by accident**, through its `dependsOn` edge to two packages that happen to sit at that depth. Deleting that edge — or "cleaning up" the meaningless glob from those leaves — would have silently stopped the frontend tracking the white-label source of truth. `$TURBO_ROOT$` resolves from the repo root at any depth.

## Verified — each previously-invisible edit now moves the hash

| edit | before | after |
|---|---|---|
| `hostScopePlugin.js` → `miniapp-build#build` | `4cfb2dbd…` | **`fa8811ff…`** |
| ↳ through `^build` → `token-mint#build` | `aab38249…` | **`90c0c2ff…`** |
| `subgraph.yaml` → `subgraph#build` | `9cbab488…` | **`0038ca90…`** |
| `tenants/fairwins/manifest.json` → `frontend#build` | 0 tenants inputs | **5 tenants inputs, hash moves** |

## And it changes no shipped byte

- `npm run build:miniapps` + digest compare → **`OK: mini-app output bytes unchanged`**
- a real `turbo run build` of the subgraph succeeds with the new `codegen` dependency (4 tasks)
- CiGates 13 passing

## Still open on #1036

Deliberately not in this PR, to keep it reviewable:

- `.env` is invisible to the cacheable `//#test` (a **local** false pass; CI passes `--force`)
- `turbo run test` schedules Matchstick, against the header's own claim that it is outside the graph
- the per-package mini-app `test` scripts are broken (`vitest run` picks up the *publish* preset and dies at import)
