### PR TITLE
chore(deps): ignore hardhat toolchain majors, not just hardhat itself

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,25 @@ updates:
       - dependency-name: hardhat
         update-types: ["version-update:semver-major"]
 
+      # The rest of the hardhat TOOLCHAIN, for the same reason. `hardhat` alone was ignored, but
+      # its plugins move in lockstep with it: Dependabot offered hardhat-toolbox ^6->^7,
+      # hardhat-ethers ^3->^4 and hardhat-ignition ^0.15->^3.1 in one grouped PR (#1047), which is
+      # a Hardhat 3 migration touching every test and deploy script — arriving as a routine
+      # "dev-tooling" bump. Ignoring only the root package let the migration in through the side
+      # door.
+      - dependency-name: "@nomicfoundation/*"
+        update-types: ["version-update:semver-major"]
+
+      # These two decide DEPLOYED PROXY BYTECODE, and no gate covers it. `upgrades.deployProxy`
+      # (scripts/deploy/lib/upgradeable.js) deploys the ERC1967Proxy artifact BUNDLED INSIDE the
+      # plugin — a different compile from anything in artifacts/contracts/**, which is all the
+      # byte-diff gate hashes. So a major bump here can silently change the CREATE2 address of a
+      # proxy this repo documents as living at a stable address. See #1039 (finding M4) and #1049.
+      - dependency-name: "@openzeppelin/hardhat-upgrades"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@openzeppelin/upgrades-core"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
`hardhat` was already pinned against major bumps in `.github/dependabot.yml`, because its internal `evmVersion` default is a build input (spec 075 FR-001). **Its plugins were not** — so Dependabot offered the entire **Hardhat 3 migration** as a routine `dev-tooling` bump (#1047):

| package | from | to |
|---|---|---|
| `@nomicfoundation/hardhat-toolbox` | ^6 | ^7 |
| `@nomicfoundation/hardhat-ethers` | ^3 | ^4 |
| `@nomicfoundation/hardhat-ignition` | ^0.15 | **^3.1** |
| `@nomicfoundation/hardhat-verify` | ^2.1 | ^3.0 |
| `@nomicfoundation/hardhat-network-helpers` | ^1.1 | ^3.0 |

Ignoring only the root package let the migration in through the side door.

## The sharper case: proxy bytecode

Also ignores `@openzeppelin/hardhat-upgrades` and `@openzeppelin/upgrades-core` majors.

`upgrades.deployProxy` (`scripts/deploy/lib/upgradeable.js:54`) deploys the `ERC1967Proxy` artifact **bundled inside that plugin** — a *different compile* from anything under `artifacts/contracts/**`, which is **all** the byte-diff gate hashes (145 baseline keys, zero exceptions). Creation bytecode differs measurably: 2082 vs 1448 hex chars.

So a major bump there can change the **CREATE2 address of a proxy this repo documents as living at a stable address**, and nothing in CI would object. Tracked as #1039 finding M4; migration sequence in #1053.

## Deliberately NOT ignored

`vite` ^7→^8, `eslint` ^9→^10, `jsdom` ^25→^30 rode in the same group and will be **re-offered separately** — which is the intent. A Vite major changes mini-app build output whose bytes are keccak-committed on-chain, and that gate now runs in CI (#1035); it should land as a PR where the gate's verdict is the point, not buried in a 27-package bump.

Closes the recurrence path for #1047 and #1049, both now closed in favour of #1053.