### PR TITLE
feat(frontend): modernize Address Book UI with colored network pills

### DIFF
--- a/frontend/src/components/account/AddressBookPanel.css
+++ b/frontend/src/components/account/AddressBookPanel.css
@@ -1,13 +1,41 @@
+/*
+ * Address Book (Spec 021, redesigned per issue #1023) — light, airy layout:
+ * elevated rounded contact cards, colored network pills (NetworkPill.css),
+ * a large rounded search input, and generous spacing. Colors ride the theme
+ * tokens so tenant themes and dark mode keep working.
+ */
+
 .ab-panel {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .ab-panel-head-titles {
   display: flex;
   align-items: center;
   gap: 0.4rem;
+}
+
+.ab-panel-head-titles h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+/* Screen-reader-only text (search label keeps its accessible name while the
+   visual affordance is the icon + placeholder). */
+.ab-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* Address input + inline QR scan button inside the contact edit modal. */
@@ -29,7 +57,7 @@
   width: 42px;
   min-width: 42px;
   border: 1px solid var(--border-color, #cbd5e1);
-  border-radius: 0.375rem;
+  border-radius: 0.625rem;
   background: var(--bg-primary, #f8fafc);
   color: inherit;
   cursor: pointer;
@@ -43,8 +71,8 @@
 
 .ab-scan-btn:hover,
 .ab-scan-btn:focus-visible {
-  border-color: var(--brand-primary, #2563eb);
-  color: var(--brand-primary, #2563eb);
+  border-color: var(--brand-primary, #36b37e);
+  color: var(--brand-primary, #36b37e);
 }
 
 .ab-panel-head {
@@ -65,44 +93,95 @@
 .ab-field {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.3rem;
 }
 
 .ab-field label,
 .ab-addresses-fieldset legend {
   font-size: 0.8rem;
   font-weight: 600;
+  color: var(--text-secondary, #5a6772);
 }
 
 .ab-field input,
 .ab-field select {
-  padding: 0.5rem 0.6rem;
+  padding: 0.55rem 0.75rem;
   border: 1px solid var(--border-color, #cbd5e1);
-  border-radius: 0.375rem;
+  border-radius: 0.625rem;
   background: var(--bg-primary, #fff);
   color: var(--text-primary, #0f172a);
   font: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
-.ab-search input {
+.ab-field input:focus-visible,
+.ab-field select:focus-visible {
+  outline: none;
+  border-color: var(--brand-primary, #36b37e);
+  box-shadow: 0 0 0 3px rgba(var(--brand-primary-rgb, 54, 179, 126), 0.18);
+}
+
+/* Large rounded search input with a leading icon (issue #1023). */
+.ab-search-box {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.ab-search-icon {
+  position: absolute;
+  left: 1rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  color: var(--text-muted, #8a959e);
+  pointer-events: none;
+}
+
+.ab-search-box input {
   width: 100%;
+  padding: 0.75rem 1.1rem 0.75rem 2.6rem;
+  font: inherit;
+  font-size: 0.95rem;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 999px;
+  background: var(--bg-secondary, #fff);
+  color: var(--text-primary, #0f172a);
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.05));
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.ab-search-box input::placeholder {
+  color: var(--text-muted, #8a959e);
+}
+
+.ab-search-box input:focus-visible {
+  outline: none;
+  border-color: var(--brand-primary, #36b37e);
+  box-shadow: 0 0 0 3px rgba(var(--brand-primary-rgb, 54, 179, 126), 0.18);
 }
 
 .ab-contact-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
 }
 
+/* Soft-shadowed, rounded contact card (issue #1023). */
 .ab-contact-card {
   border: 1px solid var(--border-color, #e2e8f0);
-  border-radius: 0.5rem;
-  padding: 0.75rem;
+  border-radius: 1rem;
+  padding: 1rem 1.1rem;
   background: var(--bg-secondary, #fff);
   color: var(--text-primary, #0f172a);
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04), 0 6px 20px rgba(15, 23, 42, 0.06);
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+
+.ab-contact-card:hover {
+  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.05), 0 10px 28px rgba(15, 23, 42, 0.09);
 }
 
 .ab-contact-head {
@@ -112,15 +191,55 @@
   gap: 0.5rem;
 }
 
+.ab-contact-id {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.ab-contact-avatar {
+  flex: none;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--brand-primary, #36b37e);
+  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.14);
+}
+
 .ab-contact-name {
   display: flex;
   align-items: center;
   gap: 0.4rem;
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .ab-contact-nickname {
+  font-size: 1.02rem;
   font-weight: 700;
+  letter-spacing: -0.01em;
+  overflow-wrap: anywhere;
+}
+
+.ab-contact-tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  padding: 0.26rem 0.55rem;
+  border-radius: 999px;
+  color: var(--brand-secondary, #4c9aff);
+  background: rgba(var(--brand-secondary-rgb, 76, 154, 255), 0.14);
+  border: 1px solid rgba(var(--brand-secondary-rgb, 76, 154, 255), 0.35);
+  white-space: nowrap;
 }
 
 .ab-contact-actions {
@@ -134,15 +253,15 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.65rem;
 }
 
 .ab-address-row {
   border-top: 1px solid var(--border-color, #f1f5f9);
-  padding-top: 0.5rem;
+  padding-top: 0.65rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.45rem;
 }
 
 .ab-address-main {
@@ -155,19 +274,29 @@
 .ab-address-value {
   font-family: ui-monospace, monospace;
   font-size: 0.85rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: 0.5rem;
+  background: var(--bg-primary, #f1f5f9);
+  color: var(--text-primary, #0f172a);
 }
 
-.ab-address-network {
-  font-size: 0.75rem;
-  color: var(--text-muted, #64748b);
-  background: var(--bg-primary, #f1f5f9);
-  padding: 0.1rem 0.4rem;
-  border-radius: 0.375rem;
+/* Network pills + screening status below the address (issue #1023). */
+.ab-address-tags {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.ab-address-status {
+  display: flex;
+  align-items: center;
 }
 
 .ab-address-notes {
   margin: 0;
   font-size: 0.8rem;
+  line-height: 1.4;
   color: var(--text-muted, #64748b);
 }
 
@@ -181,10 +310,20 @@
 
 .ab-empty {
   border: 1px dashed var(--border-color, #cbd5e1);
-  border-radius: 0.5rem;
-  padding: 1.5rem;
+  border-radius: 1rem;
+  padding: 2rem 1.5rem;
   text-align: center;
   color: var(--text-muted, #64748b);
+  background: var(--bg-secondary, #fff);
+}
+
+.ab-empty h3 {
+  margin: 0 0 0.5rem;
+  color: var(--text-primary, #0f172a);
+}
+
+.ab-empty p {
+  margin: 0;
 }
 
 .ab-btn {
@@ -192,13 +331,13 @@
   border: none;
   background: transparent;
   color: var(--text-muted, #64748b);
-  border-radius: 0.375rem;
-  padding: 0.3rem;
+  border-radius: 0.55rem;
+  padding: 0.35rem;
   font: inherit;
   font-weight: 600;
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.3rem;
   line-height: 1;
   transition: color 0.1s, background 0.1s;
 }
@@ -227,11 +366,11 @@
   }
 
   .ab-btn-sm {
-    padding: 0.3rem 0.55rem;
+    padding: 0.35rem 0.6rem;
   }
 
   .ab-btn-xs {
-    padding: 0.2rem 0.45rem;
+    padding: 0.25rem 0.5rem;
   }
 }
 
@@ -241,19 +380,24 @@
 
 .ab-btn-xs {
   font-size: 0.72rem;
-  align-self: flex-start;
 }
 
 .ab-btn-primary {
-  background: var(--brand-primary, #2563eb);
-  color: #fff;
-  padding: 0.4rem 0.75rem;
+  background: var(--primary-button, var(--brand-primary, #36b37e));
+  color: var(--primary-button-text, #fff);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
 }
 
 .ab-btn-primary:hover,
 .ab-btn-primary:focus-visible {
-  background: var(--primary-button-hover, #1d4ed8);
-  color: #fff;
+  background: var(--primary-button-hover, #2f9e6e);
+  color: var(--primary-button-text, #fff);
+}
+
+.ab-btn-primary:focus-visible {
+  box-shadow: 0 0 0 3px rgba(var(--brand-primary-rgb, 54, 179, 126), 0.3);
 }
 
 .ab-btn-danger {
@@ -297,24 +441,28 @@
 .ab-modal {
   background: var(--bg-secondary, #fff);
   color: var(--text-primary, #0f172a);
-  border-radius: 0.6rem;
-  padding: 1.25rem;
+  border-radius: 1rem;
+  padding: 1.5rem;
   width: min(560px, 100%);
   max-height: 90vh;
   overflow: auto;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  box-shadow: var(--shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
 }
 
 .ab-modal-title {
   margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
 .ab-addresses-fieldset {
   border: 1px solid var(--border-color, #e2e8f0);
-  border-radius: 0.5rem;
-  padding: 0.75rem;
+  border-radius: 0.75rem;
+  padding: 0.85rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -339,7 +487,7 @@
 
 .ab-conflict {
   border: 1px solid var(--border-color, #e2e8f0);
-  border-radius: 0.4rem;
+  border-radius: 0.6rem;
   padding: 0.5rem;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/account/AddressBookPanel.jsx
+++ b/frontend/src/components/account/AddressBookPanel.jsx
@@ -22,6 +22,14 @@ function IconPlus() {
   )
 }
 
+function IconSearch() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="ab-search-icon">
+      <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z" />
+    </svg>
+  )
+}
+
 import ContactCard from './ContactCard'
 import ContactEditModal from './ContactEditModal'
 import AddressBookImportExport from './AddressBookImportExport'
@@ -131,16 +139,21 @@ export default function AddressBookPanel({ address }) {
         </div>
       </div>
 
-      <div className="ab-field ab-search">
-        <label htmlFor="ab-search">Search</label>
-        <input
-          id="ab-search"
-          type="search"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search by name or address"
-          autoComplete="off"
-        />
+      <div className="ab-search">
+        <label htmlFor="ab-search" className="ab-sr-only">
+          Search
+        </label>
+        <div className="ab-search-box">
+          <IconSearch />
+          <input
+            id="ab-search"
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by name or address"
+            autoComplete="off"
+          />
+        </div>
       </div>
 
       {contacts.length === 0 ? (

--- a/frontend/src/components/account/ContactCard.jsx
+++ b/frontend/src/components/account/ContactCard.jsx
@@ -8,6 +8,7 @@
 import { useState } from 'react'
 import { addressKey } from '../../lib/addressBook/addressBookStore'
 import RestrictionTag from './RestrictionTag'
+import NetworkPill from '../ui/NetworkPill'
 
 function shorten(addr) {
   if (!addr || addr.length < 12) return addr
@@ -68,21 +69,28 @@ export default function ContactCard({
     })
   }
 
+  const initial = (contact.nickname || '?').trim().charAt(0).toUpperCase() || '?'
+
   return (
     <div className="ab-contact-card">
       <div className="ab-contact-head">
-        <div className="ab-contact-name">
-          <span className="ab-contact-nickname">{contact.nickname}</span>
-          {/* Spec 068 — a multisig vault is an ordinary address-book entry, badged by matching the
-              member's own vault references rather than by storing a type on the entry (the book is
-              a synced object whose loader rebuilds a fixed field list, so an extra key would be
-              dropped). Renaming it here renames it everywhere the vault appears. */}
-          {isVault && <span className="ab-contact-tag">Multisig</span>}
-          {containsRestricted && (
-            <span className="ab-contact-restricted-flag">
-              <RestrictionTag status="restricted" />
-            </span>
-          )}
+        <div className="ab-contact-id">
+          <span className="ab-contact-avatar" aria-hidden="true">
+            {initial}
+          </span>
+          <div className="ab-contact-name">
+            <span className="ab-contact-nickname">{contact.nickname}</span>
+            {/* Spec 068 — a multisig vault is an ordinary address-book entry, badged by matching the
+                member's own vault references rather than by storing a type on the entry (the book is
+                a synced object whose loader rebuilds a fixed field list, so an extra key would be
+                dropped). Renaming it here renames it everywhere the vault appears. */}
+            {isVault && <span className="ab-contact-tag">Multisig</span>}
+            {containsRestricted && (
+              <span className="ab-contact-restricted-flag">
+                <RestrictionTag status="restricted" />
+              </span>
+            )}
+          </div>
         </div>
         <div className="ab-contact-actions">
           <button
@@ -125,9 +133,18 @@ export default function ContactCard({
                   {copied ? <IconCheck /> : <IconCopy />}
                   <span className="ab-btn-label">{copied ? 'Copied!' : 'Copy'}</span>
                 </button>
-                <span className="ab-address-network">{networkName(a.chainId)}</span>
-                <RestrictionTag status={statuses[i]} />
               </div>
+              <div className="ab-address-tags">
+                <NetworkPill chainId={a.chainId} name={networkName(a.chainId)} />
+              </div>
+              {/* Screening status sits on its own line below the network pills so
+                  an Unscreened/Restricted state is never lost in the tag row
+                  (issue #1023). RestrictionTag renders nothing when clear. */}
+              {statuses[i] && statuses[i] !== 'clear' && (
+                <div className="ab-address-status">
+                  <RestrictionTag status={statuses[i]} />
+                </div>
+              )}
               {a.notes && <p className="ab-address-notes">{a.notes}</p>}
             </li>
           )

--- a/frontend/src/components/account/RestrictionTag.css
+++ b/frontend/src/components/account/RestrictionTag.css
@@ -1,12 +1,13 @@
 .ab-tag {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  font-size: 0.75rem;
-  font-weight: 600;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
   line-height: 1;
-  padding: 0.2rem 0.45rem;
-  border-radius: 0.375rem;
+  padding: 0.28rem 0.6rem;
+  border-radius: 999px;
   border: 1px solid transparent;
   white-space: nowrap;
 }
@@ -17,10 +18,12 @@
   border-color: #fca5a5;
 }
 
+/* Amber Unscreened badge — deliberately high-contrast so the state is hard to
+   miss (issue #1023). */
 .ab-tag-uncertain {
   color: #78350f;
   background: #fef3c7;
-  border-color: #fcd34d;
+  border-color: #f59e0b;
 }
 
 .ab-tag-loading {
@@ -29,20 +32,21 @@
   border-color: #cbd5e1;
 }
 
-@media (prefers-color-scheme: dark) {
-  .ab-tag-restricted {
-    color: #fecaca;
-    background: rgba(127, 29, 29, 0.4);
-    border-color: #b91c1c;
-  }
-  .ab-tag-uncertain {
-    color: #fde68a;
-    background: rgba(120, 53, 15, 0.4);
-    border-color: #b45309;
-  }
-  .ab-tag-loading {
-    color: #cbd5e1;
-    background: rgba(71, 85, 105, 0.3);
-    border-color: #475569;
-  }
+/* Dark theme (class-based, matching the app's .theme-dark toggle). */
+:root.theme-dark .ab-tag-restricted {
+  color: #fecaca;
+  background: rgba(127, 29, 29, 0.4);
+  border-color: #b91c1c;
+}
+
+:root.theme-dark .ab-tag-uncertain {
+  color: #fde68a;
+  background: rgba(120, 53, 15, 0.4);
+  border-color: #d97706;
+}
+
+:root.theme-dark .ab-tag-loading {
+  color: #cbd5e1;
+  background: rgba(71, 85, 105, 0.3);
+  border-color: #475569;
 }

--- a/frontend/src/components/ui/AddressBookPicker.jsx
+++ b/frontend/src/components/ui/AddressBookPicker.jsx
@@ -6,6 +6,7 @@
  */
 
 import RestrictionTag from '../account/RestrictionTag'
+import NetworkPill from './NetworkPill'
 import './AddressBookField.css'
 
 function shorten(addr) {
@@ -27,7 +28,7 @@ export default function AddressBookPicker({
           <button type="button" className="ab-picker-option" onClick={() => onSelect?.(e)}>
             <span className="ab-picker-nick">{e.nickname}</span>
             <code className="ab-picker-addr">{shorten(e.address)}</code>
-            <span className="ab-address-network">{networkName(e.chainId)}</span>
+            <NetworkPill chainId={e.chainId} name={networkName(e.chainId)} />
             <RestrictionTag status={getStatus(e.address, e.chainId)} />
           </button>
         </li>

--- a/frontend/src/components/ui/NetworkPill.css
+++ b/frontend/src/components/ui/NetworkPill.css
@@ -1,0 +1,134 @@
+.ab-net-pill {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  line-height: 1;
+  padding: 0.28rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+/* Per-chain hues (light mode). Text/background pairs meet WCAG AA. */
+.ab-net-pill--polygon {
+  color: #6d28d9;
+  background: #ede9fe;
+  border-color: #ddd6fe;
+}
+
+.ab-net-pill--amoy {
+  color: #a21caf;
+  background: #fae8ff;
+  border-color: #f5d0fe;
+}
+
+.ab-net-pill--eth {
+  color: #3730a3;
+  background: #e0e7ff;
+  border-color: #c7d2fe;
+}
+
+.ab-net-pill--etc {
+  color: #047857;
+  background: #d1fae5;
+  border-color: #a7f3d0;
+}
+
+.ab-net-pill--mordor {
+  color: #0f766e;
+  background: #ccfbf1;
+  border-color: #99f6e4;
+}
+
+.ab-net-pill--arb {
+  color: #0369a1;
+  background: #e0f2fe;
+  border-color: #bae6fd;
+}
+
+.ab-net-pill--base {
+  color: #1d4ed8;
+  background: #dbeafe;
+  border-color: #bfdbfe;
+}
+
+.ab-net-pill--op {
+  color: #b91c1c;
+  background: #fee2e2;
+  border-color: #fecaca;
+}
+
+.ab-net-pill--btc {
+  color: #c2410c;
+  background: #ffedd5;
+  border-color: #fed7aa;
+}
+
+.ab-net-pill--other {
+  color: var(--text-secondary, #475569);
+  background: var(--bg-primary, #f1f5f9);
+  border-color: var(--border-color, #e2e8f0);
+}
+
+/* Dark theme (class-based, matching the app's .theme-dark toggle). */
+:root.theme-dark .ab-net-pill--polygon {
+  color: #c4b5fd;
+  background: rgba(109, 40, 217, 0.22);
+  border-color: rgba(139, 92, 246, 0.45);
+}
+
+:root.theme-dark .ab-net-pill--amoy {
+  color: #f0abfc;
+  background: rgba(162, 28, 175, 0.22);
+  border-color: rgba(217, 70, 239, 0.45);
+}
+
+:root.theme-dark .ab-net-pill--eth {
+  color: #a5b4fc;
+  background: rgba(55, 48, 163, 0.28);
+  border-color: rgba(99, 102, 241, 0.45);
+}
+
+:root.theme-dark .ab-net-pill--etc {
+  color: #6ee7b7;
+  background: rgba(4, 120, 87, 0.24);
+  border-color: rgba(16, 185, 129, 0.45);
+}
+
+:root.theme-dark .ab-net-pill--mordor {
+  color: #5eead4;
+  background: rgba(15, 118, 110, 0.26);
+  border-color: rgba(20, 184, 166, 0.45);
+}
+
+:root.theme-dark .ab-net-pill--arb {
+  color: #7dd3fc;
+  background: rgba(3, 105, 161, 0.26);
+  border-color: rgba(14, 165, 233, 0.45);
+}
+
+:root.theme-dark .ab-net-pill--base {
+  color: #93c5fd;
+  background: rgba(29, 78, 216, 0.26);
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+:root.theme-dark .ab-net-pill--op {
+  color: #fca5a5;
+  background: rgba(185, 28, 28, 0.26);
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+:root.theme-dark .ab-net-pill--btc {
+  color: #fdba74;
+  background: rgba(194, 65, 12, 0.26);
+  border-color: rgba(249, 115, 22, 0.45);
+}
+
+:root.theme-dark .ab-net-pill--other {
+  color: var(--text-secondary, #aab6c2);
+  background: rgba(122, 133, 144, 0.18);
+  border-color: var(--border-color, #23303d);
+}

--- a/frontend/src/components/ui/NetworkPill.jsx
+++ b/frontend/src/components/ui/NetworkPill.jsx
@@ -1,0 +1,27 @@
+/**
+ * NetworkPill — small colored badge naming the network an address lives on.
+ *
+ * Each known chain gets its own hue so entries spanning several networks
+ * (e.g. Polygon + Ethereum Classic Mordor) read apart at a glance
+ * (issue #1023); unknown chains fall back to a neutral pill.
+ */
+
+import './NetworkPill.css'
+
+const CHAIN_VARIANT = {
+  1: 'eth',
+  10: 'op',
+  61: 'etc',
+  63: 'mordor',
+  137: 'polygon',
+  8453: 'base',
+  42161: 'arb',
+  80002: 'amoy',
+  bitcoin: 'btc',
+  'bitcoin-testnet': 'btc',
+}
+
+export default function NetworkPill({ chainId, name }) {
+  const variant = CHAIN_VARIANT[chainId] || 'other'
+  return <span className={`ab-net-pill ab-net-pill--${variant}`}>{name}</span>
+}


### PR DESCRIPTION
Closes #1023.

Frontend-only redesign of the Address Book (My Account ▸ Address Book) per the acceptance scenarios in #1023, preserving all existing functionality — add/edit/delete contact, search, copy, Export/Import, QR scan, sanctions screening, recovery notes, and the spec-068 Multisig badge.

## What changed

- **Contact cards** — soft-shadowed 1rem-radius cards with hover elevation, an avatar initial, and clearer name/address hierarchy. The address renders as a monospace chip with the copy button beside it.
- **Colored network pills** — new shared `NetworkPill` component (`frontend/src/components/ui/NetworkPill.jsx`) giving each chain a distinct hue (Polygon, Ethereum, ETC, Mordor, Arbitrum, Base, Optimism, Amoy, Bitcoin) with a neutral fallback for unknown chains. Used by both `ContactCard` and `AddressBookPicker` so the picker dropdown matches.
- **Visible screening status** — the amber "Unscreened" / red "Restricted" badge now sits on its own line below the network pills, with a stronger amber border so it can't be missed.
- **Search** — large rounded high-contrast input with a leading search icon and a brand-green focus ring; the label is kept for screen readers (`.ab-sr-only`).
- **Theming** — everything rides existing theme tokens (`--brand-primary` is already the FairWins green), so tenant themes keep working. `RestrictionTag` and the new pills use the app's class-based `.theme-dark` toggle (RestrictionTag previously used `prefers-color-scheme`, which ignored the in-app theme switch).
- **Modal & buttons** — rounded pill primary button, softer modal radius/shadow, consistent focus rings on inputs.

No contract, gateway, or config changes. Two-word class names and aria-labels used by the test suites are unchanged.

## Verification

- `npx vitest run src/test/addressBook` — 14 files, 73 tests pass (includes the axe accessibility test)
- `npx vitest run src/test/custody/CustodyAddressField.test.jsx src/test/home.axe.test.jsx src/test/PayPanel.test.jsx src/test/useOpponentName.test.jsx` — 37 tests pass
- `npx eslint` clean on changed files
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yjGYfVRKCcg61op3ZiaG4

---
_Generated by [Claude Code](https://claude.ai/code/session_011yjGYfVRKCcg61op3ZiaG4)_