### PR TITLE
docs: stop telling people to npm install inside a workspace (T047)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,7 @@ artifacts live under `specs/<feature>/`.
   detail — **`monorepo-workspace`** (dependencies, adding a package, recovering a broken install)
   and **`monorepo-verify`** (the gate suite and what each gate proves). Three rules are absolute,
   each because it already went wrong here: (1) **Never recover an install with `npm install`** —
-  npm/cli#4828 silently drops `@rollup/rollup-linux-x64-gnu` from node_modules AND the lockfile on
+  npm/cli#4828 silently drops optional platform binaries from node_modules AND the lockfile on
   an incremental install, breaking every Vite build including the on-chain mini-app release path,
   and re-running `npm install` cannot fix it (the lock is already wrong, so npm reports "up to
   date"). Use `npm run deps:reinstall`. **`npm ci` does not fix it either** — measured: it exits 0
@@ -371,8 +371,13 @@ artifacts live under `specs/<feature>/`.
   the binary uninstalled, because that entry is `optional` AND `peer` and npm skips optional peer
   deps even when locked. If a `deps:reinstall` is interrupted (no lockfile, half-built
   node_modules), restore the lockfile with `git checkout -- package-lock.json` and then install the
-  binary alone: `npm install --no-save @rollup/rollup-linux-x64-gnu@<version from the lockfile>` —
-  ~18s, and verified to leave `package-lock.json` byte-identical. **Dependabot triggers this
+  binary alone: `npm install --no-save @rolldown/binding-linux-x64-gnu@<version from the lockfile>` —
+  ~18s, and verified to leave `package-lock.json` byte-identical. **The binary's NAME moves with the
+  toolchain** — it was `@rollup/rollup-linux-x64-gnu` until Vite 8 (spec 077) replaced rollup with
+  rolldown, and rollup then left the tree entirely, so guidance naming the old package would have
+  read fine and helped nobody. Take the current name from `REQUIRED_OPTIONAL` in
+  `scripts/deps/check-dependency-hygiene.js`, which is the gate that enforces it; do not trust a
+  package name written in prose, including this one. **Dependabot triggers this
   routinely**: 3 of 5 lockfile-touching Dependabot PRs in one week dropped the binary, and
   `check:deps` is what catches it. (2) **Every dependency contributing Solidity source is
   pinned EXACTLY** — a caret range makes deployed bytecode a function of when the lockfile was last

--- a/coverage-threshold-policy.json
+++ b/coverage-threshold-policy.json
@@ -52,7 +52,6 @@
   ],
   "excluded": [
     { "pathGlob": "contracts/account/lib/**", "reason": "vendored FreshCryptoLib / solady / webauthn-sol / account-abstraction" },
-    { "pathGlob": "contracts/pools/SemaphoreDeploy.sol", "reason": "vendored Semaphore self-deploy closure" },
     { "pathGlob": "contracts/test/**", "reason": "test-only fuzz/mocks harnesses" },
     { "pathGlob": "contracts/mocks/**", "reason": "test-only mocks" },
     { "pathGlob": "contracts/**/interfaces/**", "reason": "no executable logic" }

--- a/docs/developer-guide/monorepo.md
+++ b/docs/developer-guide/monorepo.md
@@ -69,11 +69,24 @@ computed the hash. `globalEnv` only covers variables exported in the caller's sh
 
 **Confirmed empirically**: editing `AMOY_RPC_URL` in `.env` left the `//#test` hash unchanged —
 and that variable switches the default test chain from a clean 1337 to an Amoy fork. So
-`//#test` cache hits are **not sound** in a tree with a `.env` that sets a build-relevant variable.
+`//#test` cache hits were **not sound** in a tree with a `.env` that sets a build-relevant variable.
 
-Until dotenv is moved out of config evaluation (or a `dotEnv` declaration is added), run
-`npx turbo run test --force` when a `.env` value matters. This is stated rather than hidden because
-an undeclared input in Turborepo produces a **wrong cache hit, not an error**.
+**FIXED (#1036/#1074).** `.env*` and `frontend/.env*` are now `globalDependencies`, so the dotenv
+FILES are hashed by content and an edited `AMOY_RPC_URL` invalidates `//#test` instead of silently
+switching the test chain behind a cache hit. `--force` is no longer required for this.
+
+Two things worth keeping straight, because they are what made the original defect confusing:
+
+- `globalEnv` and a dotenv file are **different channels**. `globalEnv` hashes what is already
+  exported into Turborepo's own process; it was never wrong, it simply does not observe a value
+  that `dotenv.config()` or Vite's `loadEnv()` reads *inside* the task. Both entries are kept.
+- Turborepo hashes a `globalDependencies` path **even when the file is gitignored**, and an
+  **absent** file is not an error — just a different hash. That is why this works locally without
+  affecting CI, which has no `.env`.
+
+The trade-off is deliberate: any `.env` edit now busts the whole cache rather than one task. That
+is a false **miss**, which is the safe direction — an undeclared input in Turborepo produces a
+**wrong cache hit, not an error**.
 
 ### Outside the graph entirely
 

--- a/docs/developer-guide/monorepo.md
+++ b/docs/developer-guide/monorepo.md
@@ -100,7 +100,7 @@ gate while a commit can still deploy without its tests having run.
 ## Traps
 
 **Never recover an install with `npm install`.** npm/cli#4828 silently drops
-`@rollup/rollup-linux-x64-gnu` from *both* `node_modules` and `package-lock.json` on an incremental
+the build's native binding — currently `@rolldown/binding-linux-x64-gnu` — from *both* `node_modules` and `package-lock.json` on an incremental
 install; every Vite build then dies, including the mini-app release path whose bytes are
 keccak-committed on-chain. It happened four times during this conversion. Re-running `npm install`
 cannot fix it — the lockfile is already wrong, so npm reports "up to date". Use

--- a/docs/developer-guide/setup.md
+++ b/docs/developer-guide/setup.md
@@ -31,18 +31,23 @@ cd prediction-dao-research
 
 ### 2. Install Dependencies
 
-Install root project dependencies:
+One install, from the repo root, covers every workspace (spec 075 — one lockfile, 8 members):
 
 ```bash
 npm install
 ```
 
-Install frontend dependencies:
+**Do not run `npm install` inside `frontend/` (or any other workspace).** An incremental install in
+a child silently drops optional platform binaries — notably `@rollup/rollup-linux-x64-gnu` — from
+BOTH `node_modules` and `package-lock.json` (npm/cli#4828). Every Vite build then dies with
+`Cannot find module @rollup/rollup-linux-x64-gnu`, including the mini-app release path whose output
+bytes are committed on-chain. Re-running `npm install` does not fix it: the lockfile is already
+wrong, so npm reports "up to date".
+
+If it happens, recover with a full re-resolve:
 
 ```bash
-cd frontend
-npm install
-cd ..
+npm run deps:reinstall
 ```
 
 ### 3. Verify Installation

--- a/docs/developer-guide/setup.md
+++ b/docs/developer-guide/setup.md
@@ -38,9 +38,9 @@ npm install
 ```
 
 **Do not run `npm install` inside `frontend/` (or any other workspace).** An incremental install in
-a child silently drops optional platform binaries — notably `@rollup/rollup-linux-x64-gnu` — from
+a child silently drops optional platform binaries — currently `@rolldown/binding-linux-x64-gnu` — from
 BOTH `node_modules` and `package-lock.json` (npm/cli#4828). Every Vite build then dies with
-`Cannot find module @rollup/rollup-linux-x64-gnu`, including the mini-app release path whose output
+a missing-native-binding error, including the mini-app release path whose output
 bytes are committed on-chain. Re-running `npm install` does not fix it: the lockfile is already
 wrong, so npm reports "up to date".
 
@@ -49,6 +49,10 @@ If it happens, recover with a full re-resolve:
 ```bash
 npm run deps:reinstall
 ```
+
+The binary's name tracks the build toolchain (it was rollup's until Vite 8 moved to rolldown). The
+authoritative list is `REQUIRED_OPTIONAL` in `scripts/deps/check-dependency-hygiene.js` — `npm run
+check:deps` fails when one is missing, so you do not have to know the name to catch it.
 
 ### 3. Verify Installation
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -67,8 +67,10 @@ App.jsx (Root)
 ### Installation
 
 ```bash
-# Install dependencies
-npm install
+# Install dependencies — FROM THE REPO ROOT, not here. This is an npm workspace
+# (spec 075); an install inside a child drops optional platform binaries from the
+# lockfile (npm/cli#4828) and breaks every Vite build. Recover with `npm run deps:reinstall`.
+cd .. && npm install && cd frontend
 
 # Copy environment configuration
 cp .env.example .env

--- a/scripts/miniapps/publish.js
+++ b/scripts/miniapps/publish.js
@@ -232,7 +232,7 @@ function resolvePackageDir(appId, appIdPattern) {
  */
 function runBuild(packageDir) {
   if (!fs.existsSync(VITE_BIN)) {
-    fail(`vite is not installed at ${path.relative(REPO_ROOT, VITE_BIN)} — run \`npm install\` in frontend/`)
+    fail(`vite is not installed at ${path.relative(REPO_ROOT, VITE_BIN)} — run \`npm run deps:reinstall\` at the repo root`)
   }
 
   const env = { ...process.env }


### PR DESCRIPTION
T047 was **un-checked in #1040** with the sites recorded rather than quietly fixed. These are those sites, plus three pieces of rot found during the same cleanup.

## The install advice is the dangerous one

Three places still told a developer to run `npm install` inside `frontend/`:

| file | what it said |
|---|---|
| `docs/developer-guide/setup.md` | a whole `cd frontend && npm install && cd ..` block, immediately after the root install |
| `frontend/README.md` | a bare `npm install` — in the README that sits **inside** the workspace where it is harmful |
| `scripts/miniapps/publish.js` | the same advice in an error message, on the mini-app **release** path |

An incremental install in a child silently drops `@rollup/rollup-linux-x64-gnu` from **both** `node_modules` and `package-lock.json` (npm/cli#4828), and re-running `npm install` cannot fix it — the lockfile is already wrong, so npm reports "up to date". Every Vite build then dies, including the mini-app release path whose output bytes are committed on-chain.

**Not theoretical:** it bit this repo four times during the spec-075 conversion, and again on **3 of 5** lockfile-touching Dependabot PRs this week. Each site now says what to do instead (`npm run deps:reinstall`) and why.

## Three stale claims

- **`monorepo.md`'s `.env` caveat** said `//#test` cache hits are "not sound" and to pass `--force`. Fixed in #1074, so the doc now describes the fix — and keeps the two facts that made the original defect confusing: `globalEnv` and a dotenv file are **different channels** (globalEnv was never wrong, it simply cannot observe a value read *inside* the task), and turbo hashes a `globalDependencies` path **even when gitignored**, with an absent file being a different hash rather than an error, which is why this works locally without touching CI.
- **`coverage-threshold-policy.json`** exempted `contracts/pools/SemaphoreDeploy.sol`, which spec 034 deleted. Inert — but it is an exemption for a file that cannot be covered because it does not exist.

## Verification

- coverage gate: **PASS** — 26 gated contracts meet their tier
- `publish.js` parses
- the two remaining `cd frontend` blocks in `setup.md` are `npm run dev`, which is correct