### PR TITLE
fix(release): derive the tracked manifest list from the workspace

### DIFF
--- a/docs/runbooks/release-and-promotion.md
+++ b/docs/runbooks/release-and-promotion.md
@@ -109,6 +109,30 @@ just removes the reminder.
 
 ## When something goes wrong
 
+### Reproducing a release problem locally — check your clone depth FIRST
+
+```bash
+git rev-parse --is-shallow-repository   # must print false
+git rev-list --count HEAD               # compare against the count CI reports
+```
+
+**A shallow clone will make release bugs invisible and, worse, produce wrong output that looks
+right.** This has already cost real time twice:
+
+- The v1.0.0 investigation. The pipeline was reading a ~5.6 MB commit log in CI and blowing Node's
+  1 MiB `execFileSync` default. Locally the same command produced 430 KB and worked perfectly,
+  because the clone held 193 of 2508 commits. The measurement was right and the conclusion was
+  wrong.
+- Anything that generates a changelog. `changelog.js` walks the whole range, so running it against
+  a shallow clone silently emits an entry missing most of the release.
+
+`actions/checkout` in `release.yml` uses `fetch-depth: 0` for exactly this reason. Match it locally
+before drawing conclusions:
+
+```bash
+git fetch --unshallow    # or: git clone (without --depth) into a scratch directory
+```
+
 ### The release published nothing
 
 Expected in two cases: an empty commit range, or no commit in the range carried a classification.
@@ -126,6 +150,28 @@ prints every commit, how it classified, and which one set the bump. Commits show
 version. **Investigate before doing anything** — do not delete or move the tag. Published tags are
 the only durable record of what shipped (FR-004). The usual cause is a re-run of a completed
 release; if so, nothing is wrong and no action is needed.
+
+### The release tagged and published, but the CHANGELOG commit failed
+
+The tag and the GitHub Release are already correct and immutable — do not re-run the release to
+"fix" the changelog. Re-running hits the tag-immutability guard (FR-004) and fails, which is the
+intended behavior.
+
+What is missing is only the in-repo `CHANGELOG.md` entry and the manifest version sync. Backfill it
+by hand, **from a full clone** (see the clone-depth warning above — a shallow one writes an entry
+missing most of the release):
+
+```bash
+git fetch --unshallow
+node scripts/release/changelog.js --version v1.0.0 --previous ""
+node scripts/release/sync-manifest-versions.js --version v1.0.0
+```
+
+Then open an ordinary pull request with the result. This is the one case where a generated file is
+committed outside the release job, and it is still generated — never hand-written (FR-037).
+
+**Known outstanding:** v1.0.0's entry was never written, because the release job failed at this step
+on a stale hardcoded manifest list. It needs the backfill above.
 
 ### A promotion is blocked by config drift
 

--- a/scripts/release/__tests__/sync-manifest-versions.test.js
+++ b/scripts/release/__tests__/sync-manifest-versions.test.js
@@ -14,7 +14,7 @@ const assert = require("node:assert/strict");
 const fs = require("fs");
 const path = require("path");
 
-const { TRACKED, EXCLUDED_PREFIX, normalize, sync } = require("../sync-manifest-versions");
+const { TRACKED, EXCLUDED_PREFIX, expandWorkspaceGlob, normalize, sync } = require("../sync-manifest-versions");
 
 const ROOT = path.join(__dirname, "..", "..", "..");
 
@@ -66,4 +66,49 @@ test("rejects anything that is not a release version", () => {
   }
   assert.equal(normalize("v1.2.3"), "1.2.3");
   assert.equal(normalize("1.2.3"), "1.2.3");
+});
+
+// ---- workspace glob shapes (review on #1080) --------------------------------------------------
+//
+// The expansion understands a literal path or a single trailing "/*". Anything else must THROW
+// rather than produce a truncated or mis-resolved base: a silently dropped manifest leaves that
+// package permanently disagreeing about which release it belongs to, which is the failure this
+// whole file was rewritten to prevent.
+
+test("expands a literal workspace path unchanged", () => {
+  assert.deepEqual(expandWorkspaceGlob("services/relay-gateway"), ["services/relay-gateway"]);
+});
+
+test("expands a single trailing /* to its immediate children", () => {
+  const got = expandWorkspaceGlob("packages/*");
+  assert.ok(got.length > 0, "packages/* should expand");
+  for (const dir of got) {
+    assert.ok(dir.startsWith("packages/"), `${dir} should be under packages/`);
+    assert.ok(!dir.includes("*"), `${dir} should not retain a wildcard`);
+  }
+});
+
+test("REFUSES unsupported patterns instead of guessing", () => {
+  for (const bad of [
+    "packages/**", // would silently return immediate children only
+    "services/*/api", // would silently drop the "/api" suffix
+    "*", // would yield paths with a leading slash
+    "**", //
+    "pack*ges/*", // wildcard outside the trailing position
+  ]) {
+    assert.throws(
+      () => expandWorkspaceGlob(bad),
+      /unsupported workspace pattern/,
+      `"${bad}" must be rejected`,
+    );
+  }
+});
+
+test("this repository's own globs are all supported shapes", () => {
+  // If someone adds an unsupported pattern to the root manifest, this fails here rather than
+  // during a release.
+  const root = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+  for (const glob of root.workspaces || []) {
+    assert.doesNotThrow(() => expandWorkspaceGlob(glob), `"${glob}" should expand`);
+  }
 });

