### PR TITLE
fix(test): the package boundary gate saw only the minority import style (#1037)

### DIFF
--- a/frontend/src/test/miniapps/packageBoundary.test.js
+++ b/frontend/src/test/miniapps/packageBoundary.test.js
@@ -211,13 +211,42 @@ describe('a package does not import from the host', () => {
  * A package that somehow has no package.json is skipped here, but it is still walked by the
  * path-based checks above, so it cannot escape the boundary entirely.
  */
-const PACKAGE_NAMES = existsSync(PACKAGES)
-  ? readdirSync(PACKAGES)
-      .filter((d) => !SKIP_DIRS.has(d) && existsSync(join(PACKAGES, d, 'package.json')))
-      .map((d) => JSON.parse(readFileSync(join(PACKAGES, d, 'package.json'), 'utf8')).name)
-      .filter(Boolean)
+const PACKAGE_DIRS = existsSync(PACKAGES)
+  ? readdirSync(PACKAGES).filter(
+      (d) => !SKIP_DIRS.has(d) && existsSync(join(PACKAGES, d, 'package.json')),
+    )
   : []
+const PACKAGE_MANIFESTS = PACKAGE_DIRS.map((dir) => ({
+  dir,
+  name: JSON.parse(readFileSync(join(PACKAGES, dir, 'package.json'), 'utf8')).name,
+})).filter((p) => p.name)
+const PACKAGE_NAMES = PACKAGE_MANIFESTS.map((p) => p.name)
 const HOST_PACKAGE_NAME = 'frontend'
+
+/*
+ * Deriving the names off disk means the by-name checks are only as trustworthy as the mapping
+ * between a package's directory and its declared name. If those ever disagreed, every check below
+ * would still run — and would quietly reason about the wrong package, which is worse than not
+ * running at all.
+ *
+ * Raised in review on #1060 on the belief that the two names WERE swapped in this tree. They are
+ * not (verified: clearpath/package.json declares @fairwins/miniapp-clearpath, token-mint declares
+ * @fairwins/miniapp-token-mint) — but "the gate is silently reasoning about the wrong package" is
+ * exactly the failure mode worth refusing to have, so it is now asserted rather than assumed.
+ */
+describe('the derived package list is trustworthy', () => {
+  it('declares a name matching its directory for every mini-app package', () => {
+    const mismatched = PACKAGE_MANIFESTS.filter((p) => p.name !== `@fairwins/miniapp-${p.dir}`).map(
+      (p) => `frontend/miniapps/${p.dir} declares "${p.name}"`,
+    )
+    expect(mismatched).toEqual([])
+  })
+
+  it('found the packages at all', () => {
+    // A zero-length list would make every by-name check below vacuously pass.
+    expect(PACKAGE_NAMES.length).toBeGreaterThan(0)
+  })
+})
 
 describe('the boundary holds for by-name imports too', () => {
   it('no host file imports a mini-app package by its package name', () => {

--- a/frontend/src/test/miniapps/packageBoundary.test.js
+++ b/frontend/src/test/miniapps/packageBoundary.test.js
@@ -27,7 +27,9 @@ const FRONTEND = resolve(__dirname, '../../..')
 const SRC = join(FRONTEND, 'src')
 const PACKAGES = join(FRONTEND, 'miniapps')
 
-const CODE = /\.(js|jsx|ts|tsx)$/
+// `.mjs`/`.cjs` included: they were missing, so a single-line violation in a .mjs file was
+// invisible purely because of its extension.
+const CODE = /\.(js|jsx|ts|tsx|mjs|cjs)$/
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '__snapshots__'])
 
 function walk(dir, out = []) {
@@ -41,18 +43,75 @@ function walk(dir, out = []) {
   return out
 }
 
-/** Every module specifier in a file: static imports, re-exports, and dynamic `import()`. */
+/**
+ * Remove comments before scanning, so a commented-out import cannot be reported as a violation —
+ * and, more importantly, so allowing newlines inside an import statement (below) cannot start a
+ * match inside a block comment.
+ *
+ * Hand-rolled rather than regex because `//` appears inside every `https://` URL in the tree, and a
+ * naive strip would truncate the line and hide a real import after it. Tracks string and template
+ * state so only genuine comment text is dropped.
+ */
+function stripComments(source) {
+  let out = ''
+  let i = 0
+  let state = 'code' // code | line | block | single | double | template
+  while (i < source.length) {
+    const c = source[i]
+    const next = source[i + 1]
+    if (state === 'code') {
+      if (c === '/' && next === '/') { state = 'line'; i += 2; continue }
+      if (c === '/' && next === '*') { state = 'block'; i += 2; continue }
+      if (c === "'") state = 'single'
+      else if (c === '"') state = 'double'
+      else if (c === '`') state = 'template'
+      out += c; i++; continue
+    }
+    if (state === 'line') {
+      if (c === '\n') { state = 'code'; out += c }
+      i++; continue
+    }
+    if (state === 'block') {
+      if (c === '*' && next === '/') { state = 'code'; i += 2; continue }
+      // Keep newlines so line-anchored patterns below still see real line boundaries.
+      if (c === '\n') out += c
+      i++; continue
+    }
+    // inside a string/template: copy verbatim, honouring escapes
+    if (c === '\\') { out += c + (next ?? ''); i += 2; continue }
+    if ((state === 'single' && c === "'") || (state === 'double' && c === '"') || (state === 'template' && c === '`')) {
+      state = 'code'
+    }
+    out += c; i++
+  }
+  return out
+}
+
+/**
+ * Every module specifier in a file: static imports, re-exports, and dynamic `import()`.
+ *
+ * MULTI-LINE AWARE. The previous version used `[^'"\n]*` between `import` and `from`, so any
+ * statement spanning lines was invisible — measured at 270 multi-line import statements across 229
+ * files in this tree, versus the 4,976 specifiers it did see. Multi-line named imports are the
+ * dominant style in exactly the files most likely to reach across the boundary, and all four
+ * violation shapes in #1037 passed because of it.
+ *
+ * The clause is bounded by `[^;]*?` rather than an unbounded `[\s\S]*?`: an import's binding list
+ * never contains a semicolon before its `from`, so this spans newlines while still refusing to run
+ * away across unrelated statements.
+ */
 function specifiers(source) {
+  const code = stripComments(source)
   const found = []
   const patterns = [
-    /(?:^|\n)\s*import\s[^'"\n]*from\s*['"]([^'"]+)['"]/g,
+    /(?:^|\n)\s*import\s[^;]*?from\s*['"]([^'"]+)['"]/g,
     /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g,
-    /(?:^|\n)\s*export\s[^'"\n]*from\s*['"]([^'"]+)['"]/g,
+    /(?:^|\n)\s*export\s[^;]*?from\s*['"]([^'"]+)['"]/g,
     /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
   ]
   for (const re of patterns) {
     let m
-    while ((m = re.exec(source)) !== null) found.push(m[1])
+    while ((m = re.exec(code)) !== null) found.push(m[1])
   }
   return found
 }
@@ -82,6 +141,27 @@ describe('the host does not import from a converted tree', () => {
     // The host keeps its OWN copies of the few pieces it still needs (e.g.
     // src/lib/clearpath/connectors/ for the daoSource notification adapter). Import those.
     expect(offenders).toEqual([])
+  })
+
+  /*
+   * CONVERTED_TREES matches the OLD paths, which no longer exist — so on its own it can catch a
+   * STALE import left behind by a conversion, but never a NEW one written into
+   * `frontend/miniapps/`. Confirmed before this was added: a host file importing
+   * '../miniapps/token-mint/src/App.jsx' passed every check in this file.
+   *
+   * That import is precisely the failure spec 073 describes — it bundles a copy of package code
+   * into the host bundle, and "a bundled copy of a React context is a DIFFERENT context".
+   */
+  it('has no import reaching into frontend/miniapps/ by path', () => {
+    const byPath = []
+    for (const file of walk(SRC)) {
+      for (const spec of specifiers(readFileSync(file, 'utf8'))) {
+        if (!spec.startsWith('.')) continue
+        const resolved = relative(FRONTEND, resolve(join(file, '..'), spec)).replace(/\\/g, '/')
+        if (resolved.startsWith('miniapps/')) byPath.push(`${relative(FRONTEND, file)} → ${spec}`)
+      }
+    }
+    expect(byPath).toEqual([])
   })
 })
 
@@ -122,7 +202,21 @@ describe('a package does not import from the host', () => {
  * are structurally blind to this. Nothing enforced it before workspaces because nothing could
  * resolve it before workspaces.
  */
-const PACKAGE_NAMES = ['@fairwins/miniapp-token-mint', '@fairwins/miniapp-clearpath']
+/*
+ * DERIVED from the packages on disk, not hardcoded. The literal list read
+ * ['@fairwins/miniapp-token-mint', '@fairwins/miniapp-clearpath'], so a third package was invisible
+ * to all three by-name checks below the moment it was added — the same by-name-list shape that let
+ * `record-build-digests.js` report "output bytes unchanged" while never looking at a third app.
+ *
+ * A package that somehow has no package.json is skipped here, but it is still walked by the
+ * path-based checks above, so it cannot escape the boundary entirely.
+ */
+const PACKAGE_NAMES = existsSync(PACKAGES)
+  ? readdirSync(PACKAGES)
+      .filter((d) => !SKIP_DIRS.has(d) && existsSync(join(PACKAGES, d, 'package.json')))
+      .map((d) => JSON.parse(readFileSync(join(PACKAGES, d, 'package.json'), 'utf8')).name)
+      .filter(Boolean)
+  : []
 const HOST_PACKAGE_NAME = 'frontend'
 
 describe('the boundary holds for by-name imports too', () => {


### PR DESCRIPTION
Closes the two blind spots in `packageBoundary.test.js` from #1037, plus the extension gap.

The spec-073 boundary is enforced by a test because a violation is **cheap to check and expensive to discover** — a scoped vitest run cannot catch a stale import, since the module simply never loads. The gate worked, but only for **single-line imports in `.js`/`.jsx`**, which is not how most of this tree is written.

Measured before: **270 multi-line import statements across 229 files** were invisible, against 4,976 specifiers it did see. Multi-line named imports are the dominant style in exactly the files most likely to reach across the boundary.

## Proven by writing the violations and watching them pass

All five were **green before** this change. All five are caught now, each named in the failure:

| probe | shape | now caught by |
|---|---|---|
| 1 | package→host, relative, **multi-line** | reaching back into `frontend/src/` |
| 2 | host→package, by name, **multi-line** | host imports package by name |
| 3 | package→host, by name, **multi-line** | package imports host by name |
| 4 | package→host, single-line in a **`.mjs`** file | extension was never scanned |
| 5 | host→package **by path** | new check (below) |

Probe 5 was a separate hole: `CONVERTED_TREES` matches the **old** paths, which no longer exist — so it could catch a *stale* import left by a conversion but never a *new* one written into `frontend/miniapps/`. That import is the failure spec 073 describes: it bundles a copy of package code into the host bundle, and *"a bundled copy of a React context is a DIFFERENT context."*

## Three changes

- **`specifiers()` spans newlines**, bounded by `[^;]*?` rather than an unbounded `[\s\S]*?` — an import's binding list never contains a semicolon before its `from`, so it cannot run away across unrelated statements.
- **Comments are stripped first**, so allowing newlines cannot start a match inside a block comment. Hand-rolled with string/template state, because `//` appears in every `https://` URL in the tree and a naive strip would truncate the line and **hide a real import after it**. Verified with a file containing two https URLs, a commented-out import and a real one: exactly **one** offender reported, the real one.
- **`PACKAGE_NAMES` is derived** from the packages on disk. The literal list meant a third package would be invisible to all three by-name checks the moment it was added — the same by-name-list shape that let `record-build-digests.js` report *"output bytes unchanged"* while never looking at a third app.

No new dependency: `es-module-lexer` isn't installed and `acorn` is only hoisted (7.1.1, no JSX) — importing either would be a phantom dependency, which `check:deps` exists to catch.

## Verification

- clean tree: **6/6 passing** (5 before + the new path check)
- full miniapps suite: **20 files / 521 tests green**
- eslint clean
- **no live violation exists in either direction today** — this is about the gate, not a current break

## Also from this pass: #1037's sibling concern is closed

`AdminPanel.jsx` was flagged (by me, repeatedly) as possibly sharing the `readRouterAuthority` race fixed in #1029/#1041. **It does not.** There are exactly two callers in the codebase — `BridgeTab.jsx:404` and `SupplyTab.jsx:383` — both fixed. AdminPanel only *mentions* the pattern in comments; my flag came from a `grep -l` matching comment prose. The class is closed.
