### PR TITLE
Move legal/policy links from side panel into Settings > App

### DIFF
--- a/frontend/src/components/Footer.css
+++ b/frontend/src/components/Footer.css
@@ -51,10 +51,10 @@
 }
 
 /*
- * Drawer variant — the same condensed legal footer, restyled to be contained at
- * the bottom of the wallet section drawer (WalletPage.css). It stacks vertically,
- * drops the wide centered layout, and uses margin-top:auto so it is pinned to the
- * bottom of the flex-column drawer regardless of how tall the section list is.
+ * Drawer variant — copyright only (the legal/policy links moved to Settings → App,
+ * issue #1025), restyled to be contained at the bottom of the side nav drawer
+ * (AppNavDrawer.css). Uses margin-top:auto so it is pinned to the bottom of the
+ * flex-column drawer regardless of how tall the section list is.
  */
 .app-footer--drawer {
   flex-direction: column;
@@ -64,9 +64,4 @@
   margin: auto 0 0;
   padding: 1rem 12px;
   font-size: 0.8125rem;
-}
-
-.app-footer--drawer .app-footer-links {
-  flex-direction: column;
-  gap: 0.5rem;
 }

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -9,12 +9,14 @@ import './Footer.css'
  *
  *   variant="full"      → landing-page footer (brand + Oracles/Docs/Legal/Community) + copyright.
  *   variant="condensed" → in-app footer: legal/policy links + copyright only (no marketing columns).
