### PR TITLE
fix(eip712): consolidate the domains and gate them against the Solidity (#1038)

### DIFF
--- a/docs/developer-guide/callsigns.md
+++ b/docs/developer-guide/callsigns.md
@@ -107,17 +107,21 @@ callsign contract and gates each control on the caller's role there:
 All writes use the AdminPanel's plain-signer `runTx` (admin actions are not gasless). Until the registry is
 deployed and synced (`callsignRegistry` address in `contracts.js`), the tab shows a "not configured" notice.
 
-## Gasless intents (three-way sync)
+## Gasless intents (one source, gated against the contract)
 
 The EIP-712 structs (`CommitCallsignIntent`, `RegisterCallsignIntent`, `ChangeCallsignIntent`, `ReleaseCallsignIntent`,
-`RequestRepointIntent`, `CancelRepointIntent`) must stay **byte-identical** across:
+`RequestRepointIntent`, `CancelRepointIntent`) and the domain are defined **once**, in
+`packages/intent-types` (`@fairwins/intent-types`), and imported by both
+`frontend/src/lib/relay/intentTypes.js` and `services/relay-gateway/src/intent/intentTypes.js`.
+They used to be three hand-synced copies; they are now one, checked against
+`CallsignRegistry.sol`'s own `*_TYPEHASH` literals and `__EIP712_init(...)` arguments by
+`test/intent/TypehashParity.test.js`. Add a struct or a domain to the package — never to a
+call site.
 
-1. the contract typehashes (`CallsignRegistry.sol`),
-2. `frontend/src/lib/relay/intentTypes.js`,
-3. `services/relay-gateway/src/intent/intentTypes.js`.
-
-Domain: `name = "FairWins CallsignRegistry"`, `version = "1"`. `finalizeRepoint` and `reclaimLapsed`
-are permissionless and need no signed twin. Every gasless action keeps a self-submit fallback.
+Domain: `name = "FairWins CallsignRegistry"`, `version = "1"` (`CONTRACT_DOMAINS.callsignRegistry`;
+build it with `domainFor('callsignRegistry', chainId, registryAddress)`). `finalizeRepoint` and
+`reclaimLapsed` are permissionless and need no signed twin. Every gasless action keeps a self-submit
+fallback.
 
 ## Deploy & upgrade
 

--- a/docs/developer-guide/gasless-intents.md
+++ b/docs/developer-guide/gasless-intents.md
@@ -87,10 +87,25 @@ cancel open / decline / declare winner (no-stake) · membership purchase / upgra
 
 `frontend/src/lib/relay/` is the one client every flow uses:
 
-- `intentTypes.js` — the EIP-712 struct definitions (MUST stay byte-identical to the contract
-  typehashes) + per-contract domain builders + the FR-020 stablecoin-domain pre-sign check
-  (`domainVersion` in `config/networks.js`: native USDC `'2'`, bridged `'1'`, Mordor USC `null` ⇒
-  payment intents unavailable, self-submit only).
+- `intentTypes.js` — re-exports the EIP-712 struct definitions and binds the per-contract domain
+  builders, plus the FR-020 stablecoin-domain pre-sign check (`domainVersion` in
+  `config/networks.js`: native USDC `'2'`, bridged `'1'`, Mordor USC `null` ⇒ payment intents
+  unavailable, self-submit only).
+
+  **The structs and the FairWins domains are NOT defined here.** Both live once, in
+  `packages/intent-types` (`@fairwins/intent-types`), imported by this app and by the relay gateway,
+  and both halves of the EIP-712 digest are gated against the Solidity by
+  `test/intent/TypehashParity.test.js`:
+
+  - `INTENT_TYPES` / `OPEN_ACCEPT_TYPES` vs each contract's `*_TYPEHASH` literal, **in both
+    directions** — a struct present in the package but not the contracts fails, and so does one the
+    contracts verify but the package no longer defines.
+  - `CONTRACT_DOMAINS` (+ `DOMAIN_SOURCES`, `domainFor`) vs each contract's own
+    `__EIP712_init(name, version)` arguments. A correct struct signed under a wrong domain is just
+    as dead as a wrong struct — the domain separator is half the digest — so it is gated the same
+    way, not by convention.
+
+  Do not retype a struct or a `{ name, version }` pair anywhere else; add it to the package.
 - `intentClient.js` — `signIntent` / `relayIntent` / `pollStatus` / `probeHealth` / `makeRelayer`.
   `VITE_RELAYER_URL` unset ⇒ `makeRelayer` returns null ⇒ everything self-submits.
 - `useIntentAction.js` — the **never-stranded enforcement point**: relayer unset, unhealthy, 429,

--- a/frontend/src/lib/relay/intentTypes.js
+++ b/frontend/src/lib/relay/intentTypes.js
@@ -14,21 +14,35 @@
  * payment-class intents are unavailable on that chain (FR-020, e.g. Mordor/ETC USC).
  */
 import { NETWORKS } from '../../config/networks'
-import { INTENT_TYPES, INTENT_ACTIONS, RECEIVE_WITH_AUTHORIZATION_TYPES, typeStringFor } from '@fairwins/intent-types'
+import {
+  CONTRACT_DOMAINS,
+  INTENT_TYPES,
+  INTENT_ACTIONS,
+  RECEIVE_WITH_AUTHORIZATION_TYPES,
+  domainFor,
+  typeStringFor,
+} from '@fairwins/intent-types'
 import { PaymentUnsupportedOnChain } from './errors'
 
 /*
- * Struct definitions now live in @fairwins/intent-types (spec 075, FR-024/FR-025) — one source,
- * consumed by this app AND by services/relay-gateway, and checked against the verifying contracts
- * by test/intent/TypehashParity.test.js.
+ * Struct definitions AND the FairWins EIP-712 domains now live in @fairwins/intent-types
+ * (spec 075, FR-024/FR-025) — one source, consumed by this app AND by services/relay-gateway, and
+ * checked against the verifying contracts by test/intent/TypehashParity.test.js.
  *
  * They used to be duplicated here and in the gateway, kept in step by hand. That held for 26 of 27
- * structs; `InvalidateNonce` was missing from the gateway entirely.
+ * structs; `InvalidateNonce` was missing from the gateway entirely. The domains had the same three
+ * copies and no gate at all — and a struct signed under a wrong domain is just as dead as a wrong
+ * struct, because the domain separator is half of the digest.
  *
  * Re-exported so relay callers still need only this module for both signature legs.
  */
-export { INTENT_TYPES, INTENT_ACTIONS, RECEIVE_WITH_AUTHORIZATION_TYPES, typeStringFor }
+export { INTENT_TYPES, INTENT_ACTIONS, RECEIVE_WITH_AUTHORIZATION_TYPES, CONTRACT_DOMAINS, typeStringFor }
 
