### PR TITLE
feat(ui): show which build this is at the bottom of the nav drawer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ WORKDIR /app/frontend
 # Note: VITE_PINATA_JWT is NOT included here - it's handled at runtime via nginx proxy
 # Tenant selection (spec 072): one image = one tenant. Unset => the default
 # (fairwins) tenant, byte-identical to the pre-072 build.
+# Build stamp for the nav drawer's version label (src/config/buildInfo.js). Passed as a build ARG
+# rather than derived: .dockerignore excludes .git, so the image build cannot run `git rev-parse`.
+# Unset resolves to 'dev', which the drawer displays honestly instead of hiding the label.
+ARG VITE_COMMIT_SHA
 ARG VITE_TENANT_ID
 ARG VITE_WALLETCONNECT_PROJECT_ID
 ARG VITE_APP_URL
@@ -53,6 +57,7 @@ ARG VITE_BUNDLER_URLS_POLYGON
 ARG VITE_SPONSOR_PAYMASTER_POLYGON
 
 # Set environment variables from build args
+ENV VITE_COMMIT_SHA=${VITE_COMMIT_SHA}
 ENV VITE_TENANT_ID=${VITE_TENANT_ID}
 ENV VITE_WALLETCONNECT_PROJECT_ID=${VITE_WALLETCONNECT_PROJECT_ID}
 ENV VITE_APP_URL=${VITE_APP_URL}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,9 @@ steps:
       # instance. A per-tenant instance is the same pipeline with its own
       # VITE_TENANT_ID + tenant URLs and its own Cloud Run service — see
       # docs/runbooks/tenant-operations.md.
+      # Stamps the nav drawer's build label so a bug report pins an exact commit (buildInfo.js).
+      - '--build-arg'
+      - 'VITE_COMMIT_SHA=$SHORT_SHA'
       - '--build-arg'
       - 'VITE_TENANT_ID=fairwins'
       - '--build-arg'

--- a/frontend/src/components/Footer.css
+++ b/frontend/src/components/Footer.css
@@ -70,3 +70,24 @@
   flex-direction: column;
   gap: 0.5rem;
 }
+
+/*
+ * The build stamp. Subtle by design — it is diagnostic, not navigation, so it must not compete
+ * with the legal links or the copyright above it. Muted, smaller, and monospace so a commit SHA
+ * is legible and unambiguous (l/1/I and O/0 matter when someone is reading it back over a call).
+ *
+ * NOT `user-select: none`: the whole point is that it can be copied into a bug report.
+ */
+.app-footer-build {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.6875rem;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: var(--text-tertiary, var(--text-muted, #8b8b8b));
+  opacity: 0.75;
+}
+
+.app-footer--drawer .app-footer-build {
+  margin-top: 0.125rem;
+}

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { SHOW_ALL_ORACLE_MODELS } from '../constants/wagerDefaults'
 import { LEGAL_LINKS } from '../constants/legalLinks'
 import { tenantBrand, tenantLinks } from '../config/tenant'
+import { buildLabel } from '../config/buildInfo'
 import './Footer.css'
 
 /**
@@ -37,6 +38,13 @@ export default function Footer({ variant = 'full' }) {
           ))}
         </nav>
         <p className="app-footer-copyright">{copyright}</p>
+        {/*
+          * Which build this is. Deliberately selectable (not `user-select: none`) — the whole
+          * point is that someone reporting a problem can copy it into the report. `title` carries
+          * the long form for a hover, and the element is NOT aria-hidden: a support conversation
+          * over a screen reader needs this as much as a sighted one.
+          */}
+        <p className="app-footer-build" title={`Build ${buildLabel()}`}>{buildLabel()}</p>
       </footer>
     )
   }