- *   variant="drawer"    → condensed footer restyled to sit contained at the bottom of the
- *                         wallet section drawer (same links/copyright, stacked + compact).
+ *   variant="drawer"    → copyright only, restyled to sit contained at the bottom of the
+ *                         side nav drawer. The legal/policy links themselves moved out of the
+ *                         drawer into Settings → App (issue #1025) — the side panel should stay
+ *                         lean, and those links now live where Install App / Software Update do.
  *
  * The copyright year is derived from the current date so it never goes stale (FR-008),
- * and the legal links come from the single LEGAL_LINKS source so the two footers can't
- * drift and never point at the external marketing site (FR-006/009, SC-002).
+ * and the legal links come from the single LEGAL_LINKS source so the footers that still
+ * carry them can't drift and never point at the external marketing site (FR-006/009, SC-002).
  * Brand identity, docs, and community links resolve from the tenant manifest (spec 072) —
  * columns whose links the tenant does not define are simply absent.
  */
@@ -31,11 +33,13 @@ export default function Footer({ variant = 'full' }) {
     const className = variant === 'drawer' ? 'app-footer app-footer--drawer' : 'app-footer'
     return (
       <footer className={className}>
-        <nav className="app-footer-links" aria-label="Legal">
-          {LEGAL_LINKS.map((l) => (
-            <a key={l.href} href={l.href}>{l.label}</a>
-          ))}
-        </nav>
+        {variant === 'condensed' && (
+          <nav className="app-footer-links" aria-label="Legal">
+            {LEGAL_LINKS.map((l) => (
+              <a key={l.href} href={l.href}>{l.label}</a>
+            ))}
+          </nav>
+        )}
         <p className="app-footer-copyright">{copyright}</p>
       </footer>
     )

--- a/frontend/src/components/nav/AppNavDrawer.jsx
+++ b/frontend/src/components/nav/AppNavDrawer.jsx
@@ -105,7 +105,8 @@ function resolveActiveId(location, favoriteItems) {
  * under it — see the `.app-shell` padding in this file's CSS) that expands in
  * place to the full labelled panel; it never fully hides on desktop, so a
  * section is always one click away. Selecting an entry routes to the section
- * and returns to the gutter; the in-app legal footer only fits once expanded.
+ * and returns to the gutter; the copyright footer only fits once expanded (the
+ * legal/policy links that used to sit here moved to Settings → App, issue #1025).
  */
 export default function AppNavDrawer() {
   const { isOpen, close, toggle } = useNavDrawer()

--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -1375,3 +1375,51 @@
   flex-wrap: wrap;
   gap: 0.6rem;
 }
+
+/* Legal & Policies section (Preferences tab → App group, issue #1025) */
+.app-legal-links {
+  display: flex;
+  flex-direction: column;
+  margin-top: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.app-legal-link-row {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.7rem 0.85rem;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.app-legal-link-row + .app-legal-link-row {
+  border-top: 1px solid var(--border-color);
+}
+
+.app-legal-link-row:hover,
+.app-legal-link-row:focus-visible {
+  background: var(--bg-secondary, rgba(0, 0, 0, 0.03));
+}
+
+.app-legal-link-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.app-legal-link-label {
+  flex: 1;
+  font-size: 0.92rem;
+}
+
+.app-legal-link-chevron {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  line-height: 1;
+}

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -45,7 +45,18 @@ import {
 import { collectiblesGatewayUrl } from '../lib/collectibles/gatewayClient'
 import { predictGatewayUrl } from '../lib/predict/predictClient'
 import PremiumPurchaseModal from '../components/ui/PremiumPurchaseModal'
+import NavIcon from '../components/nav/NavIcon'
+import { LEGAL_LINKS } from '../constants/legalLinks'
 import './WalletPage.css'
+
+// Icon per Settings → App → Legal & Policies row (issue #1025). Keyed by href
+// since that's the stable identity LEGAL_LINKS already uses as its list key.
+const LEGAL_LINK_ICONS = {
+  '/terms': 'reports',
+  '/risk': 'alert',
+  '/privacy': 'lock',
+}
+const LEGAL_LINK_ICON_DEFAULT = 'ban' // Account Moderation (deep-links into /terms)
 
 // My Account section panels, keyed by tab id. The section MENU now lives in the
 // global nav drawer + account button (see config/appNav.js) — this page just
@@ -676,6 +687,26 @@ function WalletPage() {
                           {pwaChecking ? 'Checking…' : 'Check for updates'}
                         </button>
                       </div>
+                    </div>
+
+                    {/* Issue #1025 — moved from the side nav drawer's footer into
+                        Settings → App, after Install App / Software Update. */}
+                    <div className="section" id="legal-policies">
+                      <h3>Legal &amp; Policies</h3>
+                      <p className="section-description">
+                        Terms, risk disclosures, and other policies governing your use of FairWins.
+                      </p>
+                      <nav className="app-legal-links" aria-label="Legal and policy documents">
+                        {LEGAL_LINKS.map((link) => (
+                          <a key={link.href} href={link.href} className="app-legal-link-row">
+                            <span className="app-legal-link-icon" aria-hidden="true">
+                              <NavIcon name={LEGAL_LINK_ICONS[link.href] || LEGAL_LINK_ICON_DEFAULT} size={18} />
+                            </span>
+                            <span className="app-legal-link-label">{link.label}</span>
+                            <span className="app-legal-link-chevron" aria-hidden="true">›</span>
+                          </a>
+                        ))}
+                      </nav>
                     </div>
                   </div>
                 )}

--- a/frontend/src/test/AppNavDrawer.test.jsx
+++ b/frontend/src/test/AppNavDrawer.test.jsx
@@ -33,9 +33,10 @@ function OpenOnMount() {
 
 // App navigation redesign — the global left drawer ("us"). It lists Home plus
 // the Finance/Tools/Apps sections, routes each entry, highlights the active one
-// from the URL, and carries the in-app legal footer. Personal-account entries
+// from the URL, and carries a copyright-only footer. Personal-account entries
 // (Account/Membership/Preferences) intentionally live on the account button, not
-// here.
+// here. The legal/policy links that used to live in this footer moved to
+// Settings → App (issue #1025).
 
 function LocationProbe() {
   const location = useLocation()
@@ -127,13 +128,15 @@ describe('AppNavDrawer (global nav drawer)', () => {
     expect(screen.getByRole('button', { name: 'Trade' })).not.toHaveAttribute('aria-current')
   })
 
-  it('contains the in-app legal footer', () => {
+  it('contains a copyright-only footer, with no legal/policy links (issue #1025)', () => {
     const { container } = renderDrawer()
     const footer = container.querySelector('.app-footer--drawer')
     expect(footer).toBeTruthy()
-    expect(
-      within(footer).getByRole('link', { name: /Terms & Conditions/i })
-    ).toHaveAttribute('href', '/terms')
+    expect(within(footer).getByText(new RegExp(String(new Date().getFullYear())))).toBeInTheDocument()
+    expect(within(footer).queryByRole('link', { name: /Terms & Conditions/i })).not.toBeInTheDocument()
+    expect(within(footer).queryByRole('link', { name: /Risk Disclosure/i })).not.toBeInTheDocument()
+    expect(within(footer).queryByRole('link', { name: /Privacy Policy/i })).not.toBeInTheDocument()
+    expect(within(footer).queryByRole('link', { name: /Account Moderation/i })).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/test/Footer.test.jsx
+++ b/frontend/src/test/Footer.test.jsx
@@ -47,6 +47,20 @@ describe('Footer', () => {
     expect(screen.getByText('Polymarket')).toBeInTheDocument()
   })
 
+  it('drawer variant: copyright only, no legal/policy links (issue #1025)', () => {
+    const { container } = render(<Footer variant="drawer" />)
+    const footer = container.querySelector('footer')
+    expect(footer).toBeTruthy()
+    expect(footer).toHaveClass('app-footer--drawer')
+
+    for (const { label } of LEGAL_LINKS) {
+      expect(within(footer).queryByRole('link', { name: new RegExp(label, 'i') })).not.toBeInTheDocument()
+    }
+
+    const year = new Date().getFullYear()
+    expect(footer.textContent).toContain(String(year))
+  })
+
   it('is wired into the in-app layout as the condensed variant (FR-005)', () => {
     expect(appSource).toContain('<Footer variant="condensed" />')
   })

--- a/frontend/src/test/WalletPage.test.jsx
+++ b/frontend/src/test/WalletPage.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import WalletPage from '../pages/WalletPage'
 import { WalletContext, UIContext } from '../contexts'
+import { LEGAL_LINKS } from '../constants/legalLinks'
 
 // Spec 011 — Account tab entry point for the address QR modal
 // (contracts/address-qr-ui-contract.md, W1–W2). Wallet state is mocked at the
@@ -246,5 +247,34 @@ describe('WalletPage — section routing', () => {
     const { container } = renderPage(connectedWalletContext, '/wallet?tab=membership')
     expect(container.querySelector('.wallet-portal-current')).toBeFalsy()
     expect(container.querySelector('.wallet-portal-topbar')).toBeFalsy()
+  })
+})
+
+// Issue #1025 — Terms & Conditions / Risk Disclosure / Privacy Policy / Account
+// Moderation moved out of the side nav drawer into Settings → App, after
+// Install App / Software Update.
+describe('WalletPage — Preferences → App → Legal & Policies (issue #1025)', () => {
+  const PREFERENCES_ROUTE = '/wallet?tab=preferences'
+
+  it('lists all four legal/policy links, each pointing at its existing in-app route', () => {
+    renderPage(connectedWalletContext, PREFERENCES_ROUTE)
+    expect(screen.getByRole('heading', { name: /legal & policies/i })).toBeInTheDocument()
+
+    for (const { label, href } of LEGAL_LINKS) {
+      expect(screen.getByRole('link', { name: new RegExp(label, 'i') })).toHaveAttribute('href', href)
+    }
+  })
+
+  it('positions Legal & Policies after Install App and Software Update', () => {
+    const { container } = renderPage(connectedWalletContext, PREFERENCES_ROUTE)
+    const headings = Array.from(container.querySelectorAll('.preferences-group-heading, h3')).map(
+      (el) => el.textContent
+    )
+    const installIdx = headings.indexOf('Install App')
+    const updateIdx = headings.indexOf('Software Update')
+    const legalIdx = headings.indexOf('Legal & Policies')
+    expect(installIdx).toBeGreaterThanOrEqual(0)
+    expect(updateIdx).toBeGreaterThan(installIdx)
+    expect(legalIdx).toBeGreaterThan(updateIdx)
   })
 })


### PR DESCRIPTION
## Summary
- Removes Terms & Conditions, Risk Disclosure, Privacy Policy, and Account Moderation from the global nav drawer's footer (the "side panel") — it now shows only the copyright line.
- Adds all four as a new **Legal & Policies** section in **Preferences → App**, positioned right after *Install App* and *Software Update*, styled to match the existing App-section rows (icon, label, chevron).
- No routing changes — every link still resolves the same href from the existing `LEGAL_LINKS` source, so nothing regresses and no redirects are needed.

## Acceptance criteria (issue #1025)
- [x] Side panel no longer contains direct links for Terms & Conditions, Risk Disclaimers, Privacy Policy, or Account Moderation.
- [x] All four items appear in Settings → App, ordered after Install App and Software Update.
- [x] Clicking each item navigates to the same destination as before (unchanged hrefs from `LEGAL_LINKS`).
- [x] Existing routes/deep-links continue to work — routes themselves were not touched, only where the link is rendered.
- [x] UI matches the existing design language of the Settings → App list (icon, label, chevron).
- [x] Unit + integration tests updated to reflect the new location.

## Test plan
- [x] `npx vitest run src/test/Footer.test.jsx src/test/AppNavDrawer.test.jsx src/test/WalletPage.test.jsx` — 28 passed
- [x] `npx vitest run src/test/moderationLinks.test.jsx src/test/legalDocs.test.js src/test/LegalDocPage.test.jsx src/test/compliance.accessibility.test.jsx src/test/voucherTermsLink.test.js` — 29 passed (unaffected legal-link surfaces still green)
- [x] `npx eslint` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RL78aGDzq4t79vCRCbscZc)_