+/*
+ * The five FairWins domains, as named helpers. Each is a thin binding of a CONTRACT_DOMAINS key —
+ * the name/version pair lives in the package and is asserted against that contract's own
+ * `__EIP712_init(...)` call, so editing a literal here is no longer possible.
+ */
 
 /**
  * EIP-712 domain for CallsignRegistry intents (spec 054). Its own per-contract domain (name/version set in
@@ -37,7 +51,7 @@ export { INTENT_TYPES, INTENT_ACTIONS, RECEIVE_WITH_AUTHORIZATION_TYPES, typeStr
  * @param {string} verifyingContract - the callsignRegistry PROXY address for this chain
  */
 export function callsignRegistryDomain(chainId, verifyingContract) {
-  return { name: 'FairWins CallsignRegistry', version: '1', chainId: Number(chainId), verifyingContract }
+  return domainFor('callsignRegistry', chainId, verifyingContract)
 }
 
 /**
@@ -47,7 +61,7 @@ export function callsignRegistryDomain(chainId, verifyingContract) {
  * @param {string} verifyingContract - the wagerRegistry PROXY address for this chain
  */
 export function wagerRegistryDomain(chainId, verifyingContract) {
-  return { name: 'FairWins WagerRegistry', version: '1', chainId: Number(chainId), verifyingContract }
+  return domainFor('wagerRegistry', chainId, verifyingContract)
 }
 
 /**
@@ -56,7 +70,7 @@ export function wagerRegistryDomain(chainId, verifyingContract) {
  * @param {string} verifyingContract - the membershipManager PROXY address for this chain
  */
 export function membershipManagerDomain(chainId, verifyingContract) {
-  return { name: 'FairWins MembershipManager', version: '1', chainId: Number(chainId), verifyingContract }
+  return domainFor('membershipManager', chainId, verifyingContract)
 }
 
 /**
@@ -67,7 +81,7 @@ export function membershipManagerDomain(chainId, verifyingContract) {
  * @param {string} verifyingContract - the pool CLONE address
  */
 export function wagerPoolDomain(chainId, verifyingContract) {
-  return { name: 'FairWins WagerPool', version: '1', chainId: Number(chainId), verifyingContract }
+  return domainFor('wagerPool', chainId, verifyingContract)
 }
 
 /**
@@ -77,7 +91,7 @@ export function wagerPoolDomain(chainId, verifyingContract) {
  * @param {string} verifyingContract - the wagerPoolFactory PROXY address
  */
 export function wagerPoolFactoryDomain(chainId, verifyingContract) {
-  return { name: 'FairWins WagerPoolFactory', version: '1', chainId: Number(chainId), verifyingContract }
+  return domainFor('wagerPoolFactory', chainId, verifyingContract)
 }
 
 /**

--- a/frontend/src/lib/transfer/eip3009Transfer.js
+++ b/frontend/src/lib/transfer/eip3009Transfer.js
@@ -17,18 +17,18 @@
  * and this whole path is skipped in favour of a plain `transfer` (e.g. Mordor/ETC USC).
  */
 import { ethers } from 'ethers'
+import { TRANSFER_WITH_AUTHORIZATION_TYPES } from '@fairwins/intent-types'
 
