### PR TITLE
feat(miniapps): store UX redesign + vite 8 byte-gate resolution (spec 077)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/076-monorepo-semantic-versioning"
+  "feature_directory": "specs/077-miniapp-store-redesign"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,5 +419,5 @@ artifacts live under `specs/<feature>/`.
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/076-monorepo-semantic-versioning/plan.md
+at specs/077-miniapp-store-redesign/plan.md
 <!-- SPECKIT END -->

--- a/docs/developer-guide/miniapps.md
+++ b/docs/developer-guide/miniapps.md
@@ -62,6 +62,28 @@ network, and burn CPU. The registry is the defence, and curation review is a rea
 | Publish script | `scripts/miniapps/publish.js` |
 | First-party packages | `frontend/miniapps/token-mint/`, `frontend/miniapps/clearpath/` |
 | Package cache | `frontend/public/sw.js` (`fairwins-miniapp-packages-v1`) |
+| Store artwork + store bar (spec 077) | `frontend/src/components/miniapps/appArtwork.jsx`, `StoreBar.jsx`, `storeViews.js` |
+
+## The store surface **[host]** (spec 077)
+
+The catalog's visual layer. Three rules keep it from becoming a trust surface:
+
+- **Artwork is host-curated, full stop.** Card illustrations live in
+  `appArtwork.jsx`, keyed by the same slug the launch route uses, with a deliberate generic
+  fallback — `artworkFor()` is total over any input. Nothing on-chain, in a manifest, or in a
+  package may supply catalog imagery: an on-chain icon field would widen the registry's trust
+  surface, package art would move keccak-committed bytes, and either would hand vendors a
+  self-served image channel into the store. Adding an app's art is an ordinary reviewed host
+  change. All of it is decorative (`aria-hidden`); the card's text is the identity.
+- **The "On-chain verified market" badge is a factual claim**, so it renders only over a
+  verified listing — never the stale snapshot, the outage, or the registry gap. If you touch the
+  header, keep that gate; `storeRedesign.test.jsx` pins it across every state.
+- **Store navigation is presentation state, not navigation.** Market / My Apps / Search ride the
+  Apps tab's existing `?view=` seam (`storeViews.js` resolves it, totally — unknown values are
+  the market; `view=submit` keeps its exclusive surface). Every sub-view is a lens over the ONE
+  fetched listing: My Apps is favorites ∩ the launchable-filtered list and inherits the market's
+  launch rules; nothing refetches on a view switch. The host's global navigation (spec 069)
+  is untouched.
 
 ## The registry **[host]**
 

--- a/docs/developer-guide/miniapps.md
+++ b/docs/developer-guide/miniapps.md
@@ -62,14 +62,15 @@ network, and burn CPU. The registry is the defence, and curation review is a rea
 | Publish script | `scripts/miniapps/publish.js` |
 | First-party packages | `frontend/miniapps/token-mint/`, `frontend/miniapps/clearpath/` |
 | Package cache | `frontend/public/sw.js` (`fairwins-miniapp-packages-v1`) |
-| Store artwork + store bar (spec 077) | `frontend/src/components/miniapps/appArtwork.jsx`, `StoreBar.jsx`, `storeViews.js` |
+| Store artwork + store bar (spec 077) | `frontend/src/components/miniapps/appArt.jsx` + `appArtwork.js`, `StoreBar.jsx`, `storeViews.js` |
 
 ## The store surface **[host]** (spec 077)
 
 The catalog's visual layer. Three rules keep it from becoming a trust surface:
 
 - **Artwork is host-curated, full stop.** Card illustrations live in
-  `appArtwork.jsx`, keyed by the same slug the launch route uses, with a deliberate generic
+  `appArt.jsx` (the SVG components) behind `appArtwork.js` (the slug map), keyed by the same
+  slug the launch route uses, with a deliberate generic
   fallback — `artworkFor()` is total over any input. Nothing on-chain, in a manifest, or in a
   package may supply catalog imagery: an on-chain icon field would widen the registry's trust
   surface, package art would move keccak-committed bytes, and either would hand vendors a

--- a/docs/runbooks/miniapp-registry-operations.md
+++ b/docs/runbooks/miniapp-registry-operations.md
@@ -429,9 +429,36 @@ Categories: `0` TradeSettlement · `1` Reconciliation · `2` TreasuryLiquidity �
 
 Statuses: `0` Pending · `1` Approved · `2` Suspended · `3` Deprecated.
 
----
+### 7.1 Re-publishing after a toolchain byte move (spec 077)
 
-## 8. Known blockers
+Sometimes the packages' **source does not change but their published bytes do** — a build
+toolchain move. Spec 077 is the recorded instance: vite 7 → 8 replaced the bundler underneath
+the preset (rollup → rolldown), every emitted byte moved, the baseline
+(`specs/075-monorepo-workspaces/baseline-miniapp-builds.json`) was re-recorded in the same
+change, and both packages were hand-bumped (`1.0.0 → 1.0.1`, spec 076 FR-007b keeps the
+version/bytes pairing honest).
+
+**Until the steps below are completed on a cohort, its registry still commits to the PREVIOUS
+bytes** — members are served the old, still-approved packages. That is not an error state; it
+is content-committed approval doing its job. The repo being ahead of the chain is expected and
+harmless. The reverse — re-recording the baseline *without* intending these steps — asserts the
+published packages no longer reproduce from source, so never re-record casually.
+
+Per cohort (Mordor first, then Polygon, matching §1's table):
+
+1. **Rebuild + publish at the new CID**: `node scripts/miniapps/publish.js --app <appId>` for
+   each affected package (§7). The CID and `manifestHash` will differ from the live record —
+   that is the point.
+2. **Propose the update**: `submit-and-approve.js` with the new tuple; the record goes Pending
+   while the previous approval keeps serving (§3 — nothing is down).
+3. **Approve against the exact hash**: the curator approves with `expectedManifestHash` set to
+   the printed hash; `StaleProposal` protects against the tuple moving between review and
+   execution.
+4. **Verify from the member side**: catalog shows the bumped version, and a launch re-verifies
+   the new hash end-to-end.
+
+There is no rollback step: the old CID stays pinned and the old approval history stays
+on-chain, so an aborted rollout simply stops before step 3 and members never notice.
 
 ### The vendor gate, and how the operator key clears it  *(resolved 2026-08-02)*
 

--- a/frontend/miniapps/clearpath/package.json
+++ b/frontend/miniapps/clearpath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairwins/miniapp-clearpath",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "description": "ClearPath — external-DAO governance mini-app package (spec 073).",
@@ -11,9 +11,9 @@
     "@fairwins/miniapp-build": "*",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
-    "@vitejs/plugin-react": "^5.1.1",
-    "vite": "^7.2.4",
-    "vitest": "^4.0.18",
+    "@vitejs/plugin-react": "^5.2.0",
+    "vite": "^8.2.1",
+    "vitest": "^4.1.10",
     "vitest-axe": "^0.1.0"
   },
   "peerDependencies": {

--- a/frontend/miniapps/token-mint/package.json
+++ b/frontend/miniapps/token-mint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairwins/miniapp-token-mint",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "description": "Token Mint — first-party mini-app package (spec 073).",
@@ -11,9 +11,9 @@
     "@fairwins/miniapp-build": "*",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
-    "@vitejs/plugin-react": "^5.1.1",
-    "vite": "^7.2.4",
-    "vitest": "^4.0.18",
+    "@vitejs/plugin-react": "^5.2.0",
+    "vite": "^8.2.1",
+    "vitest": "^4.1.10",
     "vitest-axe": "^0.1.0"
   },
   "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,9 +66,9 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^5.1.1",
-    "@vitest/coverage-v8": "^4.0.18",
-    "@vitest/ui": "^4.0.18",
+    "@vitejs/plugin-react": "^5.2.0",
+    "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/ui": "^4.1.10",
     "axe-core": "^4.10.2",
     "cypress": "^15.8.1",
     "cypress-wait-until": "^3.0.2",
@@ -78,8 +78,8 @@
     "globals": "^16.5.0",
     "jsdom": "^25.0.1",
     "start-server-and-test": "^2.1.3",
-    "vite": "^7.2.4",
-    "vitest": "^4.0.18",
+    "vite": "^8.2.1",
+    "vitest": "^4.1.10",
     "vitest-axe": "^0.1.0"
   }
 }

--- a/frontend/src/components/miniapps/CatalogPanel.jsx
+++ b/frontend/src/components/miniapps/CatalogPanel.jsx
@@ -36,10 +36,12 @@
  * under a heading per category (FR-007's category is otherwise readable only per-card), in the
  * same on-chain enum order the chip row already uses, so browsing and filtering agree on one order.
  */
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import './miniapps.css'
 import SubmitAppPanel from './SubmitAppPanel'
+import StoreBar from './StoreBar'
+import { STORE_VIEWS, resolveStoreView } from './storeViews'
 import { artworkFor } from './appArtwork'
 import EmptyState from '../account/EmptyState'
 import NavIcon from '../nav/NavIcon'
@@ -261,7 +263,7 @@ function AppCard({ app, launchable, isFavorite, onToggleFavorite }) {
   )
 }
 
-function CatalogView() {
+function CatalogView({ view = STORE_VIEWS.MARKET }) {
   /**
    * The last completed read, tagged with the request it answered.
    *
@@ -350,10 +352,20 @@ function CatalogView() {
     return null
   }, [outcome])
 
-  const visible = useMemo(() => {
+  /**
+   * The sub-view's app set (spec 077, US2). My Apps is a pure FILTER of the one fetched listing —
+   * favorites ∩ launchable — so it inherits the market's trust semantics wholesale: same cards,
+   * same launch rules, same verified/stale treatment. Nothing here refetches or re-derives.
+   */
+  const storeApps = useMemo(() => {
     if (!listing) return []
+    if (view !== STORE_VIEWS.MINE) return listing.apps
+    return listing.apps.filter((app) => favoriteIds.has(app.id))
+  }, [listing, view, favoriteIds])
+
+  const visible = useMemo(() => {
     const term = query.trim().toLowerCase()
-    return listing.apps.filter((app) => {
+    return storeApps.filter((app) => {
       // An empty selection means "every category", not "no category" — the filter row starts
       // unfiltered and clearing it must return the whole list rather than emptying the grid.
       if (selectedCategories.size > 0 && !selectedCategories.has(app.category)) return false
@@ -363,7 +375,7 @@ function CatalogView() {
         String(app.description).toLowerCase().includes(term)
       )
     })
-  }, [listing, query, selectedCategories])
+  }, [storeApps, query, selectedCategories])
 
   /**
    * `visible`, grouped under a heading per category (FR-007) in the chip row's own order.
@@ -400,10 +412,21 @@ function CatalogView() {
     })
   }
 
-  const totalCount = listing ? listing.apps.length : 0
+  const totalCount = storeApps.length
   // Controls appear only when there is something to narrow. A search box over a list that is empty —
   // or that we could not read at all — is an affordance that cannot do anything.
   const showControls = totalCount > 0
+
+  /**
+   * The Search sub-view is the market with search emphasized: same listing, same filters — the
+   * input is simply focused on arrival so a member who chose "Search" can type immediately. The
+   * effect (rather than `autoFocus`) covers the switch from another sub-view, where the input is
+   * already mounted and would otherwise keep focus wherever it was.
+   */
+  const searchInputRef = useRef(null)
+  useEffect(() => {
+    if (view === STORE_VIEWS.SEARCH) searchInputRef.current?.focus()
+  }, [view, showControls])
 
   return (
     <section className="miniapp-catalog" aria-label="Apps">
@@ -516,6 +539,7 @@ function CatalogView() {
             <label className="miniapp-catalog-search">
               <span className="sr-only">Search apps by name or description</span>
               <input
+                ref={searchInputRef}
                 type="search"
                 placeholder="Search apps…"
                 value={query}
@@ -578,11 +602,21 @@ function CatalogView() {
       )}
 
       {/* The genuinely-empty catalog: the registry answered, and it holds nothing launchable. Gated on
-          `verified` so an unreadable registry can never borrow this copy. */}
-      {listing && listing.verified && totalCount === 0 && (
+          `verified` so an unreadable registry can never borrow this copy — and on the market/search
+          views, because an empty My Apps is the member's own state, not the registry's (below). */}
+      {view !== STORE_VIEWS.MINE && listing && listing.verified && totalCount === 0 && (
         <EmptyState
           title="No apps are approved yet"
           message="The registry answered — it simply holds no approved apps for this environment. Anything a curator approves will appear here."
+        />
+      )}
+
+      {/* My Apps with nothing favorited: the member's empty shelf, never confusable with an empty
+          registry. The listing exists (verified or stale) — there is simply nothing starred. */}
+      {view === STORE_VIEWS.MINE && listing && totalCount === 0 && (
+        <EmptyState
+          title="Nothing in My Apps yet"
+          message="Star an app in the Market and it will appear here for quick access."
         />
       )}
 
@@ -615,6 +649,11 @@ function CatalogView() {
           </ul>
         </section>
       ))}
+
+      {/* The store's own section navigation (spec 077, US2): persistent — sticky at the viewport
+          bottom while the catalog scrolls — and withheld only when there is no store at all (no
+          registry on this build), where all three entries would lead nowhere. */}
+      {outcome && outcome.status !== REGISTRY_STATUS.NOT_DEPLOYED && <StoreBar active={view} />}
     </section>
   )
 }