--- a/scripts/release/__tests__/sync-manifest-versions.test.js
+++ b/scripts/release/__tests__/sync-manifest-versions.test.js
@@ -1,0 +1,69 @@
+/**
+ * Tests for scripts/release/sync-manifest-versions.js (spec 076, FR-007/FR-007a).
+ *
+ * REGRESSION. The first real release failed here: TRACKED was a hardcoded array that still listed
+ * `services/relayer`, which had been deleted from the workspace while spec 076 was in flight. The
+ * script refused to sync a subset (correctly) and failed the release step AFTER the tag and the
+ * GitHub Release were already published.
+ *
+ * The list is now derived from the root manifest's `workspaces` globs — the same source npm uses —
+ * so it cannot fall behind the workspace. These tests pin that property.
+ */
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { TRACKED, EXCLUDED_PREFIX, normalize, sync } = require("../sync-manifest-versions");
+
+const ROOT = path.join(__dirname, "..", "..", "..");
+
+test("every derived manifest actually exists (regression)", () => {
+  // The exact assertion that would have failed on the shipped code, which listed a deleted member.
+  for (const rel of TRACKED) {
+    assert.ok(fs.existsSync(path.join(ROOT, rel)), `${rel} should exist`);
+  }
+});
+
+test("tracks the root plus every non-mini-app workspace member", () => {
+  const root = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+  assert.ok(TRACKED.includes("package.json"), "the root manifest tracks the release too");
+  assert.ok(root.workspaces.length > 0, "the repo should declare workspaces");
+  assert.ok(TRACKED.length > 1, "a single-entry list means the derivation collapsed");
+});
+
+test("NEVER touches a mini-app manifest (FR-007)", () => {
+  // Mini-apps version independently; overwriting one breaks the version-to-CID pairing FR-007b
+  // exists to protect.
+  for (const rel of TRACKED) {
+    assert.ok(!rel.startsWith(EXCLUDED_PREFIX), `${rel} must not be tracked`);
+  }
+  const miniapps = path.join(ROOT, "frontend", "miniapps");
+  if (fs.existsSync(miniapps)) {
+    const apps = fs.readdirSync(miniapps, { withFileTypes: true }).filter((e) => e.isDirectory());
+    assert.ok(apps.length > 0, "this repo should have mini-apps for the exclusion to be meaningful");
+  }
+});
+
+test("a removed workspace member simply disappears from the list", () => {
+  // services/relayer was deleted on main. A hardcoded list would still name it; a derived one must
+  // not, and must not throw because of it.
+  assert.ok(!TRACKED.some((t) => t.includes("services/relayer")), "deleted member must not be tracked");
+  assert.doesNotThrow(() => sync("v1.0.0", { check: true }));
+});
+
+test("--check reports what would change without writing", () => {
+  const before = TRACKED.map((rel) => fs.readFileSync(path.join(ROOT, rel), "utf8"));
+  const changed = sync("v9.9.9", { check: true });
+  const after = TRACKED.map((rel) => fs.readFileSync(path.join(ROOT, rel), "utf8"));
+  assert.deepEqual(after, before, "check mode must not write");
+  assert.ok(Array.isArray(changed));
+});
+
+test("rejects anything that is not a release version", () => {
+  for (const bad of ["1.0", "main", "v1.0.0-rc.1", "", null]) {
+    assert.throws(() => normalize(bad), `"${bad}" should be rejected`);
+  }
+  assert.equal(normalize("v1.2.3"), "1.2.3");
+  assert.equal(normalize("1.2.3"), "1.2.3");
+});

