### PR TITLE
fix(release): the release pipeline silently published nothing

### DIFF
--- a/cloudbuild.staging.yaml
+++ b/cloudbuild.staging.yaml
@@ -29,6 +29,11 @@ steps:
     args:
       - 'build'
       - '--build-arg'
+      # Nav-drawer build label (buildInfo.js, added on main while spec 076 was in flight). Mirrored
+      # here because production sets it: an unenumerated difference blocks a promotion, and staging
+      # showing a different build label than production would defeat the point of the mirror.
+      - 'VITE_COMMIT_SHA=$SHORT_SHA'
+      - '--build-arg'
       - 'VITE_TENANT_ID=fairwins'
       - '--build-arg'
       - 'VITE_WALLETCONNECT_PROJECT_ID=c30d7d7a8d575fe3dcc72ed55e5b287e'
@@ -72,6 +77,11 @@ steps:
     id: build-testnet
     args:
       - 'build'
+      - '--build-arg'
+      # Nav-drawer build label (buildInfo.js, added on main while spec 076 was in flight). Mirrored
+      # here because production sets it: an unenumerated difference blocks a promotion, and staging
+      # showing a different build label than production would defeat the point of the mirror.
+      - 'VITE_COMMIT_SHA=$SHORT_SHA'
       - '--build-arg'
       - 'VITE_TENANT_ID=fairwins'
       - '--build-arg'

--- a/scripts/release/__tests__/version.test.js
+++ b/scripts/release/__tests__/version.test.js
@@ -135,3 +135,38 @@ test("is deterministic (quickstart S1)", () => {
   assert.deepEqual(a.release, b.release);
   assert.equal(a.bump, b.bump);
 });
+
+// ---- regression: the release that silently published nothing --------------------------------
+//
+// The first live run of release.yml reported `commits: 0` on a 192-commit history, exited
+// successfully, and published no release. `subjectsSince` read the log with `allowFail: true`, so
+// ANY git failure became "" -> zero commits -> "empty-range" -> "no release". A release pipeline
+// that silently does nothing is worse than one that fails: nobody investigates a green run.
+//
+// These tests pin the two properties that make that impossible to repeat.
+
+test("subjectsSince reads the real history rather than reporting zero (regression)", () => {
+  const { subjectsSince } = require("../version");
+  const { execFileSync } = require("child_process");
+  const expected = Number.parseInt(
+    execFileSync("git", ["rev-list", "--count", "HEAD"], { encoding: "utf8" }).trim(),
+    10,
+  );
+  const got = subjectsSince(null).length;
+  assert.ok(expected > 0, "this repository should have commits");
+  assert.equal(got, expected, `parsed ${got} commits but git counts ${expected}`);
+});
+
+test("nextVersion on the real repository does not report empty-range (regression)", () => {
+  // The exact assertion that would have failed on the shipped code in CI.
+  const r = nextVersion();
+  assert.notEqual(r.reason, "empty-range", "a non-empty history must never report empty-range");
+  assert.ok(r.classifications.length > 0, "classifications must not be empty on a real history");
+});
+
+test("a git failure propagates instead of becoming 'no release'", () => {
+  const { subjectsSince } = require("../version");
+  // An unresolvable revision is the cheapest way to make git fail. Before the fix this returned []
+  // and the caller reported "nothing to release"; now it throws.
+  assert.throws(() => subjectsSince("refs/tags/definitely-not-a-real-tag-076"));
+});

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -32,17 +32,40 @@ const GROUPS = [
   { title: "🧹 Maintenance", types: ["chore", "style", "revert"] },
 ];
 