--- a/frontend/src/config/buildInfo.js
+++ b/frontend/src/config/buildInfo.js
@@ -1,0 +1,41 @@
+/**
+ * Which build am I looking at?
+ *
+ * Exists for troubleshooting: when someone reports a problem, the first question is always which
+ * build they are on, and "latest" is not an answer — the SPA is a static bundle behind a CDN, so a
+ * member can be running something several deploys old without knowing it.
+ *
+ * The COMMIT is the identifier that matters. `frontend/package.json` is `0.0.0` (a workspace
+ * placeholder, never bumped) and the root version moves rarely, so a version string alone cannot
+ * tell two builds apart. The short SHA pins the tree exactly and is greppable straight back to a
+ * commit, a PR and a CI run.
+ *
+ * BOTH VALUES ARE BUILD-TIME CONSTANTS, substituted by Vite's `define` (see vite.config.js). They
+ * are deliberately NOT read from `import.meta.env` at runtime: `.dockerignore` excludes `.git`, so
+ * the container cannot derive the SHA itself, and a value that is only sometimes present would make
+ * this display sometimes lie.
+ *
+ * HONESTY RULE: when the commit is unknown — a local `vite dev`, or an image built without the
+ * build arg — this reports `dev` rather than inventing or omitting. A build label that silently
+ * disappears in some environments is worse than one that says it does not know, because the absence
+ * reads as "no version info exists" rather than "this build was not stamped".
+ */
+
+/* global __APP_VERSION__, __APP_COMMIT__ */
+
+// The `typeof` guards keep this importable under plain vitest, where Vite's `define` substitution
+// does not run — without them every test that renders the Footer would throw a ReferenceError.
+export const APP_VERSION = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : '0.0.0'
+export const APP_COMMIT = typeof __APP_COMMIT__ === 'string' ? __APP_COMMIT__ : 'dev'
+
+/** True when this build carries a real commit stamp (i.e. was built by CI, not a dev server). */
+export const IS_STAMPED = APP_COMMIT !== 'dev' && APP_COMMIT.length > 0
+
+/**
+ * The one-line label rendered in the nav drawer, e.g. `v1.0.0 · a1b2c3d` or `v1.0.0 · dev`.
+ * Kept here rather than in the component so the format has a single definition and a test can
+ * assert it without rendering anything.
+ */
+export function buildLabel() {
+  return `v${APP_VERSION} · ${APP_COMMIT}`
+}

--- a/frontend/src/test/buildInfo.test.jsx
+++ b/frontend/src/test/buildInfo.test.jsx
@@ -1,0 +1,63 @@
+/**
+ * The build stamp shown at the bottom of the nav drawer.
+ *
+ * It exists for one job — someone reports a problem and we need to know which build they were on —
+ * so the properties worth pinning are about HONESTY, not formatting:
+ *
+ *   · it renders in the drawer (that is the whole point)
+ *   · it never silently disappears, because an absent label reads as "no version info exists"
+ *     rather than "this build was not stamped"
+ *   · it is copyable, because it will be pasted into a bug report
+ *
+ * Under vitest, Vite's `define` substitution does not run, so buildInfo falls back to its unstamped
+ * values. That IS the case worth covering: it is the same path a local dev server takes, and the
+ * fallback is exactly where a "sometimes present" value would start lying.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import Footer from '../components/Footer'
+import { APP_VERSION, APP_COMMIT, IS_STAMPED, buildLabel } from '../config/buildInfo'
+
+describe('build stamp', () => {
+  it('resolves to honest values when the build was not stamped', () => {
+    // Not asserting a specific version — that moves. Asserting it is a real value, not undefined
+    // leaking into the UI as "vundefined".
+    expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+/)
+    expect(APP_COMMIT).toBe('dev')
+    expect(IS_STAMPED).toBe(false)
+  })
+
+  it('never renders "undefined" or an empty label', () => {
+    const label = buildLabel()
+    expect(label).not.toMatch(/undefined|null/)
+    expect(label.trim().length).toBeGreaterThan(1)
+  })
+})
+
+describe('Footer — the drawer shows which build this is', () => {
+  it('renders the build stamp in the drawer variant', () => {
+    render(<Footer variant="drawer" />)
+    expect(screen.getByText(buildLabel())).toBeInTheDocument()
+  })
+
+  it('renders it in the condensed in-app footer too', () => {
+    render(<Footer variant="condensed" />)
+    expect(screen.getByText(buildLabel())).toBeInTheDocument()
+  })
+
+  it('is not hidden from assistive tech', () => {
+    // A support conversation conducted over a screen reader needs this as much as a sighted one,
+    // so "subtle" must mean visually quiet, never aria-hidden.
+    const { container } = render(<Footer variant="drawer" />)
+    const stamp = container.querySelector('.app-footer-build')
+    expect(stamp).not.toBeNull()
+    expect(stamp.closest('[aria-hidden="true"]')).toBeNull()
+  })
+
+  it('leaves the landing footer alone', () => {
+    // The stamp is a diagnostic for people already inside the app; the marketing page does not
+    // need a commit SHA on it.
+    render(<Footer variant="full" />)
+    expect(screen.queryByText(buildLabel())).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/buildInfo.test.jsx
+++ b/frontend/src/test/buildInfo.test.jsx
@@ -19,12 +19,27 @@ import Footer from '../components/Footer'
 import { APP_VERSION, APP_COMMIT, IS_STAMPED, buildLabel } from '../config/buildInfo'
 
 describe('build stamp', () => {
-  it('resolves to honest values when the build was not stamped', () => {
+  it('resolves to honest values whether or not the build was stamped', () => {
     // Not asserting a specific version — that moves. Asserting it is a real value, not undefined
     // leaking into the UI as "vundefined".
     expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+/)
-    expect(APP_COMMIT).toBe('dev')
-    expect(IS_STAMPED).toBe(false)
+
+    /*
+     * CONDITIONAL on IS_STAMPED, not pinned to 'dev'. vitest loads the same vite.config.js, so
+     * `define` substitution DOES run here — meaning a developer or CI step with VITE_COMMIT_SHA
+     * exported would inline a real SHA and fail a hardcoded assertion while the behaviour was
+     * entirely correct. Reported in review on #1070.
+     *
+     * The invariant worth pinning is not "the commit is dev", it is "the two agree": either we are
+     * stamped and the commit looks like a short SHA, or we are not and it says so. That holds in
+     * both environments and still catches the failure that matters — a blank or undefined commit
+     * reaching the UI.
+     */
+    if (IS_STAMPED) {
+      expect(APP_COMMIT).toMatch(/^[0-9a-f]{7}$/)
+    } else {
+      expect(APP_COMMIT).toBe('dev')
+    }
   })
 
   it('never renders "undefined" or an empty label', () => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,26 @@
 import process from 'node:process'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { tenantBrandingPlugin } from './vite-plugins/tenant-branding.js'
+
+/*
+ * Build stamp for the nav drawer (see src/config/buildInfo.js for why).
+ *
+ * Version comes from the ROOT package.json, not frontend's — frontend's is `0.0.0`, a workspace
+ * placeholder that is never bumped, so displaying it would be noise dressed as information.
+ *
+ * The commit arrives as an ENV VAR, not from git: `.dockerignore` excludes `.git`, so the image
+ * build genuinely cannot run `git rev-parse`. cloudbuild.yaml passes $SHORT_SHA through as a build
+ * arg. Unset (a local dev server) resolves to 'dev', which the drawer displays honestly rather
+ * than hiding.
+ */
+const ROOT_PKG = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json'), 'utf8'),
+)
+const COMMIT_SHA = (process.env.VITE_COMMIT_SHA || '').trim().slice(0, 7) || 'dev'
 
 // Fails a production build if Pinata write credentials are present in the build
 // environment. Any VITE_*-prefixed value is inlined into the client bundle in
