### PR TITLE
fix(frontend): stop the Bridge quote fetch loop that flickered between pricing and unavailable

### DIFF
--- a/frontend/src/components/wallet/BridgeView.jsx
+++ b/frontend/src/components/wallet/BridgeView.jsx
@@ -417,15 +417,39 @@ export default function BridgeView({ onRecorded } = {}) {
     }
   }, [canQuote, source, destination, route, amountRaw, symbol, decimals, address, destinationNativeRaw])
 
+  // The debounce below MUST re-arm only when the quote's actual INPUTS change, so it is
+  // keyed on this primitive signature — never on `loadQuote`'s identity. The surrounding
+  // hooks rebuild their option objects on unrelated re-renders (a portfolio poll, a
+  // balance read), which gives `source`/`destination` fresh identities and `loadQuote` a
+  // fresh identity with them; keying the effect on the callback turned every quote
+  // completion into a re-render into another fetch, an endless loop that flickered
+  // between "getting a price" and the failure copy (issue #1027).
+  const quoteKey = canQuote
+    ? [
+        source.key,
+        destination.key,
+        route.routeId,
+        String(amountRaw),
+        address || '',
+        // In the signature so a destination balance read landing AFTER the quote still
+        // refreshes the FR-012 gas disclosure — a value change, not an identity change.
+        String(destinationNativeRaw ?? 'unknown'),
+      ].join('|')
+    : null
+  const loadQuoteRef = useRef(loadQuote)
   useEffect(() => {
-    if (!canQuote) {
+    loadQuoteRef.current = loadQuote
+  })
+
+  useEffect(() => {
+    if (!quoteKey) {
       quoteSeqRef.current += 1 // abandon anything in flight for a route that no longer applies
       setQuoteState({ status: 'idle', quote: null, error: null })
       return undefined
     }
-    const timer = setTimeout(loadQuote, QUOTE_DEBOUNCE_MS)
+    const timer = setTimeout(() => loadQuoteRef.current(), QUOTE_DEBOUNCE_MS)
     return () => clearTimeout(timer)
-  }, [canQuote, loadQuote])
+  }, [quoteKey])
 
   const quote = quoteState.quote
   const stale = quote ? isQuoteStale(quote, now) : false

--- a/frontend/src/hooks/__tests__/useChainTokens.test.jsx
+++ b/frontend/src/hooks/__tests__/useChainTokens.test.jsx
@@ -1,0 +1,39 @@
+/**
+ * useChainTokens — identity stability (issue #1027).
+ *
+ * Consumers put this hook's return value (and lists derived from it, e.g.
+ * useSelectableAssets options) into dependency arrays. A fresh object every
+ * render turned those into every-render effects — the Bridge quote debounce
+ * re-armed on each render and looped between "getting a price" and the
+ * unavailable copy. The return value must keep one identity per chain id.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+let mockChainId = 137
+vi.mock('wagmi', () => ({ useChainId: () => mockChainId }))
+
+import { useChainTokens } from '../useChainTokens'
+
+describe('useChainTokens', () => {
+  it('returns the same object identity across re-renders on the same chain', () => {
+    mockChainId = 137
+    const { result, rerender } = renderHook(() => useChainTokens())
+    const first = result.current
+    expect(first.chainId).toBe(137)
+
+    rerender()
+    expect(result.current).toBe(first)
+  })
+
+  it('returns a new value when the chain actually changes', () => {
+    mockChainId = 137
+    const { result, rerender } = renderHook(() => useChainTokens())
+    const first = result.current
+
+    mockChainId = 42161
+    rerender()
+    expect(result.current).not.toBe(first)
+    expect(result.current.chainId).toBe(42161)
+  })
+})

--- a/frontend/src/hooks/useChainTokens.js
+++ b/frontend/src/hooks/useChainTokens.js
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useChainId } from 'wagmi'
 import { getNetwork, getCurrentChainId } from '../config/networks'
 
@@ -9,26 +10,33 @@ import { getNetwork, getCurrentChainId } from '../config/networks'
  * Capabilities flow through here so screens can decide whether to gate
  * features (e.g. Polymarket-pegged side bets only render on chains where
  * Polymarket's CTF lives).
+ *
+ * The returned object is memoized on the chain id: consumers put it (and
+ * lists derived from it, e.g. useSelectableAssets options) in dependency
+ * arrays, and a fresh object every render turns those into every-render
+ * effects (issue #1027 — the Bridge quote loop).
  */
 export function useChainTokens() {
   const wagmiChainId = useChainId()
   const chainId = wagmiChainId || getCurrentChainId()
-  const n = getNetwork(chainId)
 
-  return {
-    chainId,
-    networkName: n?.name || '',
-    isPrimary: Boolean(n?.isPrimary),
-    isTestnet: Boolean(n?.isTestnet),
-    capabilities: n?.capabilities || {},
-    native: n?.nativeCurrency?.symbol || '',
-    nativeName: n?.nativeCurrency?.name || '',
-    nativeDecimals: n?.nativeCurrency?.decimals || 18,
-    stable: n?.stablecoin?.symbol || 'STABLE',
-    stableName: n?.stablecoin?.name || '',
-    stableAddress: n?.stablecoin?.address || null,
-    stableDecimals: n?.stablecoin?.decimals || 6,
-  }
+  return useMemo(() => {
+    const n = getNetwork(chainId)
+    return {
+      chainId,
+      networkName: n?.name || '',
+      isPrimary: Boolean(n?.isPrimary),
+      isTestnet: Boolean(n?.isTestnet),
+      capabilities: n?.capabilities || {},
+      native: n?.nativeCurrency?.symbol || '',
+      nativeName: n?.nativeCurrency?.name || '',
+      nativeDecimals: n?.nativeCurrency?.decimals || 18,
+      stable: n?.stablecoin?.symbol || 'STABLE',
+      stableName: n?.stablecoin?.name || '',
+      stableAddress: n?.stablecoin?.address || null,
+      stableDecimals: n?.stablecoin?.decimals || 6,
+    }
+  }, [chainId])
 }
 
 export default useChainTokens