-function git(args) {
+/**
+ * `soft` is for cosmetic reads only (the release date). The COMMIT LOG must never be read softly:
+ * swallowing a git failure into "" produces a changelog entry that silently omits every change in
+ * the release, which is the same class of defect as version.js reporting "nothing to release" on a
+ * 192-commit history. A changelog that is quietly empty is worse than a failed release.
+ */
+function git(args, { soft = false } = {}) {
   try {
-    return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
-  } catch {
-    return "";
+    return execFileSync("git", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 256 * 1024 * 1024,
+    }).trim();
+  } catch (err) {
+    if (soft) return "";
+    throw err;
   }
 }
 
 function commitsIn(previous, version) {
   const range = previous ? `${previous}..${version}` : version;
   const out = git(["log", "--format=%s%x00%b%x1e", range]);
+
+  // Same cross-check as version.js: if git can count commits here but we parsed none, the read
+  // failed and an empty changelog would be a lie.
+  const expected = Number.parseInt(git(["rev-list", "--count", range]), 10);
+  const parsed = out ? out.split("\x1e").map((r) => r.trim()).filter(Boolean).length : 0;
+  if (expected > 0 && parsed === 0) {
+    throw new Error(
+      `git rev-list counts ${expected} commit(s) in "${range}" but the formatted log parsed 0. ` +
+        `Refusing to write an empty changelog entry for a non-empty release.`,
+    );
+  }
+
   if (!out) return [];
   return out
     .split("\x1e")
@@ -68,7 +91,11 @@ function group(commits) {
 }
 
 function entry({ version, previous, commits, artifacts, promotedFrom: from }) {
-  const date = git(["log", "-1", "--format=%cs", version]) || git(["log", "-1", "--format=%cs"]);
+  // Soft: the tag may not exist yet when this is called from a test or a dry run, and a missing
+  // date is cosmetic. The commit list above is not.
+  const date =
+    git(["log", "-1", "--format=%cs", version], { soft: true }) ||
+    git(["log", "-1", "--format=%cs"], { soft: true });
   const lines = [`## ${version} — ${date}`, ""];
   // FR-036: always stated. A hotfix says "none (hotfix)" rather than dropping the line, because a
   // missing line reads as an oversight and this one is load-bearing during an incident.

--- a/scripts/release/version.js
+++ b/scripts/release/version.js
@@ -33,11 +33,25 @@ const RC_TAG_RE = /^v(\d+)\.(\d+)\.(\d+)-rc\.(\d+)$/;
 
 function git(args, { allowFail = false } = {}) {
   try {
-    return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+    return execFileSync("git", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      // Node's default is 1 MiB. The full-history log with bodies is ~430 KB today and grows with
+      // every commit; crossing the default makes execFileSync throw ENOBUFS, which — before the
+      // guard in subjectsSince below — was swallowed into "no commits". Sized so it cannot be the
+      // cause again.
+      maxBuffer: 256 * 1024 * 1024,
+    }).trim();
   } catch (err) {
     if (allowFail) return "";
     throw err;
   }
+}
+
+/** Cheap, bounded, and immune to buffer limits — used to cross-check the parsed log. */
+function commitCount(range) {
+  const out = git(["rev-list", "--count", range]);
+  return Number.parseInt(out, 10);
 }
 
 function fmt(v) {
@@ -71,7 +85,29 @@ function currentRelease() {
 /** Commit subjects in (from, HEAD]. With no `from`, the whole history. */
 function subjectsSince(fromTag) {
   const range = fromTag ? `${fromTag}..HEAD` : "HEAD";
-  const out = git(["log", "--format=%s%x00%b%x1e", range], { allowFail: true });
+
+  // NO `allowFail` HERE — deliberately. It used to be `{ allowFail: true }`, and that turned any
+  // git failure into `""` -> zero commits -> "empty-range" -> "no release". The first live run of
+  // this workflow did exactly that: it reported `commits: 0` on a 192-commit history, exited
+  // successfully, and published nothing. A release pipeline that silently does nothing is worse
+  // than one that fails, because nobody investigates a green run.
+  //
+  // This is the same rule the rest of spec 076 is built on: unknown is not the same as clear.
+  const out = git(["log", "--format=%s%x00%b%x1e", range]);
+
+  // Cross-check against a command that cannot plausibly fail the same way. If git can count
+  // commits in this range but we parsed none out of the log, something is wrong with the READ,
+  // not with the repository — and reporting "nothing to release" would be a lie.
+  const expected = commitCount(range);
+  const parsed = out ? out.split("\x1e").map((r) => r.trim()).filter(Boolean).length : 0;
+  if (expected > 0 && parsed === 0) {
+    throw new Error(
+      `git rev-list counts ${expected} commit(s) in "${range}" but the formatted log parsed 0. ` +
+        `Refusing to report "nothing to release" — that would silently skip a real release. ` +
+        `Log length was ${out.length} bytes.`,
+    );
+  }
+
   if (!out) return [];
   return out
     .split("\x1e")


### PR DESCRIPTION
Follow-up to #1072. **The release pipeline has never produced a release**, and it reported success while doing so.

## What happened

The first live run of `release.yml`, on the merge of #1072, printed:

```
previous: none
commits:  0
reason:   empty-range
next:     no release
```

`commits: 0` on a **192-commit history**. The job exited successfully, every downstream step was skipped, and no tag was created. `git tag --list` is still empty — so v1.0.0 has never been cut, and it never would have been.

## Cause

`subjectsSince` read the commit log with `{ allowFail: true }`:

```js
const out = git(["log", "--format=%s%x00%b%x1e", range], { allowFail: true })
if (!out) return []
```

Any git failure became `""` → zero commits → `empty-range` → "no release". That is exactly the failure mode the rest of spec 076 is built to prevent — **unknown became clear** — and it did it on a green run, which is the kind nobody investigates.

## What I did about not being able to reproduce it

I could not reproduce the underlying git failure. The same script on the same history returns 192 commits locally, and the shell `git` calls in the *preceding* workflow step (`git rev-list --parents`, `git log -1`) both succeeded in that same job. So I did not want to ship a guess at the root cause dressed as a fix.

Instead this makes the bad state **impossible to report**:

- **No more swallowing.** `subjectsSince` lets git errors propagate. The release now fails loudly with stderr attached, which will surface the real cause on the next run instead of hiding it.
- **A cross-check that can't fail the same way.** `git rev-list --count` — tiny, bounded output — is compared against what the formatted log parsed. If git can count commits in a range but we parsed none, it throws. "Nothing to release" can no longer be claimed while the repo plainly has commits.
- **`maxBuffer` raised to 256 MiB.** The full log is ~430 KB against Node's 1 MiB default. Measured, so I know it wasn't the cause here — but it is a real cliff a few hundred commits ahead.

`changelog.js` had the identical helper and an identical consequence (an entry silently omitting every change in the release), so it gets the same treatment, with `soft` reserved for the cosmetic date read.

**Three regression tests** pin this, including the exact assertion that would have failed in CI on the shipped code:

```js
test("nextVersion on the real repository does not report empty-range (regression)", ...)
```

48/48 release tests, 20/20 config tests, `check:deps` clean.

## One thing found by the feature checking itself

`VITE_COMMIT_SHA` is mirrored into both staging images. My own promotion-config check caught it: `main` gained that build arg (the nav-drawer build label) while #1072 was in flight, and an unenumerated difference between staging and production blocks a promotion. Working as intended.

Worth raising separately though: `frontend/src/config/buildInfo.js` and `frontend/src/config/version.js` now **both** answer "which build am I?", with different fallbacks — `dev` vs `unreleased+sha`. That's the two-sources-that-must-agree problem this spec exists to remove. I did not merge them here because that means reworking a feature that landed independently, and it deserves its own review rather than riding along in a bug fix.

## Still outstanding from #1072

T031 (register required status checks), T032 (create and protect `staging`), T035 (provision the two Cloud Run services) — all in `docs/runbooks/release-and-promotion.md` § One-time setup. Note that until T031 is done, none of these gates actually block a merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RE8MdvZD5bBXmVq28wXXgy)_