### PR TITLE
docs(claude): correct three claims that went stale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,17 @@ artifacts live under `specs/<feature>/`.
   `WagerRegistryCore` — the single storage-layout definition; never declare registry state
   anywhere else — and `check:storage-layout` validates the pair. In tests use
   `test/helpers/proxy.js#deployWagerRegistry` (deploys + wires both facets, returns a merged-ABI
-  contract). The EIP-712 intent structs exist in THREE places that must stay byte-identical:
-  the contract typehashes, `frontend/src/lib/relay/intentTypes.js`, and
-  `services/relay-gateway/src/intent/intentTypes.js`. The relayer (spec 036:
+  contract). The EIP-712 intent structs have **ONE source since spec 075** —
+  `@fairwins/intent-types` — and `frontend/src/lib/relay/intentTypes.js` and
+  `services/relay-gateway/src/intent/intentTypes.js` are re-exports, not copies. Never
+  reintroduce a local table: `test/intent/TypehashParity.test.js` checks the package against
+  typehashes parsed out of the **contracts** (both directions — a struct the Solidity verifies
+  but the package lacks fails too), and `services/relay-gateway/test/actionCoverage.test.js`
+  checks the gateway's action table against it. The **domains** (`name`/`version`) are the one
+  piece still hand-synced across `intentTypes.js` in both trees plus
+  `frontend/src/utils/claimCode/deriveFromCode.js`, with nothing tying them to the contract that
+  verifies the signature — a correct type table under a wrong domain still produces an invalid
+  signature (issue #1038). The relayer (spec 036:
   `services/relay-gateway` policy gateway + `services/oz-relayer` engine config) is optional
   infrastructure — every gasless flow keeps a self-submit fallback (never-stranded rule).
   See `docs/developer-guide/gasless-intents.md` + `docs/runbooks/relayer-operations.md`.
@@ -358,7 +366,15 @@ artifacts live under `specs/<feature>/`.
   npm/cli#4828 silently drops `@rollup/rollup-linux-x64-gnu` from node_modules AND the lockfile on
   an incremental install, breaking every Vite build including the on-chain mini-app release path,
   and re-running `npm install` cannot fix it (the lock is already wrong, so npm reports "up to
-  date"). Use `npm run deps:reinstall`. (2) **Every dependency contributing Solidity source is
+  date"). Use `npm run deps:reinstall`. **`npm ci` does not fix it either** — measured: it exits 0
+  reporting "added 2955 packages" from a lockfile that *does* contain the entry, and still leaves
+  the binary uninstalled, because that entry is `optional` AND `peer` and npm skips optional peer
+  deps even when locked. If a `deps:reinstall` is interrupted (no lockfile, half-built
+  node_modules), restore the lockfile with `git checkout -- package-lock.json` and then install the
+  binary alone: `npm install --no-save @rollup/rollup-linux-x64-gnu@<version from the lockfile>` —
+  ~18s, and verified to leave `package-lock.json` byte-identical. **Dependabot triggers this
+  routinely**: 3 of 5 lockfile-touching Dependabot PRs in one week dropped the binary, and
+  `check:deps` is what catches it. (2) **Every dependency contributing Solidity source is
   pinned EXACTLY** — a caret range makes deployed bytecode a function of when the lockfile was last
   resolved; `@chainlink/contracts` floating 1.3.0→1.5.0 changed `ChainlinkFunctionsOracleAdapter`'s
   bytecode and only the byte-diff gate caught it. (3) **A shared package under `packages/` MUST be
@@ -369,7 +385,12 @@ artifacts live under `specs/<feature>/`.
   `services/relay-gateway/test/actionCoverage.test.js`. Any change touching dependencies, hoisting,
   or the build preset MUST pass the byte gates (`scripts/codegen/bytecode-digest.js`,
   `scripts/miniapps/record-build-digests.js`) — mini-app output bytes are keccak-committed
-  on-chain. See `specs/075-monorepo-workspaces/`.
+  on-chain. **Both byte gates now RUN in CI** (`test.yml`: the bytecode diff in
+  `smart-contract-tests`, the mini-app bytes in their own `miniapp-bytes` job); until then they
+  were scripts nobody was required to run, and the mini-app one reported "output bytes unchanged"
+  after a *failed* build. A gate firing here is not a chore — getting it green means deliberately
+  re-recording a baseline, i.e. accepting that deployed bytecode or a published package changed.
+  See `specs/075-monorepo-workspaces/`.
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,


### PR DESCRIPTION
`CLAUDE.md` is loaded into every session as binding instruction, so a stale claim here is worse than a stale comment — it gets **followed**.

## 1. The EIP-712 "THREE places" rule would now cause the bug it prevented

> The EIP-712 intent structs exist in THREE places that must stay byte-identical…

Untrue since spec 075, and following it means reintroducing the duplication that spec removed. Verified on `main`: both `intentTypes.js` files import from `@fairwins/intent-types` and re-export.

Replaced with what actually enforces it — `TypehashParity` checking the package against typehashes parsed out of the **contracts**, plus the gateway's `actionCoverage` — and it now names the one piece still genuinely hand-synced: **the domains**, in both trees plus `deriveFromCode.js`, with nothing tying them to the verifying contract. That is #1038, fixed in #1066; this bullet updates again when that lands.

## 2. The install-recovery rule was right but incomplete

It said to use `deps:reinstall` instead of `npm install`. Correct — but it didn't say what to do when a re-resolve is *interrupted*, and the obvious move is wrong:

**`npm ci` does not fix it.** Measured today: exits 0 reporting *"added 2955 packages"* from a lockfile that **does** contain the entry, and still leaves `@rollup/rollup-linux-x64-gnu` uninstalled — the entry is `optional` **and** `peer`, and npm skips optional peer deps even when locked. `vite build` then dies with rollup's own npm/cli#4828 message.

Adds the recovery that works — restore the lockfile, then `npm install --no-save <pkg>@<locked version>`, ~18s, verified to leave `package-lock.json` byte-identical — and the frequency: **3 of 5** lockfile-touching Dependabot PRs in one week dropped it.

## 3. "MUST pass the byte gates" read as policy but nothing enforced it

Neither gate appeared in any workflow — `bytecode-digest.js` was referenced only in a comment. Both now run in CI (#1035), and the mini-app one no longer reports *"output bytes unchanged"* after a **failed** build.

Also states what a firing gate means, since that is the part someone will get wrong under time pressure: re-recording a baseline is **accepting that deployed bytecode or a published package changed**, not a step toward green.