--- a/frontend/src/test/bridge/BridgeView.test.jsx
+++ b/frontend/src/test/bridge/BridgeView.test.jsx
@@ -549,7 +549,8 @@ describe('BridgeView — one quote per input change (issue #1027)', () => {
     const callsAfterFailure = fetchBridgeQuote.mock.calls.length
 
     // Give a re-render-driven loop more than a full debounce window (400ms) to refire.
-    await new Promise((resolve) => setTimeout(resolve, 1_000))
+    // Nothing periodic runs in the error state, so just past the debounce is enough.
+    await new Promise((resolve) => setTimeout(resolve, 600))
     expect(fetchBridgeQuote.mock.calls.length).toBe(callsAfterFailure)
     expect(screen.getByText(BRIDGE_UNAVAILABLE.gateway)).toBeInTheDocument()
     expect(screen.queryByText(/Getting a price/i)).not.toBeInTheDocument()
@@ -563,7 +564,9 @@ describe('BridgeView — one quote per input change (issue #1027)', () => {
     await screen.findByRole('region', { name: /What this transfer costs/i })
 
     // The countdown re-renders every second while a quote is on screen; none of those
-    // renders may turn into another fetch while the inputs are unchanged.
+    // renders may turn into another fetch while the inputs are unchanged. The full
+    // second is load-bearing here: a shorter wait would never span a countdown tick,
+    // and the tick is exactly the re-render this test exists to prove harmless.
     await new Promise((resolve) => setTimeout(resolve, 1_000))
     expect(fetchBridgeQuote).toHaveBeenCalledTimes(1)
   })

--- a/frontend/src/test/bridge/BridgeView.test.jsx
+++ b/frontend/src/test/bridge/BridgeView.test.jsx
@@ -34,10 +34,19 @@ const sendOnChain = vi.fn()
 const canTransactOn = vi.fn(() => true)
 
 vi.mock('../../hooks/useWalletManagement', () => ({ useWallet: () => walletState }))
+// Fresh array + object identities on EVERY render, exactly like the real hooks under a
+// portfolio poll or balance read. Stable identities here are what hid the issue-1027 quote
+// loop from this suite — keep the churn (see 'one quote per input change' below).
 vi.mock('../../hooks/useSelectableAssets', () => ({
-  useSelectableAssets: () => ({ options: selectableOptions, defaultKey: null, isGasless: () => false }),
+  useSelectableAssets: () => ({
+    options: selectableOptions.map((o) => ({ ...o })),
+    defaultKey: null,
+    isGasless: () => false,
+  }),
 }))
-vi.mock('../../hooks/usePortfolio', () => ({ default: () => ({ holdings: portfolioHoldings, status: 'ready' }) }))
+vi.mock('../../hooks/usePortfolio', () => ({
+  default: () => ({ holdings: portfolioHoldings.map((h) => ({ ...h })), status: 'ready' }),
+}))
 vi.mock('../../hooks/useEarnSend', () => ({
   useEarnSend: () => ({
     sendOnChain,
@@ -513,6 +522,50 @@ describe('BridgeView — honest unavailable states (T083, FR-051/FR-053/FR-054)'
     await user.type(screen.getByLabelText(/^Amount/), '100')
     expect(await screen.findByText(BRIDGE_UNAVAILABLE.fees)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Try again/i })).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------------------
+describe('BridgeView — one quote per input change (issue #1027)', () => {
+  // The hook seams above hand back fresh object identities on every render, like the real
+  // hooks do. Pre-fix, the quote debounce was keyed on `loadQuote`'s identity, so every
+  // quote completion re-rendered, re-armed the timer, and fetched again — an endless loop
+  // that flickered between "Getting a price…" and the unavailable copy. These tests pin
+  // the fix: the debounce is keyed on the quote's INPUTS, so a settled state stays put.
+
+  it('holds a failed quote steady instead of looping between loading and unavailable', async () => {
+    const err = Object.assign(new Error('gateway unreachable'), {
+      code: 'network_error',
+      retryable: true,
+      disabled: false,
+    })
+    fetchBridgeQuote.mockRejectedValue(err)
+    const user = userEvent.setup()
+    render(<BridgeView />)
+    await screen.findByText(/Route availability as of/i)
+    await user.type(screen.getByLabelText(/^Amount/), '100')
+
+    expect(await screen.findByText(BRIDGE_UNAVAILABLE.gateway)).toBeInTheDocument()
+    const callsAfterFailure = fetchBridgeQuote.mock.calls.length
+
+    // Give a re-render-driven loop more than a full debounce window (400ms) to refire.
+    await new Promise((resolve) => setTimeout(resolve, 1_000))
+    expect(fetchBridgeQuote.mock.calls.length).toBe(callsAfterFailure)
+    expect(screen.getByText(BRIDGE_UNAVAILABLE.gateway)).toBeInTheDocument()
+    expect(screen.queryByText(/Getting a price/i)).not.toBeInTheDocument()
+  })
+
+  it('fetches exactly one quote for a typed amount despite unstable hook identities', async () => {
+    const user = userEvent.setup()
+    render(<BridgeView />)
+    await screen.findByText(/Route availability as of/i)
+    await user.type(screen.getByLabelText(/^Amount/), '100')
+    await screen.findByRole('region', { name: /What this transfer costs/i })
+
+    // The countdown re-renders every second while a quote is on screen; none of those
+    // renders may turn into another fetch while the inputs are unchanged.
+    await new Promise((resolve) => setTimeout(resolve, 1_000))
+    expect(fetchBridgeQuote).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/frontend/src/test/useChainTokens.ethereum.test.js
+++ b/frontend/src/test/useChainTokens.ethereum.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
 
 // useChainTokens reads the active chain via wagmi's useChainId. Mock it to a plain value so we
 // can exercise the pure config resolution for the Ethereum family (spec 048 US3, contract C9).
@@ -7,13 +8,17 @@ vi.mock('wagmi', () => ({ useChainId: () => mockChainId }))
 
 import { useChainTokens } from '../hooks/useChainTokens'
 
+// The hook memoizes its return value (issue #1027), so it must run inside a real render —
+// calling it as a plain function only ever worked while it happened to use no React hooks.
+const readTokens = () => renderHook(() => useChainTokens()).result.current
+
 describe('useChainTokens on the Ethereum family (spec 048 FR-009)', () => {
   beforeEach(() => {
     mockChainId = 1
   })
 
   it('offers native ETH and the configured USDC stable on Ethereum mainnet', () => {
-    const t = useChainTokens()
+    const t = readTokens()
     expect(t.chainId).toBe(1)
     expect(t.networkName).toBe('Ethereum')
     expect(t.native).toBe('ETH')
@@ -23,7 +28,7 @@ describe('useChainTokens on the Ethereum family (spec 048 FR-009)', () => {
 
   it('offers Sepolia native ETH + faucet USDC', () => {
     mockChainId = 11155111
-    const t = useChainTokens()
+    const t = readTokens()
     expect(t.native).toBe('ETH')
     expect(t.isTestnet).toBe(true)
     expect(t.stableAddress).toMatch(/^0x[0-9a-fA-F]{40}$/)
@@ -31,7 +36,7 @@ describe('useChainTokens on the Ethereum family (spec 048 FR-009)', () => {
 
   it('keeps the picker usable native-only on Hoodi (no stablecoin → stable unavailable)', () => {
     mockChainId = 560048
-    const t = useChainTokens()
+    const t = readTokens()
     expect(t.native).toBe('ETH')
     expect(t.isTestnet).toBe(true)
     // No configured stablecoin → address is null so TransferForm defaults to native (FR-009 edge).
@@ -43,16 +48,16 @@ describe('useChainTokens on the Ethereum family (spec 048 FR-009)', () => {
     // `dex` is now true — superseding spec 048's no-in-app-swap cut. Passkey submission
     // is declared but unconfigured on this family (no bundler URL, no deployed account
     // factory), so it continues to self-disclose off.
-    const t = useChainTokens()
+    const t = readTokens()
     expect(t.capabilities.passkeyAccounts).toBe(false)
     expect(t.capabilities.dex).toBe(true)
   })
 
   it('keeps the DEX capability off on the Ethereum TESTNETS (no Uniswap configured)', () => {
     mockChainId = 11155111
-    expect(useChainTokens().capabilities.dex).toBe(false)
+    expect(readTokens().capabilities.dex).toBe(false)
     mockChainId = 560048
-    expect(useChainTokens().capabilities.dex).toBe(false)
+    expect(readTokens().capabilities.dex).toBe(false)
     mockChainId = 1
   })
 })


### PR DESCRIPTION
Fixes #1027

## The bug

On the Transfer → Bridge tab, entering an amount made the panel flicker rapidly between "Getting a price for this transfer…" and "Bridging is temporarily unavailable…", and the member could never complete a transfer.

## Root cause

The quote debounce effect in `BridgeView` was keyed on the identity of its loader callback (`loadQuote`). That callback's dependencies — the `source`/`destination` option objects — were rebuilt with **fresh identities on every render**, because `useChainTokens` returns a brand-new object each call and everything downstream (`useSelectableAssets` → `allOptions` → `source`/`destination`) recomputed from it. The result was a self-sustaining loop:

1. debounce fires → quote fetch → `setQuoteState` → re-render
2. re-render → new option identities → new `loadQuote` identity → effect re-arms the debounce
3. repeat forever (~every 400 ms)

When the pricing gateway call failed, the loop toggled loading ↔ error — the reported flicker. When it succeeded, the loop silently re-quoted the gateway every ~400 ms. The suite never caught it because the test seams mocked `useSelectableAssets`/`usePortfolio` with **stable** identities the real hooks don't have.

## The fix

Two independent fixes, either of which breaks the loop:

- **`useChainTokens`** now memoizes its return value on the chain id, so consumers that put it (or lists derived from it) in dependency arrays stop seeing a new identity per render. This benefits every consumer of the hook, not just the bridge.
- **`BridgeView`** keys the quote debounce on a primitive signature of the quote's actual inputs (asset keys, route id, amount, recipient, destination gas balance) instead of the callback's identity, holding the loader in a ref. Unrelated re-renders — a portfolio poll, the quote countdown — can no longer cancel a pending quote or turn into another fetch.

Behavior after the fix: one quote per input change, delivered with every fee on its own labelled line (unchanged `BridgeQuoteCard`), and a failed quote settles into a **stable** honest-state error with its Try-again control instead of strobing.

## Tests

- The `BridgeView` test seams now return fresh object identities on every render, exactly like the real hooks under a portfolio poll, so the whole existing suite exercises the failure condition (pre-fix, the suite hangs/times out under these seams).
- New regression tests pin: exactly one fetch per typed amount despite unstable hook identities, and a failed quote that stays put through re-renders.
- New `useChainTokens` test pins identity stability across re-renders (and a new identity on a real chain change).

`vitest run` on the bridge, hooks, transfer, pay/request, and supply suites: 19 files, 219 tests, all passing. ESLint clean on changed files. No contract, gateway, or lockfile changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2X5NpsFpe541AxxU3hm32

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2X5NpsFpe541AxxU3hm32)_