-/** EIP-3009 typed-data for a wallet-to-wallet payment (arbitrary recipient submits via a relayer). */
-export const TRANSFER_WITH_AUTHORIZATION_TYPES = {
-  TransferWithAuthorization: [
-    { name: 'from', type: 'address' },
-    { name: 'to', type: 'address' },
-    { name: 'value', type: 'uint256' },
-    { name: 'validAfter', type: 'uint256' },
-    { name: 'validBefore', type: 'uint256' },
-    { name: 'nonce', type: 'bytes32' },
-  ],
-}
+/*
+ * EIP-3009 typed-data for a wallet-to-wallet payment (any relayer may submit it) now comes from
+ * @fairwins/intent-types, next to its `ReceiveWithAuthorization` sibling — the escrow-side leg that
+ * spec 075 already consolidated. They are the same money path and the same six fields; leaving one
+ * behind was how the sibling got two copies in the first place. Pinned to the typehash deployed
+ * USDC verifies against by test/intent/TypehashParity.test.js.
+ *
+ * Re-exported so existing importers of this module are unaffected.
+ */
+export { TRANSFER_WITH_AUTHORIZATION_TYPES }
 
 /** Minimal ABI for the self-submit fallback + the relayed authorization call. */
 export const TRANSFER_ABI = [

--- a/frontend/src/utils/claimCode/deriveFromCode.js
+++ b/frontend/src/utils/claimCode/deriveFromCode.js
@@ -12,20 +12,24 @@
  * other.
  */
 import { keccak256, toUtf8Bytes, getBytes, SigningKey, computeAddress, Wallet } from 'ethers'
+import { CONTRACT_DOMAINS, OPEN_ACCEPT_TYPES, domainFor } from '@fairwins/intent-types'
 import { normalizeCode } from './wordlist.js'
 
 const CLAIM_DOMAIN = 'FairWins/claim/v1'
 const TERMS_DOMAIN = 'FairWins/terms/v1'
 
-// EIP-712 — MUST match the registry's OPEN_ACCEPT_TYPEHASH and EIP712 domain exactly.
-const EIP712_DOMAIN_NAME = 'FairWins WagerRegistry'
-const EIP712_DOMAIN_VERSION = '1'
-const OPEN_ACCEPT_TYPES = {
-  OpenAccept: [
-    { name: 'wagerId', type: 'uint256' },
-    { name: 'taker', type: 'address' }
-  ]
-}
+/*
+ * EIP-712 — MUST match the registry's OPEN_ACCEPT_TYPEHASH and EIP712 domain exactly. Both now come
+ * from @fairwins/intent-types instead of being retyped here: the struct is checked against
+ * WagerRegistryCore's OPEN_ACCEPT_TYPEHASH and the domain against WagerRegistry's own
+ * `__EIP712_init(...)` by test/intent/TypehashParity.test.js. The values are unchanged — this
+ * signature is the claim-code proof leg of acceptOpenWager and an altered domain would silently
+ * stop every open-challenge accept from verifying.
+ *
+ * Re-exported below (unchanged names) because the open-challenge tests and callers import them here.
+ */
+const EIP712_DOMAIN_NAME = CONTRACT_DOMAINS.wagerRegistry.name
+const EIP712_DOMAIN_VERSION = CONTRACT_DOMAINS.wagerRegistry.version
 
 /**
  * Derive the claim keypair and symmetric key from a four-word code.
@@ -61,12 +65,7 @@ export function deriveFromCode(code) {
 export async function signOpenAccept(code, { wagerId, taker, chainId, verifyingContract }) {
   const { claimPrivateKey } = deriveFromCode(code)
   const wallet = new Wallet(claimPrivateKey)
-  const domain = {
-    name: EIP712_DOMAIN_NAME,
-    version: EIP712_DOMAIN_VERSION,
-    chainId,
-    verifyingContract
-  }
+  const domain = domainFor('wagerRegistry', chainId, verifyingContract)
   return wallet.signTypedData(domain, OPEN_ACCEPT_TYPES, { wagerId, taker })
 }
 

--- a/packages/intent-types/package.json
+++ b/packages/intent-types/package.json
@@ -3,14 +3,21 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "The single definition of every FairWins EIP-712 intent struct (spec 075). Zero runtime dependencies; resolvable by plain Node and by Vite.",
+  "description": "The single definition of every FairWins EIP-712 intent struct and domain (spec 075). Zero runtime dependencies; resolvable by plain Node and by Vite.",
   "main": "./src/index.js",
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json"
   },
   "files": ["src"],
-  "scripts": {
-    "test": "vitest run"
-  }
+  "//gates": [
+    "This package declares no test script ON PURPOSE (as does @fairwins/abi). It used to declare",
+    "'vitest run', which exited 1 with 'No test files found' — vitest was never a dependency here",
+    "and no test file was ever added, so the script only ever reported a failure that meant nothing.",
+    "Its definitions cannot be verified in isolation anyway: they are correct only relative to the",
+    "Solidity that verifies them and the gateway that implements them, both of which live outside",
+    "this directory. The two gates that do that are:",
+    "  test/intent/TypehashParity.test.js            (structs + domains vs the contracts, both ways)",
+    "  services/relay-gateway/test/actionCoverage.test.js (declared actions vs relayed actions)"
+  ]
 }

--- a/packages/intent-types/src/index.js
+++ b/packages/intent-types/src/index.js
@@ -18,11 +18,81 @@
  * imports, explicit `exports`) so BOTH can consume it.
  *
  * RULES FOR THIS FILE
- *   · Zero runtime dependencies. It is pure data plus one pure function.
+ *   · Zero runtime dependencies. It is pure data plus pure functions.
  *   · Never import from frontend/src, services/, or a Vite virtual module.
  *   · Changing a struct changes what signatures mean. test/intent/TypehashParity.test.js checks
  *     every entry against the deployed contract's own *_TYPEHASH constant and fails on a mismatch.
+ *   · The same is true of the DOMAINS below: a correct type table signed under the wrong
+ *     name/version produces a signature that verifies nowhere. Same file, same gate.
  */
+
+/**
+ * EIP-712 DOMAINS, keyed by the `getContractAddressForChain` key of the contract that verifies the
+ * signature. `chainId` and `verifyingContract` are runtime values, so only the two STATIC halves
+ * live here — they are what the contract fixed at `__EIP712_init(name, version)` and can never be
+ * inferred from the struct tables above.
+ *
+ * WHY THESE ARE HERE AND NOT NEXT TO THE CALL SITES
+ * A struct table is only half of what a signature commits to. The digest is
+ * `keccak256(0x1901 ‖ domainSeparator ‖ hashStruct)`, so a byte-perfect struct signed under the
+ * wrong domain name or version produces a signature that verifies against NOTHING — the member is
+ * prompted, pays nothing, and the relay simply fails, or (worse, if some other deployment shares
+ * that domain) verifies somewhere it was never meant to. These pairs previously existed in three
+ * production copies (the frontend's five `*Domain()` helpers, the gateway's `CONTRACT_DOMAINS`, and
+ * a sixth literal in the claim-code signer) with nothing tying any of them to the Solidity.
+ *
+ * Entries are `{ name, version }` and NOTHING else, deliberately: consumers spread them into an
+ * EIP-712 domain object, so any extra key would land in the domain and change the separator.
+ *
+ * AUTHORITY: `DOMAIN_SOURCES` below names the contract each pair is copied from;
+ * test/intent/TypehashParity.test.js parses that contract's own `__EIP712_init(...)` arguments and
+ * fails if either half drifts, in either direction.
+ */
+export const CONTRACT_DOMAINS = Object.freeze({
+  wagerRegistry: Object.freeze({ name: 'FairWins WagerRegistry', version: '1' }),
+  membershipManager: Object.freeze({ name: 'FairWins MembershipManager', version: '1' }),
+  // Tier-2 group pools (spec 034/035). The FACTORY verifies createPoolWithSig under its own domain;
+  // each CLONE verifies the six actor twins under a per-clone domain (verifyingContract = the clone),
+  // which is why these are two entries and not one.
+  wagerPool: Object.freeze({ name: 'FairWins WagerPool', version: '1' }),
+  wagerPoolFactory: Object.freeze({ name: 'FairWins WagerPoolFactory', version: '1' }),
+  callsignRegistry: Object.freeze({ name: 'FairWins CallsignRegistry', version: '1' }),
+})
+
+/**
+ * Which contract each domain is copied FROM — repo-relative, so the parity gate can read the
+ * `__EIP712_init` call rather than trusting the comment beside it. Keys must match
+ * `CONTRACT_DOMAINS` exactly (asserted). Not used at runtime.
+ */
+export const DOMAIN_SOURCES = Object.freeze({
+  wagerRegistry: 'contracts/wagers/WagerRegistry.sol',
+  membershipManager: 'contracts/access/MembershipManager.sol',
+  wagerPool: 'contracts/pools/WagerPool.sol',
+  wagerPoolFactory: 'contracts/pools/WagerPoolFactory.sol',
+  callsignRegistry: 'contracts/naming/CallsignRegistry.sol',
+})
+
+/**
+ * Build the full EIP-712 domain for a verifying contract on a chain.
+ *
+ * Throws on an unknown key rather than returning undefined: a missing domain must surface as an
+ * error at signing time, never as `signTypedData(undefined, …)` producing a digest under an empty
+ * domain.
+ *
+ * @param {keyof typeof CONTRACT_DOMAINS} key
+ * @param {number|bigint|string} chainId
+ * @param {string} verifyingContract - the PROXY (or clone) address that will verify the signature
+ * @returns {{name: string, version: string, chainId: number, verifyingContract: string}}
+ */
+export function domainFor(key, chainId, verifyingContract) {
+  const d = CONTRACT_DOMAINS[key]
+  if (!d) {
+    throw new Error(
+      `Unknown EIP-712 domain key: ${key}. Known keys: ${Object.keys(CONTRACT_DOMAINS).join(', ')}`,
+    )
+  }
+  return { name: d.name, version: d.version, chainId: Number(chainId), verifyingContract }
+}
 
 /** Common trailing fields shared by every intent struct (schema: "Common trailing fields"). */
 const TRAILING = [
@@ -198,14 +268,57 @@ export const INTENT_TYPES = {
 }
 
 /**
- * EIP-3009 `ReceiveWithAuthorization` — the token-side leg of every gasless payment intent
- * (`joinWithAuthorization`, stake pulls). Structurally identical to the two copies it replaces:
- * frontend/src/lib/pools/gasless.js and the gateway's own literal.
+ * `OpenAccept` — the claim-code proof leg of an open-challenge accept (feature 024).
  *
- * NOTE the asymmetry with everything above: this struct's authoritative typehash lives in the
- * DEPLOYED USDC contract, not in this repository. The only in-repo Solidity copy is
- * contracts/mocks/MockUSDCPermit.sol — a MOCK. So it is verified against a recorded fixed vector
- * rather than against a contract constant; asserting it against the mock would prove nothing.
+ * WHY IT IS NOT IN `INTENT_TYPES`
+ * It is not an intent: it carries no `nonce/validAfter/validBefore`, and it is not signed by the
+ * member. It is signed by the key DERIVED FROM THE FOUR-WORD CLAIM CODE
+ * (frontend/src/utils/claimCode/deriveFromCode.js), proving the accepter holds the code, and bound
+ * to `taker` so a mempool observer cannot re-point it at their own address.
+ *
+ * WHY IT IS IN THIS PACKAGE ANYWAY
+ * It is verified on-chain by WagerRegistryCore's OPEN_ACCEPT_TYPEHASH, under the SAME
+ * `wagerRegistry` domain as the intents, and it is a required leg of the relayed
+ * `acceptOpenWager` action (`acceptOpenWagerWithAuthorization(..., claimCodeSig, ...)`). It was a
+ * hand-maintained two-place struct sitting on exactly the gasless path this package exists to
+ * protect — so it belongs under the same gate, in its own table.
+ */
+export const OPEN_ACCEPT_TYPES = {
+  OpenAccept: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'taker', type: 'address' },
+  ],
+}
+
+/**
+ * Every struct in this package that a FAIRWINS contract verifies, merged.
+ *
+ * This is the set test/intent/TypehashParity.test.js checks in BOTH directions — package→Solidity
+ * and Solidity→package. A new table of contract-verified structs must be merged in here, or the
+ * Solidity→package direction will report its structs as ungated.
+ *
+ * The two EIP-3009 tables below are deliberately absent: their authority is Circle's deployed USDC,
+ * not a contract in this repo (see the note on them).
+ */
+export const CONTRACT_VERIFIED_TYPES = { ...INTENT_TYPES, ...OPEN_ACCEPT_TYPES }
+
+/**
+ * EIP-3009 — the TOKEN-side legs. Both are structurally identical and differ only in who may
+ * submit them, which is the whole reason there are two:
+ *
+ *   · `ReceiveWithAuthorization` — the token enforces `to == msg.sender`, so ONLY the recipient
+ *     contract can submit it. This is the money leg of every gasless payment intent
+ *     (`joinWithAuthorization`, stake pulls): the escrow is both caller and recipient.
+ *   · `TransferWithAuthorization` — ANY address may submit it, moving `from → to`. This is the
+ *     wallet-to-wallet Pay & Transfer leg, where the relayer is not the recipient.
+ *
+ * NOTE the asymmetry with everything above: these typehashes' authority lives in the DEPLOYED USDC
+ * contract, not in this repository. The only in-repo Solidity copy is
+ * contracts/mocks/MockUSDCPermit.sol — a MOCK. So they are verified against recorded fixed vectors
+ * rather than against a contract constant; asserting them against the mock would prove nothing.
+ *
+ * Getting these wrong is a money-path failure with two different faces: a wrong shape simply fails
+ * to verify, but confusing the two names produces an authorization with the WRONG submitter rule.
  */
 export const RECEIVE_WITH_AUTHORIZATION_TYPES = {
   ReceiveWithAuthorization: [
@@ -218,9 +331,23 @@ export const RECEIVE_WITH_AUTHORIZATION_TYPES = {
   ],
 }
 
+export const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+}
+
 /**
  * Render an EIP-712 type string for `primaryType`, e.g.
- *   `InvalidateNonceIntent(address signer,bytes32 nonce,uint256 validBefore)`
+ *   `InvalidateNonce(address signer,bytes32 nonce,uint256 validBefore)`
+ * (`InvalidateNonce`, not `InvalidateNonceIntent` — the primary type is the key in INTENT_TYPES and
+ * is what the contract's typehash literal spells; the trailing `Intent` most siblings carry is part
+ * of their name, not a suffix this function adds.)
  *
  * keccak256 of this string is the struct's typehash, which is what the Solidity side stores as a
  * `*_TYPEHASH` constant. That equality is the machine check that replaces the convention.

--- a/services/relay-gateway/src/intent/intentTypes.js
+++ b/services/relay-gateway/src/intent/intentTypes.js
@@ -29,32 +29,22 @@ import { ethers } from 'ethers'
  * The package is authored Node-resolvable (extensioned imports + an explicit `exports` map)
  * precisely so this service can import it; the frontend's copy never could be imported here.
  */