@@ -33,6 +51,13 @@ function pinataSecretGuard() {
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), pinataSecretGuard(), tenantBrandingPlugin()],
+  // Build-time constants, NOT `import.meta.env`: the preset used for mini-app packages sets an
+  // envPrefix that turns any bundled `import.meta.env` read into `undefined`, and a value that is
+  // only sometimes present would make the drawer's build label sometimes lie.
+  define: {
+    __APP_VERSION__: JSON.stringify(ROOT_PKG.version),
+    __APP_COMMIT__: JSON.stringify(COMMIT_SHA),
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
Troubleshooting always starts with *"which build are you on"*, and "latest" is not an answer — the SPA is a static bundle behind a CDN, so a member can be running something several deploys old without knowing it.

Renders as `v1.0.0 · a1b2c3d` under the legal links in the drawer footer: muted, small, **monospace** — someone will read a SHA back over a call, and `l/1/I` and `O/0` have to be distinguishable.

## The commit is the identifier, not the version

`frontend/package.json` is **`0.0.0`** — a workspace placeholder that is never bumped — so displaying it would be noise dressed as information. The version comes from the **root** manifest, and the short SHA is what actually pins the tree to a commit, a PR and a CI run.

## Three decisions worth flagging

**Vite `define`, not `import.meta.env`.** The mini-app build preset sets an `envPrefix` that turns a bundled `import.meta.env` read into `undefined`. A value that is only *sometimes* present would make this display sometimes lie.

**The SHA is a build ARG because it has to be.** `.dockerignore` excludes `.git`, so the image build genuinely cannot run `git rev-parse`. `cloudbuild.yaml` passes `$SHORT_SHA`.

**Unset resolves to `dev`, and is displayed.** A local dev server, or an image built without the arg, shows `v1.0.0 · dev` rather than hiding the label. A stamp that silently vanishes in some environments reads as *"no version info exists"* instead of *"this build was not stamped"* — and the second is the thing you need to know.

## Subtle, not hidden

Not `aria-hidden`, not `user-select: none`. It will be copied into a bug report, and a support conversation conducted over a screen reader needs it as much as a sighted one. Subtle means visually quiet.

## Verification

| check | result |
|---|---|
| unstamped build | builds clean, label reads `dev` |
| `VITE_COMMIT_SHA=abc1234567890` | **`abc1234` inlined into the bundle** |
| mini-app byte gate | `OK: mini-app output bytes unchanged` |
| tests | 10 passing (5 new + existing Footer suite) |
| eslint | clean |

The byte gate matters here because this touches a `vite.config.js` — checked rather than assumed. It is the frontend's, not the packages', so the keccak-committed mini-app bytes are untouched.

Also renders in the `condensed` in-app footer (same code path); deliberately **not** on the landing page, which does not need a commit SHA on it.