### PR TITLE
fix: remove duplicate portfolio balance (#1078)

### DIFF
--- a/frontend/src/components/wallet/Portfolio.css
+++ b/frontend/src/components/wallet/Portfolio.css
@@ -16,24 +16,7 @@
   color: var(--danger-color, #b91c1c);
 }
 
-/* Header */
-.portfolio-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  align-items: flex-start;
-}
-.portfolio-total-label {
-  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
-  font-size: 0.85rem;
-  margin: 0;
-}
-.portfolio-total {
-  font-size: 1.8rem;
-  font-weight: 700;
-  margin: 0;
-  color: var(--color-text, var(--text-primary, #111827));
-}
+/* Error-state retry */
 .portfolio-refresh {
   appearance: none;
   background: transparent;
@@ -277,12 +260,6 @@
   }
 }
 
-.portfolio-skeleton-total {
-  width: 160px;
-  height: 34px;
-  margin: 4px auto 12px;
-}
-
 .portfolio-skeleton-heading {
   width: 180px;
   height: 16px;
@@ -327,10 +304,4 @@
   max-width: 110px;
   min-width: 48px;
   height: 10px;
-}
-
-.portfolio-updated {
-  margin: 6px 0 0;
-  font-size: 0.75rem;
-  color: var(--text-muted, var(--text-secondary, #5a6772));
 }

--- a/frontend/src/components/wallet/PortfolioPanel.jsx
+++ b/frontend/src/components/wallet/PortfolioPanel.jsx
@@ -6,7 +6,6 @@ import InfoTip from '../ui/InfoTip'
 import AssetLogo from './AssetLogo'
 import AssetDetailSheet from './AssetDetailSheet'
 import { formatAssetAmount } from '../../lib/portfolio/aggregate'
-import { formatRelativeTime } from '../../lib/account/format'
 import SensitiveValue from '../common/SensitiveValue'
 import { useCollectiblesValuation } from '../../hooks/useCollectibles'
 import { computeCollectiblesValuation } from '../../lib/collectibles/valuation'
@@ -193,14 +192,10 @@ export default function PortfolioPanel({ portfolio = null }) {
   return <SelfLoadingPortfolioPanel />
 }
 
-/** Loading bones: real header/section/row geometry, shimmer placeholders. */
+/** Loading bones: real section/row geometry, shimmer placeholders. */
 function PortfolioSkeleton() {
   return (
     <div className="portfolio-skeleton" aria-hidden="true">
-      <header className="portfolio-header">
-        <p className="portfolio-total-label">Total portfolio balance</p>
-        <span className="portfolio-skeleton-bar portfolio-skeleton-total" />
-      </header>
       {[0, 1, 2].map((section) => (
         <section className="portfolio-category" key={section}>
           <span className="portfolio-skeleton-bar portfolio-skeleton-heading" />
@@ -278,8 +273,8 @@ function PortfolioBody({ portfolio }) {
 
   if (portfolio.status === 'loading') {
     // Cold load (no session snapshot yet): show the BONES of the portfolio —
-    // header + category sections with shimmering placeholder rows — so the
-    // member sees the page shape immediately instead of a bare loading line.
+    // category sections with shimmering placeholder rows — so the member sees
+    // the page shape immediately instead of a bare loading line.
     // Placeholders are aria-hidden; the status text carries the semantics.
     return (
       <div className="portfolio-root" aria-busy="true">
@@ -293,31 +288,6 @@ function PortfolioBody({ portfolio }) {
 
   return (
     <div className="portfolio-root">
-      <header className="portfolio-header">
-        <p className="portfolio-total-label" id="portfolio-total-label">
-          Total portfolio balance
-        </p>
-        <p className="portfolio-total" aria-labelledby="portfolio-total-label">
-          <SensitiveValue>{formatUsdFull(portfolio.totalUsd)}</SensitiveValue>
-        </p>
-        <button
-          type="button"
-          className="portfolio-refresh"
-          onClick={() => portfolio.refresh()}
-          disabled={portfolio.isLoading}
-        >
-          {portfolio.isLoading ? 'Refreshing…' : 'Refresh'}
-        </button>
-        {/* Data age, honestly disclosed: hydrated snapshots (session cache or
-            the device store after a reload) show real figures with their real
-            timestamp while the background refresh brings them current. */}
-        {portfolio.lastUpdated != null && (
-          <p className="portfolio-updated" role="status">
-            Updated {formatRelativeTime(portfolio.lastUpdated)}
-          </p>
-        )}
-      </header>
-
       {portfolio.categories.map((group) => (
         <CategorySection
           key={group.category.id}

--- a/frontend/src/test/portfolio/PortfolioPanel.test.jsx
+++ b/frontend/src/test/portfolio/PortfolioPanel.test.jsx
@@ -125,8 +125,8 @@ describe('PortfolioPanel states', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'loading' }))
     const { container } = renderPanel()
     expect(screen.getByRole('status')).toHaveTextContent(/loading portfolio/i)
-    // The bones: header label + shimmering section/row placeholders.
-    expect(screen.getByText(/total portfolio balance/i)).toBeInTheDocument()
+    // The bones: shimmering section/row placeholders (the balance total lives
+    // only on the account card — issue #1078).
     const skeleton = container.querySelector('.portfolio-skeleton')
     expect(skeleton).toBeTruthy()
     expect(skeleton.getAttribute('aria-hidden')).toBe('true')
@@ -144,12 +144,13 @@ describe('PortfolioPanel states', () => {
 })
 
 describe('PortfolioPanel aggregate rows', () => {
-  it('renders one combined row per underlying with total, subtotal, and instance summary (FR-025)', () => {
+  it('renders one combined row per underlying with subtotal and instance summary (FR-025)', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
     renderPanel()
 
-    expect(screen.getByText('Total portfolio balance')).toBeInTheDocument()
-    expect(screen.getByText('$3,600.00')).toBeInTheDocument()
+    // The portfolio total lives only on the account card, not in the panel
+    // body (issue #1078 — duplicate balance removed).
+    expect(screen.queryByText('Total portfolio balance')).not.toBeInTheDocument()
 
     const commodities = screen.getByRole('region', { name: 'Digital Commodities' })
     const ethRow = within(commodities).getByRole('button', { name: /ethereum eth 3 instances/i })
@@ -218,12 +219,10 @@ describe('PortfolioPanel aggregate rows', () => {
     expect(screen.getByText(/< 0\.000001 ETH/)).toBeInTheDocument()
   })
 
-  it('refresh button triggers a reload', () => {
-    const snapshot = makeSnapshot({ aggregates: POPULATED })
-    mockUsePortfolio.mockReturnValue(snapshot)
+  it('does not render a mid-page refresh control (issue #1078 — lives on the account card only)', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
     renderPanel()
-    fireEvent.click(screen.getByRole('button', { name: /^refresh$/i }))
-    expect(snapshot.refresh).toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: /^refresh$/i })).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/test/portfolio/collectiblesLine.test.jsx
+++ b/frontend/src/test/portfolio/collectiblesLine.test.jsx
@@ -1,8 +1,8 @@
 /**
  * Portfolio collectibles estimate row (spec 055 US3 / FR-006, research D8) — a labeled
  * floor-price estimate rendered inside the Digital Collectibles taxonomy section that NEVER
- * joins the totalUsd headline or category subtotal, hides where the feature is unavailable,
- * and degrades without blocking token rendering.
+ * joins the category subtotal, hides where the feature is unavailable, and degrades without
+ * blocking token rendering.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
@@ -86,10 +86,13 @@ describe('Portfolio — collectibles estimate line', () => {
     expect(region).not.toHaveTextContent('No assets in this category.')
   })
 
-  it('NEVER merges the estimate into the verifiable headline total (research D8)', () => {
+  it('NEVER merges the estimate into the category subtotal (research D8)', () => {
     renderPanel()
-    // Headline stays exactly the token total; the disclosure says so explicitly.
-    expect(screen.getByText('$1,234.56')).toBeInTheDocument()
+    // The category subtotal stays exactly the token subtotal (no aggregates
+    // here, so $0.00); the disclosure says so explicitly. The verifiable
+    // portfolio total itself now lives only on the account card (issue #1078).
+    const region = screen.getByRole('region', { name: 'Digital Collectibles' })
+    expect(region.closest('.portfolio-category')).toHaveTextContent('$0.00')
     expect(screen.queryByText('$5,234.56')).not.toBeInTheDocument()
     expect(screen.getByText(/not included in the totals above/i)).toBeInTheDocument()
   })
@@ -128,7 +131,9 @@ describe('Portfolio — collectibles estimate line', () => {
     useCollectiblesValuation.mockReturnValue(valuationState({ status: 'degraded', items: [] }))
     renderPanel()
     expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument()
-    expect(screen.getByText('$1,234.56')).toBeInTheDocument() // tokens untouched
+    // The category subtotal still renders normally — tokens untouched.
+    const region = screen.getByRole('region', { name: 'Digital Collectibles' })
+    expect(region.closest('.portfolio-category')).toHaveTextContent('$0.00')
   })
 
   it('discloses partial (truncated) scans and stale data in the label (FR-013)', () => {


### PR DESCRIPTION
## Summary

- Fixes #1078: the Portfolio panel rendered its own "Total portfolio balance" header (amount + Refresh button + "Updated Xs ago") in addition to the balance already shown on the active account card, so the total appeared twice — once on the card, once in the middle of the page.
- Removed the duplicate header block (and its loading-skeleton placeholder) from `PortfolioPanel` so the balance is shown only on the account card, per the issue's expected behavior.
- Cleaned up the now-unused header/skeleton-total/updated-timestamp CSS in `Portfolio.css`. The error-state "Retry" button keeps the `.portfolio-refresh` class/style since it's a distinct, still-needed affordance.
- Removed the now-unused `formatRelativeTime` import.

## Test plan

- [x] `npx vitest run src/test/portfolio/PortfolioPanel.test.jsx src/test/portfolio/PortfolioPanel.axe.test.jsx src/test/portfolio/collectiblesLine.test.jsx src/test/account/MyAccountView.test.jsx src/test/account/MyAccountView.axe.test.jsx src/test/WalletPage.test.jsx src/test/collectibles/walletPageCollectibles.test.jsx` — 62/62 passing
- [x] `npx vitest run src/test/portfolio src/test/account src/test/wallet` — 263/263 passing (broader regression sweep)
- [x] Updated `PortfolioPanel.test.jsx` and `collectiblesLine.test.jsx` to assert the duplicate header/refresh control is gone instead of asserting its presence
- [x] `npx eslint` on changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFsDgd7GjfgCbT5nA3H2mS)_