-import { INTENT_TYPES, RECEIVE_WITH_AUTHORIZATION_TYPES } from '@fairwins/intent-types'
-
-export { INTENT_TYPES, RECEIVE_WITH_AUTHORIZATION_TYPES }
-import { GatewayError } from '../errors.js'
+import { CONTRACT_DOMAINS, INTENT_TYPES, RECEIVE_WITH_AUTHORIZATION_TYPES } from '@fairwins/intent-types'
 
 // ---------------------------------------------------------------------------
 // EIP-712 domains (per verifying contract; chainId + verifyingContract added at runtime)
 // ---------------------------------------------------------------------------
-
-export const CONTRACT_DOMAINS = {
-  wagerRegistry: { name: 'FairWins WagerRegistry', version: '1' },
-  membershipManager: { name: 'FairWins MembershipManager', version: '1' },
-  // Tier-2 group pools (spec 035/036). The FACTORY verifies createPoolWithSig against its own domain;
-  // the CLONE verifies the six actor twins against a per-clone domain (verifyingContract = the clone),
-  // so pool signer-attributed actions target the factory but recover under `wagerPool` with the pool
-  // address as verifyingContract (the domain/target split — see ACTIONS + verify.js).
-  wagerPool: { name: 'FairWins WagerPool', version: '1' },
-  wagerPoolFactory: { name: 'FairWins WagerPoolFactory', version: '1' },
-  // Callsign registry (spec 054) — its own domain; register/change/requestRepoint execute only while
-  // the signer holds Gold+ (revert otherwise), so the gateway SHOULD pre-screen tier before relaying.
-  callsignRegistry: { name: 'FairWins CallsignRegistry', version: '1' },
-}
-
-// ---------------------------------------------------------------------------
-// EIP-712 struct definitions (verbatim from intent-eip712-schemas.md)
-// ---------------------------------------------------------------------------
+//
+// CONTRACT_DOMAINS was a local literal here until spec 075's follow-up: the same five name/version
+// pairs also lived in the frontend and in the claim-code signer, with nothing tying any copy to the
+// Solidity. The domain separator is half of the EIP-712 digest, so a drifted domain is exactly as
+// fatal as a drifted struct — a signature that verifies nowhere — and it had no gate at all.
+// It now comes from the package and is asserted against each contract's own `__EIP712_init(...)`
+// arguments by test/intent/TypehashParity.test.js.
+//
+// Re-exported so verify.js and the tests keep importing domains from this module.
+export { CONTRACT_DOMAINS, INTENT_TYPES, RECEIVE_WITH_AUTHORIZATION_TYPES }
+import { GatewayError } from '../errors.js'
 
 
 // ---------------------------------------------------------------------------

