### PR TITLE
fix(gates): five gates that passed in the states they exist to catch (#1039)

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -349,8 +349,13 @@ module.exports = {
     // The vendored Safe v1.4.1 closure (spec 049 test shim contracts/mocks/vendor/) compiles
     // WITHOUT viaIR: Safe's inline assembly is not annotated memory-safe, so the Yul IR pipeline
     // cannot place a memoryguard and dies with a stack-too-deep YulException. The shim is test-only
-    // (never deployed by scripts) and nothing in contracts/ imports it, so legacy codegen here
+    // (never deployed by scripts) and no APP contract imports the shim — only the two
+    // policy-guard integration suites use the artifacts it pulls in — so legacy codegen here
     // cannot affect the viaIR app contracts.
+    //
+    // To be precise, since the gate below reasons about exactly this: the Safe closure IS imported,
+    // by `contracts/mocks/vendor/SafeVendorImports.sol`, which exists to pull Safe v1.4.1 into the
+    // artifact set. That is why the Safe overrides are LIVE and the Semaphore ones below were not.
     //
     // ── DEAD OVERRIDES ARE DELETED, NOT PARKED (spec 075 / issue #1039) ──────────────────────────
     // This block also carried eight overrides for the Semaphore V4 self-deploy closure

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -346,21 +346,28 @@ module.exports = {
         },
       },
     ],
-    // Compile the vendored Semaphore V4 self-deploy closure (spec 034, ETC/Mordor) WITHOUT viaIR.
-    // PoseidonT3 (auto-generated assembly) and SemaphoreVerifier (bn128 pairing assembly) are
-    // hand-optimized for legacy codegen; the Yul IR pipeline balloons their compile to ~13 GB RSS
-    // and OOM-thrashes a 16 GB box (and would do the same to CI). These are deployed standalone and
-    // linked/held by address, so different codegen here cannot affect the viaIR app contracts.
-    // Nothing in contracts/ imports this closure except SemaphoreDeploy.sol.
+    // The vendored Safe v1.4.1 closure (spec 049 test shim contracts/mocks/vendor/) compiles
+    // WITHOUT viaIR: Safe's inline assembly is not annotated memory-safe, so the Yul IR pipeline
+    // cannot place a memoryguard and dies with a stack-too-deep YulException. The shim is test-only
+    // (never deployed by scripts) and nothing in contracts/ imports it, so legacy codegen here
+    // cannot affect the viaIR app contracts.
     //