@@ -633,5 +672,9 @@ function CatalogView() {
  */
 export default function CatalogPanel() {
   const [searchParams] = useSearchParams()
-  return searchParams.get('view') === 'submit' ? <SubmitAppPanel /> : <CatalogView />
+  const rawView = searchParams.get('view')
+  if (rawView === 'submit') return <SubmitAppPanel />
+  // Everything else is the store: market / mine / search, with unknown values falling back to
+  // market (`resolveStoreView` is total) so a stale bookmark still lands somewhere real.
+  return <CatalogView view={resolveStoreView(rawView)} />
 }

--- a/frontend/src/components/miniapps/CatalogPanel.jsx
+++ b/frontend/src/components/miniapps/CatalogPanel.jsx
@@ -40,6 +40,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import './miniapps.css'
 import SubmitAppPanel from './SubmitAppPanel'
+import { artworkFor } from './appArtwork'
 import EmptyState from '../account/EmptyState'
 import NavIcon from '../nav/NavIcon'
 import { APP_CATEGORY_LABELS } from '../../abis/miniAppRegistry'
@@ -70,6 +71,66 @@ const SUBMIT_ROUTE = '/wallet?tab=apps&view=submit'
 const CATEGORY_FILTERS = Object.entries(APP_CATEGORY_LABELS)
   .map(([ordinal, label]) => ({ value: Number(ordinal), label }))
   .sort((a, b) => a.value - b.value)
+
+/**
+ * Decorative glyphs for the store chrome (spec 077). All are `aria-hidden`: each sits beside
+ * text that already says the same thing, so the art adds flavour, never meaning.
+ */
+function RocketGlyph() {
+  return (
+    <svg className="miniapp-glyph" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+      <g fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10 13.5c-1.8-.6-3-1.8-3.5-3.5C7.6 5.6 10.4 3.2 15 3c-.2 4.6-2.6 7.4-7 8.5Z" />
+        <circle cx="11.6" cy="6.4" r="1.2" />
+        <path d="M6.5 10 4 11.5 6 12M10 13.5 8.5 16l-.5-2M5.5 14.5 4 16" />
+      </g>
+    </svg>
+  )
+}
+
+function VerifiedBadgeGlyph() {
+  return (
+    <svg className="miniapp-glyph miniapp-glyph-badge" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+      {/* rosette: scalloped seal with a check — the concept art's rainbow badge, themed */}
+      <path
+        d="M10 1.6l1.9 1.2 2.2-.3 1 2 2 1-.3 2.2L18 10l-1.2 1.9.3 2.2-2 1-1 2-2.2-.3L10 18.4l-1.9-1.2-2.2.3-1-2-2-1 .3-2.2L2 10l1.2-1.9-.3-2.2 2-1 1-2 2.2.3L10 1.6Z"
+        fill="currentColor"
+        opacity="0.18"
+      />
+      <path
+        d="M10 1.6l1.9 1.2 2.2-.3 1 2 2 1-.3 2.2L18 10l-1.2 1.9.3 2.2-2 1-1 2-2.2-.3L10 18.4l-1.9-1.2-2.2.3-1-2-2-1 .3-2.2L2 10l1.2-1.9-.3-2.2 2-1 1-2 2.2.3L10 1.6Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinejoin="round"
+      />
+      <path d="M6.8 10.2l2.1 2.1 4.3-4.6" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function ScrollCheckGlyph() {
+  return (
+    <svg className="miniapp-glyph" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+      <g fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M6 3h9a1.5 1.5 0 0 1 1.5 1.5V15A2.5 2.5 0 0 1 14 17.5H7A2.5 2.5 0 0 1 4.5 15V4.5" />
+        <path d="M6 3a1.5 1.5 0 0 0-1.5 1.5V6H7V4.5A1.5 1.5 0 0 0 6 3Z" />
+        <path d="M8 10.6l2 2 3.4-3.8" />
+      </g>
+    </svg>
+  )
+}
+
+function HashShieldGlyph() {
+  return (
+    <svg className="miniapp-glyph" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+      <g fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10 2.5 16 5v4.5c0 3.7-2.4 6.5-6 8-3.6-1.5-6-4.3-6-8V5l6-2.5Z" />
+        <path d="M8.2 7.5 7 12.5M13 7.5l-1.2 5M7 9h6M6.8 11h6" />
+      </g>
+    </svg>
+  )
+}
 
 /** Vendor addresses are shown short; the full value stays available as a tooltip/copy target. */
 function shortAddress(address) {
@@ -124,65 +185,78 @@ function AppCard({ app, launchable, isFavorite, onToggleFavorite }) {
   const categoryLabel = APP_CATEGORY_LABELS[app.category] ?? `Category ${app.category}`
   const slug = appSlug(app.name)
   const canFavorite = launchable && Boolean(slug)
+  // Curated host-side art; a slug the host doesn't know — or a name with no slug at all — gets
+  // the deliberate generic illustration (spec 077 FR-001, never a broken or borrowed image).
+  const { Art } = artworkFor(slug)
 
   return (
     <li className="miniapp-card">
-      <div className="miniapp-card-head">
-        <h5 className="miniapp-card-name" id={nameId}>
-          {app.name}
-        </h5>
-        {canFavorite && (
-          <button
-            type="button"
-            className={`miniapp-card-favorite${isFavorite ? ' is-active' : ''}`}
-            aria-pressed={isFavorite}
-            aria-label={
-              isFavorite ? `Remove ${app.name} from Quick Access` : `Add ${app.name} to Quick Access`
-            }
-            onClick={() => onToggleFavorite(app, slug)}
+      {/* Decorative illustration panel — the name below is the accessible identity. */}
+      <div className="miniapp-card-art" aria-hidden="true">
+        <Art />
+      </div>
+      <div className="miniapp-card-body">
+        <div className="miniapp-card-head">
+          <h5 className="miniapp-card-name" id={nameId}>
+            {app.name}
+          </h5>
+          {canFavorite && (
+            <button
+              type="button"
+              className={`miniapp-card-favorite${isFavorite ? ' is-active' : ''}`}
+              aria-pressed={isFavorite}
+              aria-label={
+                isFavorite ? `Remove ${app.name} from Quick Access` : `Add ${app.name} to Quick Access`
+              }
+              onClick={() => onToggleFavorite(app, slug)}
+            >
+              <NavIcon name="star" size={16} />
+            </button>
+          )}
+        </div>
+        <p className="miniapp-card-category">{categoryLabel}</p>
+        {app.description && (
+          <p className="miniapp-card-description" id={descriptionId}>
+            {app.description}
+          </p>
+        )}
+        {/* The technical data box: vendor + version contained and visually separate from the
+            description (spec 077 FR-005). Same DL semantics as before the redesign. */}
+        <dl className="miniapp-card-meta">
+          <div>
+            <dt>Vendor</dt>
+            <dd>
+              <code title={app.vendor || undefined}>{shortAddress(app.vendor)}</code>
+            </dd>
+          </div>
+          <div>
+            <dt>Version</dt>
+            <dd>v{app.approved.version}</dd>
+          </div>
+        </dl>
+        {launchable && slug ? (
+          <Link
+            className="miniapp-card-launch"
+            to={`/apps/${slug}`}
+            // The visible word stays inside the accessible name (WCAG 2.5.3), and the app name makes
+            // each of these links distinguishable in a screen reader's link list. The rocket is
+            // flavour (FR-006) and stays out of the name.
+            aria-label={`Launch ${app.name}`}
+            aria-describedby={app.description ? descriptionId : undefined}
           >
-            <NavIcon name="star" size={16} />
-          </button>
+            <RocketGlyph />
+            Launch
+          </Link>
+        ) : (
+          <p className="miniapp-card-refusal" role="note">
+            {/* Provenance first: when we cannot verify the listing at all, that is the reason that
+                matters, whatever else is also true of the record. */}
+            {!launchable
+              ? 'Launch unavailable — this listing could not be verified.'
+              : 'Launch unavailable — this app’s registered name can’t be used as a web address, so the host has no way to open it. Its vendor needs to re-register it under a usable name.'}
+          </p>
         )}
       </div>
-      <p className="miniapp-card-category">{categoryLabel}</p>
-      {app.description && (
-        <p className="miniapp-card-description" id={descriptionId}>
-          {app.description}
-        </p>
-      )}
-      <dl className="miniapp-card-meta">
-        <div>
-          <dt>Vendor</dt>
-          <dd>
-            <code title={app.vendor || undefined}>{shortAddress(app.vendor)}</code>
-          </dd>
-        </div>
-        <div>
-          <dt>Version</dt>
-          <dd>v{app.approved.version}</dd>
-        </div>
-      </dl>
-      {launchable && slug ? (
-        <Link
-          className="miniapp-card-launch"
-          to={`/apps/${slug}`}
-          // The visible word stays inside the accessible name (WCAG 2.5.3), and the app name makes
-          // each of these links distinguishable in a screen reader's link list.
-          aria-label={`Launch ${app.name}`}
-          aria-describedby={app.description ? descriptionId : undefined}
-        >
-          Launch
-        </Link>
-      ) : (
-        <p className="miniapp-card-refusal" role="note">
-          {/* Provenance first: when we cannot verify the listing at all, that is the reason that
-              matters, whatever else is also true of the record. */}
-          {!launchable
-            ? 'Launch unavailable — this listing could not be verified.'
-            : 'Launch unavailable — this app’s registered name can’t be used as a web address, so the host has no way to open it. Its vendor needs to re-register it under a usable name.'}
-        </p>
-      )}
     </li>
   )
 }
@@ -334,13 +408,38 @@ function CatalogView() {
   return (
     <section className="miniapp-catalog" aria-label="Apps">
       <div className="miniapp-catalog-header">
-        <div>
-          <h3>Apps</h3>
-          <p className="miniapp-catalog-subtitle">
-            Every app listed here has been reviewed and approved on-chain. Before any of an app’s code
-            runs, the host re-reads its registry record and checks the package against the hash
-            recorded there.
-          </p>
+        <div className="miniapp-store-hero">
+          <div className="miniapp-store-title">
+            <h3>Apps</h3>
+            {/* The trust badge is a factual claim about THIS listing, so it renders only when the
+                listing is actually verified (spec 077 FR-002) — never over a stale snapshot, an
+                outage, or a registry gap. */}
+            {listing?.verified && (
+              <p className="miniapp-store-badge">
+                <VerifiedBadgeGlyph />
+                On-chain verified market
+              </p>
+            )}
+          </div>
+          {/* The spec-073 trust story, restructured into two scannable blocks (FR-003). Same
+              factual claims as the old paragraph; the glyphs are decoration, not meaning. */}
+          <ul className="miniapp-store-trust">
+            <li>
+              <ScrollCheckGlyph />
+              <span>
+                <strong>Reviewed on-chain.</strong> Every app listed here has been reviewed and
+                approved on-chain.
+              </span>
+            </li>
+            <li>
+              <HashShieldGlyph />
+              <span>
+                <strong>Hash-checked before launch.</strong> Before any of an app’s code runs, the
+                host re-reads its registry record and checks the package against the hash recorded
+                there.
+              </span>
+            </li>
+          </ul>
         </div>
         {/* No registry means nothing to refresh and nowhere to submit — offering either would be an
             affordance that leads nowhere. */}

--- a/frontend/src/components/miniapps/StoreBar.jsx
+++ b/frontend/src/components/miniapps/StoreBar.jsx
@@ -1,0 +1,43 @@
+/**
+ * StoreBar (spec 077, US2) — the store's own section navigation: Market / My Apps / Search.
+ *
+ * This is presentation state INSIDE the Apps tab, not a second app navigation. Spec 069 settled
+ * who owns global navigation (`NAV_GROUPS` + the account button), so the concept art's bottom bar
+ * is adapted rather than copied: entries ride the tab's existing `?view=` seam — the same one
+ * `view=submit` already uses — which keeps browser Back semantics and bookmarkability for free,
+ * and its "Profile" entry is deliberately absent (the host's account controls already are that).
+ *
+ * Entries are plain links inside a labelled `<nav>`: keyboard-operable by construction, active
+ * entry marked `aria-current="page"`. The glyphs sit beside visible text labels, so no meaning
+ * rides on iconography alone.
+ */
+import { Link } from 'react-router-dom'
+import NavIcon from '../nav/NavIcon'
+import { STORE_VIEWS } from './storeViews'
+
+const ENTRIES = [
+  { view: STORE_VIEWS.MARKET, label: 'Market', icon: 'grid', to: '/wallet?tab=apps' },
+  { view: STORE_VIEWS.MINE, label: 'My Apps', icon: 'star', to: '/wallet?tab=apps&view=mine' },
+  { view: STORE_VIEWS.SEARCH, label: 'Search', icon: 'search', to: '/wallet?tab=apps&view=search' },
+]
+
+export default function StoreBar({ active }) {
+  return (
+    <nav className="miniapp-store-bar" aria-label="Store sections">
+      {ENTRIES.map((entry) => {
+        const isActive = active === entry.view
+        return (
+          <Link
+            key={entry.view}
+            className={`miniapp-store-bar-link${isActive ? ' is-active' : ''}`}
+            to={entry.to}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            <NavIcon name={entry.icon} size={18} />
+            {entry.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/frontend/src/components/miniapps/appArt.jsx
+++ b/frontend/src/components/miniapps/appArt.jsx
@@ -96,24 +96,4 @@ function GenericAppArt() {
   )
 }
 
-/**
- * Slug-keyed curated entries. Adding an app's art is a host change reviewed like any other —
- * exactly the property that keeps the catalog's imagery inside the platform's trust story.
- */
-const CURATED = {
-  'token-mint': TokenMintArt,
-  clearpath: ClearPathArt,
-}
-
-/**
- * The artwork for one catalog card. Total over every input: an app the host has no curated art
- * for — including one whose name yields no slug at all — gets the generic illustration.
- */
-export function artworkFor(slug) {
-  // `Object.hasOwn`, not a bare lookup: registry names fold into slugs, and an inherited key
-  // (`__proto__`, `toString`) must never leak an Object.prototype member out as "art".
-  const Artwork = typeof slug === 'string' && Object.hasOwn(CURATED, slug) ? CURATED[slug] : GenericAppArt
-  return { Art: Artwork }
-}
-
-export { GenericAppArt }
+export { TokenMintArt, ClearPathArt, GenericAppArt }

--- a/frontend/src/components/miniapps/appArtwork.js
+++ b/frontend/src/components/miniapps/appArtwork.js
@@ -1,0 +1,27 @@
+/**
+ * Curated store artwork map (spec 077, US1) — slug → illustration.
+ *
+ * The components live in `appArt.jsx` (components-only for react-refresh); this module owns the
+ * curation decision. See appArt.jsx's header for why artwork is host-side and decorative.
+ */
+import { ClearPathArt, GenericAppArt, TokenMintArt } from './appArt'
+
+/**
+ * Slug-keyed curated entries. Adding an app's art is a host change reviewed like any other —
+ * exactly the property that keeps the catalog's imagery inside the platform's trust story.
+ */
+const CURATED = {
+  'token-mint': TokenMintArt,
+  clearpath: ClearPathArt,
+}
+
+/**
+ * The artwork for one catalog card. Total over every input: an app the host has no curated art
+ * for — including one whose name yields no slug at all — gets the generic illustration.
+ */
+export function artworkFor(slug) {
+  // `Object.hasOwn`, not a bare lookup: registry names fold into slugs, and an inherited key
+  // (`__proto__`, `toString`) must never leak an Object.prototype member out as "art".
+  const Artwork = typeof slug === 'string' && Object.hasOwn(CURATED, slug) ? CURATED[slug] : GenericAppArt
+  return { Art: Artwork }
+}

--- a/frontend/src/components/miniapps/appArtwork.jsx
+++ b/frontend/src/components/miniapps/appArtwork.jsx
@@ -1,0 +1,119 @@
+/**
+ * Curated store artwork (spec 077, US1) — the illustrations on the catalog's app cards.
+ *
+ * This map is HOST-side on purpose. Nothing in the registry record, the manifest schema, or the
+ * host object carries an icon, and none of them may grow one for this: an on-chain icon field
+ * would widen the trust surface, and artwork inside a package would move keccak-committed bytes
+ * and hand every vendor a self-served image channel into the catalog. Art here is a pure
+ * presentation concern, curated with the host, keyed by the same slug the launch route uses.
+ *
+ * Rules (contracts/store-ui.md §3):
+ *   - `artworkFor(slug)` is TOTAL: any input — unknown slug, null, garbage — returns renderable
+ *     art. Unknown apps get the deliberate generic illustration, never a broken image and never a
+ *     borrowed identity.
+ *   - Every illustration is decorative (`aria-hidden`): the card's text carries the app's name,
+ *     so the art must never be the only carrier of meaning (WCAG 1.1.1 the honest way round).
+ *   - Inline SVG only, colored through the app's theme variables with literal fallbacks — the same
+ *     convention miniapps.css uses — so light/dark and tenant themes restyle the art with no
+ *     second asset set and no external fetches (no new CSP surface).
+ */
+
+/** Shared wrapper: fixed viewBox, decorative, themed by the surrounding card. */
+function Art({ children }) {
+  return (
+    <svg
+      className="miniapp-art"
+      viewBox="0 0 64 64"
+      role="presentation"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {children}
+    </svg>
+  )
+}
+
+/** Token Mint — a coin press stamping out tokens. */
+function TokenMintArt() {
+  return (
+    <Art>
+      <g fill="none" stroke="var(--text-primary, #2f3b45)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        {/* press body */}
+        <rect x="18" y="26" width="28" height="18" rx="3" fill="var(--surface-color, #f4f7f6)" />
+        <path d="M24 44v6h16v-6" />
+        <rect x="14" y="50" width="36" height="6" rx="2" fill="var(--surface-color, #f4f7f6)" />
+        {/* hopper */}
+        <path d="M26 26v-5h12v5" />
+        {/* minted coins */}
+        <circle cx="20" cy="14" r="7" fill="var(--brand-primary, #10b981)" fillOpacity="0.18" />
+        <circle cx="20" cy="14" r="7" />
+        <path d="M17.5 14h5M20 11.5v5" />
+        <circle cx="38" cy="10" r="6" fill="var(--brand-primary, #10b981)" fillOpacity="0.18" />
+        <circle cx="38" cy="10" r="6" />
+        <circle cx="50" cy="18" r="5" fill="var(--brand-primary, #10b981)" fillOpacity="0.18" />
+        <circle cx="50" cy="18" r="5" />
+        {/* stamped token emerging */}
+        <circle cx="32" cy="35" r="5" stroke="var(--brand-primary, #10b981)" />
+        <path d="M30 35h4" stroke="var(--brand-primary, #10b981)" />
+      </g>
+    </Art>
+  )
+}
+
+/** ClearPath — a compass over a governance path: propose → vote → execute. */
+function ClearPathArt() {
+  return (
+    <Art>
+      <g fill="none" stroke="var(--text-primary, #2f3b45)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        {/* compass */}
+        <circle cx="22" cy="22" r="13" fill="var(--surface-color, #f4f7f6)" />
+        <path d="M22 11v3M22 30v3M11 22h3M30 22h3" />
+        <path d="M27 17l-3.4 6.6L17 27l3.4-6.6L27 17Z" fill="var(--brand-primary, #10b981)" fillOpacity="0.25" />
+        {/* path with checkpoints */}
+        <path d="M14 50c10 4 18-8 28-4 6 2.4 10-2 12-6" strokeDasharray="4 4" stroke="var(--text-secondary, #5a6772)" />
+        <circle cx="44" cy="44" r="5" fill="var(--brand-primary, #10b981)" fillOpacity="0.18" />
+        <circle cx="44" cy="44" r="5" />
+        <path d="M42 44l1.6 1.6L47 42.6" stroke="var(--brand-primary, #10b981)" />
+        <circle cx="55" cy="34" r="4" />
+        <circle cx="26" cy="52" r="4" />
+      </g>
+    </Art>
+  )
+}
+
+/** The deliberate generic: an app tile taking shape. Identity-free by design. */
+function GenericAppArt() {
+  return (
+    <Art>
+      <g fill="none" stroke="var(--text-secondary, #5a6772)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="12" y="12" width="18" height="18" rx="5" fill="var(--surface-color, #f4f7f6)" />
+        <rect x="34" y="12" width="18" height="18" rx="5" fill="var(--surface-color, #f4f7f6)" />
+        <rect x="12" y="34" width="18" height="18" rx="5" fill="var(--surface-color, #f4f7f6)" />
+        <rect x="34" y="34" width="18" height="18" rx="9" stroke="var(--brand-primary, #10b981)" strokeDasharray="4 3" />
+        <path d="M43 39v8M39 43h8" stroke="var(--brand-primary, #10b981)" />
+      </g>
+    </Art>
+  )
+}
+
+/**
+ * Slug-keyed curated entries. Adding an app's art is a host change reviewed like any other —
+ * exactly the property that keeps the catalog's imagery inside the platform's trust story.
+ */
+const CURATED = {
+  'token-mint': TokenMintArt,
+  clearpath: ClearPathArt,
+}
+
+/**
+ * The artwork for one catalog card. Total over every input: an app the host has no curated art
+ * for — including one whose name yields no slug at all — gets the generic illustration.
+ */
+export function artworkFor(slug) {
+  // `Object.hasOwn`, not a bare lookup: registry names fold into slugs, and an inherited key
+  // (`__proto__`, `toString`) must never leak an Object.prototype member out as "art".
+  const Artwork = typeof slug === 'string' && Object.hasOwn(CURATED, slug) ? CURATED[slug] : GenericAppArt
+  return { Art: Artwork }
+}
+
+export { GenericAppArt }

--- a/frontend/src/components/miniapps/miniapps.css
+++ b/frontend/src/components/miniapps/miniapps.css
@@ -158,6 +158,64 @@
   width: 18px;
 }
 
+/* ---- Store bar: Market / My Apps / Search (spec 077, US2) -------------- */
+
+/* A floating dock, sticky at the viewport bottom while the catalog scrolls — the concept art's
+   bottom navigation, scoped to the Apps section. It sits last in the DOM, so its visual position
+   and its tab order agree. `bottom` keeps a thumb-height gap plus the device safe area. */
+.miniapp-store-bar {
+  align-self: center;
+  background: var(--surface-color, #fff);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 999px;
+  bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--text-primary, #1f2933) 14%, transparent);
+  display: flex;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+  padding: 0.3rem;
+  position: sticky;
+  z-index: 2;
+}
+.miniapp-store-bar-link {
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--text-secondary, #5a6772);
+  display: inline-flex;
+  font-size: 0.82rem;
+  font-weight: 600;
+  gap: 0.35rem;
+  padding: 0.4rem 0.9rem;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.miniapp-store-bar-link:hover {
+  color: var(--text-primary, #1f2933);
+}
+.miniapp-store-bar-link:focus-visible {
+  outline: 2px solid var(--brand-primary, #36b37e);
+  outline-offset: 2px;
+}
+/* Active section: tinted pill + border + weight — and `aria-current` in the markup — so the
+   state never rides on colour alone. */
+.miniapp-store-bar-link.is-active {
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 14%, transparent);
+  border-color: color-mix(in srgb, var(--brand-primary, #36b37e) 45%, transparent);
+  color: var(--text-primary, #1f2933);
+}
+
+@media (max-width: 480px) {
+  .miniapp-store-bar {
+    justify-content: space-around;
+    width: 100%;
+  }
+  .miniapp-store-bar-link {
+    flex: 1 1 0;
+    justify-content: center;
+  }
+}
+
 /* ---- State blocks ------------------------------------------------------ */
 
 .miniapp-catalog-loading {

--- a/frontend/src/components/miniapps/miniapps.css
+++ b/frontend/src/components/miniapps/miniapps.css
@@ -58,7 +58,7 @@
 .miniapp-catalog-submit {
   background: transparent;
   border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 8px;
+  border-radius: 999px;
   color: var(--text-primary, #1f2933);
   cursor: pointer;
   font-size: 0.85rem;
@@ -83,6 +83,79 @@
 .miniapp-catalog-refresh[aria-disabled='true'] {
   cursor: default;
   opacity: 0.55;
+}
+
+/* ---- Store hero: title, trust badge, trust blocks (spec 077) ----------- */
+
+.miniapp-store-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  max-width: 44rem;
+}
+.miniapp-store-title {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+/* The verified-market badge. It only renders over a verified listing (see the component), so the
+   styling can afford to be celebratory. Text stays at full contrast; only the rosette glyph takes
+   the brand colour, so the claim never depends on hue to be readable (WCAG 1.4.1/1.4.3). */
+.miniapp-store-badge {
+  align-items: center;
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brand-primary, #36b37e) 45%, transparent);
+  border-radius: 999px;
+  color: var(--text-primary, #1f2933);
+  display: inline-flex;
+  font-size: 0.72rem;
+  font-weight: 700;
+  gap: 0.35rem;
+  letter-spacing: 0.05em;
+  margin: 0;
+  padding: 0.25rem 0.7rem;
+  text-transform: uppercase;
+}
+.miniapp-store-badge .miniapp-glyph-badge {
+  color: var(--brand-primary, #36b37e);
+}
+/* The trust story as two scannable blocks instead of one dense paragraph. */
+.miniapp-store-trust {
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.miniapp-store-trust li {
+  align-items: flex-start;
+  background: var(--bg-primary, #f7f9fa);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 10px;
+  color: var(--text-secondary, #5a6772);
+  display: flex;
+  font-size: 0.82rem;
+  gap: 0.5rem;
+  line-height: 1.45;
+  padding: 0.55rem 0.7rem;
+}
+.miniapp-store-trust li strong {
+  color: var(--text-primary, #1f2933);
+}
+.miniapp-store-trust .miniapp-glyph {
+  color: var(--brand-primary, #36b37e);
+  height: 20px;
+  margin-top: 0.1rem;
+  width: 20px;
+}
+
+/* Decorative glyph base: sized to sit beside a line of text, never focusable, never announced. */
+.miniapp-glyph {
+  flex: 0 0 auto;
+  height: 18px;
+  width: 18px;
 }
 
 /* ---- State blocks ------------------------------------------------------ */
@@ -155,10 +228,10 @@
 .miniapp-catalog-search input {
   background: var(--surface-color, #fff);
   border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 10px;
+  border-radius: 999px;
   color: var(--text-primary, #1f2933);
   font-size: 0.95rem;
-  padding: 0.55rem 0.75rem;
+  padding: 0.55rem 0.9rem;
   width: 100%;
 }
 .miniapp-catalog-search input:focus-visible {
@@ -170,7 +243,7 @@
   align-items: center;
   background: transparent;
   border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 10px;
+  border-radius: 999px;
   color: var(--text-primary, #1f2933);
   cursor: pointer;
   display: inline-flex;
@@ -238,13 +311,26 @@
   flex-direction: column;
   gap: 0.5rem;
 }
+/* Category banners: an accent bar plus the label — distinct from card headings at a glance, and
+   the bar is decoration over a text label rather than a colour-only signal. */
 .miniapp-catalog-group-title {
-  color: var(--text-secondary, #5a6772);
-  font-size: 0.78rem;
+  align-items: center;
+  color: var(--text-primary, #1f2933);
+  display: flex;
+  font-size: 0.8rem;
   font-weight: 700;
-  letter-spacing: 0.04em;
-  margin: 0;
+  gap: 0.5rem;
+  letter-spacing: 0.06em;
+  margin: 0.35rem 0 0;
   text-transform: uppercase;
+}
+.miniapp-catalog-group-title::before {
+  background: var(--brand-primary, #36b37e);
+  border-radius: 999px;
+  content: '';
+  display: inline-block;
+  height: 1em;
+  width: 4px;
 }
 
 /* ---- Catalog grid ------------------------------------------------------ */
@@ -261,11 +347,40 @@
 .miniapp-card {
   background: var(--surface-color, #fff);
   border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 12px;
+  border-radius: 14px;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.miniapp-card:hover {
+  border-color: color-mix(in srgb, var(--brand-primary, #36b37e) 45%, var(--border-color, #e3e7eb));
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--text-primary, #1f2933) 10%, transparent);
+}
+/* The illustration panel: a soft brand-tinted stage for the curated art. Decorative throughout —
+   it is aria-hidden in the markup and carries no text. */
+.miniapp-card-art {
+  align-items: center;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--brand-primary, #36b37e) 16%, transparent),
+    color-mix(in srgb, var(--brand-primary, #36b37e) 4%, transparent)
+  );
+  border-bottom: 1px solid var(--border-color, #e3e7eb);
+  display: flex;
+  justify-content: center;
+  padding: 0.8rem;
+}
+.miniapp-art {
+  height: 72px;
+  width: 72px;
+}
+.miniapp-card-body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
   gap: 0.4rem;
-  padding: 0.85rem 0.9rem;
+  padding: 0.8rem 0.9rem 0.9rem;
 }
 .miniapp-card-head {
   align-items: flex-start;
@@ -317,13 +432,18 @@
   line-height: 1.4;
   margin: 0;
 }
+/* The technical-data box (FR-005): vendor + version contained and visibly apart from the prose. */
 .miniapp-card-meta {
+  background: var(--bg-primary, #f7f9fa);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 10px;
   color: var(--text-secondary, #5a6772);
   display: flex;
   flex-wrap: wrap;
   font-size: 0.78rem;
   gap: 0.25rem 1rem;
-  margin: 0.15rem 0 0;
+  margin: 0.25rem 0 0;
+  padding: 0.45rem 0.65rem;
 }
 .miniapp-card-meta > div {
   align-items: baseline;
@@ -341,16 +461,23 @@
 }
 
 .miniapp-card-launch {
+  align-items: center;
   align-self: flex-start;
   background: var(--primary-button, var(--brand-primary, #36b37e));
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: 999px;
   color: var(--primary-button-text, #fff);
+  display: inline-flex;
   font-size: 0.85rem;
   font-weight: 600;
-  margin-top: 0.35rem;
-  padding: 0.35rem 0.95rem;
+  gap: 0.4rem;
+  margin-top: auto;
+  padding: 0.4rem 1.1rem;
   text-decoration: none;
+}
+.miniapp-card-launch .miniapp-glyph {
+  height: 16px;
+  width: 16px;
 }
 .miniapp-card-launch:hover {
   background: var(--primary-button-hover, #2f9e6e);

--- a/frontend/src/components/miniapps/storeViews.js
+++ b/frontend/src/components/miniapps/storeViews.js
@@ -1,0 +1,18 @@
+/**
+ * StoreView (spec 077, US2) — the Apps tab's sub-view vocabulary, resolved from `?view=`.
+ *
+ * One resolver so the panel and the store bar cannot disagree about what a view string means.
+ * Unknown values fall back to the market rather than erroring: a stale bookmark should land a
+ * member in the store, not on a blank surface. `submit` is NOT in this vocabulary — the developer
+ * submission surface keeps its pre-existing exclusive rendering in `CatalogPanel`'s wrapper.
+ */
+export const STORE_VIEWS = Object.freeze({
+  MARKET: 'market',
+  MINE: 'mine',
+  SEARCH: 'search',
+})
+
+/** `?view=` string (or null) → one of STORE_VIEWS. Total: anything unknown is the market. */
+export function resolveStoreView(raw) {
+  return raw === STORE_VIEWS.MINE || raw === STORE_VIEWS.SEARCH ? raw : STORE_VIEWS.MARKET
+}

--- a/frontend/src/test/miniapps/storeNavigation.test.jsx
+++ b/frontend/src/test/miniapps/storeNavigation.test.jsx
@@ -1,0 +1,278 @@
+/**
+ * Store navigation (spec 077, US2) — Market / My Apps / Search on the `?view=` seam.
+ *
+ * The properties under test are the contract's (contracts/store-ui.md §1):
+ *
+ *   1. **One listing, three lenses.** Every sub-view is a projection of the SAME fetched outcome.
+ *      Switching views must not refetch — the fetch effect keys on the refresh counter alone —
+ *      and My Apps is favorites ∩ the already-launchable-filtered list, never its own read.
+ *   2. **Total routing.** Unknown `view` values land on the market; `submit` keeps its
+ *      pre-existing exclusive surface.
+ *   3. **An empty My Apps is the member's state, not the registry's.** It gets its own copy, and
+ *      must never borrow "No apps are approved yet" (which asserts something about the chain).
+ *   4. **The bar is honest chrome**: links with aria-current, absent only when there is no store
+ *      at all (registry not deployed).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { axe } from 'vitest-axe'
+
+const state = vi.hoisted(() => ({ fetchCatalog: null }))
+
+vi.mock('../../lib/miniapps/registryClient', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, fetchCatalog: (...args) => state.fetchCatalog(...args) }
+})
+
+// Only the ROUTING to the submission surface is under test here (its own suite renders the real
+// thing with the wallet context it needs); a marker stands in so the wrapper's exclusive-render
+// decision is observable without dragging that context into every case.
+vi.mock('../../components/miniapps/SubmitAppPanel', () => ({
+  default: () => <p>submit-surface-marker</p>,
+}))
+
+import { AppCategory, AppStatus } from '../../abis/miniAppRegistry'
+import { REGISTRY_STATUS, UNREACHABLE_REASON, appSlug } from '../../lib/miniapps/registryClient'
+import { toggleFavoriteApp, __resetFavoriteAppsForTests } from '../../lib/miniapps/favorites'
+import CatalogPanel from '../../components/miniapps/CatalogPanel'
+
+beforeEach(() => {
+  localStorage.clear()
+  __resetFavoriteAppsForTests()
+  state.fetchCatalog = null
+})
+
+const CHAIN = 137
+const REGISTRY = '0x5a168Cc9FeFaf40e7BC536C8C61669e6d547A0A2'
+const VENDOR = '0x1234567890abcdef1234567890abcdef12345678'
+const HASH = `0x${'ab'.repeat(32)}`
+const ZERO_HASH = `0x${'0'.repeat(64)}`
+
+function appRecord({ id, name, category = AppCategory.TRADE_SETTLEMENT, launchable = true }) {
+  return Object.freeze({
+    id,
+    vendor: VENDOR,
+    name,
+    description: '',
+    category,
+    status: AppStatus.APPROVED,
+    approved: Object.freeze({
+      cid: launchable ? 'bafybeigdyrztktx5' : '',
+      manifestHash: launchable ? HASH : ZERO_HASH,
+      version: launchable ? 1 : 0,
+      present: launchable,
+    }),
+    proposed: Object.freeze({ cid: '', manifestHash: ZERO_HASH, version: 0, present: false }),
+    submittedAt: 1_700_000_000,
+    approvedAt: 1_700_000_100,
+    updatedAt: 1_700_000_200,
+    launchable,
+  })
+}
+
+function okOutcome(allApps) {
+  return {
+    status: REGISTRY_STATUS.OK,
+    apps: Object.freeze(allApps.filter((app) => app.launchable)),
+    allApps: Object.freeze(allApps),
+    fetchedAt: Date.now(),
+    ageMs: 0,
+    cached: false,
+    chainId: CHAIN,
+    registryAddress: REGISTRY,
+  }
+}
+
+const TWO_APPS = [
+  appRecord({ id: 1, name: 'Settle Desk' }),
+  appRecord({ id: 2, name: 'Ledger Match', category: AppCategory.RECONCILIATION }),
+]
+
+function favorite(app) {
+  toggleFavoriteApp({ id: app.id, slug: appSlug(app.name), name: app.name })
+}
+
+async function renderAt(url) {
+  const result = render(
+    <MemoryRouter initialEntries={[url]}>
+      <CatalogPanel />
+    </MemoryRouter>,
+  )
+  await waitFor(() => expect(screen.queryByText('Loading the app catalog…')).toBeNull())
+  return result
+}
+
+function listedApps() {
+  return screen.queryAllByRole('heading', { level: 5 }).map((node) => node.textContent)
+}
+
+function storeBar() {
+  return screen.queryByRole('navigation', { name: 'Store sections' })
+}
+
+describe('the store bar (spec 077 FR-007)', () => {
+  it('renders Market / My Apps / Search as links, marking the active view with aria-current', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    await renderAt('/wallet?tab=apps')
+
+    const bar = storeBar()
+    expect(bar).toBeInTheDocument()
+    const market = within(bar).getByRole('link', { name: /Market/ })
+    const mine = within(bar).getByRole('link', { name: /My Apps/ })
+    const search = within(bar).getByRole('link', { name: /Search/ })
+
+    expect(market).toHaveAttribute('aria-current', 'page')
+    expect(mine).not.toHaveAttribute('aria-current')
+    expect(search).not.toHaveAttribute('aria-current')
+
+    expect(market).toHaveAttribute('href', '/wallet?tab=apps')
+    expect(mine).toHaveAttribute('href', '/wallet?tab=apps&view=mine')
+    expect(search).toHaveAttribute('href', '/wallet?tab=apps&view=search')
+  })
+
+  it('is withheld when the registry is not deployed — three links into a store that does not exist', async () => {
+    state.fetchCatalog = vi.fn(async () => ({
+      status: REGISTRY_STATUS.NOT_DEPLOYED,
+      chainId: CHAIN,
+      registryAddress: null,
+    }))
+    await renderAt('/wallet?tab=apps')
+    expect(storeBar()).toBeNull()
+  })
+
+  it('stays available during an outage — the honest states are per-view content, not chrome', async () => {
+    state.fetchCatalog = vi.fn(async () => ({
+      status: REGISTRY_STATUS.UNREACHABLE,
+      chainId: CHAIN,
+      registryAddress: REGISTRY,
+      reason: UNREACHABLE_REASON.READ_FAILED,
+      error: new Error('rpc down'),
+      stale: null,
+    }))
+    await renderAt('/wallet?tab=apps')
+    expect(storeBar()).toBeInTheDocument()
+    expect(screen.getByText('Listings can’t be verified right now.')).toBeInTheDocument()
+  })
+})
+
+describe('sub-view routing is total (contract §1)', () => {
+  it('an unknown view value falls back to the market', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    await renderAt('/wallet?tab=apps&view=definitely-not-a-view')
+
+    expect(listedApps()).toEqual(['Settle Desk', 'Ledger Match'])
+    expect(within(storeBar()).getByRole('link', { name: /Market/ })).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('view=submit keeps its exclusive surface — no store bar, no grid', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    render(
+      <MemoryRouter initialEntries={['/wallet?tab=apps&view=submit']}>
+        <CatalogPanel />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('submit-surface-marker')).toBeInTheDocument()
+    expect(storeBar()).toBeNull()
+    expect(screen.queryByRole('heading', { level: 5 })).toBeNull()
+  })
+})
+
+describe('My Apps (spec 077 FR-008)', () => {
+  it('lists only favorited apps, with the same card treatment and working launch links', async () => {
+    favorite(TWO_APPS[1]) // Ledger Match
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    await renderAt('/wallet?tab=apps&view=mine')
+
+    expect(listedApps()).toEqual(['Ledger Match'])
+    expect(screen.getByRole('link', { name: 'Launch Ledger Match' })).toHaveAttribute(
+      'href',
+      `/apps/${appSlug('Ledger Match')}`,
+    )
+    expect(within(storeBar()).getByRole('link', { name: /My Apps/ })).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('shows its own empty state when nothing is favorited — never the registry\'s empty-catalog copy', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    await renderAt('/wallet?tab=apps&view=mine')
+
+    expect(listedApps()).toEqual([])
+    expect(screen.getByText('Nothing in My Apps yet')).toBeInTheDocument()
+    expect(screen.queryByText('No apps are approved yet')).toBeNull()
+    // The registry DOES hold apps; only the member's shelf is empty. No search over nothing.
+    expect(screen.queryByRole('searchbox')).toBeNull()
+  })
+
+  it('unfavoriting from the card updates the view live', async () => {
+    const user = userEvent.setup()
+    favorite(TWO_APPS[0])
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    await renderAt('/wallet?tab=apps&view=mine')
+
+    expect(listedApps()).toEqual(['Settle Desk'])
+    await user.click(screen.getByRole('button', { name: 'Remove Settle Desk from Quick Access' }))
+
+    expect(listedApps()).toEqual([])
+    expect(screen.getByText('Nothing in My Apps yet')).toBeInTheDocument()
+  })
+})
+
+describe('Search view (contract §1)', () => {
+  it('focuses the search input on arrival, with the filters still available', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    await renderAt('/wallet?tab=apps&view=search')
+
+    const input = screen.getByRole('searchbox', { name: /search apps/i })
+    await waitFor(() => expect(document.activeElement).toBe(input))
+    expect(screen.getByRole('button', { name: /^Filter/ })).toBeInTheDocument()
+  })
+
+  it('searching narrows the same listing the market shows', async () => {
+    const user = userEvent.setup()
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    await renderAt('/wallet?tab=apps&view=search')
+
+    await user.type(screen.getByRole('searchbox', { name: /search apps/i }), 'ledger')
+    expect(listedApps()).toEqual(['Ledger Match'])
+    expect(screen.getByText('Showing 1 of 2 apps.')).toBeInTheDocument()
+  })
+})
+
+describe('one listing, three lenses — switching views never refetches (contract §1)', () => {
+  it('clicking through Market → My Apps → Search issues exactly one catalog read', async () => {
+    const user = userEvent.setup()
+    favorite(TWO_APPS[0])
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    await renderAt('/wallet?tab=apps')
+
+    expect(state.fetchCatalog).toHaveBeenCalledTimes(1)
+    expect(listedApps()).toEqual(['Settle Desk', 'Ledger Match'])
+
+    await user.click(within(storeBar()).getByRole('link', { name: /My Apps/ }))
+    expect(listedApps()).toEqual(['Settle Desk'])
+
+    await user.click(within(storeBar()).getByRole('link', { name: /Search/ }))
+    expect(listedApps()).toEqual(['Settle Desk', 'Ledger Match'])
+
+    await user.click(within(storeBar()).getByRole('link', { name: /Market/ }))
+    expect(listedApps()).toEqual(['Settle Desk', 'Ledger Match'])
+
+    // The whole tour rode the first read: sub-views are lenses, not fetches.
+    expect(state.fetchCatalog).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('accessibility (WCAG 2.1 AA)', () => {
+  it('has no violations with the store bar over a populated market', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    const { container } = await renderAt('/wallet?tab=apps')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no violations on the My Apps empty state', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
+    const { container } = await renderAt('/wallet?tab=apps&view=mine')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/miniapps/storeRedesign.test.jsx
+++ b/frontend/src/test/miniapps/storeRedesign.test.jsx
@@ -145,7 +145,6 @@ describe('the trust badge renders over a verified listing and nothing else (FR-0
   })
 
   it('withholds the badge on a bare outage', async () => {
-    state.fetchCatalog = vi.fn(async () => staleOutcome([]))
     state.fetchCatalog = vi.fn(async () => ({
       status: REGISTRY_STATUS.UNREACHABLE,
       chainId: CHAIN,

--- a/frontend/src/test/miniapps/storeRedesign.test.jsx
+++ b/frontend/src/test/miniapps/storeRedesign.test.jsx
@@ -1,0 +1,244 @@
+/**
+ * Store redesign (spec 077, US1) — the market surface's new visual layer.
+ *
+ * Everything under test here is presentation the redesign ADDED. The rules it must not break —
+ * `launchable` as the serving decision, the four honest states, launch refusals, favorites — are
+ * pinned by `CatalogPanel.test.jsx` and stay green unchanged; this file covers what is new:
+ *
+ *   1. **The trust badge is a factual claim.** "On-chain verified market" renders over a verified
+ *      listing and over NOTHING else — not the stale snapshot, not the outage, not the registry
+ *      gap, not the loading line. A badge that survived into those states would be the exact
+ *      dishonesty constitution III forbids.
+ *   2. **Artwork is total and decorative.** Curated slugs get their own illustration, everything
+ *      else gets the deliberate generic — never a broken image — and all of it is aria-hidden so
+ *      the card's text remains the identity a screen reader hears.
+ *   3. **Flavour never enters the accessible name.** The rocket in Launch and the glyphs in the
+ *      trust blocks are decoration; names and copy read exactly as before.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { axe } from 'vitest-axe'
+
+const state = vi.hoisted(() => ({ fetchCatalog: null }))
+
+vi.mock('../../lib/miniapps/registryClient', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, fetchCatalog: (...args) => state.fetchCatalog(...args) }
+})
+
+import { AppCategory, AppStatus } from '../../abis/miniAppRegistry'
+import { REGISTRY_STATUS, UNREACHABLE_REASON, appSlug } from '../../lib/miniapps/registryClient'
+import { __resetFavoriteAppsForTests } from '../../lib/miniapps/favorites'
+import { artworkFor, GenericAppArt } from '../../components/miniapps/appArtwork'
+import CatalogPanel from '../../components/miniapps/CatalogPanel'
+
+beforeEach(() => {
+  localStorage.clear()
+  __resetFavoriteAppsForTests()
+  state.fetchCatalog = null
+})
+
+const CHAIN = 137
+const REGISTRY = '0x5a168Cc9FeFaf40e7BC536C8C61669e6d547A0A2'
+const VENDOR = '0x1234567890abcdef1234567890abcdef12345678'
+const HASH = `0x${'ab'.repeat(32)}`
+const ZERO_HASH = `0x${'0'.repeat(64)}`
+
+function appRecord({ id, name, category = AppCategory.TRADE_SETTLEMENT, launchable = true }) {
+  return Object.freeze({
+    id,
+    vendor: VENDOR,
+    name,
+    description: '',
+    category,
+    status: AppStatus.APPROVED,
+    approved: Object.freeze({
+      cid: launchable ? 'bafybeigdyrztktx5' : '',
+      manifestHash: launchable ? HASH : ZERO_HASH,
+      version: launchable ? 1 : 0,
+      present: launchable,
+    }),
+    proposed: Object.freeze({ cid: '', manifestHash: ZERO_HASH, version: 0, present: false }),
+    submittedAt: 1_700_000_000,
+    approvedAt: 1_700_000_100,
+    updatedAt: 1_700_000_200,
+    launchable,
+  })
+}
+
+function okOutcome(allApps) {
+  return {
+    status: REGISTRY_STATUS.OK,
+    apps: Object.freeze(allApps.filter((app) => app.launchable)),
+    allApps: Object.freeze(allApps),
+    fetchedAt: Date.now(),
+    ageMs: 0,
+    cached: false,
+    chainId: CHAIN,
+    registryAddress: REGISTRY,
+  }
+}
+
+function staleOutcome(allApps, ageMs = 120_000) {
+  return {
+    status: REGISTRY_STATUS.UNREACHABLE,
+    chainId: CHAIN,
+    registryAddress: REGISTRY,
+    reason: UNREACHABLE_REASON.READ_FAILED,
+    error: new Error('rpc down'),
+    stale: {
+      apps: Object.freeze(allApps.filter((app) => app.launchable)),
+      allApps: Object.freeze(allApps),
+      fetchedAt: Date.now() - ageMs,
+      ageMs,
+    },
+  }
+}
+
+async function renderSettled() {
+  const result = render(
+    <MemoryRouter>
+      <CatalogPanel />
+    </MemoryRouter>,
+  )
+  await waitFor(() => expect(screen.queryByText('Loading the app catalog…')).toBeNull())
+  return result
+}
+
+const BADGE = 'On-chain verified market'
+
+describe('artworkFor — total, curated, generic (FR-001)', () => {
+  it('returns curated art for the shipped apps and the generic for everything else', () => {
+    expect(artworkFor('token-mint').Art).not.toBe(GenericAppArt)
+    expect(artworkFor('clearpath').Art).not.toBe(GenericAppArt)
+    expect(artworkFor('never-heard-of-it').Art).toBe(GenericAppArt)
+  })
+
+  it('is total over degenerate inputs — null, undefined, empty, garbage', () => {
+    for (const input of [null, undefined, '', 0, 'CONSTRUCTOR', '__proto__']) {
+      const { Art } = artworkFor(input)
+      expect(typeof Art).toBe('function')
+    }
+    // `__proto__`/inherited keys must not leak an Object.prototype member out of the map.
+    expect(artworkFor('toString').Art).toBe(GenericAppArt)
+  })
+})
+
+describe('the trust badge renders over a verified listing and nothing else (FR-002)', () => {
+  it('shows the badge with a verified catalog', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 1, name: 'Settle Desk' })]))
+    await renderSettled()
+    expect(screen.getByText(BADGE)).toBeInTheDocument()
+  })
+
+  it('withholds the badge on the unverified stale snapshot — the state it exists to distinguish', async () => {
+    state.fetchCatalog = vi.fn(async () => staleOutcome([appRecord({ id: 1, name: 'Settle Desk' })]))
+    await renderSettled()
+    // The snapshot's cards ARE on screen; the badge still must not be.
+    expect(screen.getByRole('heading', { level: 5, name: 'Settle Desk' })).toBeInTheDocument()
+    expect(screen.queryByText(BADGE)).toBeNull()
+  })
+
+  it('withholds the badge on a bare outage', async () => {
+    state.fetchCatalog = vi.fn(async () => staleOutcome([]))
+    state.fetchCatalog = vi.fn(async () => ({
+      status: REGISTRY_STATUS.UNREACHABLE,
+      chainId: CHAIN,
+      registryAddress: REGISTRY,
+      reason: UNREACHABLE_REASON.READ_FAILED,
+      error: new Error('rpc down'),
+      stale: null,
+    }))
+    await renderSettled()
+    expect(screen.queryByText(BADGE)).toBeNull()
+  })
+
+  it('withholds the badge when the registry is not deployed, and while loading', async () => {
+    let release
+    state.fetchCatalog = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve({ status: REGISTRY_STATUS.NOT_DEPLOYED, chainId: CHAIN, registryAddress: null })
+        }),
+    )
+    render(
+      <MemoryRouter>
+        <CatalogPanel />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Loading the app catalog…')).toBeInTheDocument()
+    expect(screen.queryByText(BADGE)).toBeNull()
+
+    release()
+    await waitFor(() => expect(screen.queryByText('Loading the app catalog…')).toBeNull())
+    expect(screen.getByText('Apps aren’t available here.')).toBeInTheDocument()
+    expect(screen.queryByText(BADGE)).toBeNull()
+  })
+})
+
+describe('the trust story reads as prioritized blocks (FR-003)', () => {
+  it('keeps both factual claims, split under their own lead-ins', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 1, name: 'Settle Desk' })]))
+    await renderSettled()
+
+    expect(screen.getByText('Reviewed on-chain.')).toBeInTheDocument()
+    expect(screen.getByText(/reviewed and approved on-chain/i)).toBeInTheDocument()
+    expect(screen.getByText('Hash-checked before launch.')).toBeInTheDocument()
+    expect(screen.getByText(/checks the package against the hash recorded there/i)).toBeInTheDocument()
+  })
+})
+
+describe('card artwork (FR-001) and flavour staying out of accessible names (FR-006)', () => {
+  it('gives every card an aria-hidden illustration panel; unknown apps get the generic art', async () => {
+    state.fetchCatalog = vi.fn(async () =>
+      okOutcome([
+        appRecord({ id: 1, name: 'Token Mint' }), // slug: token-mint → curated
+        appRecord({ id: 2, name: 'Settle Desk' }), // no curated entry → generic
+      ]),
+    )
+    await renderSettled()
+
+    for (const name of ['Token Mint', 'Settle Desk']) {
+      const card = screen.getByRole('heading', { level: 5, name }).closest('li')
+      const art = card.querySelector('.miniapp-card-art')
+      expect(art).not.toBeNull()
+      expect(art).toHaveAttribute('aria-hidden', 'true')
+      expect(art.querySelector('svg.miniapp-art')).not.toBeNull()
+    }
+    // Sanity: the curated slug really is what the launch route uses.
+    expect(appSlug('Token Mint')).toBe('token-mint')
+  })
+
+  it('a name with no slug still gets art (the generic), alongside its launch refusal', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 1, name: 'Ünïcode Desk' })]))
+    await renderSettled()
+
+    const card = screen.getByRole('heading', { level: 5, name: 'Ünïcode Desk' }).closest('li')
+    expect(card.querySelector('.miniapp-card-art svg')).not.toBeNull()
+    expect(within(card).getByText(/registered name can’t be used as a web address/i)).toBeInTheDocument()
+  })
+
+  it('the rocket is decoration: the launch link keeps its exact accessible name', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 1, name: 'Settle Desk' })]))
+    await renderSettled()
+
+    const launch = screen.getByRole('link', { name: 'Launch Settle Desk' })
+    const glyph = launch.querySelector('svg')
+    expect(glyph).not.toBeNull()
+    expect(glyph).toHaveAttribute('aria-hidden', 'true')
+  })
+})
+
+describe('accessibility of the redesigned market (WCAG 2.1 AA)', () => {
+  it('has no violations with badge, trust blocks, artwork and data boxes all rendered', async () => {
+    state.fetchCatalog = vi.fn(async () =>
+      okOutcome([
+        appRecord({ id: 1, name: 'Token Mint', category: AppCategory.ASSET_SERVICING }),
+        appRecord({ id: 2, name: 'Settle Desk' }),
+      ]),
+    )
+    const { container } = await renderSettled()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/miniapps/storeRedesign.test.jsx
+++ b/frontend/src/test/miniapps/storeRedesign.test.jsx
@@ -30,7 +30,7 @@ vi.mock('../../lib/miniapps/registryClient', async (importOriginal) => {
 import { AppCategory, AppStatus } from '../../abis/miniAppRegistry'
 import { REGISTRY_STATUS, UNREACHABLE_REASON, appSlug } from '../../lib/miniapps/registryClient'
 import { __resetFavoriteAppsForTests } from '../../lib/miniapps/favorites'
-import { artworkFor, GenericAppArt } from '../../components/miniapps/appArtwork'
+import { artworkFor } from '../../components/miniapps/appArtwork'
 import CatalogPanel from '../../components/miniapps/CatalogPanel'
 
 beforeEach(() => {
@@ -110,9 +110,13 @@ const BADGE = 'On-chain verified market'
 
 describe('artworkFor — total, curated, generic (FR-001)', () => {
   it('returns curated art for the shipped apps and the generic for everything else', () => {
-    expect(artworkFor('token-mint').Art).not.toBe(GenericAppArt)
-    expect(artworkFor('clearpath').Art).not.toBe(GenericAppArt)
-    expect(artworkFor('never-heard-of-it').Art).toBe(GenericAppArt)
+    // The generic's identity is observable through the function itself: any two unknown slugs
+    // share it, and neither curated entry does.
+    const generic = artworkFor('never-heard-of-it').Art
+    expect(artworkFor('also-unknown').Art).toBe(generic)
+    expect(artworkFor('token-mint').Art).not.toBe(generic)
+    expect(artworkFor('clearpath').Art).not.toBe(generic)
+    expect(artworkFor('token-mint').Art).not.toBe(artworkFor('clearpath').Art)
   })
 
   it('is total over degenerate inputs — null, undefined, empty, garbage', () => {
@@ -121,7 +125,7 @@ describe('artworkFor — total, curated, generic (FR-001)', () => {
       expect(typeof Art).toBe('function')
     }
     // `__proto__`/inherited keys must not leak an Object.prototype member out of the map.
-    expect(artworkFor('toString').Art).toBe(GenericAppArt)
+    expect(artworkFor('toString').Art).toBe(artworkFor('never-heard-of-it').Art)
   })
 })
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -62,12 +62,16 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
     sourcemap: false,
-    minify: 'esbuild',
+    // Vite 8: the bundled minifier (the pre-8 'esbuild' value now needs esbuild installed
+    // separately), and rolldown only supports the function form of manualChunks.
+    minify: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom', 'react-router-dom'],
-          web3: ['ethers', 'wagmi', 'viem']
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+          if (/node_modules\/(react|react-dom|react-router-dom)\//.test(id)) return 'vendor'
+          if (/node_modules\/(ethers|wagmi|viem)\//.test(id)) return 'web3'
+          return undefined
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,9 +107,9 @@
         "@testing-library/user-event": "^14.5.2",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^5.1.1",
-        "@vitest/coverage-v8": "^4.0.18",
-        "@vitest/ui": "^4.0.18",
+        "@vitejs/plugin-react": "^5.2.0",
+        "@vitest/coverage-v8": "^4.1.10",
+        "@vitest/ui": "^4.1.10",
         "axe-core": "^4.10.2",
         "cypress": "^15.8.1",
         "cypress-wait-until": "^3.0.2",
@@ -119,8 +119,8 @@
         "globals": "^16.5.0",
         "jsdom": "^25.0.1",
         "start-server-and-test": "^2.1.3",
-        "vite": "^7.2.4",
-        "vitest": "^4.0.18",
+        "vite": "^8.2.1",
+        "vitest": "^4.1.10",
         "vitest-axe": "^0.1.0"
       },
       "engines": {
@@ -129,14 +129,14 @@
     },
     "frontend/miniapps/clearpath": {
       "name": "@fairwins/miniapp-clearpath",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "@fairwins/miniapp-build": "*",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
-        "@vitejs/plugin-react": "^5.1.1",
-        "vite": "^7.2.4",
-        "vitest": "^4.0.18",
+        "@vitejs/plugin-react": "^5.2.0",
+        "vite": "^8.2.1",
+        "vitest": "^4.1.10",
         "vitest-axe": "^0.1.0"
       },
       "peerDependencies": {
@@ -146,14 +146,14 @@
     },
     "frontend/miniapps/token-mint": {
       "name": "@fairwins/miniapp-token-mint",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "@fairwins/miniapp-build": "*",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
-        "@vitejs/plugin-react": "^5.1.1",
-        "vite": "^7.2.4",
-        "vitest": "^4.0.18",
+        "@vitejs/plugin-react": "^5.2.0",
+        "vite": "^8.2.1",
+        "vitest": "^4.1.10",
         "vitest-axe": "^0.1.0"
       },
       "peerDependencies": {
@@ -3484,448 +3484,6 @@
       "deprecated": "Please use @ensdomains/ens-contracts",
       "dev": true
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
-      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
-      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
-      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
-      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
-      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
-      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
-      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
-      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
-      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
-      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
-      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
-      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
-      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
-      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
-      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
-      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
-      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
-      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
-      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
-      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
-      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
-      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
-      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
-      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
-      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
-      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
@@ -6566,23 +6124,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
-      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^22.20 || ^24.12 || >=25"
-      }
-    },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
@@ -7853,6 +7394,15 @@
         "node": ">=20"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -8087,31 +7637,10 @@
       "dev": true,
       "license": "SEE LICENSE IN LICENSE"
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
-      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
-      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
       "cpu": [
         "arm64"
       ],
@@ -8120,12 +7649,15 @@
       "os": [
         "android"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
-      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
       "cpu": [
         "arm64"
       ],
@@ -8134,12 +7666,15 @@
       "os": [
         "darwin"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
-      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
       "cpu": [
         "x64"
       ],
@@ -8148,26 +7683,15 @@
       "os": [
         "darwin"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
-      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
-      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
       "cpu": [
         "x64"
       ],
@@ -8176,12 +7700,15 @@
       "os": [
         "freebsd"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
-      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
       "cpu": [
         "arm"
       ],
@@ -8190,26 +7717,15 @@
       "os": [
         "linux"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
-      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
-      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
       "cpu": [
         "arm64"
       ],
@@ -8218,12 +7734,15 @@
       "os": [
         "linux"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
-      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
       "cpu": [
         "arm64"
       ],
@@ -8232,40 +7751,15 @@
       "os": [
         "linux"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
-      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
-      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
-      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
       "cpu": [
         "ppc64"
       ],
@@ -8274,54 +7768,15 @@
       "os": [
         "linux"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
-      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
-      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
-      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
-      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
       "cpu": [
         "s390x"
       ],
@@ -8330,12 +7785,15 @@
       "os": [
         "linux"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
-      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
       "cpu": [
         "x64"
       ],
@@ -8344,12 +7802,15 @@
       "os": [
         "linux"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
-      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
       "cpu": [
         "x64"
       ],
@@ -8358,26 +7819,15 @@
       "os": [
         "linux"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
-      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
-      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
       "cpu": [
         "arm64"
       ],
@@ -8386,12 +7836,15 @@
       "os": [
         "openharmony"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
-      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
       "cpu": [
         "arm64"
       ],
@@ -8400,26 +7853,15 @@
       "os": [
         "win32"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
-      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
-      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
       "cpu": [
         "x64"
       ],
@@ -8428,21 +7870,17 @@
       "os": [
         "win32"
       ],
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
-      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@safe-global/safe-contracts": {
       "version": "1.4.1",
@@ -13086,6 +12524,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ethereum-protocol": {
@@ -14816,7 +14255,7 @@
       "name": "era-contracts",
       "version": "0.1.0",
       "resolved": "git+ssh://git@github.com/matter-labs/era-contracts.git#446d391d34bdb48255d5f8fef8a8248925fc98b9",
-      "integrity": "sha512-KhgPVqd/MgV/ICUEsQf1uyL321GNPqsyHSAPMCaa9vW94fbuQK6RwMWoyQOPlZP17cQD8tzLNCSXqz73652kow==",
+      "integrity": "sha512-s3OBQ0FhslQjEMq2WGzT3+V67dKoTh0/QwHGJbGkS7uRFhINn6ywtPY1QtYVpSaH5gzIseRAJ73d6Gjkmsbt1Q==",
       "dev": true,
       "workspaces": {
         "packages": [
@@ -19962,47 +19401,6 @@
       },
       "engines": {
         "node": ">=0.12"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
-      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.2",
-        "@esbuild/android-arm": "0.28.2",
-        "@esbuild/android-arm64": "0.28.2",
-        "@esbuild/android-x64": "0.28.2",
-        "@esbuild/darwin-arm64": "0.28.2",
-        "@esbuild/darwin-x64": "0.28.2",
-        "@esbuild/freebsd-arm64": "0.28.2",
-        "@esbuild/freebsd-x64": "0.28.2",
-        "@esbuild/linux-arm": "0.28.2",
-        "@esbuild/linux-arm64": "0.28.2",
-        "@esbuild/linux-ia32": "0.28.2",
-        "@esbuild/linux-loong64": "0.28.2",
-        "@esbuild/linux-mips64el": "0.28.2",
-        "@esbuild/linux-ppc64": "0.28.2",
-        "@esbuild/linux-riscv64": "0.28.2",
-        "@esbuild/linux-s390x": "0.28.2",
-        "@esbuild/linux-x64": "0.28.2",
-        "@esbuild/netbsd-arm64": "0.28.2",
-        "@esbuild/netbsd-x64": "0.28.2",
-        "@esbuild/openbsd-arm64": "0.28.2",
-        "@esbuild/openbsd-x64": "0.28.2",
-        "@esbuild/openharmony-arm64": "0.28.2",
-        "@esbuild/sunos-x64": "0.28.2",
-        "@esbuild/win32-arm64": "0.28.2",
-        "@esbuild/win32-ia32": "0.28.2",
-        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/escalade": {
@@ -27434,6 +26832,275 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -32857,50 +32524,43 @@
         "rlp": "bin/rlp"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
-      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+    "node_modules/rolldown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.9"
+        "@oxc-project/types": "=0.143.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
-        "@rollup/rollup-android-arm-eabi": "4.62.4",
-        "@rollup/rollup-android-arm64": "4.62.4",
-        "@rollup/rollup-darwin-arm64": "4.62.4",
-        "@rollup/rollup-darwin-x64": "4.62.4",
-        "@rollup/rollup-freebsd-arm64": "4.62.4",
-        "@rollup/rollup-freebsd-x64": "4.62.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
-        "@rollup/rollup-linux-arm64-musl": "4.62.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
-        "@rollup/rollup-linux-loong64-musl": "4.62.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
-        "@rollup/rollup-linux-x64-gnu": "4.62.4",
-        "@rollup/rollup-linux-x64-musl": "4.62.4",
-        "@rollup/rollup-openbsd-x64": "4.62.4",
-        "@rollup/rollup-openharmony-arm64": "4.62.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
-        "@rollup/rollup-win32-x64-gnu": "4.62.4",
-        "@rollup/rollup-win32-x64-msvc": "4.62.4",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
@@ -37542,17 +37202,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -37568,9 +37227,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -37583,13 +37243,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -37611,23 +37274,6 @@
           "optional": true
         },
         "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
           "optional": true
         }
       }
@@ -40432,7 +40078,7 @@
       },
       "devDependencies": {
         "supertest": "^7.0.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=20"
@@ -40709,7 +40355,7 @@
       "name": "@fairwins/miniapp-build",
       "version": "1.0.0",
       "peerDependencies": {
-        "vite": "^7.2.4"
+        "vite": "^8.2.1"
       }
     }
   }

--- a/scripts/deps/check-dependency-hygiene.js
+++ b/scripts/deps/check-dependency-hygiene.js
@@ -288,7 +288,7 @@ for (const u of UNITS) {
 // tree entirely with that bump, so guarding the old name would pass vacuously.
 //
 // The recovery is always the same and is NOT `npm install` again:
-//     rm -rf node_modules package-lock.json && npm install
+//     npm run deps:reinstall
 const REQUIRED_OPTIONAL = ["@rolldown/binding-linux-x64-gnu"];
 const lockPath = path.join(ROOT, "package-lock.json");
 const missingOptional = [];
@@ -340,7 +340,7 @@ if (missingOptional.length) {
       "  fail with a missing-native-binding error (rolldown cannot load without its platform\n" +
       "  binding), including the mini-app release path whose bytes are committed on-chain.\n" +
       "  Recover with a FULL re-resolve:\n" +
-      "      rm -rf node_modules package-lock.json && npm install\n" +
+      "      npm run deps:reinstall\n" +
       "  Re-running `npm install` alone does NOT fix it.",
   );
 }

--- a/scripts/deps/check-dependency-hygiene.js
+++ b/scripts/deps/check-dependency-hygiene.js
@@ -282,9 +282,14 @@ for (const u of UNITS) {
 // keccak-committed on-chain. CI runs ubuntu-x64, so a lockfile missing the linux-x64 entry breaks
 // the build for everyone even though it may work on the machine that produced it.
 //
+// Vite 8 (spec 077) replaced rollup with rolldown, whose linux-x64 binding is the binary the
+// build actually needs now — and it is declared `optional` AND `peer`, the exact shape npm is
+// known to skip even when locked (see CLAUDE.md on `npm ci`). Rollup itself left the dependency
+// tree entirely with that bump, so guarding the old name would pass vacuously.
+//
 // The recovery is always the same and is NOT `npm install` again:
 //     rm -rf node_modules package-lock.json && npm install
-const REQUIRED_OPTIONAL = ["@rollup/rollup-linux-x64-gnu"];
+const REQUIRED_OPTIONAL = ["@rolldown/binding-linux-x64-gnu"];
 const lockPath = path.join(ROOT, "package-lock.json");
 const missingOptional = [];
 if (fs.existsSync(lockPath)) {
@@ -332,8 +337,9 @@ if (missingOptional.length) {
   for (const n of missingOptional) console.error(`  · ${n}`);
   console.error(
     "\n  This is npm/cli#4828 — an incremental `npm install` dropped them. Every Vite build will\n" +
-      "  fail with \"Cannot find module @rollup/rollup-linux-x64-gnu\", including the mini-app release\n" +
-      "  path whose bytes are committed on-chain. Recover with a FULL re-resolve:\n" +
+      "  fail with a missing-native-binding error (rolldown cannot load without its platform\n" +
+      "  binding), including the mini-app release path whose bytes are committed on-chain.\n" +
+      "  Recover with a FULL re-resolve:\n" +
       "      rm -rf node_modules package-lock.json && npm install\n" +
       "  Re-running `npm install` alone does NOT fix it.",
   );

--- a/services/relay-gateway/package.json
+++ b/services/relay-gateway/package.json
@@ -26,6 +26,6 @@
   },
   "devDependencies": {
     "supertest": "^7.0.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.10"
   }
 }

--- a/specs/075-monorepo-workspaces/baseline-miniapp-builds.json
+++ b/specs/075-monorepo-workspaces/baseline-miniapp-builds.json
@@ -1,8 +1,8 @@
 {
- "token-mint/entry.js": "08b770f429e1f1b7938e5deda8f69ecf4a8972b21b18a356acdbeb0d2fff5ec2",
- "token-mint/manifest.json": "e03c69fe08316a2ea17d87d0d8b2f3368a39156061d60ed171614528e88d7ee7",
- "token-mint/style.css": "6460e7686e9bd9047d8ce380cd2fafa0f79d95f63c41001b23ec2f7715afe94e",
- "clearpath/entry.js": "8acbfa764d41f16733f0e3cb4527413168c893edcccfe6bb7854c14e128b02e8",
- "clearpath/manifest.json": "ace18c71fecfcca57d7718e4b65d261b294d8eeb76fee7c1d7cf4aaaca986f19",
- "clearpath/style.css": "a202c3d608ae5859d9a0b63bdfa8907ff292ff46438ffce09025432804820da8"
+ "token-mint/entry.js": "7ac5984932237fae03e5e94b950a97fa07009ccf70c202aa186225d8e3a023bf",
+ "token-mint/manifest.json": "5137825f5ad31709106b30b38828e677340e1240480ca8d545342274b5aa8e8b",
+ "token-mint/style.css": "366ca9390251961a336704a2b44b5cac85cd93d75f7dc7c1f352680fc33e23a6",
+ "clearpath/entry.js": "ca28def625831c678721f7f43b94fb187e53b8350aa4bed4ec59abb91dfaa39f",
+ "clearpath/manifest.json": "86d9c4f649065b6cacc536f5bbc22a2bec1554c44bd70963e9e3bd223ebee39c",
+ "clearpath/style.css": "1498a81e32a134174eeb8effe70461ce0705e0c77131c6ebfa33f3199b0aaecc"
 }

--- a/specs/077-miniapp-store-redesign/checklists/requirements.md
+++ b/specs/077-miniapp-store-redesign/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Mini-App Store UX Redesign
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-013–FR-016 name concrete tooling (vite, the byte-gate scripts) by necessity: the byte
+  gate resolution is inherently about that toolchain, and the issue's scoping comment is the
+  source of record. This is accepted as scope-defining fact, not an implementation choice.
+- The concept art's "Profile" bottom-nav entry is deliberately adapted (see Assumptions) —
+  the host app already owns global navigation and profile; duplicating it would conflict
+  with spec 073/069 navigation rules.

--- a/specs/077-miniapp-store-redesign/contracts/store-ui.md
+++ b/specs/077-miniapp-store-redesign/contracts/store-ui.md
@@ -21,7 +21,7 @@
 - Stale snapshot / unreachable / not-deployed states keep their existing warning blocks and
   MUST NOT show the badge.
 
-## 3. Artwork map contract (`appArtwork.jsx`)
+## 3. Artwork map contract (`appArtwork.js`, components in `appArt.jsx`)
 
 - `artworkFor(slug) → { Art }` — total function: any input (including `null`) returns
   renderable art; unknown slugs get the generic fallback.

--- a/specs/077-miniapp-store-redesign/contracts/store-ui.md
+++ b/specs/077-miniapp-store-redesign/contracts/store-ui.md
@@ -1,0 +1,56 @@
+# UI Contracts: Mini-App Store (spec 077)
+
+## 1. Store sub-view contract (`?view=` on the Apps tab)
+
+- URL seam: `/wallet?tab=apps&view=<market|mine|search|submit>`; absent/unknown ⇒ market.
+- `submit` keeps its pre-existing exclusive rendering (SubmitAppPanel); the store bar links
+  Market / My Apps / Search; "Submit an app" remains a distinct developer entry.
+- The store bar: rendered whenever the catalog surface is shown; `<nav>` with an accessible
+  name, entries are links (keyboard operable), active entry carries `aria-current="page"`.
+- Every sub-view consumes the same fetched listing and the same honest-state branches;
+  sub-views MUST NOT fetch independently or re-derive `launchable`/`verified`.
+- My Apps = favorites ∩ listing; empty ⇒ honest empty state, never the market grid.
+- Search view = market view with search emphasized (autofocused input, filters available);
+  same result-count live region.
+
+## 2. Trust banner contract
+
+- Renders ONLY when the current listing is verified (`REGISTRY_STATUS.OK` path).
+- Content: stylized verified badge + claim copy (restructured spec-073 facts: on-chain
+  review/approval; host re-reads the record and hash-checks the package before code runs).
+- Stale snapshot / unreachable / not-deployed states keep their existing warning blocks and
+  MUST NOT show the badge.
+
+## 3. Artwork map contract (`appArtwork.jsx`)
+
+- `artworkFor(slug) → { Art }` — total function: any input (including `null`) returns
+  renderable art; unknown slugs get the generic fallback.
+- Art is decorative: `aria-hidden="true"`, no title; the card's text carries the name.
+- Inline SVG only, themed via `currentColor`/CSS variables; no external fetches, no new CSP
+  grants, nothing sourced from packages or the chain.
+- Initial entries: `token-mint`, `clearpath`, plus the generic fallback.
+
+## 4. App card contract (redesigned)
+
+Preserved from spec 073 (restyle, not re-decide):
+
+- Launch link only when `launchable && slug`; refusal notes keep their two distinct reasons.
+- Vendor shortened with full address as tooltip/copy target; version shown as `v{approved.version}`.
+- Favorite star only when launchable with a working slug; `aria-pressed` semantics kept.
+- New: artwork panel, contained vendor/version data box, rocket glyph inside the Launch link
+  (decorative — accessible name stays "Launch {name}").
+
+## 5. Byte-gate resolution contract
+
+- Stamped compare flow (the false-pass guard is load-bearing):
+  `STAMP=$(($(date +%s) * 1000))` → `npm run build:miniapps` →
+  `node scripts/miniapps/record-build-digests.js --compare specs/075-monorepo-workspaces/baseline-miniapp-builds.json --since "$STAMP"`
+  MUST fail against the old baseline (detected move), then `--out` re-records.
+- `npm run check:deps` green after `npm run deps:reinstall` (never incremental
+  `npm install`), including the optional-binary guard updated for the rolldown toolchain if
+  rollup leaves the lockfile.
+- `scripts/release/check-miniapp-versions.js --base <main> --head HEAD` green: baseline
+  moved ⇔ both mini-app versions moved.
+- Runbook documents: rebuild → publish to IPFS (new CIDs) → `submitApp`/`proposeUpdate` →
+  `approveApp(id, expectedManifestHash)` per cohort, and that the chain serves old bytes
+  until then.

--- a/specs/077-miniapp-store-redesign/data-model.md
+++ b/specs/077-miniapp-store-redesign/data-model.md
@@ -1,0 +1,77 @@
+# Data Model: Mini-App Store UX Redesign (spec 077)
+
+No new persisted data, no on-chain changes, no schema changes. The model below is
+presentation state plus the release artifacts the byte-gate resolution touches.
+
+## Presentation entities (host frontend, in-memory)
+
+### StoreView
+
+The Apps section's sub-view, carried on the existing `?view=` query parameter.
+
+| Value | Meaning | Source of truth |
+|---|---|---|
+| *(absent)* / `market` | Full grouped catalog (default) | `useSearchParams` |
+| `mine` | Favorited apps only ("My Apps") | `useSearchParams` |
+| `search` | Search-focused catalog view | `useSearchParams` |
+| `submit` | Developer submission surface (pre-existing) | `useSearchParams` |
+
+Rules: unknown values fall back to market; `submit` keeps its existing exclusive rendering;
+the store bar marks the active view with `aria-current`. All views read the SAME
+`listing` object — sub-views never re-fetch or re-derive trust state.
+
+### CuratedArtwork
+
+Host-side map entry, keyed by app slug (the registry client's `appSlug(name)`).
+
+| Field | Type | Notes |
+|---|---|---|
+| slug (key) | string | e.g. `token-mint`, `clearpath` |
+| art | inline SVG component | theme-aware (currentColor / CSS vars), `aria-hidden` |
+
+Fallback: a single generic app illustration for any slug not in the map (including
+null slugs). The map is never consulted for trust decisions.
+
+### Listing (pre-existing, read-only)
+
+`fetchCatalog` outcome → `{ apps, verified, fetchedAt, ageMs }` as today. The redesign adds
+no fields. `verified === true` is the ONLY condition under which the trust banner renders.
+
+### FavoriteApp (pre-existing)
+
+`lib/miniapps/favorites` entries `{ id, slug, name }` — the "My Apps" membership set.
+Unchanged; the view is a filter of `listing.apps` by favorited id.
+
+## Release artifacts (byte-gate resolution)
+
+### Mini-app output baseline
+
+`specs/075-monorepo-workspaces/baseline-miniapp-builds.json` — sha256 per
+`{app}/{entry.js,manifest.json,style.css}`. Re-recorded once, in the same change as the
+toolchain bump. The gate compare must FAIL against the old baseline before re-record
+(proof the move was detected, never silent).
+
+### Package version ↔ bytes pairing
+
+| Package | Version before | Version after | Why |
+|---|---|---|---|
+| `@fairwins/miniapp-token-mint` | 1.0.0 | 1.0.1 | toolchain-only byte move (patch) |
+| `@fairwins/miniapp-clearpath` | 1.0.0 | 1.0.1 | toolchain-only byte move (patch) |
+
+`manifest.version` is read from each package.json at build time, so the version bump is
+itself part of the recorded byte move. Enforced by
+`scripts/release/check-miniapp-versions.js` (spec 076 FR-007b, both directions).
+
+### Toolchain alignment (FR-015 skew gate: one range everywhere)
+
+| Package | Manifests declaring it | Range after |
+|---|---|---|
+| `vite` | frontend, token-mint, clearpath, miniapp-build (peer) | `^8.2.1` |
+| `@vitejs/plugin-react` | frontend, token-mint, clearpath | `^5.2.0` |
+| `vitest` / `@vitest/coverage-v8` / `@vitest/ui` | frontend (+ vitest in both mini-apps) | `^4.1.10` |
+
+### On-chain records (NOT changed by this feature)
+
+`MiniAppRegistry` entries still commit to the previous published bytes until curators run
+the re-publish (IPFS) + `approveApp(id, expectedManifestHash)` flow per the updated runbook.
+The repo is explicit about that lag; nothing renders the new bytes as live.

--- a/specs/077-miniapp-store-redesign/plan.md
+++ b/specs/077-miniapp-store-redesign/plan.md
@@ -1,0 +1,159 @@
+# Implementation Plan: Mini-App Store UX Redesign
+
+**Branch**: `claude/mini-app-redesign-k7f1lu` | **Date**: 2026-08-09 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/077-miniapp-store-redesign/spec.md`
+
+## Summary
+
+Two independent deliverables that share a release (issue #1024 + its byte-gate scoping
+comment):
+
+1. **Host-only store redesign** — `frontend/src/components/miniapps/` gets the "fun modern
+   mini app store" treatment: curated inline-SVG artwork per app (slug-keyed, generic
+   fallback), a verified-market trust banner shown only on verified listings, restructured
+   security copy as prioritized blocks, styled category group headers, a contained
+   vendor/version data box, a rocket-icon Launch CTA, restyled search/filter/refresh
+   controls, and an in-section Market / My Apps / Search store bar on the existing `?view=`
+   seam. No mini-app package byte moves; trust semantics (`launchable`, four honest states)
+   unchanged.
+2. **Byte-gate resolution** — absorb the deferred vite 7→8 toolchain move (closed Dependabot
+   #1061 item) deliberately: align `vite ^8.2.1` + `@vitejs/plugin-react ^5.2.0` +
+   `vitest`-family `^4.1.10` across every declaring manifest (FR-015 skew gate forbids a
+   partial bump), reinstall via `deps:reinstall`, rebuild packages with the stamped byte-gate
+   flow, re-record `baseline-miniapp-builds.json`, patch-bump both mini-app package versions
+   (FR-007b pairing gate), update the npm/cli#4828 optional-binary guard for the
+   rolldown-based toolchain if rollup leaves the lockfile, and extend the runbook with the
+   re-publish/re-approve procedure the moved bytes require.
+
+## Technical Context
+
+**Language/Version**: JavaScript (React 19, Node 22); no Solidity changes
+
+**Primary Dependencies**: React 19 + Vite (host build), `vite`/`@vitejs/plugin-react`/
+`vitest` (bumped: ^8.2.1 / ^5.2.0 / ^4.1.10), `@fairwins/miniapp-build` preset,
+react-router-dom (query-param sub-views)
+
+**Storage**: none new — favorites via existing `lib/miniapps/favorites`; no on-chain or
+schema changes
+
+**Testing**: Vitest (scoped runs locally, full suite in CI), axe accessibility checks,
+byte gate (`scripts/miniapps/record-build-digests.js`), `check:deps`,
+`scripts/release/check-miniapp-versions.js`
+
+**Target Platform**: Web (mobile-first store surface), light/dark + tenant themes
+
+**Project Type**: Web frontend (workspace monorepo)
+
+**Performance Goals**: no regression — artwork is inline SVG (no network fetches), sub-view
+switching is client-side state
+
+**Constraints**: zero package-byte moves from the redesign itself; all byte moves come from
+the deliberate toolchain bump and are recorded + version-paired in the same change; registry
+trust semantics untouched (spec 073 rules 1–5)
+
+**Scale/Scope**: 1 CSS file + 1 component file redesigned, ~2 new host modules
+(artwork, store bar), 2 live apps' artwork + 1 fallback; 4 manifests + lockfile for the bump;
+2 mini-app version bumps; baseline + runbook/docs updates
+
+## Constitution Check
+
+*GATE: evaluated against `.specify/memory/constitution.md` v1.0.0 — PASS (re-checked after
+Phase 1 design, still PASS).*
+
+- **I. Security-first contracts** — no `contracts/` changes. The registry's trust surface is
+  deliberately untouched: `launchable` stays the serving decision (spec 073 rule 1), no new
+  host-object keys, no manifest schema changes. PASS.
+- **II. Test-first / coverage** — behavior changes land with Vitest coverage: store bar
+  sub-views, artwork fallback, badge-only-when-verified, preserved honest states; existing
+  CatalogPanel suites updated in the same change. Byte-gate + version-pairing checks are
+  themselves the tests for the toolchain bump. PASS.
+- **III. Honest state** — the verified badge renders only on verified listings (R5); stale/
+  unreachable/not-deployed/empty renderings keep their distinct meanings; artwork fallback is
+  a deliberate generic, never a fabricated identity; runbook states plainly that on-chain
+  records commit to the OLD bytes until re-publish/re-approve. PASS.
+- **IV. Fail loudly in CI** — no `continue-on-error`; the work *strengthens* gates if needed
+  (optional-binary guard updated for rolldown rather than deleted). The byte gate firing is
+  treated as the deliverable, per the issue's scoping comment. PASS.
+- **V. Accessible, consistent frontend** — WCAG 2.1 AA: decorative SVGs `aria-hidden`,
+  labelled controls, `aria-current` store bar, colour-independent state blocks, existing live
+  regions preserved; theme via CSS variables only (no tenant identity hardcoding, spec 072).
+  PASS.
+- **Workflow** — Spec → Plan → Tasks → Implement followed; no deviations to log in
+  Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/077-miniapp-store-redesign/
+├── spec.md
+├── plan.md              # this file
+├── research.md          # R1–R6 decisions
+├── data-model.md        # presentation-state + artwork-map + gate-artifact model
+├── quickstart.md        # validation walkthrough
+├── contracts/
+│   └── store-ui.md      # store sub-view + artwork-map contracts
+├── checklists/requirements.md
+└── tasks.md             # /speckit-tasks output (not created by plan)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/components/miniapps/
+├── CatalogPanel.jsx        # redesigned: store bar, badge, grouped market, My Apps, Search
+├── appArtwork.jsx          # NEW: slug-keyed inline-SVG artwork map + generic fallback
+├── StoreBar.jsx            # NEW: Market / My Apps / Search in-section navigation
+├── MiniAppWorkspace.jsx    # unchanged (launch path)
+├── SubmitAppPanel.jsx      # unchanged (reached via existing view=submit)
+└── miniapps.css            # extended: store-* styles, badge, cards, data box, store bar
+
+frontend/src/test/miniapps/ # updated + new Vitest suites for the surface
+
+# Byte-gate resolution
+frontend/package.json                    # vite ^8.2.1, plugin-react ^5.2.0, vitest family ^4.1.10
+frontend/miniapps/token-mint/package.json    # same bumps + version 1.0.0 → 1.0.1
+frontend/miniapps/clearpath/package.json     # same bumps + version 1.0.0 → 1.0.1
+tools/miniapp-build/package.json         # peerDependencies.vite → ^8.2.1
+package-lock.json                        # full re-resolve (deps:reinstall)
+scripts/deps/check-dependency-hygiene.js # REQUIRED_OPTIONAL updated for rolldown binary (if needed)
+specs/075-monorepo-workspaces/baseline-miniapp-builds.json  # re-recorded
+docs/runbooks/miniapp-registry-operations.md  # re-publish/re-approve after toolchain byte move
+docs/developer-guide/miniapps.md         # artwork-map + store-surface notes
+```
+
+**Structure Decision**: All redesign work stays in the host component tree
+(`frontend/src/components/miniapps/`) — nothing under `frontend/miniapps/*` or
+`tools/miniapp-build/` changes source; only their manifests move for the dependency
+alignment, and their `dist` byte change is the recorded, version-paired toolchain move.
+
+## Implementation strategy (ordering rationale)
+
+1. **Toolchain bump first, in isolation** — one commit for manifests + lockfile + baseline +
+   versions + guard updates. Keeping it separate from the redesign makes the byte-gate diff
+   reviewable on its own and proves the redesign commits move no package bytes.
+2. **Redesign second** — artwork module, store bar, CatalogPanel/CSS overhaul, tests.
+3. **Docs last** — runbook re-publish/re-approve procedure, developer-guide updates.
+
+Verification at each stage per the `monorepo-verify` skill: `check:deps`, stamped byte-gate
+compare, scoped Vitest runs locally (full suite only in CI — local full runs OOM), frontend
+build, lint.
+
+## Risks
+
+- **Vite 8 is rolldown-based**: the host build and custom `frontend/vite-plugins/*` must be
+  validated under the new bundler; if a plugin or config option is incompatible, fixing it is
+  in scope (it's the cost of the absorbed bump). Mini-app dist bytes will move heavily —
+  expected and recorded.
+- **npm/cli#4828 guard**: rollup's binary may leave the lockfile with rollup itself; the
+  guard must follow the toolchain (add rolldown's linux-x64-gnu binding) rather than pass
+  vacuously or fail spuriously.
+- **On-chain records lag by design**: until curators re-publish + re-approve, the chain
+  serves the previous approved packages — the runbook update makes that explicit, and the
+  repo's release record stays true because versions and bytes move together.
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/077-miniapp-store-redesign/plan.md
+++ b/specs/077-miniapp-store-redesign/plan.md
@@ -104,7 +104,8 @@ specs/077-miniapp-store-redesign/
 ```text
 frontend/src/components/miniapps/
 ├── CatalogPanel.jsx        # redesigned: store bar, badge, grouped market, My Apps, Search
-├── appArtwork.jsx          # NEW: slug-keyed inline-SVG artwork map + generic fallback
+├── appArt.jsx              # NEW: inline-SVG illustration components (curated + generic)
+├── appArtwork.js           # NEW: slug-keyed artwork map + artworkFor resolver
 ├── StoreBar.jsx            # NEW: Market / My Apps / Search in-section navigation
 ├── MiniAppWorkspace.jsx    # unchanged (launch path)
 ├── SubmitAppPanel.jsx      # unchanged (reached via existing view=submit)

--- a/specs/077-miniapp-store-redesign/quickstart.md
+++ b/specs/077-miniapp-store-redesign/quickstart.md
@@ -1,0 +1,49 @@
+# Quickstart: validating the Mini-App Store redesign (spec 077)
+
+## Prerequisites
+
+- Workspace installed via `npm run deps:reinstall` (this feature changes dependencies —
+  never recover with incremental `npm install`).
+
+## 1. Byte-gate resolution (toolchain bump)
+
+```bash
+npm run check:deps                       # FR-015 alignment + optional-binary guard green
+
+STAMP=$(($(date +%s) * 1000))
+npm run build:miniapps                   # both packages build under vite 8
+node scripts/miniapps/record-build-digests.js \
+  --compare specs/075-monorepo-workspaces/baseline-miniapp-builds.json --since "$STAMP"
+# Expected AFTER the re-record lands: OK (bytes match the new baseline).
+# In review, the change itself must show baseline digests moved + both versions bumped.
+
+node scripts/release/check-miniapp-versions.js --base origin/main --head HEAD
+# Expected: "mini-app version/bytes pairing OK"
+```
+
+## 2. Redesigned store surface
+
+```bash
+npx vitest run src/test/miniapps --root frontend   # scoped suites (full suite in CI only)
+npm run frontend                                    # dev server
+```
+
+Manual walkthrough (Apps tab, small viewport for the store bar ergonomics):
+
+1. **Market**: verified banner + badge visible; apps grouped under styled category headers;
+   each card shows artwork (Token Mint and ClearPath specific; anything else generic),
+   contained Vendor/Version box, rocket Launch CTA.
+2. **My Apps**: shows only favorited apps; unfavorite everything ⇒ honest empty state.
+3. **Search**: search box focused, filters usable, live result count announced.
+4. **Honest states** (simulate registry failure / empty registry): stale snapshot shows the
+   unverified warning WITHOUT the badge and with no Launch affordances; not-deployed and
+   verified-empty keep distinct copy.
+5. **Themes**: light + dark render correctly; no hardcoded tenant identity.
+6. **Accessibility**: keyboard-only pass over store bar/filters/cards; axe checks green.
+
+## 3. Docs
+
+- `docs/runbooks/miniapp-registry-operations.md` gains the "re-publish + re-approve after a
+  toolchain byte move" procedure; it states the chain serves the previously approved bytes
+  until curators complete it.
+- `docs/developer-guide/miniapps.md` notes the host-side artwork map and store sub-views.

--- a/specs/077-miniapp-store-redesign/research.md
+++ b/specs/077-miniapp-store-redesign/research.md
@@ -1,0 +1,121 @@
+# Research: Mini-App Store UX Redesign (spec 077)
+
+## R1 — Where per-app artwork can live without moving committed bytes
+
+**Decision**: Curated artwork is a host-side module — inline SVG illustrations keyed by app
+slug (`frontend/src/components/miniapps/appArtwork.jsx`), with a generic fallback entry.
+
+**Rationale**: Nothing in the registry record, manifest schema, or host object carries an icon
+today (`grep icon frontend/src/lib/miniapps` → nothing). Adding one on-chain or in package
+manifests would (a) change the manifest schema every published package commits to, (b) move
+package bytes, and (c) hand vendors a self-served image channel into the catalog — a new
+review surface. Host-curated art is a pure presentation concern, ships with the host, and an
+unknown slug degrades honestly to the generic illustration (never a fabricated identity).
+Inline SVG (not image files) keeps the art theme-aware via CSS variables and avoids new asset
+pipeline/CSP considerations.
+
+**Alternatives considered**: on-chain icon URL field (schema + trust surface change, rejected);
+IPFS icon in package (byte moves + vendor-controlled imagery, rejected); generated blockies
+from vendor address (no functional identity value, fails the issue's "visually represents its
+core function" requirement — kept only as inspiration for the generic fallback).
+
+## R2 — In-section navigation vs. the host's global navigation
+
+**Decision**: The store navigation (Market / My Apps / Search) is presentation state inside
+`CatalogPanel`, carried on the existing query-string seam (`?view=`, already used by
+`view=submit`), rendered as a persistent store-bar (bottom-anchored on small viewports, inline
+tab-style on wide viewports).
+
+**Rationale**: Spec 069 fixed navigation ownership: `NAV_GROUPS` and the account button own
+global navigation, and the Apps section is one tab of the wallet app. The concept art's
+bottom nav (Market, My Apps, Search, Profile) is an app-store-native idiom; mapping it to a
+second global nav would conflict with the host's. Using `?view=` matches the existing
+`view=submit` mechanism, keeps browser Back semantics, stays bookmarkable, and requires no
+route changes. "Profile" is deliberately satisfied by the host's existing account controls
+(documented in spec Assumptions).
+
+**Alternatives considered**: new routes `/apps/market|mine|search` (route churn, breaks the
+tab seam, rejected); React state only (not bookmarkable, Back broken, rejected); global
+bottom nav (conflicts with spec 069/073 nav ownership, rejected).
+
+## R3 — "My Apps" definition
+
+**Decision**: My Apps = the member's favorited (Quick Access) apps, from the existing
+`lib/miniapps/favorites` store, rendered with the same `AppCard` and identical launch rules.
+
+**Rationale**: Favorites are the platform's only per-member app relationship; there is no
+install concept. The favorites store already has subscribe semantics used by the nav drawer,
+so the view is a pure filter over the verified listing — launch rules and honest states are
+inherited rather than reimplemented.
+
+## R4 — The byte gate: what binds, and the vite 8 reality
+
+**Decision**: Absorb the deferred vite major (closed Dependabot #1061 item) as vite
+`^7.2.4 → ^8.2.1` across ALL manifests that declare it, with the companion bumps the peer
+graph requires. Rebuild packages, let the gate detect the move, re-record the baseline, bump
+both mini-app package versions (patch), and document the re-publish/re-approve steps.
+
+**Facts established** (from npm registry + repo gates):
+
+- `vite@latest = 8.2.1`; vite 8 is **rolldown-based** (`dependencies: rolldown ~1.2.1`, no
+  rollup) — mini-app output bytes will change substantially, which is exactly the absorbed
+  move. Node engine `^20.19.0 || >=22.12.0` — satisfied (repo runs Node 22).
+- `@vitejs/plugin-react@5.2.0` adds `^8.0.0` to its vite peer range (5.1.x tops out at ^7);
+  plugin-react 6.x requires rolldown-plugin-babel and a config shift — **stay on ^5.2.0**.
+- `vitest@4.0.18` depends on `vite ^6 || ^7` — incompatible with vite 8. `vitest@4.1.10`
+  accepts `^8`. So the vitest family (`vitest`, `@vitest/coverage-v8`, `@vitest/ui`) must move
+  to `^4.1.10` wherever declared (frontend + both mini-app packages).
+- **FR-015 version-skew gate** (`check:deps`): disagreeing ranges across manifests FAIL CI.
+  A mini-app-path-only vite bump (miniapps ^8, frontend ^7) is therefore not landable — the
+  bump must align `frontend/package.json`, both `frontend/miniapps/*/package.json`, and
+  `tools/miniapp-build` `peerDependencies` in one change.
+- `check:deps` also asserts `@rollup/rollup-linux-x64-gnu` exists in the lockfile
+  (npm/cli#4828 guard). With vite 8 dropping rollup, that entry may leave the tree; the guard
+  must then be updated to the binary the build actually needs
+  (`@rolldown/binding-linux-x64-gnu` for rolldown) — same defect class, new binary. Verify
+  against the post-reinstall lockfile rather than assuming.
+- Install discipline: dependency changes recover ONLY via `npm run deps:reinstall`, then
+  `npm run check:deps` (monorepo-workspace skill, spec 075 rule 1).
+- Byte gate flow (issue #1024 scoping comment + `record-build-digests.js`): stamp before
+  building (`--since`), `npm run build:miniapps`, compare against
+  `specs/075-monorepo-workspaces/baseline-miniapp-builds.json`, expect a REPORTED diff, then
+  re-record with `--out`. Turbo's `@fairwins/miniapp-build#build` inputs hash the preset files
+  and `package-lock.json` is a global dependency, so the toolchain bump busts the cache by
+  construction (#1046 fix).
+- Version pairing (`scripts/release/check-miniapp-versions.js`, spec 076 FR-007b): baseline
+  digests moved ⇒ each affected package's `package.json` version MUST move in the same change
+  (both directions checked). Toolchain-only rebuild = **patch** bump: `1.0.0 → 1.0.1` for
+  `@fairwins/miniapp-token-mint` and `@fairwins/miniapp-clearpath`. The version feeds
+  `manifest.version` via each package's `vite.config.js` (read from its own package.json), so
+  the bump itself is part of the byte move — consistent by construction.
+
+**What is NOT in scope**: the other 17 bumps from the closed #1061 sweep (chai, typescript,
+eslint majors, etc.) — they do not feed the mini-app build path and stay ordinary dependency
+work; and the on-chain re-publish/re-approve itself, which is a curator operation this change
+documents but cannot execute (Polygon registry currently lists 0 apps; Mordor lists 3 — the
+live re-approvals happen on Mordor first, per the runbook).
+
+## R5 — Trust badge honesty
+
+**Decision**: The "on-chain verified" banner renders only on a verified listing
+(`listing.verified === true`); the stale-snapshot and unreachable states keep their warning
+treatments and never inherit the badge.
+
+**Rationale**: Constitution III (honest state). The badge is a factual claim — "this list is
+what the chain says, and packages are hash-checked before code runs". On a stale snapshot that
+claim is false. The existing four-state rendering (loading / not-deployed / unreachable /
+verified) is preserved; the redesign restyles, it does not re-decide.
+
+## R6 — Theming and accessibility approach
+
+**Decision**: All new styles extend `frontend/src/components/miniapps/miniapps.css` using the
+established pattern — `var(--token, literal-fallback)` theme variables, everything scoped
+under `.miniapp-catalog` / new `.miniapp-store-*` classes; artwork SVGs use `currentColor` and
+CSS variables so light/dark/tenant themes apply; decorative art gets `aria-hidden`, meaningful
+icons get labels. Category headers, badge, and state blocks stay distinguishable without
+colour alone (WCAG 1.4.1), matching the file's existing discipline. The store bar is keyboard
+operable (real links/buttons), with `aria-current` on the active sub-view.
+
+**Rationale**: Constitution V (WCAG 2.1 AA, axe audits in CI), spec 072 (no hardcoded tenant
+identity — the badge/title come from copy, not tenant brand assets), and the existing CSS
+file's scoping rules.

--- a/specs/077-miniapp-store-redesign/research.md
+++ b/specs/077-miniapp-store-redesign/research.md
@@ -3,7 +3,7 @@
 ## R1 — Where per-app artwork can live without moving committed bytes
 
 **Decision**: Curated artwork is a host-side module — inline SVG illustrations keyed by app
-slug (`frontend/src/components/miniapps/appArtwork.jsx`), with a generic fallback entry.
+slug (`frontend/src/components/miniapps/appArtwork.js`, components in `appArt.jsx`), with a generic fallback entry.
 
 **Rationale**: Nothing in the registry record, manifest schema, or host object carries an icon
 today (`grep icon frontend/src/lib/miniapps` → nothing). Adding one on-chain or in package

--- a/specs/077-miniapp-store-redesign/spec.md
+++ b/specs/077-miniapp-store-redesign/spec.md
@@ -1,0 +1,259 @@
+# Feature Specification: Mini-App Store UX Redesign
+
+**Feature Branch**: `077-miniapp-store-redesign`
+
+**Created**: 2026-08-09
+
+**Status**: Draft
+
+**Input**: User description: "Mini-app store UX redesign (issue #1024): a complete visual and
+structural overhaul of the Apps catalog surface to a fun, modern, high-trust mini app store
+aesthetic. Per-app illustrative icons, prominent on-chain-verified trust badge, distinct category
+headers, stylized search/filter/refresh controls, vendor+version technical data in a contained box,
+Launch call-to-action with rocket icon, bottom navigation (Market, My Apps, Search, Profile), and
+restructured security explanation into prioritized readable blocks. Scope also includes resolving
+the mini-app output byte gate items raised on the issue: absorbing the vite 7→8 build-preset bump
+(from closed Dependabot PR #1061) with the required package version bumps, baseline re-record, and
+re-publish/re-approve release steps."
+
+## Context
+
+The current Apps catalog (spec 073) is functionally honest but visually sterile: uniform
+text-heavy cards, dense security prose, and minimal navigation. Issue #1024 reports low trust
+(members can't quickly see that apps are verified), poor scannability (no visual identity per
+app), information overload (the security explanation is one dense block), and limited
+interaction (excessive scrolling, no quick section switching). Concept art supplied with the
+issue shows the target aesthetic: a "fun modern mini app store" with a rainbow verified badge,
+per-app illustrated icons, category banner headers, a clover-motif search bar, a boxed
+vendor/version data strip, a rocket-icon Launch button, and a bottom navigation bar.
+
+A scoping comment on the issue also defines when the mini-app **output byte gate** binds this
+work: the store surface is host code and moves no committed package bytes, but the closed
+Dependabot PR #1061 (vite 7→8, feeding the mini-app build preset) was deliberately deferred to
+this effort so the byte change is absorbed in a release that knowingly re-records the baseline
+and plans the re-publish/re-approve of the affected packages.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Trustworthy, scannable app market (Priority: P1)
+
+As a store member browsing the Apps section, I want each app presented as a visually distinct,
+verified-looking card — unique illustrative icon, clear name, category grouping, contained
+technical data (vendor, version), and an inviting Launch action — under a prominent
+"on-chain verified" trust banner, so I can find and trust the right app at a glance instead of
+reading dense text.
+
+**Why this priority**: This is the core of issue #1024 — trust and scannability failures are
+the reported pain points, and every other story builds on the redesigned card/market layout.
+
+**Independent Test**: Load the Apps catalog against a reachable registry holding approved apps
+and verify each card shows an app-specific illustration (or an honest generic fallback), the
+verified-market banner is present, apps group under styled category headers, vendor/version sit
+in a contained data box, and Launch carries the rocket icon.
+
+**Acceptance Scenarios**:
+
+1. **Given** a list of approved apps, **When** a member views an app listing, **Then** it
+   displays a unique illustrative icon that visually represents its core function, and an app
+   with no curated artwork shows a deliberate generic app illustration (never a broken image).
+2. **Given** a verified catalog read, **When** a member views the store header, **Then** a
+   prominent stylized "on-chain verified" badge/banner is visible with a one-line trust summary.
+3. **Given** a set of apps, **When** a member views the store, **Then** apps are grouped under
+   clear, visually distinct category headers (e.g. "Asset Servicing").
+4. **Given** an app card, **When** a member reads it, **Then** vendor and version are visually
+   separated in a contained, styled data box distinct from the description text.
+5. **Given** an app card for a launchable app, **When** the member looks for the call to action,
+   **Then** the Launch button includes a rocket icon and remains a clearly labelled action.
+6. **Given** the security explanation, **When** a member reads the store intro, **Then** the
+   verification story is split into short, prioritized blocks with supporting iconography rather
+   than one dense paragraph.
+
+---
+
+### User Story 2 - Quick section navigation (Priority: P2)
+
+As a store member, I want a persistent store navigation (Market, My Apps, Search) inside the
+Apps section, so I can jump between browsing the catalog, my favorited/quick-access apps, and
+searching without scrolling or leaving the section.
+
+**Why this priority**: Navigation friction is a reported pain point but the store remains
+usable without it; it layers on top of the P1 market view.
+
+**Independent Test**: From the Apps catalog, switch to "My Apps" and see only favorited apps;
+switch to "Search" and get a focused search experience; switch back to "Market" and see the
+full grouped catalog. State (favorites, filters) survives switching.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Apps section on a small viewport, **When** a member views the store, **Then**
+   a persistent store navigation bar is available with Market, My Apps, and Search entries,
+   without duplicating or breaking the host app's own global navigation.
+2. **Given** favorited apps, **When** the member opens My Apps, **Then** only their favorited
+   apps are listed, with the same card treatment and launch rules as the market view, and an
+   honest empty state when nothing is favorited.
+3. **Given** the Search entry, **When** selected, **Then** the member lands in a search-focused
+   view of the catalog with the existing category filters available.
+4. **Given** any store sub-view, **When** the registry is unreachable or absent, **Then** the
+   existing honest-state disclosures (unverified snapshot, refusal to launch, deployment gap)
+   are preserved unchanged in meaning.
+
+---
+
+### User Story 3 - Byte-gate resolution: absorb the vite build-preset bump (Priority: P2)
+
+As a maintainer, I want the deferred vite 7→8 mini-app build toolchain bump absorbed by this
+redesign release — with the mini-app output byte change acknowledged deliberately (package
+version bumps, baseline re-record, and documented re-publish/re-approve steps) — so the byte
+gate stops binding future unrelated work and the on-chain release record stays true.
+
+**Why this priority**: This is the "byte code issue raised" on #1024. It is independent of the
+visual redesign (host code moves no package bytes) but was explicitly scoped to this effort so
+the byte change ships inside a knowing release rather than surprising a dependency sweep.
+
+**Independent Test**: Build the mini-app packages with the bumped toolchain, run the byte-gate
+compare, and verify (a) the gate detects the byte change against the old baseline, (b) the
+re-recorded baseline matches the new builds reproducibly, (c) each changed package's version is
+bumped in the same change, and (d) the release/runbook documents the required re-publish to
+IPFS and on-chain re-approval before the new bytes are treated as live.
+
+**Acceptance Scenarios**:
+
+1. **Given** the mini-app build preset on vite 8, **When** packages are rebuilt, **Then** the
+   byte-gate compare against the previous baseline reports the moved bytes (never a silent or
+   false pass), and the new baseline is recorded in the same change.
+2. **Given** moved package bytes, **When** the change lands, **Then** each affected package's
+   independent version is bumped by hand in the same change (per the release-versioning rules),
+   and the change documents that the on-chain records still commit to the previous bytes until
+   re-publish and re-approve happen.
+3. **Given** the host frontend build, **When** the toolchain bump lands, **Then** the frontend
+   and mini-app builds and their test suites still pass.
+
+---
+
+### Edge Cases
+
+- Registry unreachable with a stale snapshot: the redesigned cards must keep the "reference
+  only, nothing launchable" treatment — no launch affordance, no verified badge on the stale list.
+- Registry answered but empty, or not deployed on this build: the redesigned surface keeps the
+  existing distinct honest states (empty ≠ unreachable ≠ not deployed).
+- An app whose registered name yields no usable slug: card renders with icon and refusal note,
+  never a dead Launch link; the fallback illustration applies.
+- A future approved app the host has no curated artwork for: generic illustration, not a broken
+  or missing image, and never a fabricated category illustration implying curation.
+- Unknown category ordinal ahead of the build's label map: still gets a styled group header
+  under its raw ordinal label.
+- Theme: all new visuals must render correctly in both light and dark themes and for tenant
+  theme classes (no hardcoded tenant identity in the store surface).
+- Byte gate: a failed mini-app build must never let the compare report "bytes unchanged"
+  (the `--since` stamp discipline is preserved).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Each app card MUST display an illustrative icon unique to that app, resolved
+  host-side by the app's identity (slug), with a deliberate generic illustration for apps
+  without curated artwork. Artwork MUST NOT be sourced from or added to mini-app packages
+  (no package byte moves for the redesign).
+- **FR-002**: The store header MUST present a prominent, stylized "on-chain verified" trust
+  badge and title, shown only when the listing is actually verified (never on a stale
+  snapshot or unreachable state).
+- **FR-003**: The security/verification explanation MUST be restructured into short,
+  prioritized blocks with supporting iconography, preserving the existing factual claims
+  (host re-reads the registry record, package checked against on-chain hash before code runs).
+- **FR-004**: Apps MUST be grouped under visually distinct category headers, preserving the
+  existing on-chain enum ordering and the unknown-ordinal fallback grouping.
+- **FR-005**: Each app card MUST present vendor (shortened, full value preserved as
+  tooltip/copy target) and version in a visually contained technical-data box, separate from
+  the description.
+- **FR-006**: The Launch call-to-action MUST carry a rocket icon while remaining an
+  accessible, clearly labelled link; the existing launch-withholding rules (unverified
+  listing, unusable slug) and their explanations are preserved.
+- **FR-007**: The store MUST provide a persistent in-section navigation with at least Market
+  (full catalog), My Apps (favorited apps), and Search entries; it MUST NOT replace, duplicate,
+  or conflict with the host application's global navigation, and MUST respect small-viewport
+  ergonomics (thumb-reachable on mobile).
+- **FR-008**: The My Apps view MUST list the member's favorited apps with identical launch
+  rules and card treatment, and an honest empty state.
+- **FR-009**: Search, category filter, and refresh controls MUST be restyled to the new
+  aesthetic while preserving existing behavior: keyboard operability, aria states, the polite
+  result-count live region, filter-count disclosure, and non-focus-stealing refresh.
+- **FR-010**: All existing honest-state renderings (loading, not-deployed, unreachable with
+  and without stale snapshot, verified-empty, no-matches) MUST survive the redesign with
+  their meanings and copy intent intact.
+- **FR-011**: The redesign MUST meet WCAG 2.1 AA (contrast, focus visibility, screen-reader
+  labels for all new iconography — decorative art marked decorative), and MUST render
+  correctly in light/dark themes and under tenant theme classes without hardcoding tenant
+  identity.
+- **FR-012**: The redesigned surface MUST NOT change the registry client's trust semantics:
+  `launchable` from the chain remains the serving decision; nothing re-derives status.
+- **FR-013**: The mini-app build preset MUST be moved to vite 8 (absorbing the deferred
+  Dependabot #1061 item for the mini-app build path), with the workspace's install-integrity
+  rules followed for the dependency change.
+- **FR-014**: The mini-app output byte baseline MUST be re-recorded in the same change that
+  moves the bytes, using the stamped compare flow so a failed build cannot false-pass, and
+  the change MUST show the gate detected the move (old baseline → diff → new baseline).
+- **FR-015**: Each mini-app package whose output bytes move MUST have its independent version
+  bumped by hand in the same change, and the release documentation MUST record that on-chain
+  records commit to the previous bytes until the packages are re-published to IPFS and
+  re-approved on-chain (content-committed approval), including the operational steps.
+- **FR-016**: The host frontend build, mini-app package builds, and affected test suites MUST
+  pass after the toolchain bump; any preset-hash-sensitive caching must reflect the new
+  toolchain.
+
+### Key Entities
+
+- **App listing (AppView)**: On-chain registry record as normalized by the registry client —
+  id, name, slug, description, category ordinal, vendor address, approved version,
+  launchable flag. Redesign consumes it read-only.
+- **Curated artwork map**: Host-side association from app slug to illustrative artwork and
+  alt text, with a generic fallback entry. Never on-chain, never in packages.
+- **Store sub-view**: Market | My Apps | Search — presentation state within the Apps section,
+  bookmarkable without breaking existing routes/tabs.
+- **Mini-app output baseline**: The recorded digest set for published package bytes
+  (`baseline-miniapp-builds.json`), the byte gate's comparison anchor.
+- **Package version + on-chain record**: Each mini-app's independent version and the
+  registry's committed manifest hash/CID; they must agree or the release record is untrue.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member can identify any app's purpose and verified standing within 5 seconds
+  of the catalog rendering (icon + badge + category visible without reading body text).
+- **SC-002**: A member can reach their favorited apps in one interaction from anywhere in the
+  store (My Apps entry), versus scrolling the full list today.
+- **SC-003**: 100% of existing honest-state scenarios (verified, stale, unreachable,
+  not-deployed, empty, no-match) render with unchanged meaning — verified by the existing and
+  extended test suites passing.
+- **SC-004**: Accessibility checks (automated axe/CI audits) pass with no new violations on
+  the redesigned surface.
+- **SC-005**: The mini-app byte gate is green on the new baseline, every moved package has a
+  bumped version, and the runbook contains an executable re-publish/re-approve procedure —
+  and after this release, no deferred toolchain byte-move remains attributed to #1061.
+- **SC-006**: All frontend and mini-app test suites pass in CI.
+
+## Assumptions
+
+- Per-app artwork is curated host-side (bundled with the host frontend), keyed by app slug,
+  starting with the two live apps (Token Mint, ClearPath) plus one generic fallback; the
+  concept art supplied on the issue guides style but exact assets may be original SVG
+  illustrations drawn for this feature.
+- The concept art's bottom navigation (Market, My Apps, Search, Profile) is adapted to the
+  host: the Apps section lives inside the wallet app which already owns global navigation and
+  profile. "Profile" is therefore satisfied by the existing account controls, and the store
+  navigation ships as Market / My Apps / Search plus the existing "Submit an app" developer
+  entry — not a second app-wide nav bar.
+- "My Apps" is defined as the member's favorited (Quick Access) apps — the closest existing
+  concept to "installed apps" in this platform; no new installation concept is introduced.
+- The theme (day/night) toggle and profile iconography shown in the concept art's top bar
+  belong to the host chrome, which already provides theme switching; restyling the host's
+  global header is out of scope.
+- Only the mini-app build path portion of closed Dependabot #1061 (vite and its preset
+  dependencies) is in scope; the other dev-tooling bumps from that sweep are not.
+- Re-publish to IPFS and on-chain re-approval are curator/release operations executed outside
+  this change; this change delivers the moved bytes, versions, baseline, and the documented
+  procedure — and is explicit that until those operations run, the chain still serves the
+  previous approved packages.
+- The registry ABI/host object are untouched: no new on-chain fields (e.g. icon URLs) are
+  introduced.

--- a/specs/077-miniapp-store-redesign/tasks.md
+++ b/specs/077-miniapp-store-redesign/tasks.md
@@ -63,7 +63,8 @@ steps documented. **Independent test**: quickstart §1.
 **Goal**: redesigned market view — artwork, badge, category headers, data box, rocket CTA,
 restructured trust copy. **Independent test**: quickstart §2 steps 1, 4–6.
 
-- [X] T010 [P] [US1] Create `frontend/src/components/miniapps/appArtwork.jsx`: slug-keyed inline
+- [X] T010 [P] [US1] Create `frontend/src/components/miniapps/appArt.jsx` (illustration
+      components) + `appArtwork.js` (slug map + resolver): slug-keyed inline
       SVG illustrations for `token-mint` (token/mint motif) and `clearpath` (governance/compass
       motif) plus a generic fallback; `artworkFor(slug)` total function; art theme-aware
       (currentColor/CSS vars) and `aria-hidden` per contracts/store-ui.md §3.

--- a/specs/077-miniapp-store-redesign/tasks.md
+++ b/specs/077-miniapp-store-redesign/tasks.md
@@ -1,0 +1,135 @@
+# Tasks: Mini-App Store UX Redesign
+
+**Input**: Design documents from `/specs/077-miniapp-store-redesign/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/store-ui.md, quickstart.md
+
+**Tests**: Included — constitution II makes Vitest coverage for behavior changes non-optional,
+and the byte-gate/pairing checks ARE the tests for US3.
+
+**Organization**: Phases follow the plan's execution order: the byte-gate resolution (US3) runs
+first as an isolated, separately-committed increment so the redesign commits demonstrably move
+no package bytes and the redesign is validated on the final toolchain. US1 then US2 follow.
+
+## Phase 1: Setup
+
+- [ ] T001 Verify clean baseline before any change: `npm run check:deps` and the stamped byte-gate
+      compare (`STAMP=$(($(date +%s) * 1000)); npm run build:miniapps && node
+      scripts/miniapps/record-build-digests.js --compare
+      specs/075-monorepo-workspaces/baseline-miniapp-builds.json --since "$STAMP"`) both green on
+      the unmodified tree, proving any later diff is caused by this feature.
+
+## Phase 2: User Story 3 — Byte-gate resolution: absorb the vite build-preset bump (Priority: P2, executed first per plan)
+
+**Goal**: vite 8 toolchain absorbed deliberately; bytes re-recorded + version-paired; release
+steps documented. **Independent test**: quickstart §1.
+
+- [ ] T002 [US3] Align toolchain ranges in `frontend/package.json` (`vite` → `^8.2.1`,
+      `@vitejs/plugin-react` → `^5.2.0`, `vitest`/`@vitest/coverage-v8`/`@vitest/ui` → `^4.1.10`),
+      `frontend/miniapps/token-mint/package.json` and `frontend/miniapps/clearpath/package.json`
+      (`vite` → `^8.2.1`, `@vitejs/plugin-react` → `^5.2.0`, `vitest` → `^4.1.10`), and
+      `tools/miniapp-build/package.json` (`peerDependencies.vite` → `^8.2.1`).
+- [ ] T003 [US3] Bump mini-app package versions by hand (spec 076 FR-007/FR-007b):
+      `frontend/miniapps/token-mint/package.json` and `frontend/miniapps/clearpath/package.json`
+      `1.0.0 → 1.0.1`.
+- [ ] T004 [US3] Full re-resolve via `npm run deps:reinstall` (NEVER incremental `npm install`),
+      updating `package-lock.json`.
+- [ ] T005 [US3] Run `npm run check:deps`; if the rollup optional binary left the lockfile with the
+      rolldown-based vite 8, update `REQUIRED_OPTIONAL` in
+      `scripts/deps/check-dependency-hygiene.js` to guard the binary the build actually needs
+      (`@rolldown/binding-linux-x64-gnu`), keeping the rollup entry only if rollup remains in the
+      tree. Gate must end green for a real reason, never vacuously.
+- [ ] T006 [US3] Rebuild + prove detection: stamp, `npm run build:miniapps` (fix any vite-8/preset
+      incompatibilities in the packages' configs if the build fails — preset source changes are
+      part of the absorbed move), run the `--compare` against the OLD baseline and confirm it
+      FAILS reporting moved digests; then re-record with `node
+      scripts/miniapps/record-build-digests.js --out
+      specs/075-monorepo-workspaces/baseline-miniapp-builds.json` and re-run `--compare` green.
+- [ ] T007 [US3] Run `node scripts/release/check-miniapp-versions.js --base origin/main --head
+      HEAD` → "pairing OK"; run the host build (`npm run build --workspace frontend`) and scoped
+      frontend suites (`npx vitest run src/test/miniapps --root frontend`) under the new
+      toolchain; fix any vite-8/vitest-4.1 breakage in host config (`frontend/vite.config.js`,
+      `frontend/vite-plugins/*`) — behavior-preserving only.
+- [ ] T008 [US3] Update `docs/runbooks/miniapp-registry-operations.md` with the "re-publish +
+      re-approve after a toolchain byte move" procedure (rebuild → publish to IPFS → propose →
+      `approveApp(id, expectedManifestHash)` per cohort) stating explicitly that on-chain records
+      commit to the previous bytes until curators complete it; note the v1.0.1 rebuilds.
+- [ ] T009 [US3] Commit Phase 2 as its own commit (manifests + lockfile + baseline + versions +
+      guard + runbook), so the byte diff is reviewable in isolation.
+
+**Checkpoint**: byte gate green on new baseline; pairing check green; host build green.
+
+## Phase 3: User Story 1 — Trustworthy, scannable app market (Priority: P1) 🎯 MVP
+
+**Goal**: redesigned market view — artwork, badge, category headers, data box, rocket CTA,
+restructured trust copy. **Independent test**: quickstart §2 steps 1, 4–6.
+
+- [ ] T010 [P] [US1] Create `frontend/src/components/miniapps/appArtwork.jsx`: slug-keyed inline
+      SVG illustrations for `token-mint` (token/mint motif) and `clearpath` (governance/compass
+      motif) plus a generic fallback; `artworkFor(slug)` total function; art theme-aware
+      (currentColor/CSS vars) and `aria-hidden` per contracts/store-ui.md §3.
+- [ ] T011 [US1] Redesign `frontend/src/components/miniapps/CatalogPanel.jsx` market surface:
+      verified-market banner (badge + title) rendered ONLY on `listing.verified`; security
+      explanation restructured into short prioritized blocks with icons preserving the spec-073
+      factual claims; `AppCard` gains artwork panel, contained Vendor/Version data box, rocket
+      glyph inside the Launch link (accessible name unchanged); all four honest states and both
+      launch-refusal reasons preserved verbatim in meaning.
+- [ ] T012 [US1] Extend `frontend/src/components/miniapps/miniapps.css` with the store aesthetic:
+      badge/banner, card artwork panel, data box, category group headers, control styling —
+      scoped under existing class-name discipline, `var(--token, fallback)` theming, WCAG 1.4.1
+      colour-independence, light/dark/tenant-safe.
+- [ ] T013 [US1] Add/extend Vitest suites in `frontend/src/test/miniapps/` covering: artwork
+      fallback for unknown/null slugs; badge present on verified listing and ABSENT on stale
+      snapshot/unreachable/not-deployed; data box renders vendor tooltip + version; Launch
+      accessible name intact; honest-state copy branches still render; axe pass on the redesigned
+      surface.
+
+**Checkpoint**: market view fully redesigned and tested — MVP deliverable.
+
+## Phase 4: User Story 2 — Quick section navigation (Priority: P2)
+
+**Goal**: persistent Market / My Apps / Search store bar on the `?view=` seam.
+**Independent test**: quickstart §2 steps 2–3.
+
+- [ ] T014 [P] [US2] Create `frontend/src/components/miniapps/StoreBar.jsx`: `<nav>` with
+      accessible name, link entries Market (`view` absent), My Apps (`view=mine`), Search
+      (`view=search`), `aria-current="page"` on the active entry; bottom-anchored on small
+      viewports, inline on wide (styles in miniapps.css).
+- [ ] T015 [US2] Wire sub-views in `frontend/src/components/miniapps/CatalogPanel.jsx`: StoreView
+      resolution from `useSearchParams` (unknown → market; `submit` keeps exclusive rendering);
+      My Apps = favorites ∩ verified listing with identical AppCard/launch rules and honest empty
+      state; Search = market with autofocused search + filters; all sub-views share the single
+      fetched listing and state branches per contracts/store-ui.md §1.
+- [ ] T016 [US2] Store bar + sub-view styles in
+      `frontend/src/components/miniapps/miniapps.css` (thumb-reachable bottom bar on small
+      viewports without occluding content; safe-area padding).
+- [ ] T017 [US2] Vitest suites in `frontend/src/test/miniapps/`: view switching via query param,
+      unknown view falls back to market, My Apps filtering + empty state, Search focus/filters,
+      store bar aria-current and keyboard operability, sub-views never refetch (single
+      fetchCatalog call), honest states rendered identically across sub-views.
+
+**Checkpoint**: full store navigation working with US1 visuals.
+
+## Phase 5: Polish & Cross-Cutting
+
+- [ ] T018 [P] Update `docs/developer-guide/miniapps.md`: host-side artwork map (why art never
+      comes from packages/chain), store sub-view seam, badge honesty rule.
+- [ ] T019 Final verification sweep (monorepo-verify): `npm run check:deps`, stamped byte-gate
+      compare green against the NEW baseline, `check-miniapp-versions` pairing green, scoped
+      frontend suites + lint + host build green; confirm the redesign commits (Phases 3–5)
+      moved NO baseline digest.
+
+## Dependencies & Execution Order
+
+- Phase 1 → Phase 2 (US3) → Phase 3 (US1) → Phase 4 (US2) → Phase 5.
+- US3 is functionally independent of US1/US2 but runs first by plan decision (isolated byte
+  diff; redesign validated on final toolchain).
+- US2 depends on US1's redesigned AppCard/CSS only for visual consistency; its logic is
+  independent (could be built against the old card if needed).
+- [P] opportunities: T010 alongside T011-prep; T014 alongside T015-prep; T018 anytime after
+  Phase 4.
+
+## Implementation Strategy
+
+MVP = Phase 3 (US1) — the redesigned market alone satisfies the issue's core pain points.
+Phases commit separately: toolchain bump (one commit), US1, US2, polish — each leaving the
+tree green.

--- a/specs/077-miniapp-store-redesign/tasks.md
+++ b/specs/077-miniapp-store-redesign/tasks.md
@@ -111,9 +111,9 @@ restructured trust copy. **Independent test**: quickstart §2 steps 1, 4–6.
 
 ## Phase 5: Polish & Cross-Cutting
 
-- [ ] T018 [P] Update `docs/developer-guide/miniapps.md`: host-side artwork map (why art never
+- [X] T018 [P] Update `docs/developer-guide/miniapps.md`: host-side artwork map (why art never
       comes from packages/chain), store sub-view seam, badge honesty rule.
-- [ ] T019 Final verification sweep (monorepo-verify): `npm run check:deps`, stamped byte-gate
+- [X] T019 Final verification sweep (monorepo-verify): `npm run check:deps`, stamped byte-gate
       compare green against the NEW baseline, `check-miniapp-versions` pairing green, scoped
       frontend suites + lint + host build green; confirm the redesign commits (Phases 3–5)
       moved NO baseline digest.

--- a/specs/077-miniapp-store-redesign/tasks.md
+++ b/specs/077-miniapp-store-redesign/tasks.md
@@ -12,7 +12,7 @@ no package bytes and the redesign is validated on the final toolchain. US1 then 
 
 ## Phase 1: Setup
 
-- [ ] T001 Verify clean baseline before any change: `npm run check:deps` and the stamped byte-gate
+- [X] T001 Verify clean baseline before any change: `npm run check:deps` and the stamped byte-gate
       compare (`STAMP=$(($(date +%s) * 1000)); npm run build:miniapps && node
       scripts/miniapps/record-build-digests.js --compare
       specs/075-monorepo-workspaces/baseline-miniapp-builds.json --since "$STAMP"`) both green on
@@ -23,37 +23,37 @@ no package bytes and the redesign is validated on the final toolchain. US1 then 
 **Goal**: vite 8 toolchain absorbed deliberately; bytes re-recorded + version-paired; release
 steps documented. **Independent test**: quickstart §1.
 
-- [ ] T002 [US3] Align toolchain ranges in `frontend/package.json` (`vite` → `^8.2.1`,
+- [X] T002 [US3] Align toolchain ranges in `frontend/package.json` (`vite` → `^8.2.1`,
       `@vitejs/plugin-react` → `^5.2.0`, `vitest`/`@vitest/coverage-v8`/`@vitest/ui` → `^4.1.10`),
       `frontend/miniapps/token-mint/package.json` and `frontend/miniapps/clearpath/package.json`
       (`vite` → `^8.2.1`, `@vitejs/plugin-react` → `^5.2.0`, `vitest` → `^4.1.10`), and
       `tools/miniapp-build/package.json` (`peerDependencies.vite` → `^8.2.1`).
-- [ ] T003 [US3] Bump mini-app package versions by hand (spec 076 FR-007/FR-007b):
+- [X] T003 [US3] Bump mini-app package versions by hand (spec 076 FR-007/FR-007b):
       `frontend/miniapps/token-mint/package.json` and `frontend/miniapps/clearpath/package.json`
       `1.0.0 → 1.0.1`.
-- [ ] T004 [US3] Full re-resolve via `npm run deps:reinstall` (NEVER incremental `npm install`),
+- [X] T004 [US3] Full re-resolve via `npm run deps:reinstall` (NEVER incremental `npm install`),
       updating `package-lock.json`.
-- [ ] T005 [US3] Run `npm run check:deps`; if the rollup optional binary left the lockfile with the
+- [X] T005 [US3] Run `npm run check:deps`; if the rollup optional binary left the lockfile with the
       rolldown-based vite 8, update `REQUIRED_OPTIONAL` in
       `scripts/deps/check-dependency-hygiene.js` to guard the binary the build actually needs
       (`@rolldown/binding-linux-x64-gnu`), keeping the rollup entry only if rollup remains in the
       tree. Gate must end green for a real reason, never vacuously.
-- [ ] T006 [US3] Rebuild + prove detection: stamp, `npm run build:miniapps` (fix any vite-8/preset
+- [X] T006 [US3] Rebuild + prove detection: stamp, `npm run build:miniapps` (fix any vite-8/preset
       incompatibilities in the packages' configs if the build fails — preset source changes are
       part of the absorbed move), run the `--compare` against the OLD baseline and confirm it
       FAILS reporting moved digests; then re-record with `node
       scripts/miniapps/record-build-digests.js --out
       specs/075-monorepo-workspaces/baseline-miniapp-builds.json` and re-run `--compare` green.
-- [ ] T007 [US3] Run `node scripts/release/check-miniapp-versions.js --base origin/main --head
+- [X] T007 [US3] Run `node scripts/release/check-miniapp-versions.js --base origin/main --head
       HEAD` → "pairing OK"; run the host build (`npm run build --workspace frontend`) and scoped
       frontend suites (`npx vitest run src/test/miniapps --root frontend`) under the new
       toolchain; fix any vite-8/vitest-4.1 breakage in host config (`frontend/vite.config.js`,
       `frontend/vite-plugins/*`) — behavior-preserving only.
-- [ ] T008 [US3] Update `docs/runbooks/miniapp-registry-operations.md` with the "re-publish +
+- [X] T008 [US3] Update `docs/runbooks/miniapp-registry-operations.md` with the "re-publish +
       re-approve after a toolchain byte move" procedure (rebuild → publish to IPFS → propose →
       `approveApp(id, expectedManifestHash)` per cohort) stating explicitly that on-chain records
       commit to the previous bytes until curators complete it; note the v1.0.1 rebuilds.
-- [ ] T009 [US3] Commit Phase 2 as its own commit (manifests + lockfile + baseline + versions +
+- [X] T009 [US3] Commit Phase 2 as its own commit (manifests + lockfile + baseline + versions +
       guard + runbook), so the byte diff is reviewable in isolation.
 
 **Checkpoint**: byte gate green on new baseline; pairing check green; host build green.
@@ -63,21 +63,21 @@ steps documented. **Independent test**: quickstart §1.
 **Goal**: redesigned market view — artwork, badge, category headers, data box, rocket CTA,
 restructured trust copy. **Independent test**: quickstart §2 steps 1, 4–6.
 
-- [ ] T010 [P] [US1] Create `frontend/src/components/miniapps/appArtwork.jsx`: slug-keyed inline
+- [X] T010 [P] [US1] Create `frontend/src/components/miniapps/appArtwork.jsx`: slug-keyed inline
       SVG illustrations for `token-mint` (token/mint motif) and `clearpath` (governance/compass
       motif) plus a generic fallback; `artworkFor(slug)` total function; art theme-aware
       (currentColor/CSS vars) and `aria-hidden` per contracts/store-ui.md §3.
-- [ ] T011 [US1] Redesign `frontend/src/components/miniapps/CatalogPanel.jsx` market surface:
+- [X] T011 [US1] Redesign `frontend/src/components/miniapps/CatalogPanel.jsx` market surface:
       verified-market banner (badge + title) rendered ONLY on `listing.verified`; security
       explanation restructured into short prioritized blocks with icons preserving the spec-073
       factual claims; `AppCard` gains artwork panel, contained Vendor/Version data box, rocket
       glyph inside the Launch link (accessible name unchanged); all four honest states and both
       launch-refusal reasons preserved verbatim in meaning.
-- [ ] T012 [US1] Extend `frontend/src/components/miniapps/miniapps.css` with the store aesthetic:
+- [X] T012 [US1] Extend `frontend/src/components/miniapps/miniapps.css` with the store aesthetic:
       badge/banner, card artwork panel, data box, category group headers, control styling —
       scoped under existing class-name discipline, `var(--token, fallback)` theming, WCAG 1.4.1
       colour-independence, light/dark/tenant-safe.
-- [ ] T013 [US1] Add/extend Vitest suites in `frontend/src/test/miniapps/` covering: artwork
+- [X] T013 [US1] Add/extend Vitest suites in `frontend/src/test/miniapps/` covering: artwork
       fallback for unknown/null slugs; badge present on verified listing and ABSENT on stale
       snapshot/unreachable/not-deployed; data box renders vendor tooltip + version; Launch
       accessible name intact; honest-state copy branches still render; axe pass on the redesigned

--- a/specs/077-miniapp-store-redesign/tasks.md
+++ b/specs/077-miniapp-store-redesign/tasks.md
@@ -90,19 +90,19 @@ restructured trust copy. **Independent test**: quickstart §2 steps 1, 4–6.
 **Goal**: persistent Market / My Apps / Search store bar on the `?view=` seam.
 **Independent test**: quickstart §2 steps 2–3.
 
-- [ ] T014 [P] [US2] Create `frontend/src/components/miniapps/StoreBar.jsx`: `<nav>` with
+- [X] T014 [P] [US2] Create `frontend/src/components/miniapps/StoreBar.jsx`: `<nav>` with
       accessible name, link entries Market (`view` absent), My Apps (`view=mine`), Search
       (`view=search`), `aria-current="page"` on the active entry; bottom-anchored on small
       viewports, inline on wide (styles in miniapps.css).
-- [ ] T015 [US2] Wire sub-views in `frontend/src/components/miniapps/CatalogPanel.jsx`: StoreView
+- [X] T015 [US2] Wire sub-views in `frontend/src/components/miniapps/CatalogPanel.jsx`: StoreView
       resolution from `useSearchParams` (unknown → market; `submit` keeps exclusive rendering);
       My Apps = favorites ∩ verified listing with identical AppCard/launch rules and honest empty
       state; Search = market with autofocused search + filters; all sub-views share the single
       fetched listing and state branches per contracts/store-ui.md §1.
-- [ ] T016 [US2] Store bar + sub-view styles in
+- [X] T016 [US2] Store bar + sub-view styles in
       `frontend/src/components/miniapps/miniapps.css` (thumb-reachable bottom bar on small
       viewports without occluding content; safe-area padding).
-- [ ] T017 [US2] Vitest suites in `frontend/src/test/miniapps/`: view switching via query param,
+- [X] T017 [US2] Vitest suites in `frontend/src/test/miniapps/`: view switching via query param,
       unknown view falls back to market, My Apps filtering + empty state, Search focus/filters,
       store bar aria-current and keyboard operability, sub-views never refetch (single
       fetchCatalog call), honest states rendered identically across sub-views.

--- a/tools/miniapp-build/index.js
+++ b/tools/miniapp-build/index.js
@@ -158,7 +158,8 @@ function validateOptions({ appId, version, permissions, storeKeys, contracts, ro
  * @param {import('vite').PluginOption[]} [options.plugins] - package plugins, e.g. `react()`
  * @param {Array<{specifier: string, package: string, exports?: string[]}>} [options.sharedModules]
  *   Override the host-owned module table; must stay in step with the host scope
- * @param {boolean|string} [options.minify] - Vite `build.minify`; defaults to `'esbuild'`
+ * @param {boolean|string} [options.minify] - Vite `build.minify`; defaults to `true` (Vite 8's
+ *   bundled minifier — the pre-8 `'esbuild'` default now requires esbuild installed separately)
  * @param {string} [options.target] - Vite `build.target`; defaults to `'es2022'`
  * @param {Record<string, string>} [options.define] - extra `define` entries
  * @returns {import('vite').UserConfig} config for `vite build`
@@ -176,7 +177,7 @@ export function createMiniAppConfig(options = {}) {
     contracts = [],
     plugins = [],
     sharedModules = SHARED_MODULES,
-    minify = 'esbuild',
+    minify = true,
     target = 'es2022',
     define = {}
   } = options
@@ -230,7 +231,8 @@ export function createMiniAppConfig(options = {}) {
       rollupOptions: {
         output: {
           // A single verified module: the host hashes and imports exactly one file.
-          inlineDynamicImports: true,
+          // (Vite 8/rolldown spelling of the former `inlineDynamicImports: true`.)
+          codeSplitting: false,
           entryFileNames: ENTRY_FILENAME,
           chunkFileNames: '[name].js',
           assetFileNames

--- a/tools/miniapp-build/manifestPlugin.js
+++ b/tools/miniapp-build/manifestPlugin.js
@@ -65,7 +65,7 @@ export function manifestPlugin(options) {
         throw new Error(
           '[miniapp-build] the build produced more than one chunk: ' +
             chunks.map((chunk) => chunk.fileName).join(', ') +
-            '. Dynamic imports must stay inlined (rollupOptions.output.inlineDynamicImports).'
+            '. Dynamic imports must stay inlined (rollupOptions.output.codeSplitting: false).'
         )
       }
 

--- a/tools/miniapp-build/package.json
+++ b/tools/miniapp-build/package.json
@@ -12,6 +12,6 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "vite": "^7.2.4"
+    "vite": "^8.2.1"
   }
 }


### PR DESCRIPTION
Closes #1024.

Delivered through the Spec Kit flow as **spec 077** (`specs/077-miniapp-store-redesign/`: spec → plan with constitution check → research → tasks → implement). Two independent deliverables sharing this release, per the byte-gate scoping comment on the issue.

## 1. Byte-gate resolution — vite 8 absorbed deliberately (own commit, reviewable in isolation)

Takes the deferred mini-app-build item from the closed Dependabot sweep #1061:

- `vite ^7.2.4 → ^8.2.1` aligned across `frontend`, both mini-app packages, and the preset's peer range — the FR-015 skew gate forbids a partial bump, which pulls `@vitejs/plugin-react ^5.2.0` and the vitest family `^4.1.10` (vitest 4.0.x pins vite `^6||^7`) along, including relay-gateway's vitest.
- Vite 8 replaces rollup with **rolldown**: every published mini-app byte moves. The gate **detected all 6 digests changing** against the old baseline before `baseline-miniapp-builds.json` was re-recorded (stamped `--since` flow, no false pass), and a fresh rebuild reproduces the new baseline exactly.
- Both packages hand-bumped `1.0.0 → 1.0.1`; `check-miniapp-versions` pairing green (spec 076 FR-007b).
- npm/cli#4828 guard updated: rollup left the tree entirely, so `check:deps` now watches `@rolldown/binding-linux-x64-gnu` — which is `optional` **and** `peer`, exactly the shape npm skips even when locked.
- Preset/host follow vite 8: default minify off the removed `'esbuild'` path, `inlineDynamicImports` → `codeSplitting: false`, `manualChunks` object → function form.
- **On-chain records still commit to the previous bytes until curators re-publish + re-approve** — the procedure is now runbook §7.1 (`docs/runbooks/miniapp-registry-operations.md`), Mordor first, then Polygon. That lag is content-committed approval working as designed; nothing renders the new bytes as live.

## 2. Store redesign — host-only, zero package byte moves (verified: baseline untouched by these commits)

The Apps catalog gets the high-trust market treatment from the issue's concept art, restyling without re-deciding — `launchable` stays the serving decision, and all four honest states keep their meanings (the pre-existing CatalogPanel suite passes unchanged):

- **Per-app artwork**: curated inline-SVG illustrations, host-side and slug-keyed (`appArt.jsx` + `appArtwork.js`), deliberate generic fallback, `aria-hidden` — never sourced from packages or chain, so no committed byte can move and no vendor gets an image channel into the catalog.
- **"On-chain verified market" badge**, rendered **only** over a verified listing — never the stale snapshot, outage, or registry gap.
- **Trust copy** restructured into two scannable iconed blocks (same factual claims).
- **Cards**: illustration panel, contained Vendor/Version data box, rocket-icon Launch pill (accessible name unchanged), category headers with accent bars, cohesive pill controls.
- **Store bar** (Market / My Apps / Search): persistent sticky dock inside the Apps section on the existing `?view=` seam — browser Back/bookmarks work, global nav (spec 069) untouched. Sub-views are lenses over the one fetched listing (a full view tour issues exactly one catalog read); My Apps = favorites ∩ launchable with its own empty state; Search focuses the input on arrival; unknown views fall back to Market; `view=submit` keeps its exclusive surface.

## Verification

- `check:deps` green (version alignment + rolldown binary guard)
- Byte gate: detected the toolchain move, then green + reproducible on the new baseline; **redesign commits moved no digest**
- `check-miniapp-versions --base origin/main` → pairing OK
- Frontend + both mini-app builds green under vite 8
- 22 mini-app host test files / **551 tests** pass (two new suites: `storeRedesign`, `storeNavigation` — badge honesty across states, artwork totality incl. a `__proto__` lookup hazard the new test caught, one-read view switching, axe passes)
- ESLint green on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWVW8rHFHVJVwn7gFjSafw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWVW8rHFHVJVwn7gFjSafw)_