--- a/test/intent/TypehashParity.test.js
+++ b/test/intent/TypehashParity.test.js
@@ -4,20 +4,34 @@ const path = require("path");
 const { keccak256, toUtf8Bytes } = require("ethers");
 
 /**
- * Spec 075, FR-026/FR-027 — every shared EIP-712 struct is checked against the contract that
+ * Spec 075, FR-026/FR-027 — every shared EIP-712 definition is checked against the contract that
  * actually verifies it.
  *
- * These field lists decide what a member's signature AUTHORISES. A mismatch between signer and
+ * These definitions decide what a member's signature AUTHORISES. A mismatch between signer and
  * verifier does not throw — it produces a signature that verifies against something other than
  * what the member was shown. CLAUDE.md required three copies to stay byte-identical and enforced
  * it by convention; the convention held for 26 of 27 structs and failed on the 27th
  * (`InvalidateNonce` was missing from the relay gateway entirely).
+ *
+ * TWO HALVES, ONE DIGEST
+ * An EIP-712 digest is `keccak256(0x1901 ‖ domainSeparator ‖ hashStruct(message))`. This file
+ * therefore gates BOTH halves:
+ *   · the STRUCTS, against each contract's `*_TYPEHASH` literal, and
+ *   · the DOMAINS, against each contract's `__EIP712_init(name, version)` arguments.
+ * The domains were the gap: a byte-perfect struct signed under a wrong name or version is exactly
+ * as dead as a wrong struct, and nothing checked them at all.
  *
  * WHY COMPARE STRINGS RATHER THAN HASHES
  * The contracts declare `keccak256("<literal type string>")`, so the literal is right there in the
  * source. Comparing strings is exactly as strong as comparing hashes and infinitely more useful
  * when it fails: you see WHICH field moved, not that two opaque 32-byte values differ. The hash
  * equality is asserted too, so the test still speaks the contract's language.
+ *
+ * BOTH DIRECTIONS, ALWAYS
+ * Every gate here runs package→Solidity AND Solidity→package. A one-directional gate only proves
+ * that what you kept is right; it says nothing about what you DELETED. Iterating the package alone
+ * meant a struct could be removed from the package while a contract still verified it, and all
+ * three spec-075 gates stayed green.
  *
  * MOCKS ARE NOT AUTHORITATIVE — see the EIP-3009 block at the bottom.
  */
@@ -27,29 +41,101 @@ const CONTRACTS = path.join(ROOT, "contracts");
 const TYPEHASH_RE =
   /bytes32\s+(?:private\s+|internal\s+|public\s+)?constant\s+(\w*TYPEHASH)\s*=\s*keccak256\(\s*"([^"]+)"\s*\)/g;
 
-function solidityTypeStrings() {
-  const out = {};
+// `__EIP712_init("<name>", "<version>")` — the call that fixes a contract's domain separator.
+const EIP712_INIT_RE = /__EIP712_init\(\s*"([^"]*)"\s*,\s*"([^"]*)"\s*\)/g;
+
+/** Every non-mock .sol file, repo-relative path + source. */
+function productionSources() {
+  const out = [];
   const walk = (dir) => {
     for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
       const p = path.join(dir, e.name);
       if (e.isDirectory()) {
-        // contracts/mocks/ is test-only. A mock's typehash proves nothing about what a deployed
-        // contract verifies, so it must never satisfy this gate.
+        // contracts/mocks/ is test-only. A mock's typehash or domain proves nothing about what a
+        // deployed contract verifies, so it must never satisfy this gate.
         if (e.name === "mocks") continue;
         walk(p);
       } else if (e.name.endsWith(".sol")) {
-        const src = fs.readFileSync(p, "utf8");
-        for (const m of src.matchAll(TYPEHASH_RE)) {
-          const typeString = m[2];
-          const primary = typeString.slice(0, typeString.indexOf("("));
-          out[primary] = { typeString, file: path.relative(ROOT, p), constant: m[1] };
-        }
+        out.push({ file: path.relative(ROOT, p).split(path.sep).join("/"), src: fs.readFileSync(p, "utf8") });
       }
     }
   };
   walk(CONTRACTS);
   return out;
 }