-    // The vendored Safe v1.4.1 closure (spec 049 test shim contracts/mocks/vendor/) likewise
-    // compiles WITHOUT viaIR: Safe's inline assembly is not annotated memory-safe, so the Yul IR
-    // pipeline cannot place a memoryguard and dies with a stack-too-deep YulException. The shim
-    // is test-only (never deployed by scripts) and nothing in contracts/ imports it, so legacy
-    // codegen here cannot affect the viaIR app contracts.
+    // ── DEAD OVERRIDES ARE DELETED, NOT PARKED (spec 075 / issue #1039) ──────────────────────────
+    // This block also carried eight overrides for the Semaphore V4 self-deploy closure
+    // (`contracts/pools/SemaphoreDeploy.sol` plus `@semaphore-protocol/contracts/*`,
+    // `@zk-kit/lean-imt.sol/*` and `poseidon-solidity/PoseidonT3.sol`). Spec 034 removed Semaphore
+    // from the pools design and deleted SemaphoreDeploy.sol; nothing under contracts/ has imported
+    // any of those packages since, so the entries named files that were never in the compilation.
+    // They were pure decoration — and worse than decoration, because an override that matches
+    // nothing looks like a live compiler decision when read. `@zk-kit/lean-imt.sol` and
+    // `poseidon-solidity` were not even root dependencies (they resolved transitively through
+    // `@semaphore-protocol/contracts`, itself declared as a FLOATING `^4.14.2`), so the config
+    // appeared to pin compiler settings for source this repo did not control the version of.
+    //
+    // `test/config/CompilerTargets.test.js` now fails on any override whose target is not a real
+    // file belonging to a package contracts/ actually imports, so this cannot silently come back.
     overrides: Object.fromEntries(
       [
-        "contracts/pools/SemaphoreDeploy.sol",
         "contracts/mocks/vendor/SafeVendorImports.sol",
         "@safe-global/safe-contracts/contracts/Safe.sol",
         "@safe-global/safe-contracts/contracts/SafeL2.sol",
@@ -391,13 +398,6 @@ module.exports = {
         "@safe-global/safe-contracts/contracts/proxies/IProxyCreationCallback.sol",
         "@safe-global/safe-contracts/contracts/proxies/SafeProxy.sol",
         "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol",
-        "@semaphore-protocol/contracts/Semaphore.sol",
-        "@semaphore-protocol/contracts/base/SemaphoreGroups.sol",
-        "@semaphore-protocol/contracts/base/SemaphoreVerifier.sol",
-        "@semaphore-protocol/contracts/base/SemaphoreVerifierKeyPts.sol",
-        "@zk-kit/lean-imt.sol/InternalLeanIMT.sol",
-        "@zk-kit/lean-imt.sol/LeanIMT.sol",
-        "poseidon-solidity/PoseidonT3.sol",
         // `evmVersion: "paris"` is REQUIRED here, not decorative (spec 075, FR-001). An override
         // that omits it inherits Hardhat's internal default exactly as a compiler entry does —
         // verified: before spec 075 the user config declared evmVersion on 0 of these 38 entries

--- a/scripts/deploy/check-storage-layout.js
+++ b/scripts/deploy/check-storage-layout.js
@@ -140,13 +140,63 @@ function chainIdFromDeploymentsFile(file) {
 }
 
 /**
+ * Ephemeral local chains, skipped (issue #1039).
+ *
+ * The filename filter accepts ANY `deployments/*.json` naming a chain id, which included a
+ * developer's local anvil/hardhat record. Those chains are wiped and redeployed constantly and
+ * hardhat-upgrades writes no manifest for them, so every implementation they record is
+ * undiffable — and the gate is required to FAIL on an undiffable implementation. Net effect: this
+ * gate exited 1 on a clean checkout as soon as anyone ran a local deploy. Measured on this tree,
+ * with an untracked `deployments/localhost-chain1337-v2.json` present: 3 failures
+ * (WagerRegistry, MembershipManager, TokenFactory), exit 1, nothing actually wrong.
+ *
+ * A gate that fails for a reason unrelated to what it checks gets ignored, which is how a real
+ * failure gets waved through. Local chains carry no upgrade-safety meaning: there is no live proxy
+ * whose state a bad layout could corrupt. Skip them, and say so on the run.
+ */
+const LOCAL_CHAIN_IDS = new Set([1337, 31337]);
+
+/**
+ * The estate this repo is KNOWN to have deployed, per chain.
+ *
+ *   records — implementation entries `deployments/` records for that chain
+ *   diffed  — how many of those were actually compared against a committed layout
+ *
+ * ── WHY A FLOOR, AND NOT JUST `compared === 0` (issue #1039) ─────────────────────────────────────
+ * The zero-comparison guard below was written against exactly one threat — everything disappearing
+ * — while its own comment named threats that are PARTIAL by nature: "a bad path join, a renamed
+ * record, a build system that relocates them". Measured: deleting 13 of the 14 deployment records
+ * left the gate green at `compared = 7` (of 26). Losing 73% of the estate's coverage looked
+ * identical to a pass, because the only question asked was "more than nothing?".
+ *
+ * Two floors rather than one, because they catch different regressions:
+ *   · `records`  drops when deployment records go missing or stop being found — the relocation
+ *                threat, and the one that leaves proxies silently unchecked.
+ *   · `diffed`   drops when verification is weakened without records moving — most realistically by
+ *                adding a KNOWN_UNVERIFIABLE entry to silence a failure rather than fix it.
+ *
+ * They are floors (`>=`), so deploying MORE never fails the gate. Deploying to a brand-new chain is
+ * reported and requires adding an entry here; that is a deliberate, one-line acknowledgement that
+ * the estate grew, not a hurdle.
+ */
+const EXPECTED_LIVE_IMPLS = {
+  1: { records: 3, diffed: 0, label: "Ethereum" }, // all 3 declared unverifiable (direct-deploy path)
+  10: { records: 3, diffed: 3, label: "Optimism" },
+  63: { records: 7, diffed: 7, label: "Mordor" },
+  137: { records: 9, diffed: 8, label: "Polygon" }, // wagerPoolFactory impl is declared unverifiable
+  8453: { records: 3, diffed: 3, label: "Base" },
+  42161: { records: 3, diffed: 3, label: "Arbitrum" },
+  80002: { records: 2, diffed: 2, label: "Amoy" },
+};
+
+/**
  * Every implementation this repo records as live, across every chain.
  *
  * Deliberately NOT filtered by the connected network — the whole point is that one run covers the
  * estate. One entry per (chain, address): the same address on two chains is two different
  * implementations to verify, which is exactly the case that broke the first attempt.
  */
-function loadRecordedImpls(deploymentsKey) {
+function loadRecordedImpls(deploymentsKey, skippedLocal) {
   const dir = path.join(process.cwd(), "deployments");
   if (!fs.existsSync(dir)) return [];
   const out = [];
@@ -162,6 +212,10 @@ function loadRecordedImpls(deploymentsKey) {
     if (!impl) continue;
     const chainId = chainIdFromDeploymentsFile(file);
     if (chainId === null) continue;
+    if (LOCAL_CHAIN_IDS.has(chainId)) {
+      skippedLocal?.add(file.replace(/\.json$/, ""));
+      continue;
+    }
     out.push({ impl, chainId, where: file.replace(/\.json$/, "") });
   }
   return out;
@@ -217,6 +271,14 @@ async function main() {
   let failed = false;
   let compared = 0;
   const unverified = [];
+  const skippedLocal = new Set();
+  /** chainId -> { records, diffed } actually observed on this run. */
+  const observed = new Map();
+  const bump = (chainId, field) => {
+    const row = observed.get(chainId) || { records: 0, diffed: 0 };
+    row[field] += 1;
+    observed.set(chainId, row);
+  };
 
   for (const { main: mainName, facet: facetName } of FACET_PAIRS) {
     try {
@@ -251,13 +313,14 @@ async function main() {
       continue;
     }
 
-    const recorded = loadRecordedImpls(deploymentsKey);
+    const recorded = loadRecordedImpls(deploymentsKey, skippedLocal);
     if (recorded.length === 0) {
       console.log(`· ${name}: implementation is upgrade-safe; not deployed anywhere yet`);
       continue;
     }
 
     for (const { impl, chainId, where } of recorded) {
+      bump(chainId, "records");
       const deployed = manifestLayouts.get(chainId)?.get(String(impl).toLowerCase());
       if (!deployed) {
         if (isUnverifiable(deploymentsKey, impl, chainId)) {
@@ -274,6 +337,7 @@ async function main() {
       try {
         core.assertStorageUpgradeSafe(deployed, updated, opts);
         compared += 1;
+        bump(chainId, "diffed");
         console.log(`✓ ${name}: storage-compatible with live impl ${impl} (${where})`);
       } catch (e) {
         failed = true;
@@ -294,34 +358,69 @@ async function main() {
     }
   }
 
+  if (skippedLocal.size > 0) {
+    console.log(
+      `\n· skipped ${skippedLocal.size} local-chain deployment record(s) — ephemeral dev chains carry no ` +
+        `live proxy to protect: ${[...skippedLocal].join(", ")}`,
+    );
+  }
+
+  // ── COVERAGE FLOORS: comparing SOME of the estate is not a pass either (spec 075, FR-004) ──────
+  //
+  // The original guard fired only at `compared === 0`. That was the exact failure recorded in the
+  // header — every contract fell through "no deployed impl to diff against", the script printed a
+  // checkmark, and a deliberately corrupted __gap sailed through — but the fix stopped one step
+  // short: a PARTIAL loss of the estate still reported success. Measured with 13 of 14 deployment
+  // records removed: green, at `compared = 7` instead of 26.
+  const shortfalls = [];
+  for (const [chainIdStr, want] of Object.entries(EXPECTED_LIVE_IMPLS)) {
+    const chainId = Number(chainIdStr);
+    const got = observed.get(chainId) || { records: 0, diffed: 0 };
+    if (got.records < want.records) {
+      shortfalls.push(
+        `${want.label} (chain ${chainId}): found ${got.records} recorded implementation(s), expected at least ${want.records}`,
+      );
+    }
+    if (got.diffed < want.diffed) {
+      shortfalls.push(
+        `${want.label} (chain ${chainId}): diffed ${got.diffed} implementation(s) against a committed layout, expected at least ${want.diffed}`,
+      );
+    }
+  }
+
+  const newChains = [...observed.keys()].filter((c) => !EXPECTED_LIVE_IMPLS[c]);
+  if (newChains.length > 0) {
+    console.log(
+      `\n· ${newChains.length} chain(s) carry deployment records but no entry in EXPECTED_LIVE_IMPLS: ` +
+        `${newChains.join(", ")}. Add them so their coverage is held from now on.`,
+    );
+  }
+
+  if (shortfalls.length > 0) {
+    failed = true;
+    console.error(`\n::error::Storage-layout coverage SHRANK on ${shortfalls.length} count(s):`);
+    for (const s of shortfalls) console.error(`  · ${s}`);
+    console.error(
+      "\n  This gate compares compiled layouts against DEPLOYED ones; comparing fewer than the estate\n" +
+        "  is known to contain is not a pass, it is a partial abstention that looks identical to one.\n" +
+        "  Most likely: deployments/*.json or .openzeppelin/*.json moved, were renamed, or stopped\n" +
+        "  being found (they are committed, irreproducible state — see specs/075-monorepo-workspaces/).\n" +
+        "  A drop in `diffed` alone usually means a KNOWN_UNVERIFIABLE entry was added to silence a\n" +
+        "  failure instead of recording the layout.\n" +
+        "  If an estate change is deliberate (a proxy genuinely retired), lower EXPECTED_LIVE_IMPLS in\n" +
+        "  this file in the same commit — explicitly, and reviewably.",
+    );
+  }
+
   if (failed) {
     console.error("\nStorage-layout / upgrade-safety check FAILED.");
     process.exit(1);
   }
 
-  // A gate that compared nothing has not passed — it has abstained (spec 075, FR-004).
-  //
-  // This is the exact failure recorded in the header above: every contract fell through the
-  // "no deployed impl to diff against" branch and the script printed a checkmark and exited 0,
-  // while a deliberately corrupted __gap sailed through. The comparison was fixed then; the
-  // ZERO-COMPARISON case was not, so a future change that empties `deployments/` or
-  // `.openzeppelin/` — a bad path join, a renamed record, a build system that relocates them —
-  // silently restores the same green-but-blind gate. Refuse to report success instead.
-  if (compared === 0) {
-    console.error(
-      "\nStorage-layout check FAILED: 0 live implementations were diffed.\n" +
-        "This gate exists to compare compiled layouts against deployed ones; comparing nothing is\n" +
-        "not a pass. Check that deployments/*.json and .openzeppelin/*.json are present and readable\n" +
-        "(they are committed, irreproducible state — see specs/075-monorepo-workspaces/).\n" +
-        "If this repo genuinely has no live upgradeable implementations, that is a deliberate change\n" +
-        "and this guard must be updated explicitly.",
-    );
-    process.exit(1);
-  }
-
   console.log(
     `\nAll upgradeable contracts passed. ${compared} live implementation(s) diffed for append-only compatibility` +
-      (unverified.length ? `; ${unverified.length} declared unverifiable (above).` : "."),
+      (unverified.length ? `; ${unverified.length} declared unverifiable (above).` : ".") +
+      `\nCoverage floors met on ${Object.keys(EXPECTED_LIVE_IMPLS).length} chains.`,
   );
 }
 

--- a/scripts/deps/check-dependency-hygiene.js
+++ b/scripts/deps/check-dependency-hygiene.js
@@ -22,6 +22,9 @@ const path = require("path");
 
 const ROOT = path.join(__dirname, "..", "..");
 
+const readJson = (p) => JSON.parse(fs.readFileSync(path.join(ROOT, p), "utf8"));
+const declared = (m) => ({ ...(m.dependencies || {}), ...(m.devDependencies || {}), ...(m.peerDependencies || {}) });
+
 /** Manifests in the repo, and which source trees each one owns. */
 /*
  * `rootFallback` — may a ROOT declaration satisfy this unit's import?
@@ -40,13 +43,69 @@ const ROOT = path.join(__dirname, "..", "..");
  * build then failed in CI with "Rollup failed to resolve import". A gate that reports clean while
  * the build breaks is exactly the failure mode spec 075 exists to remove.
  */
+/*
+ * ── THE UNIT LIST IS DERIVED, NOT TYPED (issue #1039) ────────────────────────────────────────
+ *
+ * It used to be a hand-written array of six manifests, and it had silently fallen three members
+ * behind the workspace: `frontend/miniapps/token-mint`, `frontend/miniapps/clearpath`,
+ * `packages/abi` and `packages/intent-types` were never scanned at all. Proven by injection — a
+ * phantom `chalk` in packages/intent-types/src, `axios` in frontend/miniapps/token-mint/src and
+ * `fast-glob` in frontend/vite-plugins/ all reported CLEAN.
+ *
+ * A hardcoded list is the same class of defect the gate exists to catch: an invariant held by
+ * human discipline. Adding a workspace member is routine; remembering to add it here is not. So
+ * the members come from the root manifest's `workspaces` globs — the same source npm itself uses,
+ * which means the gate cannot fall behind the workspace by construction.
+ *
+ * Coverage inside a unit was also partial: only `<unit>/src` was scanned, so
+ * `frontend/vite-plugins/`, `frontend/vite.config.js`, `frontend/cypress.config.js` and
+ * `frontend/cypress/` (32 files, several of them merge-gating) were invisible. A unit now owns
+ * EVERYTHING under its directory except build output and nested workspace members — a build plugin
+ * with an undeclared import breaks the build just as thoroughly as a src/ file does.
+ */
+
+/** Directory names that are build output or vendored code — never a unit's own source. */
+const IGNORED_DIRS = new Set(["node_modules", "dist", "dist-archive", "build", "coverage", "generated"]);
+
+/** Expand one `workspaces` glob. npm's patterns here are literal paths or a single trailing `/*`. */
+function expandWorkspaceGlob(glob) {
+  if (!glob.includes("*")) return [glob];
+  const base = glob.slice(0, glob.indexOf("/*"));
+  const abs = path.join(ROOT, base);
+  if (!fs.existsSync(abs)) return [];
+  return fs
+    .readdirSync(abs, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+    .map((e) => `${base}/${e.name}`)
+    .sort();
+}
+
+const workspaceGlobs = readJson("package.json").workspaces || [];
+
+/*
+ * A glob that expands to nothing is a coverage hole wearing a green light: rename a directory and
+ * every unit under it stops being checked while this script still prints OK. Fail instead.
+ */
+const emptyGlobs = workspaceGlobs.filter(
+  (g) => expandWorkspaceGlob(g).filter((d) => fs.existsSync(path.join(ROOT, d, "package.json"))).length === 0,
+);
+
+const workspaceMembers = workspaceGlobs
+  .flatMap(expandWorkspaceGlob)
+  .filter((dir) => fs.existsSync(path.join(ROOT, dir, "package.json")))
+  .sort();
+
 const UNITS = [
-  { manifest: "package.json", label: "root", sources: ["scripts", "test"], rootFallback: true },
-  { manifest: "frontend/package.json", label: "frontend", sources: ["frontend/src"], rootFallback: false },
-  { manifest: "services/relay-gateway/package.json", label: "relay-gateway", sources: ["services/relay-gateway/src"], rootFallback: false },
-  { manifest: "services/relayer/package.json", label: "relayer", sources: ["services/relayer/src"], rootFallback: false },
-  { manifest: "subgraph/package.json", label: "subgraph", sources: ["subgraph/src"], rootFallback: false },
-  { manifest: "tools/miniapp-build/package.json", label: "miniapp-build", sources: ["tools/miniapp-build"], rootFallback: false },
+  // The root owns the code that runs in the root project: scripts/, test/ and the hardhat config.
+  { manifest: "package.json", label: "root", sources: ["scripts", "test", "hardhat.config.js"], rootFallback: true },
+  ...workspaceMembers.map((dir) => ({
+    manifest: `${dir}/package.json`,
+    label: dir,
+    sources: [dir],
+    rootFallback: false,
+    // A nested member owns its own subtree — frontend must not be blamed for frontend/miniapps/*.
+    skip: new Set(workspaceMembers.filter((other) => other !== dir && other.startsWith(`${dir}/`))),
+  })),
 ];
 
 /**
@@ -58,10 +117,8 @@ const ALLOW = {
   "@nomicfoundation/hardhat-ethers": "hardhat plugin, resolved through the hardhat runtime",
   "virtual:tenant": "Vite virtual module supplied by frontend/vite-plugins/tenant-branding.js",
   "@fairwins/miniapp-sdk": "host-provided shared scope, externalized by the mini-app build preset",
+  "k6": "k6 runtime built-in (k6/http, k6/data, k6/metrics) in services/relay-gateway/load/ — supplied by the k6 binary, never an npm package",
 };
-
-const readJson = (p) => JSON.parse(fs.readFileSync(path.join(ROOT, p), "utf8"));
-const declared = (m) => ({ ...(m.dependencies || {}), ...(m.devDependencies || {}), ...(m.peerDependencies || {}) });
 
 /** Bare specifier -> package name (`@scope/pkg/sub` -> `@scope/pkg`). */
 function pkgOf(spec) {
@@ -69,14 +126,28 @@ function pkgOf(spec) {
   return spec.split("/")[0];
 }
 
-function walk(dir, out = []) {
+const SOURCE_EXT = /\.(js|jsx|mjs|cjs|ts|tsx)$/;
+
+/**
+ * Every source file a unit owns.
+ *
+ * `skip` holds nested workspace members, which own themselves. Build output (`dist/`, `build/`,
+ * `coverage/`, `generated/`) is excluded because it is derived: a bundle inlines its dependencies,
+ * so scanning it reports imports that no manifest should ever have declared.
+ */
+function walk(dir, skip = new Set(), out = []) {
   const abs = path.join(ROOT, dir);
   if (!fs.existsSync(abs)) return out;
+  if (fs.statSync(abs).isFile()) {
+    if (SOURCE_EXT.test(dir)) out.push(dir);
+    return out;
+  }
   for (const e of fs.readdirSync(abs, { withFileTypes: true })) {
     const rel = path.join(dir, e.name);
-    if (e.name === "node_modules" || e.name.startsWith(".")) continue;
-    if (e.isDirectory()) walk(rel, out);
-    else if (/\.(js|jsx|mjs|cjs|ts|tsx)$/.test(e.name)) out.push(rel);
+    if (IGNORED_DIRS.has(e.name) || e.name.startsWith(".")) continue;
+    if (skip.has(rel)) continue;
+    if (e.isDirectory()) walk(rel, skip, out);
+    else if (SOURCE_EXT.test(e.name)) out.push(rel);
   }
   return out;
 }
@@ -149,6 +220,8 @@ function stripTemplateLiterals(src) {
 }
 
 const problems = { versionSkew: [], phantom: [] };
+/** unit label -> files actually scanned. Reported, so a unit going dark is visible, not silent. */
+const scanned = new Map();
 
 // ── FR-015: one installed version per package name ───────────────────────────────────────────
 const ranges = {}; // pkg -> { range -> [units] }
@@ -175,7 +248,8 @@ for (const u of UNITS) {
   const own = declared(readJson(u.manifest));
   // The root manifest is a legitimate fallback for scripts/ and test/, which run in the root project.
   const rootDeclared = u.rootFallback ? declared(readJson("package.json")) : {};
-  const files = u.sources.flatMap((s) => walk(s));
+  const files = u.sources.flatMap((s) => walk(s, u.skip || new Set()));
+  scanned.set(u.label, files.length);
   const seen = new Map();
   for (const f of files) {
     const src = codeLines(fs.readFileSync(path.join(ROOT, f), "utf8"));
@@ -220,6 +294,30 @@ if (process.argv.includes("--json")) {
 
 let failed = false;
 
+// ── coverage first: a clean report from a gate that scanned nothing is the defect, not the pass ──
+if (emptyGlobs.length) {
+  failed = true;
+  console.error(`\n::error::${emptyGlobs.length} workspaces glob(s) in package.json match no package:`);
+  for (const g of emptyGlobs) console.error(`  · "${g}"`);
+  console.error(
+    "\n  Every unit under such a glob is silently UNCHECKED by this gate (and unlinked by npm).\n" +
+      "  Either the directory moved and the glob needs updating, or the members are genuinely gone\n" +
+      "  and the glob should be deleted.",
+  );
+}
+
+const emptyUnits = [...scanned].filter(([, n]) => n === 0).map(([label]) => label);
+if (emptyUnits.length) {
+  failed = true;
+  console.error(`\n::error::${emptyUnits.length} unit(s) contributed 0 source files to the scan:`);
+  for (const label of emptyUnits) console.error(`  · ${label}`);
+  console.error(
+    "\n  This gate reports nothing about them, which reads as a pass. Usually the unit's source moved\n" +
+      "  into a directory this script treats as build output (see IGNORED_DIRS). If the package really\n" +
+      "  ships no JS/TS, say so explicitly here rather than leaving the silence.",
+  );
+}
+
 if (missingOptional.length) {
   failed = true;
   console.error(`\n::error::${missingOptional.length} optional platform binary/ies missing from package-lock.json:`);
@@ -256,7 +354,13 @@ if (problems.phantom.length) {
 }
 
 if (failed) process.exit(1);
+
+// Name what was covered. "OK across 6 manifests" was true while four workspace members were not
+// being scanned at all — the number was the only clue, and nothing compared it to the workspace.
+const totalFiles = [...scanned.values()].reduce((a, b) => a + b, 0);
 console.log(
-  `Dependency hygiene OK — ${Object.keys(ranges).length} distinct packages across ${UNITS.length} manifests, ` +
+  `Dependency hygiene OK — ${Object.keys(ranges).length} distinct packages across ${UNITS.length} manifests ` +
+    `(root + ${workspaceMembers.length} workspace members), ${totalFiles} source files scanned, ` +
     "no version skew, no phantom imports.",
 );
+for (const [label, n] of scanned) console.log(`  · ${label}: ${n} file(s)`);

--- a/test/config/CompilerTargets.test.js
+++ b/test/config/CompilerTargets.test.js
@@ -1,5 +1,9 @@
 const { expect } = require("chai");
 const hre = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.join(__dirname, "..", "..");
 
 /**
  * Spec 074, FR-002 / SC-002 — the EVM target must be DECLARED BY THIS REPOSITORY.
@@ -99,8 +103,10 @@ describe("Compiler configuration: EVM target is declared, not inherited", functi
  * and @safe-global/safe-contracts already were.
  */
 describe("Solidity-source dependencies are pinned exactly (spec 075, FR-001)", function () {
-  // Every package whose .sol files are imported by contracts/. Keep in sync with the imports —
-  // a new `import "@vendor/..."` in a contract belongs here.
+  // The packages whose .sol files contracts/ is EXPECTED to import. This list is documentation of
+  // an intended build surface — it is no longer the input to the check. `solidityImportPackages()`
+  // below reads the imports themselves, and the first test asserts the two agree in BOTH
+  // directions, so neither a new vendor import nor a stale entry here can pass unnoticed.
   const SOLIDITY_SOURCE_PACKAGES = [
     "@openzeppelin/contracts",
     "@openzeppelin/contracts-upgradeable",
@@ -109,16 +115,80 @@ describe("Solidity-source dependencies are pinned exactly (spec 075, FR-001)", f
     "@safe-global/safe-contracts",
   ];
 
-  const EXACT = /^\d+\.\d+\.\d+/;
+  /**
+   * ANCHORED, and that matters (issue #1039).
+   *
+   * The original was `/^\d+\.\d+\.\d+/` — unanchored, so it matched a PREFIX. `"1.3.0 - 1.5.0"`
+   * (a hyphen range spanning three minors) and `"1.3.0 || ^2.0.0"` (an explicit alternative major)
+   * both passed a test whose entire purpose is to reject exactly those. Measured on a mutated copy
+   * of package.json: both forms → 5 passing.
+   *
+   * This is the full semver grammar for a SINGLE version — major.minor.patch with optional
+   * prerelease and build metadata — anchored at both ends, so anything npm would treat as a range
+   * (`^`, `~`, `x`, `>=`, `-`, `||`, `*`, `latest`, `npm:`, `file:`, `git+…`) is rejected.
+   *
+   * The `semver` package would express this more legibly, but it is NOT declared in the root
+   * manifest (verified: absent from dependencies and devDependencies — it is only present as a
+   * hoisted transitive of other packages). Importing it here would make `npm run check:deps`
+   * report a phantom dependency for the root unit, i.e. fixing one gate by breaking another.
+   * A regex with no dependency is the right trade at this size.
+   */
+  const EXACT_VERSION =
+    /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
-  it("declares an exact version for every package that compiles into our bytecode", function () {
-    const pkg = require("../../package.json");
+  it("the documented package list matches what contracts/ actually imports", function () {
+    const imported = solidityImportPackages();
+    const documented = new Set(SOLIDITY_SOURCE_PACKAGES);
+
+    const undocumented = [...imported.keys()].filter((p) => !documented.has(p));
+    const stale = SOLIDITY_SOURCE_PACKAGES.filter((p) => !imported.has(p));
+
+    expect(
+      undocumented,
+      "contracts/ imports Solidity source from package(s) missing from SOLIDITY_SOURCE_PACKAGES, so " +
+        "nothing checks how their version is pinned:\n  " +
+        undocumented.map((p) => `${p}  (e.g. ${imported.get(p)})`).join("\n  "),
+    ).to.deep.equal([]);
+
+    expect(
+      stale,
+      "SOLIDITY_SOURCE_PACKAGES names package(s) no contract imports any more. Delete them — a stale " +
+        `entry makes the gate look broader than it is:\n  ${stale.join("\n  ")}`,
+    ).to.deep.equal([]);
+  });
+
+  it("declares an exact version at the ROOT for every package that compiles into our bytecode", function () {
+    // Read from disk rather than `require`, so a mutated copy can be diffed against this same test.
+    const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"));
     const declared = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+    const imported = solidityImportPackages();
 
-    const floating = SOLIDITY_SOURCE_PACKAGES.filter((name) => {
-      const range = declared[name];
-      return range !== undefined && !EXACT.test(range);
-    }).map((name) => `${name}@${declared[name]}`);
+    /*
+     * UNDECLARED IS A FAILURE, NOT A PASS (issue #1039).
+     *
+     * The original filter was `range !== undefined && !EXACT.test(range)` — it skipped any package
+     * the root manifest did not declare at all. So it caught "declared loosely" and missed "not
+     * declared", which is the strictly worse condition and the one a workspace conversion actually
+     * produces: move a Solidity-source dependency into a member's manifest, or let it arrive
+     * transitively, and the version compiling into deployed bytecode becomes an install-time
+     * artifact with this gate still green. Measured: deleting `@chainlink/contracts` from a mutated
+     * package.json → 5 passing.
+     *
+     * The ROOT manifest specifically: contracts/ compiles in the root project, so a declaration in
+     * a workspace member's manifest does not pin what solc reads. (`npm run check:deps` separately
+     * fails if two manifests declare disagreeing ranges for the same package.)
+     */
+    const undeclared = [...imported.keys()].filter((name) => declared[name] === undefined);
+    const floating = [...imported.keys()]
+      .filter((name) => declared[name] !== undefined && !EXACT_VERSION.test(String(declared[name]).trim()))
+      .map((name) => `${name}@${declared[name]}`);
+
+    expect(
+      undeclared,
+      "These contribute Solidity source to the compile but the ROOT manifest does not declare them " +
+        "at all, so the version that produces our bytecode is whatever the install happens to hoist:\n  " +
+        undeclared.join("\n  "),
+    ).to.deep.equal([]);
 
     expect(
       floating,
@@ -128,3 +198,102 @@ describe("Solidity-source dependencies are pinned exactly (spec 075, FR-001)", f
     ).to.deep.equal([]);
   });
 });
+
+/**
+ * Spec 075 / issue #1039 — a per-file compiler override must describe source that is actually
+ * COMPILED.
+ *
+ * Eight of the 38 overrides named source that had not been in the compilation for months: the
+ * Semaphore V4 self-deploy closure, dropped from the pools design by spec 034 along with
+ * `contracts/pools/SemaphoreDeploy.sol` itself. Hardhat silently ignores an override that matches
+ * no source file, so they cost nothing at build time and read, to anyone auditing the config, as
+ * live decisions about how deployed bytecode is produced. Two of the three packages involved
+ * (`@zk-kit/lean-imt.sol`, `poseidon-solidity`) were not even root dependencies.
+ *
+ * File existence alone would NOT have caught them — the packages are still installed transitively,
+ * so the .sol files are on disk. The property that distinguishes live from dead is whether the
+ * override's package is one contracts/ imports.
+ */
+describe("Compiler overrides target source that is actually compiled (issue #1039)", function () {
+  it("every per-file override names a real file in the compile graph", function () {
+    const overrides = Object.keys(hre.userConfig.solidity.overrides || {});
+    expect(overrides, "expected at least one per-file override").to.have.length.greaterThan(0);
+
+    const imported = solidityImportPackages();
+    const dead = [];
+
+    for (const key of overrides) {
+      if (key.startsWith("contracts/")) {
+        // First-party: the file must exist. `contracts/pools/SemaphoreDeploy.sol` did not.
+        if (!fs.existsSync(path.join(REPO_ROOT, key))) {
+          dead.push(`${key}  — no such file in contracts/`);
+        }
+        continue;
+      }
+      // Third-party: the package must be one contracts/ imports, AND the file must exist.
+      const pkg = key.startsWith("@") ? key.split("/").slice(0, 2).join("/") : key.split("/")[0];
+      if (!imported.has(pkg)) {
+        dead.push(`${key}  — nothing under contracts/ imports ${pkg}, so this file is never compiled`);
+        continue;
+      }
+      if (!resolveDependencyFile(key)) {
+        dead.push(`${key}  — package ${pkg} is imported but this file does not exist in it`);
+      }
+    }
+
+    expect(
+      dead,
+      "Dead compiler override(s). Hardhat ignores an override that matches no source file, so these " +
+        "are invisible at build time while reading as live compiler decisions. DELETE them rather " +
+        "than allowlisting them:\n  " +
+        dead.join("\n  "),
+    ).to.deep.equal([]);
+  });
+});
+
+/**
+ * Every external package imported by a .sol file under `contracts/`, mapped to one importing file
+ * (for the failure message). Relative imports are skipped; `contracts-archive/` is not scanned
+ * because it is reference-only and never compiled.
+ */
+function solidityImportPackages() {
+  const found = new Map();
+  const IMPORT_RE = /^\s*import\s+[^;]*?["']([^"']+)["']/gm;
+
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+        walk(abs);
+      } else if (entry.name.endsWith(".sol")) {
+        const src = fs.readFileSync(abs, "utf8");
+        for (const m of src.matchAll(IMPORT_RE)) {
+          const spec = m[1];
+          if (spec.startsWith(".") || spec.startsWith("/")) continue;
+          const pkg = spec.startsWith("@") ? spec.split("/").slice(0, 2).join("/") : spec.split("/")[0];
+          if (!found.has(pkg)) found.set(pkg, path.relative(REPO_ROOT, abs));
+        }
+      }
+    }
+  };
+
+  walk(path.join(REPO_ROOT, "contracts"));
+  return found;
+}
+
+/** A dependency-relative .sol path (`@scope/pkg/a/b.sol`) → absolute path, or null if absent. */
+function resolveDependencyFile(spec) {
+  const direct = path.join(REPO_ROOT, "node_modules", spec);
+  if (fs.existsSync(direct)) return direct;
+  // Fall back to Node resolution for a nested/hoisted-elsewhere install.
+  const pkg = spec.startsWith("@") ? spec.split("/").slice(0, 2).join("/") : spec.split("/")[0];
+  const rest = spec.slice(pkg.length + 1);
+  try {
+    const base = path.dirname(require.resolve(`${pkg}/package.json`, { paths: [REPO_ROOT] }));
+    const full = path.join(base, rest);
+    return fs.existsSync(full) ? full : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Every finding was confirmed by mutation **before** fixing, and every fix is mutation-tested. #1039 is the issue about gates that pass when they shouldn't, so a fix that isn't demonstrably falsifiable would miss the point.

| # | gate | before | after |
|---|---|---|---|
| 1 | Solidity dep **removed** from manifest | 5 passing, exit 0 | 1 failing, exit 1 |
| 2 | `"1.3.0 - 1.5.0"` / `"1.3.0 \|\| ^2.0.0"` | passed | fail |
| 3 | 6 phantom imports across unscanned members | OK, exit 0 | all six named, exit 1 |
| 4 | 13 of 14 deployment records deleted | green at 8 diffed | exit 1, 11 shortfalls named |
| 4b | one record renamed away | green at 24 diffed | exit 1, names the chain |
| 4c | comparison silenced via `KNOWN_UNVERIFIABLE` | green at 25 | exit 1 |
| 5 | 8 dead compiler overrides restored | 5 passing, exit 0 | exit 1, all 8 with distinct reasons |

## Two findings worth calling out

**`check:deps` was scanning ~a third of what it claimed.** Units are now derived from the root `workspaces` globs — the same source npm uses — and each member's whole directory is scanned rather than just `<unit>/src`. Coverage went **6 → 10 manifests, 1,731 files**; `frontend` alone gained `vite-plugins/`, `vite.config.js` and `cypress/`. A brand-new workspace member is now picked up with **no edit to the gate**, and a glob that matches nothing fails instead of silently covering less.

**`check-storage-layout` was failing on a clean tree.** It accepted any `deployments/*.json` matching `chain(\d+)`, so any developer with a local anvil record got exit 1 — the gate was crying wolf locally while being too weak in CI. Local chains are now skipped *and reported*, and the `compared === 0` floor became a per-chain floor over two counts.

## One thing deliberately not done

Finding 2 was **not** fixed with the `semver` package. It is not declared at the root — only hoisted transitively — so importing it would make `check:deps` report a phantom root dependency. Verified by injecting it: `FR-003 — 1 undeclared (phantom) dependency: [root] semver`. Fixing one gate by breaking another isn't a fix; the anchored regex carries a comment saying so.

## Verification

`check:deps` exit 0 · `check:storage-layout` exit 0 (**was exit 1**) · `test/config` 20 passing · mini-app byte gate `OK: mini-app output bytes unchanged`.

## Follow-up noted, not fixed

- `coverage-threshold-policy.json:55` still exempts the deleted `SemaphoreDeploy.sol` — inert, same class of rot.
- `@semaphore-protocol/*` (4 packages, floating) remain in the root manifest. They no longer contribute Solidity source so they are not a bytecode risk, but they may now be dead JS dependencies. Removing them touches the lockfile, which this PR does not.