### PR TITLE
feat(miniapps): app-store rows, details sheet, fixed bottom nav (spec 077 iteration 2)

### DIFF
--- a/docs/developer-guide/miniapps.md
+++ b/docs/developer-guide/miniapps.md
@@ -78,7 +78,14 @@ The catalog's visual layer. Three rules keep it from becoming a trust surface:
   change. All of it is decorative (`aria-hidden`); the card's text is the identity.
 - **The "On-chain verified market" badge is a factual claim**, so it renders only over a
   verified listing — never the stale snapshot, the outage, or the registry gap. If you touch the
-  header, keep that gate; `storeRedesign.test.jsx` pins it across every state.
+  header, keep that gate; `storeRedesign.test.jsx` pins it across every state. The badge is the
+  ONLY trust copy on the surface (iteration 2): the explanation prose was removed deliberately —
+  do not reintroduce it; this guide and the runbooks are where the depth lives.
+- **Rows promise nothing the sheet walks back.** Catalog entries are tappable store rows; the
+  launch affordance, the My Apps toggle, and both launch-refusal explanations live in the
+  app-details sheet (`AppSheet.jsx`), gated on the SAME `verified`/slug pair the cards used.
+  `appSheet.test.jsx` pins the dialog mechanics (labelling, Escape/backdrop/close, focus
+  restoration to the invoking row).
 - **Store navigation is presentation state, not navigation.** Market / My Apps / Search ride the
   Apps tab's existing `?view=` seam (`storeViews.js` resolves it, totally — unknown values are
   the market; `view=submit` keeps its exclusive surface). Every sub-view is a lens over the ONE