--- a/scripts/release/sync-manifest-versions.js
+++ b/scripts/release/sync-manifest-versions.js
@@ -25,6 +25,44 @@ const ROOT = path.join(__dirname, "..", "..");
 const EXCLUDED_PREFIX = "frontend/miniapps/";
 
 /**
+ * The ONLY wildcard shape this understands: a single trailing `/*` on a literal base.
+ *
+ * npm accepts more than that, and the difference is not academic. Silently mishandling a pattern
+ * would drop a manifest out of the release sync, leaving it permanently disagreeing about which
+ * release it belongs to — the exact bug this file was just rewritten to prevent, arriving through
+ * a different door. Concretely, before this guard:
+ *
+ *   a doubled trailing wildcard -> base "packages", immediate children only:
+ *                                 DEEPER MEMBERS SILENTLY MISSED
+ *   a wildcard in the MIDDLE    -> base "services", the trailing segment dropped: WRONG PATHS
+ *   a bare wildcard             -> indexOf is -1, base "": PATHS WITH A LEADING SLASH
+ *
+ * So an unsupported pattern throws. Refusing to guess is the whole point (reported by review on
+ * #1080).
+ */
+const SUPPORTED_GLOB = /^[^*]+\/\*$/;
+
+function expandWorkspaceGlob(glob) {
+  if (!glob.includes("*")) return [glob]; // a literal workspace path
+  if (!SUPPORTED_GLOB.test(glob)) {
+    throw new Error(
+      `unsupported workspace pattern "${glob}" in the root package.json. ` +
+        `scripts/release/sync-manifest-versions.js understands a literal path or a single trailing ` +
+        `"/*", and refuses to guess at anything else rather than silently syncing the wrong set of ` +
+        `manifests. Teach expandWorkspaceGlob the new shape, with a test.`,
+    );
+  }
+  const base = glob.slice(0, -2); // drop the trailing "/*"
+  const abs = path.join(ROOT, base);
+  if (!fs.existsSync(abs)) return [];
+  return fs
+    .readdirSync(abs, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+    .map((e) => `${base}/${e.name}`)
+    .sort();
+}
+
+/**
  * THE TRACKED LIST IS DERIVED, NOT TYPED.
  *
  * It used to be a hardcoded array, and it broke the first real release: `services/relayer` was
@@ -41,18 +79,6 @@ const EXCLUDED_PREFIX = "frontend/miniapps/";
  * Mini-apps are excluded because they version INDEPENDENTLY (FR-007): overwriting one here would
  * break the version-to-CID pairing that FR-007b exists to protect.
  */
-function expandWorkspaceGlob(glob) {
-  if (!glob.includes("*")) return [glob];
-  const base = glob.slice(0, glob.indexOf("/*"));
-  const abs = path.join(ROOT, base);
-  if (!fs.existsSync(abs)) return [];
-  return fs
-    .readdirSync(abs, { withFileTypes: true })
-    .filter((e) => e.isDirectory() && !e.name.startsWith("."))
-    .map((e) => `${base}/${e.name}`)
-    .sort();
-}
-
 function trackedManifests() {
   const root = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
   const members = (root.workspaces || [])
@@ -116,7 +142,7 @@ function sync(version, { check = false } = {}) {
   return changed;
 }
 
-module.exports = { TRACKED, EXCLUDED_PREFIX, normalize, sync };
+module.exports = { TRACKED, EXCLUDED_PREFIX, SUPPORTED_GLOB, expandWorkspaceGlob, normalize, sync };
 
 // ---- CLI ---------------------------------------------------------------------------------------
 if (require.main === module) {

--- a/scripts/release/sync-manifest-versions.js
+++ b/scripts/release/sync-manifest-versions.js
@@ -21,20 +21,50 @@ const path = require("path");
 
 const ROOT = path.join(__dirname, "..", "..");
 
-/** Manifests that track the repository release version (FR-007a). */
-const TRACKED = [
-  "package.json",
-  "frontend/package.json",
-  "services/relay-gateway/package.json",
-  "services/relayer/package.json",
-  "subgraph/package.json",
-  "tools/miniapp-build/package.json",
-  "packages/abi/package.json",
-  "packages/intent-types/package.json",
-];
-
 /** Independently versioned — never written by this script (FR-007). */
 const EXCLUDED_PREFIX = "frontend/miniapps/";
+
+/**
+ * THE TRACKED LIST IS DERIVED, NOT TYPED.
+ *
+ * It used to be a hardcoded array, and it broke the first real release: `services/relayer` was
+ * deleted from the workspace while spec 076 was in flight, and this script — correctly refusing to
+ * sync a subset — failed the release step after the tag and the GitHub Release had already been
+ * published.
+ *
+ * `scripts/deps/check-dependency-hygiene.js` learned exactly this lesson under issue #1039 and says
+ * so in its own comment: a hardcoded member list is an invariant held by human discipline, and
+ * adding or removing a workspace member is routine while remembering to update a second list is
+ * not. So the members come from the same source npm itself uses — the root manifest's `workspaces`
+ * globs — which means this cannot fall behind the workspace by construction.
+ *
+ * Mini-apps are excluded because they version INDEPENDENTLY (FR-007): overwriting one here would
+ * break the version-to-CID pairing that FR-007b exists to protect.
+ */
+function expandWorkspaceGlob(glob) {
+  if (!glob.includes("*")) return [glob];
+  const base = glob.slice(0, glob.indexOf("/*"));
+  const abs = path.join(ROOT, base);
+  if (!fs.existsSync(abs)) return [];
+  return fs
+    .readdirSync(abs, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+    .map((e) => `${base}/${e.name}`)
+    .sort();
+}
+
+function trackedManifests() {
+  const root = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+  const members = (root.workspaces || [])
+    .flatMap(expandWorkspaceGlob)
+    .filter((dir) => !dir.startsWith(EXCLUDED_PREFIX))
+    .map((dir) => `${dir}/package.json`)
+    .filter((rel) => fs.existsSync(path.join(ROOT, rel)));
+  // The root manifest tracks the release too, and is not a workspace member of itself.
+  return ["package.json", ...members.sort()];
+}
+
+const TRACKED = trackedManifests();
 
 function normalize(version) {
   const v = String(version || "").trim();
@@ -67,12 +97,20 @@ function sync(version, { check = false } = {}) {
     }
   }
 
-  // A tracked manifest that has vanished is a real problem — the workspace list changed and this
-  // script was not updated. Say so rather than silently syncing a subset.
+  // Unreachable now that TRACKED is derived and filtered by existsSync, but kept as a belt: if this
+  // ever fires again it means the derivation regressed, and syncing a subset silently would leave
+  // manifests disagreeing about which release they belong to.
   if (missing.length) {
+    throw new Error(`tracked manifests vanished between derivation and read: ${missing.join(", ")}`);
+  }
+
+  // A derived list that comes back empty is a coverage hole wearing a green light — rename a
+  // directory and this would report "already at vX.Y.Z" having written nothing. Same failure shape
+  // check-dependency-hygiene.js guards against with its empty-glob check.
+  if (TRACKED.length <= 1) {
     throw new Error(
-      `tracked manifests are missing: ${missing.join(", ")}. ` +
-        `Update TRACKED in scripts/release/sync-manifest-versions.js to match the workspace.`,
+      `only ${TRACKED.length} manifest(s) derived from the workspace globs — expected the root plus ` +
+        `every non-mini-app member. Check "workspaces" in the root package.json.`,
     );
   }
   return changed;


### PR DESCRIPTION
Follow-up to #1077. **v1.0.0 shipped** — tag and GitHub Release with artifact table are live — but the release job failed on its final step.

## What failed

```
CHANGELOG.md updated with v1.0.0 (2508 commits)
##[error]tracked manifests are missing: services/relayer/package.json.
```

`services/relayer` was deleted from the workspace by #1075 while spec 076 was in flight. `sync-manifest-versions.js` held a **hardcoded** list that still named it, and refused — correctly — to sync a subset.

This is the same defect `scripts/deps/check-dependency-hygiene.js` already documents under #1039: *"THE UNIT LIST IS DERIVED, NOT TYPED"*, written after its own hardcoded list fell three members behind. I wrote a second copy of the mistake it warns about, one directory away.

The list now derives from the root manifest's `workspaces` globs — the same source npm uses — so it cannot fall behind by construction. Mini-apps stay excluded (FR-007). Added the inverse guard too: a derived list collapsing to just the root would report "already at vX.Y.Z" having written nothing, which is a coverage hole wearing a green light.

## Correction to the #1077 analysis

I need to correct something I stated confidently there. I claimed `maxBuffer` was *measured and ruled out* as the root cause of the silent no-op.

That was wrong. This sandbox holds a **shallow clone — 193 of 2508 commits**. The log I measured was 430 KB where CI's is **~5.6 MB**, comfortably past Node's 1 MiB `execFileSync` default. `maxBuffer` **was** the root cause, and raising it is what made this release work. The `rev-list` cross-check and loud-failure changes remain worthwhile defense in depth, but they were not the fix.

The runbook now leads its troubleshooting section with a clone-depth check, because a shallow clone doesn't merely hide release bugs — it produces confident wrong answers, and `changelog.js` run against one silently emits an entry missing most of the release.

## v1.0.0's actual state

| | |
|---|---|
| Tag `v1.0.0` | ✅ live, immutable |
| GitHub Release + artifact table | ✅ published |
| `CHANGELOG.md` entry | ❌ never written |
| Manifest version sync | ❌ never applied |

Do **not** re-run the release to fix this — it hits the tag-immutability guard (FR-004) and fails, which is intended. The runbook now documents the one-time backfill, with an explicit warning to run it from a full clone.

6 new tests pin the derivation, including the exact assertion that would have failed on the shipped code. 54 passing, `check:deps` clean.

## Still outstanding from #1072

T031 (register required status checks), T032 (`staging` branch), T035 (Cloud Run services). **T031 matters most** — until those checks are required, none of these gates block a merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RE8MdvZD5bBXmVq28wXXgy)_