+
+/**
+ * primaryType -> { typeString, files[], constants[] } for every `*_TYPEHASH` in a production
+ * contract.
+ *
+ * THROWS on a colliding primary type with a DIFFERENT shape. It used to assign `out[primary] = …`
+ * unconditionally, so whichever file the directory walk happened to visit last won. Nothing
+ * collides today, but `Cancel`, `Refund`, `ClaimShare` and `CreatePool` are generic enough names
+ * that a second contract could plausibly declare its own — and the effect would be that one of the
+ * two structs is silently no longer gated by anything, which is precisely the failure mode this
+ * file exists to prevent. An identical redeclaration is harmless (both agree) and is recorded with
+ * every file it appears in, so failures name all of them.
+ */
+function solidityTypeStrings(sources = productionSources()) {
+  const out = {};
+  for (const { file, src } of sources) {
+    for (const m of src.matchAll(TYPEHASH_RE)) {
+      const typeString = m[2];
+      const primary = typeString.slice(0, typeString.indexOf("("));
+      const prior = out[primary];
+      if (prior && prior.typeString !== typeString) {
+        throw new Error(
+          `Two production contracts declare a DIFFERENTLY-SHAPED "${primary}" typehash. ` +
+            `Only one of them can be gated by the package's single "${primary}" entry, so the other ` +
+            `is unverified — rename one struct.\n` +
+            `  ${prior.files.join(", ")} :: ${prior.constants.join(", ")}\n      ${prior.typeString}\n` +
+            `  ${file} :: ${m[1]}\n      ${typeString}`,
+        );
+      }
+      if (prior) {
+        prior.files.push(file);
+        prior.constants.push(m[1]);
+      } else {
+        out[primary] = { typeString, files: [file], constants: [m[1]] };
+      }
+    }
+  }
+  return out;
+}
+
+/** repo-relative file -> [{ name, version }] for every `__EIP712_init` in a production contract. */
+function solidityDomainInits(sources = productionSources()) {
+  const byFile = {};
+  for (const { file, src } of sources) {
+    for (const m of src.matchAll(EIP712_INIT_RE)) {
+      (byFile[file] ||= []).push({ name: m[1], version: m[2] });
+    }
+  }
+  return byFile;
+}
+
+const describeSol = (sol) => `${sol.files.join(", ")} :: ${sol.constants.join(", ")}`;
+
+/**
+ * Typehashes in production contracts that are deliberately NOT defined in @fairwins/intent-types.
+ * Every entry needs a reason; each is asserted to still EXIST in the Solidity, so a stale exemption
+ * fails rather than quietly widening the hole.
+ */
+const NON_PACKAGE_TYPEHASHES = {
+  CoinbaseSmartWalletMessage:
+    "Third-party. This is Coinbase Smart Wallet's ERC-1271 replay-safe message wrapper " +
+    "(contracts/account/ERC1271.sol), reproduced so a passkey account can verify signatures the " +
+    "way Coinbase's own tooling produces them. It is not a FairWins intent, no FairWins client " +
+    "signs it from a shared table, and its shape is fixed by an external wallet standard rather " +
+    "than by this repo — so putting it in the package would misrepresent who owns it.",
+};
+
+/**
+ * Production contracts whose `__EIP712_init` domain is deliberately NOT in CONTRACT_DOMAINS.
+ * Empty today: all five EIP-712 contracts in the tree are signed against by FairWins clients.
+ * A new EIP-712 contract must either register a domain or be exempted here WITH a reason.
+ */
+const NON_PACKAGE_DOMAINS = {};
 
 describe("EIP-712 intent structs match the contracts that verify them (spec 075)", function () {
   let pkg;
@@ -64,8 +150,8 @@ describe("EIP-712 intent structs match the contracts that verify them (spec 075)
     expect(Object.keys(solidity).length, "no *_TYPEHASH constants parsed — the regex or layout changed").to.be.greaterThan(20);
   });
 
-  it("has a production-contract counterpart for every shared intent struct", function () {
-    const orphans = Object.keys(pkg.INTENT_TYPES).filter((k) => !solidity[k]);
+  it("has a production-contract counterpart for every shared struct", function () {
+    const orphans = Object.keys(pkg.CONTRACT_VERIFIED_TYPES).filter((k) => !solidity[k]);
     expect(
       orphans,
       "These structs exist in @fairwins/intent-types with no matching typehash in a non-mock " +
@@ -74,15 +160,43 @@ describe("EIP-712 intent structs match the contracts that verify them (spec 075)
     ).to.deep.equal([]);
   });
 
+  it("has a package definition for every typehash a production contract verifies", function () {
+    // The direction that was missing. Without it, DELETING a struct from the package passes every
+    // gate in the repo while a deployed contract still verifies signatures over it — the package
+    // stops being the single source and nothing says so.
+    const ungated = Object.keys(solidity).filter(
+      (k) => !pkg.CONTRACT_VERIFIED_TYPES[k] && !NON_PACKAGE_TYPEHASHES[k],
+    );
+    expect(
+      ungated,
+      "These typehashes are verified by a production contract but have no definition in " +
+        "@fairwins/intent-types, so nothing checks what clients sign against them. Add them to the " +
+        "package (and to CONTRACT_VERIFIED_TYPES), or exempt them in NON_PACKAGE_TYPEHASHES with a " +
+        "reason:\n  " +
+        ungated.map((k) => `${k}  (${describeSol(solidity[k])})`).join("\n  "),
+    ).to.deep.equal([]);
+  });
+
+  it("keeps every non-package typehash exemption justified and still real", function () {
+    for (const [primary, reason] of Object.entries(NON_PACKAGE_TYPEHASHES)) {
+      expect(solidity[primary], `${primary} is exempted but no production contract declares it — drop the exemption`).to.exist;
+      expect(
+        pkg.CONTRACT_VERIFIED_TYPES[primary],
+        `${primary} is now in the package — remove it from NON_PACKAGE_TYPEHASHES so it is gated`,
+      ).to.equal(undefined);
+      expect(reason.length, `${primary} needs a real reason, not a placeholder`).to.be.greaterThan(40);
+    }
+  });
+
   it("renders a type string identical to each contract's literal", function () {
     const mismatches = [];
-    for (const primary of Object.keys(pkg.INTENT_TYPES)) {
+    for (const primary of Object.keys(pkg.CONTRACT_VERIFIED_TYPES)) {
       const sol = solidity[primary];
       if (!sol) continue; // reported by the previous test
-      const ours = pkg.typeStringFor(primary);
+      const ours = pkg.typeStringFor(primary, pkg.CONTRACT_VERIFIED_TYPES);
       if (ours !== sol.typeString) {
         mismatches.push(
-          `${primary}  (${sol.file} :: ${sol.constant})\n` +
+          `${primary}  (${describeSol(sol)})\n` +
             `    package : ${ours}\n` +
             `    contract: ${sol.typeString}`,
         );
@@ -96,51 +210,252 @@ describe("EIP-712 intent structs match the contracts that verify them (spec 075)
   });
 
   it("agrees on the keccak256 typehash the contract actually stores", function () {
-    for (const primary of Object.keys(pkg.INTENT_TYPES)) {
+    for (const primary of Object.keys(pkg.CONTRACT_VERIFIED_TYPES)) {
       const sol = solidity[primary];
       if (!sol) continue;
       expect(
-        keccak256(toUtf8Bytes(pkg.typeStringFor(primary))),
-        `${primary} typehash differs from ${sol.file}`,
+        keccak256(toUtf8Bytes(pkg.typeStringFor(primary, pkg.CONTRACT_VERIFIED_TYPES))),
+        `${primary} typehash differs from ${describeSol(sol)}`,
       ).to.equal(keccak256(toUtf8Bytes(sol.typeString)));
     }
   });
-});
 
-describe("EIP-3009 ReceiveWithAuthorization is pinned to a recorded vector (spec 075, FR-027)", function () {
-  /**
-   * This struct is DIFFERENT in kind from every struct above, and the difference matters.
-   *
-   * Its authoritative typehash lives in the DEPLOYED USDC contract — Circle's, not ours. The only
-   * in-repo Solidity copy is contracts/mocks/MockUSDCPermit.sol, a mock we wrote. Checking our
-   * definition against our own mock would be circular: both could drift together and the gate
-   * would stay green while every gasless payment stopped verifying against real USDC.
-   *
-   * So it is pinned to the canonical EIP-3009 typehash instead — a fixed vector, independently
-   * checkable against the standard and against any deployed FiatTokenV2.
-   */
-  const CANONICAL_TYPE_STRING =
-    "ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)";
-  // keccak256 of the string above, and the value FiatTokenV2 stores as
-  // RECEIVE_WITH_AUTHORIZATION_TYPEHASH. PROVENANCE: read live from deployed USDC on Polygon 137
-  // (0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359) on 2026-08-03 and confirmed equal — so this is an
-  // independent vector, not a hash of our own string.
-  const CANONICAL_TYPEHASH = "0xd099cc98ef71107a616c4f0f941f04c322d8e254fe26b3c6668db87aae413de8";
-
-  it("renders the canonical EIP-3009 type string", async function () {
-    const pkg = await import("@fairwins/intent-types");
+  it("resolves every action's primaryType to a struct definition", function () {
+    // INTENT_ACTIONS is the table clients build signatures from. An action naming a primaryType
+    // that INTENT_TYPES no longer defines is not a type error anywhere — `types[primaryType]` is
+    // just `undefined` — so it surfaces at signing time, on a member's screen.
+    const broken = [];
+    for (const [action, meta] of Object.entries(pkg.INTENT_ACTIONS)) {
+      if (meta.authOnly) {
+        // poolJoin: the EIP-3009 authorization IS the whole intent; there is no struct to sign.
+        expect(meta.primaryType, `${action} is authOnly but still names a primaryType`).to.equal(undefined);
+        continue;
+      }
+      if (!meta.primaryType) broken.push(`${action}: no primaryType and not authOnly`);
+      else if (!pkg.INTENT_TYPES[meta.primaryType]) {
+        broken.push(`${action}: primaryType "${meta.primaryType}" is not defined in INTENT_TYPES`);
+      }
+    }
     expect(
-      pkg.typeStringFor("ReceiveWithAuthorization", pkg.RECEIVE_WITH_AUTHORIZATION_TYPES),
-    ).to.equal(CANONICAL_TYPE_STRING);
+      broken,
+      "These actions cannot be signed — the struct they name does not exist:\n  " + broken.join("\n  "),
+    ).to.deep.equal([]);
   });
 
-  it("hashes to the typehash deployed USDC verifies against", async function () {
+  it("leaves no struct in INTENT_TYPES unreachable from any action", function () {
+    // The reverse: a struct nothing signs is either dead weight or a missing action entry. Either
+    // way it should be a decision, not a leftover.
+    const used = new Set(Object.values(pkg.INTENT_ACTIONS).map((m) => m.primaryType).filter(Boolean));
+    const unused = Object.keys(pkg.INTENT_TYPES).filter((k) => !used.has(k));
+    expect(
+      unused,
+      "Defined in INTENT_TYPES but named by no action in INTENT_ACTIONS — dead struct, or a missing " +
+        "action:\n  " + unused.join("\n  "),
+    ).to.deep.equal([]);
+  });
+});
+
+describe("EIP-712 domains match the contracts that verify under them (spec 075)", function () {
+  let pkg;
+  let inits;
+
+  before(async function () {
+    pkg = await import("@fairwins/intent-types");
+    inits = solidityDomainInits();
+  });
+
+  it("finds __EIP712_init calls in the production contracts", function () {
+    const total = Object.values(inits).reduce((n, l) => n + l.length, 0);
+    expect(total, "no __EIP712_init calls parsed — the regex or the contracts changed").to.be.greaterThan(4);
+  });
+
+  it("declares a source contract for every domain, and nothing more", function () {
+    expect(
+      Object.keys(pkg.DOMAIN_SOURCES).sort(),
+      "CONTRACT_DOMAINS and DOMAIN_SOURCES must describe the same set of domains",
+    ).to.deep.equal(Object.keys(pkg.CONTRACT_DOMAINS).sort());
+  });
+
+  it("carries only name and version, so nothing extra leaks into the domain separator", function () {
+    // Consumers spread these into an EIP-712 domain object. An extra key would be a THIRD domain
+    // field on some paths and not others, i.e. two different separators for the same contract.
+    for (const [key, d] of Object.entries(pkg.CONTRACT_DOMAINS)) {
+      expect(Object.keys(d).sort(), `CONTRACT_DOMAINS.${key} must be exactly { name, version }`).to.deep.equal([
+        "name",
+        "version",
+      ]);
+    }
+  });
+
+  it("matches the name and version each source contract initialises", function () {
+    const mismatches = [];
+    for (const [key, d] of Object.entries(pkg.CONTRACT_DOMAINS)) {
+      const file = pkg.DOMAIN_SOURCES[key];
+      const found = inits[file];
+      if (!found || found.length === 0) {
+        mismatches.push(`${key}: ${file} contains no __EIP712_init — moved, renamed, or deleted?`);
+        continue;
+      }
+      // A contract may init in both `initialize` and a `reinitializer` (WagerRegistry,
+      // MembershipManager, WagerPoolFactory all do). They must agree: EIP712Upgradeable stores the
+      // name/version, so a re-init under different arguments would silently change the separator of
+      // an already-deployed proxy and invalidate every signature in flight.
+      for (const got of found) {
+        if (got.name !== d.name || got.version !== d.version) {
+          mismatches.push(
+            `${key}  (${file})\n` +
+              `    package : name=${JSON.stringify(d.name)} version=${JSON.stringify(d.version)}\n` +
+              `    contract: name=${JSON.stringify(got.name)} version=${JSON.stringify(got.version)}`,
+          );
+        }
+      }
+    }
+    expect(
+      mismatches,
+      `${mismatches.length} domain(s) disagree with the verifying contract. The domain separator is ` +
+        `half of the EIP-712 digest, so a signature built from the package domain would NOT verify ` +
+        `on-chain:\n\n${mismatches.join("\n\n")}`,
+    ).to.deep.equal([]);
+  });
+
+  it("has a package domain for every EIP-712 contract in the tree", function () {
+    // The Solidity→package direction, same argument as the struct gate: without it, deleting a
+    // domain from the package leaves a contract whose separator nothing checks.
+    const declared = new Map(Object.entries(pkg.DOMAIN_SOURCES).map(([key, file]) => [file, key]));
+    const ungated = Object.keys(inits).filter((f) => !declared.has(f) && !NON_PACKAGE_DOMAINS[f]);
+    expect(
+      ungated,
+      "These contracts fix an EIP-712 domain that no CONTRACT_DOMAINS entry tracks. If FairWins " +
+        "clients sign against them, add a domain; if not, exempt them in NON_PACKAGE_DOMAINS with a " +
+        "reason:\n  " + ungated.join("\n  "),
+    ).to.deep.equal([]);
+  });
+
+  it("keeps every non-package domain exemption justified and still real", function () {
+    for (const [file, reason] of Object.entries(NON_PACKAGE_DOMAINS)) {
+      expect(inits[file], `${file} is exempted but declares no __EIP712_init — drop the exemption`).to.exist;
+      expect(reason.length, `${file} needs a real reason, not a placeholder`).to.be.greaterThan(40);
+    }
+  });
+
+  it("builds a complete domain that keeps the contract's own name and version", function () {
+    const d = pkg.domainFor("wagerRegistry", 137, "0x0000000000000000000000000000000000000001");
+    expect(d).to.deep.equal({
+      ...pkg.CONTRACT_DOMAINS.wagerRegistry,
+      chainId: 137,
+      verifyingContract: "0x0000000000000000000000000000000000000001",
+    });
+  });
+
+  it("throws on an unknown domain key rather than signing under an empty domain", function () {
+    expect(() => pkg.domainFor("notAContract", 137, "0x0000000000000000000000000000000000000001")).to.throw(
+      /Unknown EIP-712 domain key/,
+    );
+  });
+});
+
+describe("the Solidity parser itself refuses to hide a struct (spec 075)", function () {
+  // These feed the parser synthetic sources rather than mutating contracts/. The collision rule is
+  // the one behaviour with no natural occurrence in the tree today, so it would otherwise be
+  // asserted by nothing — which is exactly the state it was in.
+  const constant = (name, typeString) =>
+    `bytes32 private constant ${name} = keccak256("${typeString}");`;
+
+  it("throws when two contracts declare a same-named struct with different fields", function () {
+    const sources = [
+      { file: "contracts/a/A.sol", src: constant("CANCEL_TYPEHASH", "Cancel(address creator,bytes32 nonce)") },
+      { file: "contracts/b/B.sol", src: constant("CANCEL_TYPEHASH", "Cancel(address anyone,uint256 id)") },
+    ];
+    // Before this rule the walk simply overwrote, so ONE of the two Cancel structs was gated and the
+    // other silently was not — with no failure to notice, and the winner decided by directory order.
+    expect(() => solidityTypeStrings(sources)).to.throw(/DIFFERENTLY-SHAPED "Cancel"/);
+  });
+
+  it("accepts an identical redeclaration and names every file it came from", function () {
+    const same = "Cancel(address creator,bytes32 nonce)";
+    const out = solidityTypeStrings([
+      { file: "contracts/a/A.sol", src: constant("CANCEL_TYPEHASH", same) },
+      { file: "contracts/b/B.sol", src: constant("CANCEL_TYPEHASH", same) },
+    ]);
+    expect(out.Cancel.typeString).to.equal(same);
+    expect(out.Cancel.files).to.deep.equal(["contracts/a/A.sol", "contracts/b/B.sol"]);
+  });
+
+  it("reads the domain out of the __EIP712_init call, per file", function () {
+    const inits = solidityDomainInits([
+      { file: "contracts/x/X.sol", src: '__EIP712_init("Some Name", "7");' },
+      { file: "contracts/y/Y.sol", src: '__EIP712_init("A", "1");\n__EIP712_init("A", "2");' },
+    ]);
+    expect(inits["contracts/x/X.sol"]).to.deep.equal([{ name: "Some Name", version: "7" }]);
+    // Both occurrences are kept: a contract that re-inits under a different version would change an
+    // already-deployed proxy's separator, and the domain gate asserts every occurrence agrees.
+    expect(inits["contracts/y/Y.sol"]).to.deep.equal([
+      { name: "A", version: "1" },
+      { name: "A", version: "2" },
+    ]);
+  });
+});
+
+describe("the EIP-3009 token legs are pinned to recorded vectors (spec 075, FR-027)", function () {
+  /**
+   * These two structs are DIFFERENT in kind from every struct above, and the difference matters.
+   *
+   * Their authoritative typehashes live in the DEPLOYED USDC contract — Circle's, not ours. The only
+   * in-repo Solidity copy is contracts/mocks/MockUSDCPermit.sol, a mock we wrote. Checking our
+   * definitions against our own mock would be circular: both could drift together and the gate
+   * would stay green while every gasless payment stopped verifying against real USDC.
+   *
+   * So they are pinned to the canonical EIP-3009 typehashes instead — fixed vectors, independently
+   * checkable against the standard and against any deployed FiatTokenV2.
+   *
+   * PROVENANCE for both: read live from deployed USDC on Polygon 137
+   * (0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359, `version()` == "2") via its
+   * RECEIVE_/TRANSFER_WITH_AUTHORIZATION_TYPEHASH getters and confirmed equal — so these are
+   * independent vectors, not hashes of our own strings.
+   */
+  const VECTORS = {
+    ReceiveWithAuthorization: {
+      table: "RECEIVE_WITH_AUTHORIZATION_TYPES",
+      // Recorded 2026-08-03; re-read 2026-08-08.
+      typeString:
+        "ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)",
+      typehash: "0xd099cc98ef71107a616c4f0f941f04c322d8e254fe26b3c6668db87aae413de8",
+      // The escrow-side leg: the token enforces `to == msg.sender`, so only the recipient contract
+      // can submit it (pool joins, stake pulls).
+    },
+    TransferWithAuthorization: {
+      table: "TRANSFER_WITH_AUTHORIZATION_TYPES",
+      // Recorded 2026-08-08.
+      typeString:
+        "TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)",
+      typehash: "0x7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267",
+      // The wallet-to-wallet leg (Pay & Transfer): any address may submit it, so the relayer need
+      // not be the recipient.
+    },
+  };
+
+  for (const [primaryType, v] of Object.entries(VECTORS)) {
+    it(`renders the canonical ${primaryType} type string`, async function () {
+      const pkg = await import("@fairwins/intent-types");
+      expect(pkg.typeStringFor(primaryType, pkg[v.table])).to.equal(v.typeString);
+    });
+
+    it(`hashes ${primaryType} to the typehash deployed USDC verifies against`, async function () {
+      const pkg = await import("@fairwins/intent-types");
+      const ours = keccak256(toUtf8Bytes(pkg.typeStringFor(primaryType, pkg[v.table])));
+      expect(ours, "a gasless payment signed with this struct would not verify against real USDC").to.equal(
+        v.typehash,
+      );
+    });
+  }
+
+  it("keeps the two legs distinct", async function () {
+    // Same six fields, different names — and the name is the whole difference: it decides whether
+    // the token will accept a submitter that is not the recipient. Collapsing them into one table
+    // would silently let a wallet-to-wallet payment be signed as a receive-only authorization.
     const pkg = await import("@fairwins/intent-types");
-    const ours = keccak256(
-      toUtf8Bytes(pkg.typeStringFor("ReceiveWithAuthorization", pkg.RECEIVE_WITH_AUTHORIZATION_TYPES)),
-    );
-    expect(ours, "a gasless payment signed with this struct would not verify against real USDC").to.equal(
-      CANONICAL_TYPEHASH,
-    );
+    expect(Object.keys(pkg.RECEIVE_WITH_AUTHORIZATION_TYPES)).to.deep.equal(["ReceiveWithAuthorization"]);
+    expect(Object.keys(pkg.TRANSFER_WITH_AUTHORIZATION_TYPES)).to.deep.equal(["TransferWithAuthorization"]);
+    expect(VECTORS.ReceiveWithAuthorization.typehash).to.not.equal(VECTORS.TransferWithAuthorization.typehash);
   });
 });


### PR DESCRIPTION
Spec 075 moved the **type tables** into `@fairwins/intent-types`, and `TypehashParity` genuinely checks those against typehashes parsed out of the contracts. The **domains** were left behind — five `{name, version}` literals in the frontend, the same five in the gateway, and a sixth for `OpenAccept` — with **nothing tying any of them to the contract that verifies the signature**.

A correct type table under a wrong domain still produces an invalid signature. A `version` bump on a re-initialised proxy that wasn't mirrored in both copies would have failed silently at signing time.

## No signature changed — proven, not assumed

- domain separators for all **5 domains × 4 chains**: byte-identical to the previous literals
- `signOpenAccept` produces the identical signature on 137, `80002n` (bigint — the `Number(chainId)` path) and 63

## The gate now reaches the Solidity

It parses `__EIP712_init("name","version")` out of the contract each domain names, and asserts **every** occurrence agrees — WagerRegistry, MembershipManager and WagerPoolFactory each initialise twice, and a re-init under different args would change a deployed proxy's separator.

The proof it really reads the contracts: repointing `DOMAIN_SOURCES.wagerRegistry` at `MembershipManager.sol` fails quoting `contract: name="FairWins MembershipManager"` — a string that can only come from parsing that file.

## Three more gaps

- **TypehashParity was one-directional.** Deleting `RedeemVoucherIntent` — while a contract still verified it and `INTENT_ACTIONS` still referenced it — passed **all three** gates (parity 6 passing, actionCoverage 4 passing, frontend relay 46 passing). It now iterates the Solidity side too.
- **Duplicate primary types last-won silently.** `Cancel`, `Refund`, `ClaimShare`, `CreatePool` are generic enough that a second contract declaring a differently-shaped one would have un-gated whichever file the walk reached first. Now throws.
- **`OpenAccept`** was a hand-maintained two-place struct on the gasless claim-code path, invisible to the gate. Now in the package, under both directions.

## Also

`TRANSFER_WITH_AUTHORIZATION_TYPES` joins its `Receive` sibling in the package — pinned to a vector **re-read from deployed USDC on Polygon 137**, so the test vector is independent rather than a hash of our own strings, with a test that the two legs stay distinct. The name is the entire difference between *"only the recipient may submit"* and *"anyone may submit"*.

## Verification

Parity gate **24 passing** · gateway **230/230** · plain-Node ESM import OK · frontend relay/claimCode/transfer/pools **107 passing** · eslint clean.

## Deliberately left

- **`CLAUDE.md` untouched.** Its gasless-intents bullet still says the structs "exist in THREE places" — stale since spec 075 and now stale for domains too. That is a project-instruction change and wants your call, not an agent's.
- Domain literals remain in `intentClient.test.js` and `claimCode.test.js`: they are hardcoded *expected* values, and importing them from the package would make those assertions circular.