### PR TITLE
chore(deps): scoped overrides for three vulnerable transitive packages (#1021)

### DIFF
--- a/coverage-threshold-policy.json
+++ b/coverage-threshold-policy.json
@@ -52,7 +52,6 @@
   ],
   "excluded": [
     { "pathGlob": "contracts/account/lib/**", "reason": "vendored FreshCryptoLib / solady / webauthn-sol / account-abstraction" },
-    { "pathGlob": "contracts/pools/SemaphoreDeploy.sol", "reason": "vendored Semaphore self-deploy closure" },
     { "pathGlob": "contracts/test/**", "reason": "test-only fuzz/mocks harnesses" },
     { "pathGlob": "contracts/mocks/**", "reason": "test-only mocks" },
     { "pathGlob": "contracts/**/interfaces/**", "reason": "no executable logic" }

--- a/docs/developer-guide/monorepo.md
+++ b/docs/developer-guide/monorepo.md
@@ -69,11 +69,24 @@ computed the hash. `globalEnv` only covers variables exported in the caller's sh
 
 **Confirmed empirically**: editing `AMOY_RPC_URL` in `.env` left the `//#test` hash unchanged —
 and that variable switches the default test chain from a clean 1337 to an Amoy fork. So
-`//#test` cache hits are **not sound** in a tree with a `.env` that sets a build-relevant variable.
+`//#test` cache hits were **not sound** in a tree with a `.env` that sets a build-relevant variable.
 
-Until dotenv is moved out of config evaluation (or a `dotEnv` declaration is added), run
-`npx turbo run test --force` when a `.env` value matters. This is stated rather than hidden because
-an undeclared input in Turborepo produces a **wrong cache hit, not an error**.
+**FIXED (#1036/#1074).** `.env*` and `frontend/.env*` are now `globalDependencies`, so the dotenv
+FILES are hashed by content and an edited `AMOY_RPC_URL` invalidates `//#test` instead of silently
+switching the test chain behind a cache hit. `--force` is no longer required for this.
+
+Two things worth keeping straight, because they are what made the original defect confusing:
+
+- `globalEnv` and a dotenv file are **different channels**. `globalEnv` hashes what is already
+  exported into Turborepo's own process; it was never wrong, it simply does not observe a value
+  that `dotenv.config()` or Vite's `loadEnv()` reads *inside* the task. Both entries are kept.
+- Turborepo hashes a `globalDependencies` path **even when the file is gitignored**, and an
+  **absent** file is not an error — just a different hash. That is why this works locally without
+  affecting CI, which has no `.env`.
+
+The trade-off is deliberate: any `.env` edit now busts the whole cache rather than one task. That
+is a false **miss**, which is the safe direction — an undeclared input in Turborepo produces a
+**wrong cache hit, not an error**.
 
 ### Outside the graph entirely
 

--- a/docs/developer-guide/setup.md
+++ b/docs/developer-guide/setup.md
@@ -31,18 +31,23 @@ cd prediction-dao-research
 
 ### 2. Install Dependencies
 
-Install root project dependencies:
+One install, from the repo root, covers every workspace (spec 075 — one lockfile, 8 members):
 
 ```bash
 npm install
 ```
 
-Install frontend dependencies:
+**Do not run `npm install` inside `frontend/` (or any other workspace).** An incremental install in
+a child silently drops optional platform binaries — notably `@rollup/rollup-linux-x64-gnu` — from
+BOTH `node_modules` and `package-lock.json` (npm/cli#4828). Every Vite build then dies with
+`Cannot find module @rollup/rollup-linux-x64-gnu`, including the mini-app release path whose output
+bytes are committed on-chain. Re-running `npm install` does not fix it: the lockfile is already
+wrong, so npm reports "up to date".
+
+If it happens, recover with a full re-resolve:
 
 ```bash
-cd frontend
-npm install
-cd ..
+npm run deps:reinstall
 ```
 
 ### 3. Verify Installation

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -67,8 +67,10 @@ App.jsx (Root)
 ### Installation
 
 ```bash
-# Install dependencies
-npm install
+# Install dependencies — FROM THE REPO ROOT, not here. This is an npm workspace
+# (spec 075); an install inside a child drops optional platform binaries from the
+# lockfile (npm/cli#4828) and breaks every Vite build. Recover with `npm run deps:reinstall`.
+cd .. && npm install && cd frontend
 
 # Copy environment configuration
 cp .env.example .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -5780,30 +5780,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@hapi/address": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
@@ -6275,13 +6251,6 @@
       "engines": {
         "node": ">=v12.0.0"
       }
-    },
-    "node_modules/@jsdoc/salty/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@ledgerhq/cryptoassets": {
       "version": "5.53.0",
@@ -10507,22 +10476,6 @@
         "node-fetch": "^2.7.0"
       }
     },
-    "node_modules/@truffle/contract/node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
     "node_modules/@truffle/contract/node_modules/eth-lib": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
@@ -11182,29 +11135,6 @@
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
-    },
-    "node_modules/@truffle/interface-adapter/node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/@truffle/interface-adapter/node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
-      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@truffle/interface-adapter/node_modules/eth-lib": {
       "version": "0.2.8",
@@ -18577,13 +18507,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/cypress/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cypress/node_modules/proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -19541,23 +19464,8 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eccrypto/node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
+      "optional": true
     },
     "node_modules/eccrypto/node_modules/secp256k1": {
       "version": "3.7.1",
@@ -27618,9 +27526,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -31297,25 +31205,23 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
-      "dev": true,
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -37947,13 +37853,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/wait-on/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/wait-on/node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -40627,29 +40526,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "services/relay-gateway/node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "services/relay-gateway/node_modules/retry-request": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,12 @@
   "overrides": {
     "@safe-global/safe-contracts": {
       "ethers": "$ethers"
+    },
+    "elliptic": "^6.6.1",
+    "lodash": "^4.18.0",
+    "protobufjs": "^7.5.6",
+    "ipfs-unixfs": {
+      "protobufjs": "^6.11.4"
     }
   },
   "engines": {

--- a/scripts/miniapps/publish.js
+++ b/scripts/miniapps/publish.js
@@ -232,7 +232,7 @@ function resolvePackageDir(appId, appIdPattern) {
  */
 function runBuild(packageDir) {
   if (!fs.existsSync(VITE_BIN)) {
-    fail(`vite is not installed at ${path.relative(REPO_ROOT, VITE_BIN)} — run \`npm install\` in frontend/`)
+    fail(`vite is not installed at ${path.relative(REPO_ROOT, VITE_BIN)} — run \`npm run deps:reinstall\` at the repo root`)
   }
 
   const env = { ...process.env }


### PR DESCRIPTION
Triage of the 109 remaining alerts (#1021) found only **three** packages that are both vulnerable **at their installed version** and fixable **without a major bump**. This takes those. Everything else needs a parent bump or a migration and is recorded on the issue rather than forced.

| package | before | after | alerts cleared |
|---|---|---|---|
| `elliptic` | 6.5.4 + 6.6.1 | **6.6.1** | 7 (1 **critical**) |
| `protobufjs` | 7.2.4 + 6.11.6 + 7.6.5 | **6.11.6 + 7.6.5** | 8 (1 **critical**) |
| `lodash` | 4.17.21 + 4.18.1 | **4.18.1** | 3 |

## Why this is scoped, not blanket

`elliptic` and `lodash` are same-major unifications — the vulnerable copy was the older nested one, nothing spans a major, so forcing the patched version is a no-op for consumers.

**`protobufjs` is not that shape**, which is the whole reason this PR is careful. The tree carries **6.11.6 (ipfs-unixfs)** alongside 7.x, so a blanket `^7.5.6` would drag ipfs-unixfs across a major. The 6.x subtree is pinned back with a nested override:

```json
"protobufjs": "^7.5.6",
"ipfs-unixfs": { "protobufjs": "^6.11.4" }
```

Verified after the re-resolve: **ipfs-unixfs still resolves 6.11.6**, and the vulnerable top-level 7.2.4 is gone.

This follows the existing `@safe-global` pattern — scope an override, never blanket one. A bare `ethers` override breaks this install outright (ethers 5.8.0 ×9 and 4.0.49 ×2 under `@uma`/`@chainlink`/`@across`).

## Verified after a full re-resolve

A lockfile regeneration is exactly when hoisting can move committed bytes, so:

| | |
|---|---|
| `@rollup/rollup-linux-x64-gnu` | present in lockfile **and** on disk |
| `check:deps` | exit 0 |
| **bytecode digest** | byte-identical to baseline |
| **mini-app output bytes** | unchanged |
| contracts (non-fork) | **1029 passing, 0 failing** |
| frontend miniapps + admin | 32 files / 709 tests |
| relay-gateway | 9 files / 234 tests |

## The two fork failures are not this

Two `test/fork/` tests fail locally; both need a live Polygon RPC. One is a **signature** failure, which looked alarming next to an `elliptic` bump — so I checked rather than assumed: **ethers 6.17.0 signs via `@noble/curves`/`@noble/hashes` and does not depend on `elliptic`**. Here `elliptic` serves only truffle/web3-era packages. CI, which has the RPC secrets, reports 0 failing on the same suite.