--- a/frontend/src/components/miniapps/AppSheet.jsx
+++ b/frontend/src/components/miniapps/AppSheet.jsx
@@ -34,8 +34,17 @@ export default function AppSheet({ app, slug, verified, isFavorite, onToggleFavo
   const { Art } = artworkFor(slug)
   const openable = verified && Boolean(slug)
 
+  // Focus lands on the close control ONCE, when the sheet opens. This must not share an effect
+  // with anything keyed on `onClose`: the panel re-creates that handler every render, so a
+  // combined effect re-fires on any state change inside the sheet (toggling My Apps) and steals
+  // focus from the control the member just pressed.
   useEffect(() => {
     closeRef.current?.focus()
+  }, [])
+
+  // Escape dismisses for as long as the sheet is mounted. Re-attaching when `onClose`'s identity
+  // changes is harmless — the listener carries no focus or state of its own.
+  useEffect(() => {
     function onKeyDown(event) {
       if (event.key === 'Escape') onClose()
     }

--- a/frontend/src/components/miniapps/AppSheet.jsx
+++ b/frontend/src/components/miniapps/AppSheet.jsx
@@ -1,0 +1,132 @@
+/**
+ * AppSheet (spec 077 iteration 2, FR-017) — the app-details bottom sheet.
+ *
+ * Tapping a catalog row opens this sheet; it is where the detail and the actions moved when the
+ * rows went store-style. Three rules carried over from the card era, unchanged in meaning:
+ *
+ *   1. **`verified` decides the actions.** Open and the My Apps toggle exist only for a verified
+ *      listing with a usable slug — the same `canFavorite`/launchable pair the cards enforced.
+ *      An unverified (stale-snapshot) sheet shows the refusal explanation instead of a disabled
+ *      button: the launch is refused on principle, not busy.
+ *   2. **The two refusal reasons stay distinct.** "Listing could not be verified" (provenance)
+ *      and "name can't be a web address" (slug) are different facts and keep their own copy,
+ *      provenance first.
+ *   3. **The sheet decides nothing.** It renders what the panel's one fetched listing says;
+ *      no fetches, no re-derivation.
+ *
+ * Dialog mechanics: `role="dialog"` + `aria-modal`, labelled by the app name; dismissed by the
+ * close button, a backdrop tap, or Escape (document-level listener while mounted). Focus moves
+ * to the close button on open; the PANEL restores focus to the invoking row on close (it owns
+ * the row refs). Sheet content scrolls internally so long descriptions never push the actions
+ * off-screen.
+ */
+import { useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { APP_CATEGORY_LABELS } from '../../abis/miniAppRegistry'
+import { RocketGlyph } from './appArt'
+import { artworkFor } from './appArtwork'
+
+export default function AppSheet({ app, slug, verified, isFavorite, onToggleFavorite, onClose }) {
+  const closeRef = useRef(null)
+  const titleId = `miniapp-sheet-${app.id}-title`
+  const descriptionId = `miniapp-sheet-${app.id}-description`
+  const categoryLabel = APP_CATEGORY_LABELS[app.category] ?? `Category ${app.category}`
+  const { Art } = artworkFor(slug)
+  const openable = verified && Boolean(slug)
+
+  useEffect(() => {
+    closeRef.current?.focus()
+    function onKeyDown(event) {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  return (
+    <div
+      className="miniapp-sheet-backdrop"
+      // Backdrop tap dismisses; taps INSIDE the sheet bubble up to this handler too, so only a
+      // click that started and ended on the backdrop itself counts.
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+    >
+      <div className="miniapp-sheet" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+        <div className="miniapp-sheet-head">
+          <div className="miniapp-sheet-art" aria-hidden="true">
+            <Art />
+          </div>
+          <div className="miniapp-sheet-title">
+            <h4 id={titleId}>{app.name}</h4>
+            <p className="miniapp-sheet-category">{categoryLabel}</p>
+          </div>
+          <button
+            type="button"
+            ref={closeRef}
+            className="miniapp-sheet-close"
+            aria-label={`Close ${app.name} details`}
+            onClick={onClose}
+          >
+            <svg viewBox="0 0 20 20" aria-hidden="true" focusable="false" className="miniapp-glyph">
+              <path d="M5 5l10 10M15 5 5 15" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {app.description && (
+          <p className="miniapp-sheet-description" id={descriptionId}>
+            {app.description}
+          </p>
+        )}
+
+        <dl className="miniapp-sheet-meta">
+          <div>
+            <dt>Vendor</dt>
+            <dd>
+              <code>{app.vendor || '—'}</code>
+            </dd>
+          </div>
+          <div>
+            <dt>Version</dt>
+            <dd>v{app.approved.version}</dd>
+          </div>
+          <div>
+            <dt>Category</dt>
+            <dd>{categoryLabel}</dd>
+          </div>
+        </dl>
+
+        {openable ? (
+          <div className="miniapp-sheet-actions">
+            <Link
+              className="miniapp-sheet-open"
+              to={`/apps/${slug}`}
+              aria-label={`Open ${app.name}`}
+              aria-describedby={app.description ? descriptionId : undefined}
+            >
+              <RocketGlyph />
+              Open
+            </Link>
+            <button
+              type="button"
+              className={`miniapp-sheet-favorite${isFavorite ? ' is-active' : ''}`}
+              aria-pressed={isFavorite}
+              onClick={() => onToggleFavorite(app, slug)}
+            >
+              {isFavorite ? `Remove ${app.name} from My Apps` : `Add ${app.name} to My Apps`}
+            </button>
+          </div>
+        ) : (
+          <p className="miniapp-sheet-refusal" role="note">
+            {/* Provenance first: an unverified listing is the reason that matters, whatever else
+                is also true of the record. */}
+            {!verified
+              ? 'Launch unavailable — this listing could not be verified.'
+              : 'Launch unavailable — this app’s registered name can’t be used as a web address, so the host has no way to open it. Its vendor needs to re-register it under a usable name.'}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/miniapps/CatalogPanel.jsx
+++ b/frontend/src/components/miniapps/CatalogPanel.jsx
@@ -39,9 +39,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import './miniapps.css'
+import AppSheet from './AppSheet'
 import SubmitAppPanel from './SubmitAppPanel'
 import StoreBar from './StoreBar'
 import { STORE_VIEWS, resolveStoreView } from './storeViews'
+import { RefreshGlyph, VerifiedBadgeGlyph } from './appArt'
 import { artworkFor } from './appArtwork'
 import EmptyState from '../account/EmptyState'
 import NavIcon from '../nav/NavIcon'
@@ -74,66 +76,6 @@ const CATEGORY_FILTERS = Object.entries(APP_CATEGORY_LABELS)
   .map(([ordinal, label]) => ({ value: Number(ordinal), label }))
   .sort((a, b) => a.value - b.value)
 
-/**
- * Decorative glyphs for the store chrome (spec 077). All are `aria-hidden`: each sits beside
- * text that already says the same thing, so the art adds flavour, never meaning.
- */
-function RocketGlyph() {
-  return (
-    <svg className="miniapp-glyph" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <g fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M10 13.5c-1.8-.6-3-1.8-3.5-3.5C7.6 5.6 10.4 3.2 15 3c-.2 4.6-2.6 7.4-7 8.5Z" />
-        <circle cx="11.6" cy="6.4" r="1.2" />
-        <path d="M6.5 10 4 11.5 6 12M10 13.5 8.5 16l-.5-2M5.5 14.5 4 16" />
-      </g>
-    </svg>
-  )
-}
-
-function VerifiedBadgeGlyph() {
-  return (
-    <svg className="miniapp-glyph miniapp-glyph-badge" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      {/* rosette: scalloped seal with a check — the concept art's rainbow badge, themed */}
-      <path
-        d="M10 1.6l1.9 1.2 2.2-.3 1 2 2 1-.3 2.2L18 10l-1.2 1.9.3 2.2-2 1-1 2-2.2-.3L10 18.4l-1.9-1.2-2.2.3-1-2-2-1 .3-2.2L2 10l1.2-1.9-.3-2.2 2-1 1-2 2.2.3L10 1.6Z"
-        fill="currentColor"
-        opacity="0.18"
-      />
-      <path
-        d="M10 1.6l1.9 1.2 2.2-.3 1 2 2 1-.3 2.2L18 10l-1.2 1.9.3 2.2-2 1-1 2-2.2-.3L10 18.4l-1.9-1.2-2.2.3-1-2-2-1 .3-2.2L2 10l1.2-1.9-.3-2.2 2-1 1-2 2.2.3L10 1.6Z"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.3"
-        strokeLinejoin="round"
-      />
-      <path d="M6.8 10.2l2.1 2.1 4.3-4.6" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  )
-}
-
-function ScrollCheckGlyph() {
-  return (
-    <svg className="miniapp-glyph" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <g fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M6 3h9a1.5 1.5 0 0 1 1.5 1.5V15A2.5 2.5 0 0 1 14 17.5H7A2.5 2.5 0 0 1 4.5 15V4.5" />
-        <path d="M6 3a1.5 1.5 0 0 0-1.5 1.5V6H7V4.5A1.5 1.5 0 0 0 6 3Z" />
-        <path d="M8 10.6l2 2 3.4-3.8" />
-      </g>
-    </svg>
-  )
-}
-
-function HashShieldGlyph() {
-  return (
-    <svg className="miniapp-glyph" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <g fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M10 2.5 16 5v4.5c0 3.7-2.4 6.5-6 8-3.6-1.5-6-4.3-6-8V5l6-2.5Z" />
-        <path d="M8.2 7.5 7 12.5M13 7.5l-1.2 5M7 9h6M6.8 11h6" />
-      </g>
-    </svg>
-  )
-}
-
 /** Vendor addresses are shown short; the full value stays available as a tooltip/copy target. */
 function shortAddress(address) {
   return typeof address === 'string' && address.length > 12
@@ -162,103 +104,52 @@ function formatAge(ms) {
 }
 
 /**
- * One catalog entry: name, vendor, version, category (FR-007) plus its launch affordance.
+ * One catalog entry as a store row (spec 077 iteration 2, FR-017): leading art, bold name, a
+ * category-and-vendor metadata line, a version chip, and — when favorited — a non-interactive
+ * "My Apps" indicator. The whole row is tappable and opens the app's details sheet; the launch
+ * link, the favorite toggle, and the refusal explanations all live THERE now, so the row makes
+ * no promise the sheet has to walk back.
  *
- * Two independent things can withhold the launch affordance, and each says which one it was:
- *
- *   - `launchable` is about the LISTING's provenance, not the app's — false only when this card came
- *     from an unverified snapshot, in which case no launch link is rendered at all. A disabled button
- *     would be worse: it invites the member to keep clicking something refused on principle rather
- *     than temporarily busy.
- *   - `appSlug(name)` is null when the registered name cannot become a URL slug. The client refuses a
- *     lossy best effort there on purpose (two distinct on-chain listings must never collapse onto one
- *     address), so the app is genuinely unreachable by URL. Rendering `/apps/null` would be a link
- *     the catalog knows lands nowhere.
- *
- * The favorite star shares the second condition: a shortcut into the nav drawer's Quick Access
- * group is a link like any other, so it needs the same working slug the Launch button does. It is
- * withheld silently rather than shown disabled, for the same reason Launch is.
+ * Structure note: the tap target is a "stretched" button laid over the row rather than a button
+ * wrapping the content — a heading (h5, which the grouping semantics and screen-reader listings
+ * rely on) is not valid phrasing content inside a <button>. The overlay keeps the row's own
+ * semantics intact while making every pixel tappable, and its accessible name pairs the app's
+ * name with what tapping does.
  */
-function AppCard({ app, launchable, isFavorite, onToggleFavorite }) {
-  const nameId = `miniapp-${app.id}-name`
-  const descriptionId = `miniapp-${app.id}-description`
-  // An on-chain enum may gain values ahead of this build's label map. Naming the raw ordinal is
-  // honest; folding an unknown category into a familiar label would misfile the app.
+function AppRow({ app, isFavorite, onOpen }) {
   const categoryLabel = APP_CATEGORY_LABELS[app.category] ?? `Category ${app.category}`
   const slug = appSlug(app.name)
-  const canFavorite = launchable && Boolean(slug)
   // Curated host-side art; a slug the host doesn't know — or a name with no slug at all — gets
   // the deliberate generic illustration (spec 077 FR-001, never a broken or borrowed image).
   const { Art } = artworkFor(slug)
 
   return (
-    <li className="miniapp-card">
-      {/* Decorative illustration panel — the name below is the accessible identity. */}
-      <div className="miniapp-card-art" aria-hidden="true">
+    <li className="miniapp-row">
+      <div className="miniapp-row-art" aria-hidden="true">
         <Art />
       </div>
-      <div className="miniapp-card-body">
-        <div className="miniapp-card-head">
-          <h5 className="miniapp-card-name" id={nameId}>
-            {app.name}
-          </h5>
-          {canFavorite && (
-            <button
-              type="button"
-              className={`miniapp-card-favorite${isFavorite ? ' is-active' : ''}`}
-              aria-pressed={isFavorite}
-              aria-label={
-                isFavorite ? `Remove ${app.name} from Quick Access` : `Add ${app.name} to Quick Access`
-              }
-              onClick={() => onToggleFavorite(app, slug)}
-            >
-              <NavIcon name="star" size={16} />
-            </button>
+      <div className="miniapp-row-body">
+        <h5 className="miniapp-row-name">{app.name}</h5>
+        <p className="miniapp-row-meta">
+          {categoryLabel} • <code title={app.vendor || undefined}>{shortAddress(app.vendor)}</code>
+        </p>
+        <p className="miniapp-row-chips">
+          <span className="miniapp-row-chip">v{app.approved.version}</span>
+          {isFavorite && (
+            <span className="miniapp-row-chip is-favorite">
+              <NavIcon name="star" size={12} />
+              My Apps
+            </span>
           )}
-        </div>
-        <p className="miniapp-card-category">{categoryLabel}</p>
-        {app.description && (
-          <p className="miniapp-card-description" id={descriptionId}>
-            {app.description}
-          </p>
-        )}
-        {/* The technical data box: vendor + version contained and visually separate from the
-            description (spec 077 FR-005). Same DL semantics as before the redesign. */}
-        <dl className="miniapp-card-meta">
-          <div>
-            <dt>Vendor</dt>
-            <dd>
-              <code title={app.vendor || undefined}>{shortAddress(app.vendor)}</code>
-            </dd>
-          </div>
-          <div>
-            <dt>Version</dt>
-            <dd>v{app.approved.version}</dd>
-          </div>
-        </dl>
-        {launchable && slug ? (
-          <Link
-            className="miniapp-card-launch"
-            to={`/apps/${slug}`}
-            // The visible word stays inside the accessible name (WCAG 2.5.3), and the app name makes
-            // each of these links distinguishable in a screen reader's link list. The rocket is
-            // flavour (FR-006) and stays out of the name.
-            aria-label={`Launch ${app.name}`}
-            aria-describedby={app.description ? descriptionId : undefined}
-          >
-            <RocketGlyph />
-            Launch
-          </Link>
-        ) : (
-          <p className="miniapp-card-refusal" role="note">
-            {/* Provenance first: when we cannot verify the listing at all, that is the reason that
-                matters, whatever else is also true of the record. */}
-            {!launchable
-              ? 'Launch unavailable — this listing could not be verified.'
-              : 'Launch unavailable — this app’s registered name can’t be used as a web address, so the host has no way to open it. Its vendor needs to re-register it under a usable name.'}
-          </p>
-        )}
+        </p>
       </div>
+      <button
+        type="button"
+        className="miniapp-row-tap"
+        onClick={(event) => onOpen(app, event.currentTarget)}
+      >
+        <span className="sr-only">{app.name} details</span>
+      </button>
     </li>
   )
 }
@@ -380,7 +271,7 @@ function CatalogView({ view = STORE_VIEWS.MARKET }) {
   /**
    * `visible`, grouped under a heading per category (FR-007) in the chip row's own order.
    *
-   * A category ordinal ahead of this build's label map (see `AppCard`'s fallback) still gets a
+   * A category ordinal ahead of this build's label map (see `AppRow`'s fallback) still gets a
    * group — under its raw ordinal — rather than being dropped: grouping must never quietly shrink
    * the list `visible` already promised via the result count above it.
    */
@@ -428,8 +319,33 @@ function CatalogView({ view = STORE_VIEWS.MARKET }) {
     if (view === STORE_VIEWS.SEARCH) searchInputRef.current?.focus()
   }, [view, showControls])
 
+  /**
+   * The open app-details sheet (iteration 2, FR-017), by app id — id rather than the record so a
+   * Refresh that drops the app from the listing closes the sheet instead of showing a ghost.
+   * `sheetReturnFocus` is the row button that opened it; focus goes back there on close, so a
+   * keyboard member lands exactly where they left the list.
+   */
+  const [sheetAppId, setSheetAppId] = useState(null)
+  const sheetReturnFocus = useRef(null)
+  const sheetApp = sheetAppId !== null ? (listing?.apps.find((app) => app.id === sheetAppId) ?? null) : null
+
+  function handleOpenSheet(app, trigger) {
+    sheetReturnFocus.current = trigger
+    setSheetAppId(app.id)
+  }
+
+  function handleCloseSheet() {
+    setSheetAppId(null)
+    sheetReturnFocus.current?.focus()
+    sheetReturnFocus.current = null
+  }
+
+  // The fixed bottom navigation needs breathing room under the list so it never occludes the
+  // last row; the spacer class applies exactly when the bar renders.
+  const showStoreBar = outcome && outcome.status !== REGISTRY_STATUS.NOT_DEPLOYED
+
   return (
-    <section className="miniapp-catalog" aria-label="Apps">
+    <section className={`miniapp-catalog${showStoreBar ? ' miniapp-catalog-with-bar' : ''}`} aria-label="Apps">
       <div className="miniapp-catalog-header">
         <div className="miniapp-store-hero">
           <div className="miniapp-store-title">
@@ -444,25 +360,8 @@ function CatalogView({ view = STORE_VIEWS.MARKET }) {
               </p>
             )}
           </div>
-          {/* The spec-073 trust story, restructured into two scannable blocks (FR-003). Same
-              factual claims as the old paragraph; the glyphs are decoration, not meaning. */}
-          <ul className="miniapp-store-trust">
-            <li>
-              <ScrollCheckGlyph />
-              <span>
-                <strong>Reviewed on-chain.</strong> Every app listed here has been reviewed and
-                approved on-chain.
-              </span>
-            </li>
-            <li>
-              <HashShieldGlyph />
-              <span>
-                <strong>Hash-checked before launch.</strong> Before any of an app’s code runs, the
-                host re-reads its registry record and checks the package against the hash recorded
-                there.
-              </span>
-            </li>
-          </ul>
+          {/* No explanation prose here (iteration 2, FR-003 superseded): the badge is the trust
+              signal, and the verification story lives in the developer docs. */}
         </div>
         {/* No registry means nothing to refresh and nowhere to submit — offering either would be an
             affordance that leads nowhere. */}
@@ -483,10 +382,13 @@ function CatalogView({ view = STORE_VIEWS.MARKET }) {
                 if (refreshing) return
                 setReloadKey((key) => key + 1)
               }}
+              // Icon-only (iteration 2, FR-018): the aria-label carries the same state change the
+              // visible text used to, so the still-focused control keeps announcing the outcome.
+              aria-label={refreshing ? 'Refreshing…' : 'Refresh'}
               aria-disabled={refreshing || undefined}
               aria-busy={refreshing || undefined}
             >
-              {refreshing ? 'Refreshing…' : 'Refresh'}
+              <RefreshGlyph />
             </button>
             <Link className="miniapp-catalog-submit" to={SUBMIT_ROUTE}>
               Submit an app
@@ -638,22 +540,35 @@ function CatalogView({ view = STORE_VIEWS.MARKET }) {
           </h4>
           <ul className="miniapp-catalog-grid">
             {group.apps.map((app) => (
-              <AppCard
+              <AppRow
                 key={app.id}
                 app={app}
-                launchable={listing.verified}
                 isFavorite={favoriteIds.has(app.id)}
-                onToggleFavorite={handleToggleFavorite}
+                onOpen={handleOpenSheet}
               />
             ))}
           </ul>
         </section>
       ))}
 
-      {/* The store's own section navigation (spec 077, US2): persistent — sticky at the viewport
-          bottom while the catalog scrolls — and withheld only when there is no store at all (no
-          registry on this build), where all three entries would lead nowhere. */}
-      {outcome && outcome.status !== REGISTRY_STATUS.NOT_DEPLOYED && <StoreBar active={view} />}
+      {/* The app-details sheet (iteration 2, FR-017). `listing` is non-null whenever a row
+          existed to open it; `verified` carries the listing's provenance into the sheet's
+          action rules unchanged. */}
+      {sheetApp && listing && (
+        <AppSheet
+          app={sheetApp}
+          slug={appSlug(sheetApp.name)}
+          verified={listing.verified}
+          isFavorite={favoriteIds.has(sheetApp.id)}
+          onToggleFavorite={handleToggleFavorite}
+          onClose={handleCloseSheet}
+        />
+      )}
+
+      {/* The store's own section navigation (spec 077, US2 as amended): a fixed bottom
+          navigation bar, withheld only when there is no store at all (no registry on this
+          build), where all three entries would lead nowhere. */}
+      {showStoreBar && <StoreBar active={view} />}
     </section>
   )
 }

--- a/frontend/src/components/miniapps/StoreBar.jsx
+++ b/frontend/src/components/miniapps/StoreBar.jsx
@@ -33,7 +33,11 @@ export default function StoreBar({ active }) {
             to={entry.to}
             aria-current={isActive ? 'page' : undefined}
           >
-            <NavIcon name={entry.icon} size={18} />
+            {/* Icon over label (iteration 2): the pill behind the active icon is the material
+                idiom, and the text label below keeps the state readable without hue. */}
+            <span className="miniapp-store-bar-icon">
+              <NavIcon name={entry.icon} size={20} />
+            </span>
             {entry.label}
           </Link>
         )

--- a/frontend/src/components/miniapps/appArt.jsx
+++ b/frontend/src/components/miniapps/appArt.jsx
@@ -96,4 +96,56 @@ function GenericAppArt() {
   )
 }
 
+/* ---- Chrome glyphs (spec 077) ------------------------------------------------------------- */
+/*
+ * Decorative glyphs for the store chrome. All `aria-hidden`: each sits beside (or inside a
+ * control that carries) text or an aria-label saying the same thing, so the art adds flavour,
+ * never meaning. They live here rather than in CatalogPanel so components-only files stay
+ * components-only (react-refresh) and the sheet can share them.
+ */
+
+export function RocketGlyph() {
+  return (
+    <svg className="miniapp-glyph" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+      <g fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10 13.5c-1.8-.6-3-1.8-3.5-3.5C7.6 5.6 10.4 3.2 15 3c-.2 4.6-2.6 7.4-7 8.5Z" />
+        <circle cx="11.6" cy="6.4" r="1.2" />
+        <path d="M6.5 10 4 11.5 6 12M10 13.5 8.5 16l-.5-2M5.5 14.5 4 16" />
+      </g>
+    </svg>
+  )
+}
+
+export function RefreshGlyph() {
+  return (
+    <svg className="miniapp-glyph" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+      <g fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M16.5 10a6.5 6.5 0 1 1-1.9-4.6" />
+        <path d="M16.5 2.8v3.4h-3.4" />
+      </g>
+    </svg>
+  )
+}
+
+export function VerifiedBadgeGlyph() {
+  return (
+    <svg className="miniapp-glyph miniapp-glyph-badge" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+      {/* rosette: scalloped seal with a check — the concept art's rainbow badge, themed */}
+      <path
+        d="M10 1.6l1.9 1.2 2.2-.3 1 2 2 1-.3 2.2L18 10l-1.2 1.9.3 2.2-2 1-1 2-2.2-.3L10 18.4l-1.9-1.2-2.2.3-1-2-2-1 .3-2.2L2 10l1.2-1.9-.3-2.2 2-1 1-2 2.2.3L10 1.6Z"
+        fill="currentColor"
+        opacity="0.18"
+      />
+      <path
+        d="M10 1.6l1.9 1.2 2.2-.3 1 2 2 1-.3 2.2L18 10l-1.2 1.9.3 2.2-2 1-1 2-2.2-.3L10 18.4l-1.9-1.2-2.2.3-1-2-2-1 .3-2.2L2 10l1.2-1.9-.3-2.2 2-1 1-2 2.2.3L10 1.6Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinejoin="round"
+      />
+      <path d="M6.8 10.2l2.1 2.1 4.3-4.6" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
 export { TokenMintArt, ClearPathArt, GenericAppArt }

--- a/frontend/src/components/miniapps/miniapps.css
+++ b/frontend/src/components/miniapps/miniapps.css
@@ -120,37 +120,6 @@
 .miniapp-store-badge .miniapp-glyph-badge {
   color: var(--brand-primary, #36b37e);
 }
-/* The trust story as two scannable blocks instead of one dense paragraph. */
-.miniapp-store-trust {
-  display: grid;
-  gap: 0.45rem;
-  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.miniapp-store-trust li {
-  align-items: flex-start;
-  background: var(--bg-primary, #f7f9fa);
-  border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 10px;
-  color: var(--text-secondary, #5a6772);
-  display: flex;
-  font-size: 0.82rem;
-  gap: 0.5rem;
-  line-height: 1.45;
-  padding: 0.55rem 0.7rem;
-}
-.miniapp-store-trust li strong {
-  color: var(--text-primary, #1f2933);
-}
-.miniapp-store-trust .miniapp-glyph {
-  color: var(--brand-primary, #36b37e);
-  height: 20px;
-  margin-top: 0.1rem;
-  width: 20px;
-}
-
 /* Decorative glyph base: sized to sit beside a line of text, never focusable, never announced. */
 .miniapp-glyph {
   flex: 0 0 auto;
@@ -158,37 +127,35 @@
   width: 18px;
 }
 
-/* ---- Store bar: Market / My Apps / Search (spec 077, US2) -------------- */
+/* ---- Store bar: fixed bottom navigation (spec 077 iteration 2) --------- */
 
-/* A floating dock, sticky at the viewport bottom while the catalog scrolls — the concept art's
-   bottom navigation, scoped to the Apps section. It sits last in the DOM, so its visual position
-   and its tab order agree. `bottom` keeps a thumb-height gap plus the device safe area. */
+/* A proper bottom nav, app-store style: fixed to the viewport bottom, full-width on small
+   screens with icon-over-label entries, floating as a centered dock on wide ones. It sits last
+   in the DOM (tab order = "after the content", the native idiom for bottom navs) and the
+   catalog carries a spacer (`.miniapp-catalog-with-bar`) so it never occludes the last row. */
 .miniapp-store-bar {
-  align-self: center;
   background: var(--surface-color, #fff);
-  border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 999px;
-  bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
-  box-shadow: 0 4px 16px color-mix(in srgb, var(--text-primary, #1f2933) 14%, transparent);
+  border-top: 1px solid var(--border-color, #e3e7eb);
+  bottom: 0;
   display: flex;
-  gap: 0.25rem;
-  margin-top: 0.25rem;
-  padding: 0.3rem;
-  position: sticky;
-  z-index: 2;
+  justify-content: space-around;
+  left: 0;
+  padding: 0.3rem 0.5rem calc(0.3rem + env(safe-area-inset-bottom, 0px));
+  position: fixed;
+  right: 0;
+  z-index: 30;
 }
 .miniapp-store-bar-link {
   align-items: center;
-  border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: 12px;
   color: var(--text-secondary, #5a6772);
   display: inline-flex;
-  font-size: 0.82rem;
+  flex-direction: column;
+  font-size: 0.72rem;
   font-weight: 600;
-  gap: 0.35rem;
-  padding: 0.4rem 0.9rem;
+  gap: 0.1rem;
+  padding: 0.2rem 0.75rem 0.3rem;
   text-decoration: none;
-  white-space: nowrap;
 }
 .miniapp-store-bar-link:hover {
   color: var(--text-primary, #1f2933);
@@ -197,359 +164,226 @@
   outline: 2px solid var(--brand-primary, #36b37e);
   outline-offset: 2px;
 }
-/* Active section: tinted pill + border + weight — and `aria-current` in the markup — so the
-   state never rides on colour alone. */
+.miniapp-store-bar-icon {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  justify-content: center;
+  line-height: 0;
+  padding: 0.2rem 0.85rem;
+}
+/* Active entry: tinted pill behind the icon plus full-contrast text — with `aria-current` in
+   the markup, so the state never rides on colour alone. */
 .miniapp-store-bar-link.is-active {
-  background: color-mix(in srgb, var(--brand-primary, #36b37e) 14%, transparent);
-  border-color: color-mix(in srgb, var(--brand-primary, #36b37e) 45%, transparent);
   color: var(--text-primary, #1f2933);
 }
+.miniapp-store-bar-link.is-active .miniapp-store-bar-icon {
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 18%, transparent);
+  color: var(--brand-primary, #36b37e);
+}
 
-@media (max-width: 480px) {
+/* Room for the fixed bar: applied to the section exactly when the bar renders. */
+.miniapp-catalog-with-bar {
+  padding-bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px));
+}
+
+@media (min-width: 720px) {
+  /* Wide viewports: the same nav floats as a centered dock instead of spanning the window. */
   .miniapp-store-bar {
-    justify-content: space-around;
-    width: 100%;
+    border: 1px solid var(--border-color, #e3e7eb);
+    border-radius: 999px;
+    bottom: 0.75rem;
+    box-shadow: 0 4px 16px color-mix(in srgb, var(--text-primary, #1f2933) 14%, transparent);
+    gap: 0.25rem;
+    left: 50%;
+    padding: 0.3rem 0.5rem;
+    right: auto;
+    transform: translateX(-50%);
   }
-  .miniapp-store-bar-link {
-    flex: 1 1 0;
-    justify-content: center;
-  }
 }
 
-/* ---- State blocks ------------------------------------------------------ */
+/* ---- App details sheet (spec 077 iteration 2, FR-017) ------------------ */
 
-.miniapp-catalog-loading {
-  color: var(--text-secondary, #5a6772);
-  margin: 0;
-}
-
-.miniapp-catalog-state-title {
-  font-weight: 600;
-  margin: 0 0 0.35rem;
-}
-
-/* "No registry on this build" — a configuration fact, not a fault: stated plainly, no alarm. */
-.miniapp-catalog-unavailable {
-  background: var(--bg-primary, #f7f9fa);
-  border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 10px;
-  color: var(--text-primary, #1f2933);
-  font-size: 0.88rem;
-  padding: 0.75rem 0.9rem;
-}
-.miniapp-catalog-unavailable p {
-  margin: 0;
-}
-.miniapp-catalog-unavailable p + p {
-  margin-top: 0.35rem;
-}
-
-/* "We could not read the registry" — the one state where we are refusing to serve. Heavier border
-   and a warning accent, with the text itself at full contrast rather than tinted. */
-.miniapp-catalog-unverified {
-  background: color-mix(in srgb, var(--warning-color, #f59e0b) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--warning-color, #f59e0b) 45%, transparent);
-  border-left-width: 4px;
-  border-radius: 10px;
-  color: var(--text-primary, #1f2933);
-  font-size: 0.88rem;
-  padding: 0.75rem 0.9rem;
-}
-.miniapp-catalog-unverified p {
-  margin: 0;
-}
-.miniapp-catalog-unverified p + p {
-  margin-top: 0.4rem;
-}
-.miniapp-catalog-stale {
-  font-style: italic;
-}
-
-/* ---- Search + category filters ---------------------------------------- */
-
-.miniapp-catalog-controls {
+.miniapp-sheet-backdrop {
+  align-items: flex-end;
+  background: color-mix(in srgb, var(--text-primary, #1f2933) 45%, transparent);
   display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
+  inset: 0;
+  justify-content: center;
+  position: fixed;
+  z-index: 40;
 }
-/* Search box and the Filter disclosure sit on one row (the request this satisfies: category
-   chips move behind a Filter button inline with search, rather than always on screen). */
-.miniapp-catalog-searchrow {
-  align-items: stretch;
-  display: flex;
-  gap: 0.5rem;
-}
-.miniapp-catalog-search {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-.miniapp-catalog-search input {
+.miniapp-sheet {
   background: var(--surface-color, #fff);
   border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 999px;
-  color: var(--text-primary, #1f2933);
-  font-size: 0.95rem;
-  padding: 0.55rem 0.9rem;
+  border-bottom: none;
+  border-radius: 20px 20px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 85vh;
+  max-width: 480px;
+  overflow-y: auto;
+  padding: 1rem 1rem calc(1rem + env(safe-area-inset-bottom, 0px));
   width: 100%;
 }
-.miniapp-catalog-search input:focus-visible {
-  outline: 2px solid var(--brand-primary, #36b37e);
-  outline-offset: 1px;
+@media (prefers-reduced-motion: no-preference) {
+  .miniapp-sheet {
+    animation: miniapp-sheet-rise 0.18s ease-out;
+  }
+  @keyframes miniapp-sheet-rise {
+    from {
+      transform: translateY(1.5rem);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
 }
-
-.miniapp-catalog-filter-toggle {
+.miniapp-sheet-head {
   align-items: center;
-  background: transparent;
-  border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 999px;
-  color: var(--text-primary, #1f2933);
-  cursor: pointer;
-  display: inline-flex;
-  flex: 0 0 auto;
-  font-size: 0.85rem;
-  gap: 0.35rem;
-  padding: 0 0.85rem;
-  white-space: nowrap;
-}
-.miniapp-catalog-filter-toggle:hover {
-  border-color: var(--brand-primary, #36b37e);
-}
-.miniapp-catalog-filter-toggle:focus-visible {
-  outline: 2px solid var(--brand-primary, #36b37e);
-  outline-offset: 2px;
-}
-/* A category is selected: marked by weight + a tinted background, not colour alone — the label's
-   own "(N)" count is the third, text-based signal. */
-.miniapp-catalog-filter-toggle.is-active {
-  background: color-mix(in srgb, var(--brand-primary, #36b37e) 14%, transparent);
-  border-color: var(--brand-primary, #36b37e);
-  font-weight: 600;
-}
-
-.miniapp-catalog-filters {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
+  gap: 0.85rem;
 }
-.miniapp-catalog-filter {
-  background: transparent;
-  border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 999px;
-  color: var(--text-secondary, #5a6772);
-  cursor: pointer;
-  font-size: 0.8rem;
-  padding: 0.3rem 0.75rem;
-}
-.miniapp-catalog-filter:hover {
-  border-color: var(--brand-primary, #36b37e);
-  color: var(--text-primary, #1f2933);
-}
-.miniapp-catalog-filter:focus-visible {
-  outline: 2px solid var(--brand-primary, #36b37e);
-  outline-offset: 2px;
-}
-/* Pressed state carries a border, a weight change and a background — not colour alone. */
-.miniapp-catalog-filter.is-active {
-  background: color-mix(in srgb, var(--brand-primary, #36b37e) 14%, transparent);
-  border-color: var(--brand-primary, #36b37e);
-  color: var(--text-primary, #1f2933);
-  font-weight: 600;
-}
-
-.miniapp-catalog-count {
-  color: var(--text-secondary, #5a6772);
-  font-size: 0.8rem;
-  margin: 0;
-}
-
-/* ---- Category groups ---------------------------------------------------- */
-
-.miniapp-catalog-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-/* Category banners: an accent bar plus the label — distinct from card headings at a glance, and
-   the bar is decoration over a text label rather than a colour-only signal. */
-.miniapp-catalog-group-title {
-  align-items: center;
-  color: var(--text-primary, #1f2933);
-  display: flex;
-  font-size: 0.8rem;
-  font-weight: 700;
-  gap: 0.5rem;
-  letter-spacing: 0.06em;
-  margin: 0.35rem 0 0;
-  text-transform: uppercase;
-}
-.miniapp-catalog-group-title::before {
-  background: var(--brand-primary, #36b37e);
-  border-radius: 999px;
-  content: '';
-  display: inline-block;
-  height: 1em;
-  width: 4px;
-}
-
-/* ---- Catalog grid ------------------------------------------------------ */
-
-.miniapp-catalog-grid {
-  display: grid;
-  gap: 0.6rem;
-  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.miniapp-card {
-  background: var(--surface-color, #fff);
-  border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 14px;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
-}
-.miniapp-card:hover {
-  border-color: color-mix(in srgb, var(--brand-primary, #36b37e) 45%, var(--border-color, #e3e7eb));
-  box-shadow: 0 6px 18px color-mix(in srgb, var(--text-primary, #1f2933) 10%, transparent);
-}
-/* The illustration panel: a soft brand-tinted stage for the curated art. Decorative throughout —
-   it is aria-hidden in the markup and carries no text. */
-.miniapp-card-art {
+.miniapp-sheet-art {
   align-items: center;
   background: linear-gradient(
     135deg,
     color-mix(in srgb, var(--brand-primary, #36b37e) 16%, transparent),
     color-mix(in srgb, var(--brand-primary, #36b37e) 4%, transparent)
   );
-  border-bottom: 1px solid var(--border-color, #e3e7eb);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 16px;
   display: flex;
+  flex: 0 0 auto;
+  height: 64px;
   justify-content: center;
-  padding: 0.8rem;
+  width: 64px;
 }
-.miniapp-art {
-  height: 72px;
-  width: 72px;
+.miniapp-sheet-art .miniapp-art {
+  height: 46px;
+  width: 46px;
 }
-.miniapp-card-body {
-  display: flex;
+.miniapp-sheet-title {
   flex: 1 1 auto;
-  flex-direction: column;
-  gap: 0.4rem;
-  padding: 0.8rem 0.9rem 0.9rem;
+  min-width: 0;
 }
-.miniapp-card-head {
-  align-items: flex-start;
-  display: flex;
-  gap: 0.5rem;
-  justify-content: space-between;
-}
-.miniapp-card-name {
+.miniapp-sheet-title h4 {
   color: var(--text-primary, #1f2933);
-  font-size: 0.98rem;
-  line-height: 1.3;
+  font-size: 1.15rem;
   margin: 0;
 }
-/* Star toggle for Quick Access (nav drawer). Filled + brand colour when favorited — a shape
-   change, not just a colour change, so the state reads without relying on hue (WCAG 1.4.1). */
-.miniapp-card-favorite {
-  background: transparent;
-  border: none;
-  border-radius: 6px;
+.miniapp-sheet-category {
   color: var(--text-secondary, #5a6772);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  margin: 0.1rem 0 0;
+  text-transform: uppercase;
+}
+.miniapp-sheet-close {
+  align-self: flex-start;
+  background: var(--bg-primary, #f7f9fa);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 999px;
+  color: var(--text-primary, #1f2933);
   cursor: pointer;
   flex: 0 0 auto;
   line-height: 0;
-  padding: 0.2rem;
+  padding: 0.4rem;
 }
-.miniapp-card-favorite:hover {
-  color: var(--brand-primary, #36b37e);
-}
-.miniapp-card-favorite:focus-visible {
+.miniapp-sheet-close:focus-visible {
   outline: 2px solid var(--brand-primary, #36b37e);
   outline-offset: 2px;
 }
-.miniapp-card-favorite.is-active {
-  color: var(--brand-primary, #36b37e);
-}
-.miniapp-card-favorite.is-active .nav-icon {
-  fill: currentColor;
-}
-.miniapp-card-category {
+.miniapp-sheet-description {
   color: var(--text-secondary, #5a6772);
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
-  margin: 0;
-  text-transform: uppercase;
-}
-.miniapp-card-description {
-  color: var(--text-secondary, #5a6772);
-  font-size: 0.85rem;
-  line-height: 1.4;
+  font-size: 0.88rem;
+  line-height: 1.5;
   margin: 0;
 }
-/* The technical-data box (FR-005): vendor + version contained and visibly apart from the prose. */
-.miniapp-card-meta {
+/* The technical-data box, sheet edition: same containment idea as the old card box. */
+.miniapp-sheet-meta {
   background: var(--bg-primary, #f7f9fa);
   border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 10px;
+  border-radius: 12px;
   color: var(--text-secondary, #5a6772);
   display: flex;
-  flex-wrap: wrap;
-  font-size: 0.78rem;
-  gap: 0.25rem 1rem;
-  margin: 0.25rem 0 0;
-  padding: 0.45rem 0.65rem;
+  flex-direction: column;
+  font-size: 0.8rem;
+  gap: 0.3rem;
+  margin: 0;
+  padding: 0.6rem 0.75rem;
 }
-.miniapp-card-meta > div {
+.miniapp-sheet-meta > div {
   align-items: baseline;
   display: flex;
-  gap: 0.3rem;
+  gap: 0.4rem;
 }
-.miniapp-card-meta dt {
+.miniapp-sheet-meta dt {
+  flex: 0 0 auto;
   font-weight: 600;
 }
-.miniapp-card-meta dd {
+.miniapp-sheet-meta dd {
   margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
-.miniapp-card-meta code {
-  font-size: 0.78rem;
+.miniapp-sheet-meta code {
+  font-size: 0.75rem;
 }
-
-.miniapp-card-launch {
+.miniapp-sheet-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.miniapp-sheet-open {
   align-items: center;
-  align-self: flex-start;
   background: var(--primary-button, var(--brand-primary, #36b37e));
   border: 1px solid transparent;
   border-radius: 999px;
   color: var(--primary-button-text, #fff);
   display: inline-flex;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   font-weight: 600;
   gap: 0.4rem;
-  margin-top: auto;
-  padding: 0.4rem 1.1rem;
+  padding: 0.5rem 1.3rem;
   text-decoration: none;
 }
-.miniapp-card-launch .miniapp-glyph {
-  height: 16px;
-  width: 16px;
-}
-.miniapp-card-launch:hover {
+.miniapp-sheet-open:hover {
   background: var(--primary-button-hover, #2f9e6e);
 }
-.miniapp-card-launch:focus-visible {
+.miniapp-sheet-open:focus-visible {
   outline: 2px solid var(--brand-primary, #36b37e);
   outline-offset: 2px;
 }
-
-/* No launch affordance at all when the listing is unverified — this replaces it, and says why. */
-.miniapp-card-refusal {
+.miniapp-sheet-favorite {
+  background: transparent;
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 999px;
+  color: var(--text-primary, #1f2933);
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+}
+.miniapp-sheet-favorite:hover {
+  border-color: var(--brand-primary, #36b37e);
+}
+.miniapp-sheet-favorite:focus-visible {
+  outline: 2px solid var(--brand-primary, #36b37e);
+  outline-offset: 2px;
+}
+/* Pressed (in My Apps): tint + border + the label itself flips — never colour alone. */
+.miniapp-sheet-favorite.is-active {
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 12%, transparent);
+  border-color: color-mix(in srgb, var(--brand-primary, #36b37e) 45%, transparent);
+}
+/* Replaces the actions when the launch is refused on principle — same copy rules as the cards
+   had (provenance first), relocated with the actions. */
+.miniapp-sheet-refusal {
   color: var(--text-secondary, #5a6772);
-  font-size: 0.8rem;
-  margin: 0.35rem 0 0;
+  font-size: 0.82rem;
+  margin: 0;
 }
 
 /* ---------------------------------------------------------------------------------------------

--- a/frontend/src/components/miniapps/miniapps.css
+++ b/frontend/src/components/miniapps/miniapps.css
@@ -127,6 +127,291 @@
   width: 18px;
 }
 
+/* ---- State blocks ------------------------------------------------------ */
+
+.miniapp-catalog-loading {
+  color: var(--text-secondary, #5a6772);
+  margin: 0;
+}
+
+.miniapp-catalog-state-title {
+  font-weight: 600;
+  margin: 0 0 0.35rem;
+}
+
+/* "No registry on this build" — a configuration fact, not a fault: stated plainly, no alarm. */
+.miniapp-catalog-unavailable {
+  background: var(--bg-primary, #f7f9fa);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 10px;
+  color: var(--text-primary, #1f2933);
+  font-size: 0.88rem;
+  padding: 0.75rem 0.9rem;
+}
+.miniapp-catalog-unavailable p {
+  margin: 0;
+}
+.miniapp-catalog-unavailable p + p {
+  margin-top: 0.35rem;
+}
+
+/* "We could not read the registry" — the one state where we are refusing to serve. Heavier border
+   and a warning accent, with the text itself at full contrast rather than tinted. */
+.miniapp-catalog-unverified {
+  background: color-mix(in srgb, var(--warning-color, #f59e0b) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning-color, #f59e0b) 45%, transparent);
+  border-left-width: 4px;
+  border-radius: 10px;
+  color: var(--text-primary, #1f2933);
+  font-size: 0.88rem;
+  padding: 0.75rem 0.9rem;
+}
+.miniapp-catalog-unverified p {
+  margin: 0;
+}
+.miniapp-catalog-unverified p + p {
+  margin-top: 0.4rem;
+}
+.miniapp-catalog-stale {
+  font-style: italic;
+}
+
+/* ---- Search + category filters ---------------------------------------- */
+
+.miniapp-catalog-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+/* Search box and the Filter disclosure sit on one row (the request this satisfies: category
+   chips move behind a Filter button inline with search, rather than always on screen). */
+.miniapp-catalog-searchrow {
+  align-items: stretch;
+  display: flex;
+  gap: 0.5rem;
+}
+.miniapp-catalog-search {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.miniapp-catalog-search input {
+  background: var(--surface-color, #fff);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 999px;
+  color: var(--text-primary, #1f2933);
+  font-size: 0.95rem;
+  padding: 0.55rem 0.9rem;
+  width: 100%;
+}
+.miniapp-catalog-search input:focus-visible {
+  outline: 2px solid var(--brand-primary, #36b37e);
+  outline-offset: 1px;
+}
+
+.miniapp-catalog-filter-toggle {
+  align-items: center;
+  background: transparent;
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 999px;
+  color: var(--text-primary, #1f2933);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 0.85rem;
+  gap: 0.35rem;
+  padding: 0 0.85rem;
+  white-space: nowrap;
+}
+.miniapp-catalog-filter-toggle:hover {
+  border-color: var(--brand-primary, #36b37e);
+}
+.miniapp-catalog-filter-toggle:focus-visible {
+  outline: 2px solid var(--brand-primary, #36b37e);
+  outline-offset: 2px;
+}
+/* A category is selected: marked by weight + a tinted background, not colour alone — the label's
+   own "(N)" count is the third, text-based signal. */
+.miniapp-catalog-filter-toggle.is-active {
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 14%, transparent);
+  border-color: var(--brand-primary, #36b37e);
+  font-weight: 600;
+}
+
+.miniapp-catalog-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+.miniapp-catalog-filter {
+  background: transparent;
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 999px;
+  color: var(--text-secondary, #5a6772);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.3rem 0.75rem;
+}
+.miniapp-catalog-filter:hover {
+  border-color: var(--brand-primary, #36b37e);
+  color: var(--text-primary, #1f2933);
+}
+.miniapp-catalog-filter:focus-visible {
+  outline: 2px solid var(--brand-primary, #36b37e);
+  outline-offset: 2px;
+}
+/* Pressed state carries a border, a weight change and a background — not colour alone. */
+.miniapp-catalog-filter.is-active {
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 14%, transparent);
+  border-color: var(--brand-primary, #36b37e);
+  color: var(--text-primary, #1f2933);
+  font-weight: 600;
+}
+
+.miniapp-catalog-count {
+  color: var(--text-secondary, #5a6772);
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+/* ---- Category groups ---------------------------------------------------- */
+
+.miniapp-catalog-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+/* Category banners: an accent bar plus the label — distinct from card headings at a glance, and
+   the bar is decoration over a text label rather than a colour-only signal. */
+.miniapp-catalog-group-title {
+  align-items: center;
+  color: var(--text-primary, #1f2933);
+  display: flex;
+  font-size: 0.8rem;
+  font-weight: 700;
+  gap: 0.5rem;
+  letter-spacing: 0.06em;
+  margin: 0.35rem 0 0;
+  text-transform: uppercase;
+}
+.miniapp-catalog-group-title::before {
+  background: var(--brand-primary, #36b37e);
+  border-radius: 999px;
+  content: '';
+  display: inline-block;
+  height: 1em;
+  width: 4px;
+}
+
+/* ---- Catalog list (iteration 2: store rows) ---------------------------- */
+
+.miniapp-catalog-grid {
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* A store row: leading art tile, text block, and a stretched tap target (see AppRow's note on
+   why the button overlays rather than wraps). Rows read as one tappable surface — hover/focus
+   feedback lands on the whole row via the overlay's states. */
+.miniapp-row {
+  align-items: center;
+  border-radius: 14px;
+  display: flex;
+  gap: 0.85rem;
+  padding: 0.6rem 0.6rem;
+  position: relative;
+}
+.miniapp-row:hover {
+  background: color-mix(in srgb, var(--brand-primary, #36b37e) 7%, transparent);
+}
+.miniapp-row-art {
+  align-items: center;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--brand-primary, #36b37e) 16%, transparent),
+    color-mix(in srgb, var(--brand-primary, #36b37e) 4%, transparent)
+  );
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 14px;
+  display: flex;
+  flex: 0 0 auto;
+  height: 56px;
+  justify-content: center;
+  width: 56px;
+}
+.miniapp-row-art .miniapp-art {
+  height: 40px;
+  width: 40px;
+}
+.miniapp-row-body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+.miniapp-row-name {
+  color: var(--text-primary, #1f2933);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin: 0;
+}
+.miniapp-row-meta {
+  color: var(--text-secondary, #5a6772);
+  font-size: 0.8rem;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.miniapp-row-meta code {
+  font-size: 0.78rem;
+}
+.miniapp-row-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.1rem 0 0;
+}
+.miniapp-row-chip {
+  align-items: center;
+  background: var(--bg-primary, #f7f9fa);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 999px;
+  color: var(--text-secondary, #5a6772);
+  display: inline-flex;
+  font-size: 0.7rem;
+  font-weight: 600;
+  gap: 0.25rem;
+  padding: 0.1rem 0.5rem;
+}
+.miniapp-row-chip.is-favorite {
+  border-color: color-mix(in srgb, var(--brand-primary, #36b37e) 45%, transparent);
+  color: var(--text-primary, #1f2933);
+}
+.miniapp-row-chip.is-favorite .nav-icon {
+  color: var(--brand-primary, #36b37e);
+  fill: currentColor;
+}
+/* The stretched tap target: every pixel of the row opens the sheet, and the row's focus ring is
+   the button's, drawn around the whole row. */
+.miniapp-row-tap {
+  background: transparent;
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+  inset: 0;
+  padding: 0;
+  position: absolute;
+}
+.miniapp-row-tap:focus-visible {
+  outline: 2px solid var(--brand-primary, #36b37e);
+  outline-offset: -2px;
+}
+
 /* ---- Store bar: fixed bottom navigation (spec 077 iteration 2) --------- */
 
 /* A proper bottom nav, app-store style: fixed to the viewport bottom, full-width on small

--- a/frontend/src/test/miniapps/CatalogPanel.test.jsx
+++ b/frontend/src/test/miniapps/CatalogPanel.test.jsx
@@ -166,6 +166,12 @@ async function openFilters(user) {
   await user.click(screen.getByRole('button', { name: /^Filter/ }))
 }
 
+/** Taps an app's row (the stretched details button) and returns the opened sheet dialog. */
+async function openSheet(user, name) {
+  await user.click(screen.getByRole('button', { name: `${name} details` }))
+  return screen.getByRole('dialog', { name })
+}
+
 describe('CatalogPanel — listing (spec 073 FR-003/FR-007)', () => {
   beforeEach(() => {
     state.fetchCatalog = null
@@ -195,7 +201,8 @@ describe('CatalogPanel — listing (spec 073 FR-003/FR-007)', () => {
     expect(screen.getByText('Showing all 2 apps.')).toBeInTheDocument()
   })
 
-  it('shows name, vendor, version and category on each card, and links launch at /apps/<slug>', async () => {
+  it('shows name, category, vendor and version on each row, and opens the details sheet on tap', async () => {
+    const user = userEvent.setup()
     state.fetchCatalog = vi.fn(async () =>
       okOutcome([
         appRecord({
@@ -210,17 +217,28 @@ describe('CatalogPanel — listing (spec 073 FR-003/FR-007)', () => {
 
     await renderSettled()
 
-    const card = screen.getByRole('heading', { level: 5, name: 'Treasury Sweep' }).closest('li')
-    expect(within(card).getByText(APP_CATEGORY_LABELS[AppCategory.TREASURY_LIQUIDITY])).toBeInTheDocument()
-    expect(within(card).getByText('v4')).toBeInTheDocument()
-    expect(within(card).getByText('0x1234…5678')).toBeInTheDocument()
-    expect(within(card).getByText('Sweeps idle balances into the operating account.')).toBeInTheDocument()
+    // The row: bold name heading, category • vendor metadata line, version chip. The description
+    // and the launch affordance are NOT here — they moved to the sheet.
+    const row = screen.getByRole('heading', { level: 5, name: 'Treasury Sweep' }).closest('li')
+    expect(within(row).getByText(new RegExp(APP_CATEGORY_LABELS[AppCategory.TREASURY_LIQUIDITY]))).toBeInTheDocument()
+    expect(within(row).getByText('v4')).toBeInTheDocument()
+    expect(within(row).getByText('0x1234…5678')).toBeInTheDocument()
+    expect(within(row).queryByText('Sweeps idle balances into the operating account.')).toBeNull()
+    expect(within(row).queryByRole('link')).toBeNull()
 
-    const launch = within(card).getByRole('link', { name: 'Launch Treasury Sweep' })
-    expect(launch).toHaveAttribute('href', `/apps/${appSlug('Treasury Sweep')}`)
+    // The sheet: full detail plus the Open action, linked at the same /apps/<slug> the launch
+    // route resolves.
+    const sheet = await openSheet(user, 'Treasury Sweep')
+    expect(within(sheet).getByText('Sweeps idle balances into the operating account.')).toBeInTheDocument()
+    expect(within(sheet).getByText(VENDOR)).toBeInTheDocument()
+    expect(within(sheet).getByText('v4')).toBeInTheDocument()
+    expect(within(sheet).getByRole('link', { name: 'Open Treasury Sweep' })).toHaveAttribute(
+      'href',
+      `/apps/${appSlug('Treasury Sweep')}`,
+    )
   })
 
-  it('renders no launch link for a name that has no slug, and says why', async () => {
+  it('offers no Open action for a name that has no slug, and says why in the sheet', async () => {
     // `appSlug` refuses a lossy best effort — a name it cannot fold into a valid slug returns null
     // rather than a mangled one, because two distinct on-chain listings must never share an address.
     // The catalog's job is to say that plainly instead of linking to `/apps/null`.
@@ -232,14 +250,21 @@ describe('CatalogPanel — listing (spec 073 FR-003/FR-007)', () => {
       ]),
     )
 
+    const user = userEvent.setup()
     await renderSettled()
 
     // The listing is still shown — it IS approved and it IS launchable; only its address is missing.
     expect(listedApps()).toEqual(['Ünïcode Desk', 'Settle Desk'])
-    expect(screen.queryByRole('link', { name: 'Launch Ünïcode Desk' })).toBeNull()
-    expect(screen.getByText(/registered name can’t be used as a web address/i)).toBeInTheDocument()
+
+    // Its sheet explains the refusal and offers no Open action…
+    const refused = await openSheet(user, 'Ünïcode Desk')
+    expect(within(refused).getByText(/registered name can’t be used as a web address/i)).toBeInTheDocument()
+    expect(within(refused).queryByRole('link', { name: /^Open / })).toBeNull()
+    await user.click(within(refused).getByRole('button', { name: /^Close/ }))
+
     // …and it does not contaminate its neighbour.
-    expect(screen.getByRole('link', { name: 'Launch Settle Desk' })).toHaveAttribute(
+    const ok = await openSheet(user, 'Settle Desk')
+    expect(within(ok).getByRole('link', { name: 'Open Settle Desk' })).toHaveAttribute(
       'href',
       `/apps/${appSlug('Settle Desk')}`,
     )
@@ -442,43 +467,49 @@ describe('CatalogPanel — apps grouped by category', () => {
   })
 })
 
-describe('CatalogPanel — Quick Access favorites', () => {
-  it('offers no favorite star for a card that cannot be launched by URL', async () => {
+describe('CatalogPanel — My Apps (Quick Access favorites, toggled from the sheet)', () => {
+  it('offers no My Apps toggle in the sheet of an app that cannot be launched by URL', async () => {
+    const user = userEvent.setup()
     state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 1, name: 'Ünïcode Desk' })]))
     await renderSettled()
 
-    expect(screen.queryByRole('button', { name: /Quick Access/ })).toBeNull()
+    const sheet = await openSheet(user, 'Ünïcode Desk')
+    expect(within(sheet).queryByRole('button', { name: /My Apps/ })).toBeNull()
   })
 
-  it('offers no favorite star on an unverified stale snapshot', async () => {
+  it('offers no My Apps toggle on an unverified stale snapshot', async () => {
+    const user = userEvent.setup()
     state.fetchCatalog = vi.fn(async () =>
       unreachableOutcome({ stale: staleSnapshot([appRecord({ id: 1, name: 'Settle Desk' })], 60_000) }),
     )
     await renderSettled()
 
-    expect(screen.queryByRole('button', { name: /Quick Access/ })).toBeNull()
+    const sheet = await openSheet(user, 'Settle Desk')
+    expect(within(sheet).queryByRole('button', { name: /My Apps/ })).toBeNull()
   })
 
-  it('adds a launchable app to Quick Access and persists it, then removes it on a second press', async () => {
+  it('adds a launchable app to My Apps from its sheet, persists it, and removes it on a second press', async () => {
     const user = userEvent.setup()
     state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 9, name: 'Settle Desk' })]))
     await renderSettled()
 
-    const star = screen.getByRole('button', { name: 'Add Settle Desk to Quick Access' })
-    expect(star).toHaveAttribute('aria-pressed', 'false')
+    const sheet = await openSheet(user, 'Settle Desk')
+    const toggle = within(sheet).getByRole('button', { name: 'Add Settle Desk to My Apps' })
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
 
-    await user.click(star)
+    await user.click(toggle)
 
-    const active = screen.getByRole('button', { name: 'Remove Settle Desk from Quick Access' })
+    const active = within(sheet).getByRole('button', { name: 'Remove Settle Desk from My Apps' })
     expect(active).toHaveAttribute('aria-pressed', 'true')
     expect(loadFavoriteApps()).toEqual([{ id: 9, slug: appSlug('Settle Desk'), name: 'Settle Desk' }])
 
-    await user.click(active)
+    // The row picks up the state as a non-interactive indicator chip.
+    await user.click(within(sheet).getByRole('button', { name: /^Close/ }))
+    const row = screen.getByRole('heading', { level: 5, name: 'Settle Desk' }).closest('li')
+    expect(within(row).getByText('My Apps')).toBeInTheDocument()
 
-    expect(screen.getByRole('button', { name: 'Add Settle Desk to Quick Access' })).toHaveAttribute(
-      'aria-pressed',
-      'false',
-    )
+    const reopened = await openSheet(user, 'Settle Desk')
+    await user.click(within(reopened).getByRole('button', { name: 'Remove Settle Desk from My Apps' }))
     expect(loadFavoriteApps()).toEqual([])
   })
 })
@@ -538,7 +569,7 @@ describe('CatalogPanel — honest degradation (spec.md edge cases)', () => {
     expect(screen.queryByText('No apps are approved yet')).toBeNull()
     expect(screen.queryByText('Apps aren’t available here.')).toBeNull()
     expect(listedApps()).toEqual([])
-    expect(screen.queryByRole('link', { name: /^Launch / })).toBeNull()
+    expect(screen.queryByRole('link', { name: /^Open / })).toBeNull()
   })
 
   it('registry unreachable with no route: names the missing connection rather than blaming the registry', async () => {
@@ -580,10 +611,14 @@ describe('CatalogPanel — honest degradation (spec.md edge cases)', () => {
     expect(screen.getByText(/it is not current, and nothing in it can be launched/i)).toBeInTheDocument()
 
     // The snapshot IS shown — that is what makes this state different from the bare outage — but
-    // every launch affordance is gone and each card says why.
+    // every launch affordance is gone, and an opened sheet says why instead of offering Open.
     expect(listedApps()).toEqual(['Settle Desk', 'Ledger Match'])
-    expect(screen.queryByRole('link', { name: /^Launch / })).toBeNull()
-    expect(screen.getAllByText('Launch unavailable — this listing could not be verified.')).toHaveLength(2)
+    expect(screen.queryByRole('link', { name: /^Open / })).toBeNull()
+
+    const user = userEvent.setup()
+    const sheet = await openSheet(user, 'Settle Desk')
+    expect(within(sheet).getByText('Launch unavailable — this listing could not be verified.')).toBeInTheDocument()
+    expect(within(sheet).queryByRole('link', { name: /^Open / })).toBeNull()
   })
 
   it('a throwing registry client is an outage, not an empty catalog', async () => {

--- a/frontend/src/test/miniapps/appSheet.test.jsx
+++ b/frontend/src/test/miniapps/appSheet.test.jsx
@@ -1,0 +1,142 @@
+/**
+ * AppSheet dialog mechanics (spec 077 iteration 2, FR-017).
+ *
+ * The row → sheet interaction is the store's whole navigation-to-detail gesture now, so its
+ * dialog behavior gets its own suite: every dismissal path works, focus is managed (into the
+ * sheet on open, back to the invoking row on close), the dialog is properly labelled, and the
+ * overlay passes axe. The sheet's CONTENT rules (actions, refusals, honesty) live in
+ * CatalogPanel.test.jsx and storeRedesign.test.jsx — this file is about the mechanics.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { axe } from 'vitest-axe'
+
+const state = vi.hoisted(() => ({ fetchCatalog: null }))
+
+vi.mock('../../lib/miniapps/registryClient', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, fetchCatalog: (...args) => state.fetchCatalog(...args) }
+})
+
+import { AppCategory, AppStatus } from '../../abis/miniAppRegistry'
+import { REGISTRY_STATUS } from '../../lib/miniapps/registryClient'
+import { __resetFavoriteAppsForTests } from '../../lib/miniapps/favorites'
+import CatalogPanel from '../../components/miniapps/CatalogPanel'
+
+beforeEach(() => {
+  localStorage.clear()
+  __resetFavoriteAppsForTests()
+  state.fetchCatalog = null
+})
+
+const VENDOR = '0x1234567890abcdef1234567890abcdef12345678'
+const HASH = `0x${'ab'.repeat(32)}`
+const ZERO_HASH = `0x${'0'.repeat(64)}`
+
+function appRecord({ id, name, description = '' }) {
+  return Object.freeze({
+    id,
+    vendor: VENDOR,
+    name,
+    description,
+    category: AppCategory.TRADE_SETTLEMENT,
+    status: AppStatus.APPROVED,
+    approved: Object.freeze({ cid: 'bafybeigdyrztktx5', manifestHash: HASH, version: 1, present: true }),
+    proposed: Object.freeze({ cid: '', manifestHash: ZERO_HASH, version: 0, present: false }),
+    submittedAt: 1_700_000_000,
+    approvedAt: 1_700_000_100,
+    updatedAt: 1_700_000_200,
+    launchable: true,
+  })
+}
+
+function okOutcome(allApps) {
+  return {
+    status: REGISTRY_STATUS.OK,
+    apps: Object.freeze(allApps),
+    allApps: Object.freeze(allApps),
+    fetchedAt: Date.now(),
+    ageMs: 0,
+    cached: false,
+    chainId: 137,
+    registryAddress: '0x5a168Cc9FeFaf40e7BC536C8C61669e6d547A0A2',
+  }
+}
+
+async function renderSettled() {
+  const result = render(
+    <MemoryRouter>
+      <CatalogPanel />
+    </MemoryRouter>,
+  )
+  await waitFor(() => expect(screen.queryByText('Loading the app catalog…')).toBeNull())
+  return result
+}
+
+const APP = appRecord({ id: 1, name: 'Settle Desk', description: 'Settles bilateral trades.' })
+
+describe('AppSheet — dialog mechanics (FR-017)', () => {
+  beforeEach(() => {
+    state.fetchCatalog = vi.fn(async () => okOutcome([APP]))
+  })
+
+  it('opens labelled by the app name, aria-modal, with focus moved onto the close control', async () => {
+    const user = userEvent.setup()
+    await renderSettled()
+
+    await user.click(screen.getByRole('button', { name: 'Settle Desk details' }))
+
+    const sheet = screen.getByRole('dialog', { name: 'Settle Desk' })
+    expect(sheet).toHaveAttribute('aria-modal', 'true')
+    expect(document.activeElement).toBe(within(sheet).getByRole('button', { name: /^Close/ }))
+  })
+
+  it('closes via the close button, returning focus to the row that opened it', async () => {
+    const user = userEvent.setup()
+    await renderSettled()
+
+    const row = screen.getByRole('button', { name: 'Settle Desk details' })
+    await user.click(row)
+    await user.click(screen.getByRole('button', { name: 'Close Settle Desk details' }))
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+    // The member lands exactly where they left the list — the row keeps their place.
+    expect(document.activeElement).toBe(row)
+  })
+
+  it('closes on Escape', async () => {
+    const user = userEvent.setup()
+    await renderSettled()
+
+    await user.click(screen.getByRole('button', { name: 'Settle Desk details' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Settle Desk details' }))
+  })
+
+  it('closes on a backdrop tap, but not on a tap inside the sheet', async () => {
+    const user = userEvent.setup()
+    const { container } = await renderSettled()
+
+    await user.click(screen.getByRole('button', { name: 'Settle Desk details' }))
+
+    // A click INSIDE the sheet (its description) must not dismiss it.
+    await user.click(screen.getByText('Settles bilateral trades.'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.click(container.querySelector('.miniapp-sheet-backdrop'))
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('has no axe violations with the sheet open', async () => {
+    const user = userEvent.setup()
+    const { container } = await renderSettled()
+
+    await user.click(screen.getByRole('button', { name: 'Settle Desk details' }))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/miniapps/appSheet.test.jsx
+++ b/frontend/src/test/miniapps/appSheet.test.jsx
@@ -132,6 +132,21 @@ describe('AppSheet — dialog mechanics (FR-017)', () => {
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 
+  it('keeps focus on the My Apps toggle after pressing it — the open-focus never re-fires', async () => {
+    // Regression (iteration-2 review): the focus-on-open effect used to share deps with the
+    // Escape listener, so any panel re-render (like the favorite toggle's state change) yanked
+    // focus back to the close button mid-interaction.
+    const user = userEvent.setup()
+    await renderSettled()
+
+    await user.click(screen.getByRole('button', { name: 'Settle Desk details' }))
+    const toggle = screen.getByRole('button', { name: 'Add Settle Desk to My Apps' })
+    await user.click(toggle)
+
+    const active = screen.getByRole('button', { name: 'Remove Settle Desk from My Apps' })
+    expect(document.activeElement).toBe(active)
+  })
+
   it('has no axe violations with the sheet open', async () => {
     const user = userEvent.setup()
     const { container } = await renderSettled()

--- a/frontend/src/test/miniapps/storeNavigation.test.jsx
+++ b/frontend/src/test/miniapps/storeNavigation.test.jsx
@@ -180,13 +180,15 @@ describe('sub-view routing is total (contract §1)', () => {
 })
 
 describe('My Apps (spec 077 FR-008)', () => {
-  it('lists only favorited apps, with the same card treatment and working launch links', async () => {
+  it('lists only favorited apps, with the same row treatment and a working Open action', async () => {
+    const user = userEvent.setup()
     favorite(TWO_APPS[1]) // Ledger Match
     state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
     await renderAt('/wallet?tab=apps&view=mine')
 
     expect(listedApps()).toEqual(['Ledger Match'])
-    expect(screen.getByRole('link', { name: 'Launch Ledger Match' })).toHaveAttribute(
+    await user.click(screen.getByRole('button', { name: 'Ledger Match details' }))
+    expect(screen.getByRole('link', { name: 'Open Ledger Match' })).toHaveAttribute(
       'href',
       `/apps/${appSlug('Ledger Match')}`,
     )
@@ -204,17 +206,22 @@ describe('My Apps (spec 077 FR-008)', () => {
     expect(screen.queryByRole('searchbox')).toBeNull()
   })
 
-  it('unfavoriting from the card updates the view live', async () => {
+  it('unfavoriting from the app sheet updates the view live', async () => {
     const user = userEvent.setup()
     favorite(TWO_APPS[0])
     state.fetchCatalog = vi.fn(async () => okOutcome(TWO_APPS))
     await renderAt('/wallet?tab=apps&view=mine')
 
     expect(listedApps()).toEqual(['Settle Desk'])
-    await user.click(screen.getByRole('button', { name: 'Remove Settle Desk from Quick Access' }))
+    await user.click(screen.getByRole('button', { name: 'Settle Desk details' }))
+    await user.click(screen.getByRole('button', { name: 'Remove Settle Desk from My Apps' }))
 
+    // The rows update live: the app leaves the My Apps projection and the honest empty state
+    // takes over. The sheet itself stays open (it reads the full listing, so the member can
+    // change their mind and re-add without hunting the app down again).
     expect(listedApps()).toEqual([])
     expect(screen.getByText('Nothing in My Apps yet')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add Settle Desk to My Apps' })).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/test/miniapps/storeRedesign.test.jsx
+++ b/frontend/src/test/miniapps/storeRedesign.test.jsx
@@ -12,11 +12,16 @@
  *   2. **Artwork is total and decorative.** Curated slugs get their own illustration, everything
  *      else gets the deliberate generic — never a broken image — and all of it is aria-hidden so
  *      the card's text remains the identity a screen reader hears.
- *   3. **Flavour never enters the accessible name.** The rocket in Launch and the glyphs in the
- *      trust blocks are decoration; names and copy read exactly as before.
+ *   3. **Flavour never enters the accessible name.** The rocket in the sheet's Open action and
+ *      the chrome glyphs are decoration; names and copy carry the meaning.
+ *
+ * Iteration 2 (post-merge feedback): the explanation prose is GONE from the surface (FR-003
+ * superseded — the badge is the trust signal, depth lives in the docs), cards became store
+ * rows, and the launch affordance moved into the app sheet as Open.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { axe } from 'vitest-axe'
 
@@ -180,20 +185,30 @@ describe('the trust badge renders over a verified listing and nothing else (FR-0
   })
 })
 
-describe('the trust story reads as prioritized blocks (FR-003)', () => {
-  it('keeps both factual claims, split under their own lead-ins', async () => {
+describe('the explanation prose is gone (iteration 2, FR-003 superseded)', () => {
+  it('renders neither of the old trust paragraphs anywhere on the surface', async () => {
     state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 1, name: 'Settle Desk' })]))
     await renderSettled()
 
-    expect(screen.getByText('Reviewed on-chain.')).toBeInTheDocument()
-    expect(screen.getByText(/reviewed and approved on-chain/i)).toBeInTheDocument()
-    expect(screen.getByText('Hash-checked before launch.')).toBeInTheDocument()
-    expect(screen.getByText(/checks the package against the hash recorded there/i)).toBeInTheDocument()
+    expect(screen.queryByText(/reviewed and approved on-chain/i)).toBeNull()
+    expect(screen.queryByText(/checks the package against the hash recorded there/i)).toBeNull()
+    // The badge — the compact trust signal — is what remains.
+    expect(screen.getByText(BADGE)).toBeInTheDocument()
+  })
+
+  it('Refresh is icon-only but keeps its accessible name (FR-018)', async () => {
+    state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 1, name: 'Settle Desk' })]))
+    await renderSettled()
+
+    const refresh = screen.getByRole('button', { name: 'Refresh' })
+    // No visible text — the glyph plus the aria-label carry the control.
+    expect(refresh.textContent).toBe('')
+    expect(refresh.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
   })
 })
 
 describe('card artwork (FR-001) and flavour staying out of accessible names (FR-006)', () => {
-  it('gives every card an aria-hidden illustration panel; unknown apps get the generic art', async () => {
+  it('gives every row an aria-hidden illustration tile; unknown apps get the generic art', async () => {
     state.fetchCatalog = vi.fn(async () =>
       okOutcome([
         appRecord({ id: 1, name: 'Token Mint' }), // slug: token-mint → curated
@@ -203,8 +218,8 @@ describe('card artwork (FR-001) and flavour staying out of accessible names (FR-
     await renderSettled()
 
     for (const name of ['Token Mint', 'Settle Desk']) {
-      const card = screen.getByRole('heading', { level: 5, name }).closest('li')
-      const art = card.querySelector('.miniapp-card-art')
+      const row = screen.getByRole('heading', { level: 5, name }).closest('li')
+      const art = row.querySelector('.miniapp-row-art')
       expect(art).not.toBeNull()
       expect(art).toHaveAttribute('aria-hidden', 'true')
       expect(art.querySelector('svg.miniapp-art')).not.toBeNull()
@@ -213,21 +228,27 @@ describe('card artwork (FR-001) and flavour staying out of accessible names (FR-
     expect(appSlug('Token Mint')).toBe('token-mint')
   })
 
-  it('a name with no slug still gets art (the generic), alongside its launch refusal', async () => {
+  it('a name with no slug still gets art (the generic) on its row, with the refusal in its sheet', async () => {
+    const user = userEvent.setup()
     state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 1, name: 'Ünïcode Desk' })]))
     await renderSettled()
 
-    const card = screen.getByRole('heading', { level: 5, name: 'Ünïcode Desk' }).closest('li')
-    expect(card.querySelector('.miniapp-card-art svg')).not.toBeNull()
-    expect(within(card).getByText(/registered name can’t be used as a web address/i)).toBeInTheDocument()
+    const row = screen.getByRole('heading', { level: 5, name: 'Ünïcode Desk' }).closest('li')
+    expect(row.querySelector('.miniapp-row-art svg')).not.toBeNull()
+
+    await user.click(screen.getByRole('button', { name: 'Ünïcode Desk details' }))
+    const sheet = screen.getByRole('dialog', { name: 'Ünïcode Desk' })
+    expect(within(sheet).getByText(/registered name can’t be used as a web address/i)).toBeInTheDocument()
   })
 
-  it('the rocket is decoration: the launch link keeps its exact accessible name', async () => {
+  it('the rocket is decoration: the sheet\'s Open link keeps its exact accessible name', async () => {
+    const user = userEvent.setup()
     state.fetchCatalog = vi.fn(async () => okOutcome([appRecord({ id: 1, name: 'Settle Desk' })]))
     await renderSettled()
 
-    const launch = screen.getByRole('link', { name: 'Launch Settle Desk' })
-    const glyph = launch.querySelector('svg')
+    await user.click(screen.getByRole('button', { name: 'Settle Desk details' }))
+    const open = screen.getByRole('link', { name: 'Open Settle Desk' })
+    const glyph = open.querySelector('svg')
     expect(glyph).not.toBeNull()
     expect(glyph).toHaveAttribute('aria-hidden', 'true')
   })

--- a/specs/077-miniapp-store-redesign/spec.md
+++ b/specs/077-miniapp-store-redesign/spec.md
@@ -257,3 +257,51 @@ IPFS and on-chain re-approval before the new bytes are treated as live.
   previous approved packages.
 - The registry ABI/host object are untouched: no new on-chain fields (e.g. icon URLs) are
   introduced.
+
+## Iteration 2 — App-store experience (post-merge feedback, 2026-08-09)
+
+Member feedback on the shipped surface: it reads as a demo, not a store. Reference supplied: a
+Google Play "Top charts" screenshot — dense tappable rows, bold titles, chips, a fixed bottom
+navigation, details behind a tap. This iteration supersedes parts of US1/US2 above:
+
+### User Story 4 - Store rows and an app details sheet (Priority: P1)
+
+As a store member, I want the catalog to read like a real app store — a compact list of
+tappable rows (icon, bold title, metadata line, chips) — and tapping an app to open a bottom
+sheet with its details and the actions (open it, add it to / remove it from My Apps), so
+browsing and acting feel native instead of like a document.
+
+**Acceptance Scenarios**:
+
+1. **Given** a verified catalog, **When** the member views the market, **Then** apps render as
+   list rows — leading icon, bold name, category/vendor metadata line, version chip, and an
+   "in My Apps" indicator when favorited — with no always-visible explanation prose.
+2. **Given** a row, **When** the member taps it, **Then** a bottom sheet opens with the app's
+   artwork, name, description, vendor (full value available), version, category, and actions:
+   **Open** (launch) and **Add to / Remove from My Apps**; the sheet is dismissible by close
+   button, backdrop tap, and Escape, and focus returns to the row on close.
+3. **Given** an unverified (stale) listing or an app with no usable slug, **When** its sheet is
+   open, **Then** the launch-refusal explanation appears there and no Open action is offered —
+   the honest-state rules are unchanged, only relocated.
+4. **Given** the store header, **When** the member looks at it, **Then** the trust explanation
+   paragraphs are gone (the verified badge remains, and deep detail lives in the docs), and
+   Refresh is an icon-only control that keeps its accessible name and focus behavior.
+5. **Given** a small viewport, **When** the member browses any store view, **Then** Market /
+   My Apps / Search sit in a fixed, full-width bottom navigation (icon over label, active
+   tint, safe-area padding) that never occludes the last row.
+
+### Amended requirements
+
+- **FR-003 (superseded)**: the restructured trust blocks are REMOVED from the store surface;
+  the factual verification story lives in the developer docs. The verified badge (FR-002) and
+  every honest-state disclosure (FR-010) are unchanged.
+- **FR-006 (amended)**: the launch call-to-action moves into the app sheet as **Open** (rocket
+  retained), accessible name "Open {app}"; rows themselves carry no launch link.
+- **FR-007 (amended)**: the store navigation is a fixed bottom navigation bar, not a floating
+  dock.
+- **FR-017 (new)**: each catalog entry is a single tappable row control opening an app-details
+  bottom sheet (`role="dialog"`, labelled by the app name, Escape/backdrop/close dismissal,
+  focus restored to the invoking row). Favorite toggling moves from the row into the sheet;
+  rows show a non-interactive favorited indicator.
+- **FR-018 (new)**: the Refresh control is icon-only with an accessible name that continues to
+  announce Refresh/Refreshing states without losing keyboard focus.

--- a/specs/077-miniapp-store-redesign/tasks.md
+++ b/specs/077-miniapp-store-redesign/tasks.md
@@ -134,3 +134,33 @@ restructured trust copy. **Independent test**: quickstart §2 steps 1, 4–6.
 MVP = Phase 3 (US1) — the redesigned market alone satisfies the issue's core pain points.
 Phases commit separately: toolchain bump (one commit), US1, US2, polish — each leaving the
 tree green.
+
+## Phase 6: User Story 4 — App-store experience (iteration 2, post-merge feedback)
+
+**Goal**: Play-Store-like list rows + app details bottom sheet, fixed bottom nav, icon
+refresh, no explainer prose. **Independent test**: spec Iteration 2 acceptance scenarios.
+
+- [X] T020 [US4] Create `frontend/src/components/miniapps/AppSheet.jsx`: bottom-sheet dialog
+      (`role="dialog"`, `aria-modal`, labelled by app name) showing artwork, name, category,
+      description, vendor (full value), version; actions Open (launch link, rocket, only when
+      verified + slug) and Add to / Remove from My Apps (aria-pressed, same canFavorite rule);
+      launch-refusal copy for unverified/no-slug; Escape + backdrop + close-button dismissal;
+      focus into the sheet on open and back to the invoking row on close.
+- [X] T021 [US4] Rework `frontend/src/components/miniapps/CatalogPanel.jsx`: remove the trust
+      blocks (badge stays, gated on verified); Refresh becomes an icon-only button whose
+      accessible name still announces Refresh/Refreshing; `AppCard` becomes a tappable list
+      row (leading art, bold name, category • vendor line, version chip, non-interactive
+      favorited indicator) that opens the AppSheet; favorite star and launch link leave the
+      row.
+- [X] T022 [US4] Restyle `frontend/src/components/miniapps/StoreBar.jsx` +
+      `frontend/src/components/miniapps/miniapps.css` as a fixed full-width bottom navigation
+      (icon over label, active tint, safe-area padding) with a content spacer so no row is
+      occluded; add row-list and sheet styles; drop the dead trust-block styles.
+- [X] T023 [US4] Update the affected suites (`CatalogPanel.test.jsx`, `storeRedesign.test.jsx`,
+      `storeNavigation.test.jsx`) to the row+sheet interaction model and add sheet-focused
+      coverage: open/close (button, backdrop, Escape), focus restoration, Open link href,
+      favorite toggle from the sheet, refusal copy inside the sheet on stale/no-slug, axe
+      passes with the sheet open.
+- [ ] T024 [US4] Verify (lint, scoped suites, host build, byte gate untouched), update
+      `docs/developer-guide/miniapps.md`'s store-surface section, commit, push, and open the
+      iteration-2 PR.


### PR DESCRIPTION
Iteration 2 on the mini-app store (follow-up to #1082 / issue #1024), from post-merge feedback: the shipped surface read as a demo. This makes it read like a store, per the supplied Play-Store reference. Spec 077 is amended in place (US4, FR-017/FR-018, FR-003 superseded).

## What changed

- **Store rows instead of cards.** Each catalog entry is a compact tappable row — leading art tile, bold title, `category • vendor` metadata line, version chip, and a non-interactive "My Apps" chip when favorited. The tap target is a stretched button over the row (headings stay valid HTML; every pixel taps).
- **App details bottom sheet (`AppSheet.jsx`).** Tapping a row opens a `role="dialog"` bottom sheet with artwork, description, full vendor/version/category, and the actions: **Open** (launch, rocket icon) and **Add to / Remove from My Apps**. Dismissible by close button, backdrop tap, and Escape; focus moves into the sheet on open and returns to the invoking row on close.
- **Trust rules unchanged, relocated.** Open and the My Apps toggle are gated on the same `verified` + slug pair the cards enforced; both launch-refusal explanations moved into the sheet verbatim; the verified badge still renders only over a verified listing; all four honest states unchanged.
- **Proper bottom nav.** Market / My Apps / Search are now a fixed, full-width bottom navigation (icon-over-label, active pill, safe-area padding, content spacer so the last row is never occluded); centered floating dock on wide viewports. Still the `?view=` seam — no global-nav conflict (spec 069).
- **Less chrome.** The trust explanation prose is removed from the surface (depth lives in the developer docs); Refresh is icon-only while keeping its accessible name and the no-focus-loss behavior.

## Verification

- 23 mini-app test files / **557 tests** green, including the reworked CatalogPanel/storeRedesign/storeNavigation suites and a new `appSheet.test.jsx` dialog-mechanics suite (labelling, dismissal paths, focus restoration, axe with the sheet open)
- ESLint green; host build green under vite 8
- Mini-app output bytes **unchanged** (host-only change — byte gate compared clean against the committed baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWVW8rHFHVJVwn7gFjSafw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWVW8rHFHVJVwn7gFjSafw)_