### PR TITLE
fix(test): BridgeView screening asserted call order, not the requirement

### DIFF
--- a/frontend/src/test/bridge/BridgeView.screening.test.jsx
+++ b/frontend/src/test/bridge/BridgeView.screening.test.jsx
@@ -253,11 +253,15 @@ describe('BridgeView — screening the acting wallet (T116/T120, FR-032)', () =>
      * Waiting for the forced call specifically also removes the ordering assumption entirely:
      * whichever order they arrive in, the requirement is that submission re-screens.
      */
-    await waitFor(() => {
-      expect(screenOne.mock.calls.some(([, , options]) => options?.force === true)).toBe(true)
-    })
     // Forced: a cached 'clear' from the quote is exactly what must not be reused here.
-    const forced = screenOne.mock.calls.find(([, , options]) => options?.force === true)
+    // `waitFor` RETURNS the matched call, so the search happens once and the value is already
+    // proven non-null by the assertion inside — indexing it below cannot become a TypeError that
+    // masks the real expectation failure.
+    const forced = await waitFor(() => {
+      const call = screenOne.mock.calls.find(([, , options]) => options?.force === true)
+      expect(call, 'submission should re-screen with force: true').toBeDefined()
+      return call
+    })
     expect(forced[1]).toBe(137)
   })
 

--- a/frontend/src/test/bridge/BridgeView.screening.test.jsx
+++ b/frontend/src/test/bridge/BridgeView.screening.test.jsx
@@ -240,11 +240,25 @@ describe('BridgeView — screening the acting wallet (T116/T120, FR-032)', () =>
 
     await user.click(confirmButton())
 
-    await waitFor(() => expect(screenOne).toHaveBeenCalled())
-    const [, chainId, options] = screenOne.mock.calls[0]
-    expect(chainId).toBe(137)
+    /*
+     * Asserts that a FORCED screen happened, not that the first call after the click was the
+     * forced one. Those are different claims, and the second is not what this test is named for.
+     *
+     * It waited for any call and then read `mock.calls[0]`, so an unforced re-screen landing first
+     * — a re-render on the quote path, which is ordinary under load — made it fail with
+     * `expected { provider: {…} } to match object { force: true }` while the behaviour under test
+     * was correct. It failed that way on two unrelated PRs (#1060, #1067) and passes 3/3 locally,
+     * i.e. it was a CI-load artifact, not a regression.
+     *
+     * Waiting for the forced call specifically also removes the ordering assumption entirely:
+     * whichever order they arrive in, the requirement is that submission re-screens.
+     */
+    await waitFor(() => {
+      expect(screenOne.mock.calls.some(([, , options]) => options?.force === true)).toBe(true)
+    })
     // Forced: a cached 'clear' from the quote is exactly what must not be reused here.
-    expect(options).toMatchObject({ force: true })
+    const forced = screenOne.mock.calls.find(([, , options]) => options?.force === true)
+    expect(forced[1]).toBe(137)
   })
 
   it('treats an unscreenable wallet as an unknown, never as a flagged one', async () => {


### PR DESCRIPTION
This flake failed **two unrelated PRs** (#1060, #1067) while passing 3/3 locally — a CI-load artifact, not a regression:

```
expected { provider: {…} } to match object { force: true }
```

## Cause

```js
await waitFor(() => expect(screenOne).toHaveBeenCalled())   // waits for ANY call
const [, chainId, options] = screenOne.mock.calls[0]        // then reads the FIRST
expect(options).toMatchObject({ force: true })
```

An unforced re-screen landing first — an ordinary re-render on the quote path — fails it.

The test is named *"re-reads the verdict live at submission"*. That a **forced** screen happened, and that it happened **first**, are different claims — and only the first is the requirement.

## Fix

Waits for the forced call specifically and asserts its chainId. That removes the ordering assumption entirely rather than papering over it with a longer timeout or a retry.

## Still catches the real defect

Mutation — `BridgeView.jsx:528` `force: true` → `force: false`:

```
× re-reads the verdict live at submission rather than trusting the cached one
  Tests  1 failed | 9 passed (10)
```

Passes 3/3 locally after the fix, 10/10.

Same class as the other flakes cleaned up this week (#1029 AdminSupplyTab, #1032 AEAD tamper, #1041 AdminBridgeTab): reading one sample of an async sequence and assuming an order that nothing guarantees.