### PR TITLE
feat(frontend): rework Address Book into 3a expandable roster

### DIFF
--- a/frontend/src/components/account/AddressBookPanel.css
+++ b/frontend/src/components/account/AddressBookPanel.css
@@ -160,45 +160,110 @@
   box-shadow: 0 0 0 3px rgba(var(--brand-primary-rgb, 54, 179, 126), 0.18);
 }
 
-.ab-contact-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 1rem;
+/* Search + round green add button on one line (design 3a). */
+.ab-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
 }
 
-/* Soft-shadowed, rounded contact card (issue #1023). */
+.ab-search-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.ab-search-box {
+  flex: 1;
+  min-width: 0;
+}
+
+.ab-add-btn {
+  flex: none;
+}
+
+/* Icon-only circle on small screens (the label span is display:none there). */
+@media (max-width: 639.98px) {
+  .ab-add-btn {
+    width: 48px;
+    height: 48px;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .ab-add-btn .ab-icon {
+    width: 1.2rem;
+    height: 1.2rem;
+  }
+}
+
+/* Meta row: saved-address count left, amber needs-review count right. */
+.ab-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.ab-meta-count {
+  color: var(--text-muted, #8a959e);
+}
+
+.ab-meta-review {
+  color: #b45309;
+}
+
+:root.theme-dark .ab-meta-review {
+  color: #fbbf24;
+}
+
+.ab-contact-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Compact expandable roster card (issue #1023, design 3a). */
 .ab-contact-card {
   border: 1px solid var(--border-color, #e2e8f0);
   border-radius: 1rem;
-  padding: 1rem 1.1rem;
+  padding: 0.9rem 1rem;
   background: var(--bg-secondary, #fff);
   color: var(--text-primary, #0f172a);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65rem;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04), 0 6px 20px rgba(15, 23, 42, 0.06);
-  transition: box-shadow 0.15s, transform 0.15s;
+  transition: box-shadow 0.15s;
 }
 
 .ab-contact-card:hover {
   box-shadow: 0 2px 4px rgba(15, 23, 42, 0.05), 0 10px 28px rgba(15, 23, 42, 0.09);
 }
 
-.ab-contact-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.5rem;
+/* Collapsed row: two lines on mobile, one roster line on wider screens. */
+.ab-contact-main {
+  display: grid;
+  grid-template-areas:
+    'avatar name flag'
+    'line line btn';
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  column-gap: 0.65rem;
+  row-gap: 0.55rem;
 }
 
-.ab-contact-id {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  min-width: 0;
+@media (min-width: 720px) {
+  .ab-contact-main {
+    grid-template-areas: 'avatar name line flag btn';
+    grid-template-columns: auto minmax(130px, 200px) 1fr auto auto;
+  }
 }
 
 .ab-contact-avatar {
+  grid-area: avatar;
   flex: none;
   width: 2.4rem;
   height: 2.4rem;
@@ -206,13 +271,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 700;
   color: var(--brand-primary, #36b37e);
   background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.14);
 }
 
 .ab-contact-name {
+  grid-area: name;
   display: flex;
   align-items: center;
   gap: 0.4rem;
@@ -221,7 +287,7 @@
 }
 
 .ab-contact-nickname {
-  font-size: 1.02rem;
+  font-size: 1rem;
   font-weight: 700;
   letter-spacing: -0.01em;
   overflow-wrap: anywhere;
@@ -242,9 +308,69 @@
   white-space: nowrap;
 }
 
-.ab-contact-actions {
+.ab-contact-flag {
+  grid-area: flag;
   display: flex;
-  gap: 0.35rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.ab-contact-flag:empty {
+  display: none;
+}
+
+.ab-contact-line {
+  grid-area: line;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.ab-contact-netcount {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted, #8a959e);
+  white-space: nowrap;
+}
+
+.ab-details-btn {
+  grid-area: btn;
+  justify-self: end;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  padding: 0.45rem 0 0.45rem 0.6rem;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--brand-primary, #36b37e);
+  line-height: 1;
+  border-radius: 0.55rem;
+}
+
+.ab-details-btn:hover,
+.ab-details-btn:focus-visible {
+  color: var(--primary-button-hover, #2f9e6e);
+  outline: none;
+}
+
+.ab-details-btn:focus-visible {
+  box-shadow: 0 0 0 3px rgba(var(--brand-primary-rgb, 54, 179, 126), 0.3);
+}
+
+/* Expanded details: per-network addresses, notes, then Edit / Delete. */
+.ab-contact-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+@media (min-width: 720px) {
+  .ab-contact-details {
+    padding-left: 3.05rem;
+  }
 }
 
 .ab-address-list {
@@ -261,17 +387,30 @@
   padding-top: 0.65rem;
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.35rem;
+}
+
+.ab-address-netlabel {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-secondary, #5a6772);
 }
 
 .ab-address-main {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  flex-wrap: wrap;
+  min-width: 0;
 }
 
-.ab-address-value {
+.ab-address-value,
+.ab-address-full {
   font-family: ui-monospace, monospace;
   font-size: 0.85rem;
   padding: 0.3rem 0.55rem;
@@ -280,24 +419,24 @@
   color: var(--text-primary, #0f172a);
 }
 
-/* Network pills + screening status below the address (issue #1023). */
-.ab-address-tags {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  flex-wrap: wrap;
-}
-
-.ab-address-status {
-  display: flex;
-  align-items: center;
+.ab-address-full {
+  font-size: 0.78rem;
+  line-height: 1.5;
+  word-break: break-all;
 }
 
 .ab-address-notes {
   margin: 0;
   font-size: 0.8rem;
-  line-height: 1.4;
+  line-height: 1.5;
   color: var(--text-muted, #64748b);
+}
+
+.ab-contact-actions {
+  display: flex;
+  gap: 0.5rem;
+  border-top: 1px solid var(--border-color, #f1f5f9);
+  padding-top: 0.5rem;
 }
 
 .ab-address-edit-row {

--- a/frontend/src/components/account/AddressBookPanel.jsx
+++ b/frontend/src/components/account/AddressBookPanel.jsx
@@ -69,6 +69,23 @@ export default function AddressBookPanel({ address }) {
     if (entries.length) screen(entries)
   }, [book, screen])
 
+  // Meta row (design 3a): total saved addresses, and how many contacts carry a
+  // non-clear screening state.
+  const savedCount = useMemo(
+    () => contacts.reduce((n, c) => n + c.addresses.length, 0),
+    [contacts],
+  )
+  const needsReview = useMemo(
+    () =>
+      contacts.filter((c) =>
+        c.addresses.some((a) => {
+          const s = getStatus(a.address, a.chainId)
+          return s === 'restricted' || s === 'uncertain'
+        }),
+      ).length,
+    [contacts, getStatus],
+  )
+
   // Filter contacts by the search query (nickname or any address) (FR-015).
   const filteredContacts = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -127,15 +144,6 @@ export default function AddressBookPanel({ address }) {
         </div>
         <div className="ab-panel-head-actions">
           <AddressBookImportExport />
-          <button
-            type="button"
-            className="ab-btn ab-btn-primary"
-            onClick={() => setEditing({ contact: null })}
-            aria-label="Add contact"
-          >
-            <IconPlus />
-            <span className="ab-btn-label">Add contact</span>
-          </button>
         </div>
       </div>
 
@@ -143,17 +151,40 @@ export default function AddressBookPanel({ address }) {
         <label htmlFor="ab-search" className="ab-sr-only">
           Search
         </label>
-        <div className="ab-search-box">
-          <IconSearch />
-          <input
-            id="ab-search"
-            type="search"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search by name or address"
-            autoComplete="off"
-          />
+        <div className="ab-search-row">
+          <div className="ab-search-box">
+            <IconSearch />
+            <input
+              id="ab-search"
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search by name or address"
+              autoComplete="off"
+            />
+          </div>
+          <button
+            type="button"
+            className="ab-btn ab-btn-primary ab-add-btn"
+            onClick={() => setEditing({ contact: null })}
+            aria-label="Add contact"
+          >
+            <IconPlus />
+            <span className="ab-btn-label">Add contact</span>
+          </button>
         </div>
+        {contacts.length > 0 && (
+          <div className="ab-meta-row">
+            <span className="ab-meta-count">
+              {savedCount === 1 ? '1 saved address' : `${savedCount} saved addresses`}
+            </span>
+            {needsReview > 0 && (
+              <span className="ab-meta-review">
+                {needsReview === 1 ? '1 needs review' : `${needsReview} need review`}
+              </span>
+            )}
+          </div>
+        )}
       </div>
 
       {contacts.length === 0 ? (

--- a/frontend/src/components/account/ContactCard.jsx
+++ b/frontend/src/components/account/ContactCard.jsx
@@ -1,14 +1,15 @@
 /**
- * ContactCard (Spec 021) — one address-book contact: nickname plus its grouped
- * addresses (network, shortened address, notes), each with an optional
- * sanctions RestrictionTag. A contact containing a restricted address is marked
- * at the contact level (FR-012).
+ * ContactCard (Spec 021, roster redesign per issue #1023 design 3a) — one
+ * address-book contact as a compact expandable row: avatar, nickname, a
+ * contact-level screening flag, the primary address with copy, and a network
+ * count. "Details" expands to per-network full addresses (each with its own
+ * copy action and notes) plus the Edit / Delete actions. A contact containing
+ * a restricted address is flagged at the contact level (FR-012).
  */
 
 import { useState } from 'react'
 import { addressKey } from '../../lib/addressBook/addressBookStore'
 import RestrictionTag from './RestrictionTag'
-import NetworkPill from '../ui/NetworkPill'
 
 function shorten(addr) {
   if (!addr || addr.length < 12) return addr
@@ -16,6 +17,21 @@ function shorten(addr) {
 }
 
 const noStatus = () => 'clear'
+
+// Worst screening status across a contact's addresses, for the contact-level flag.
+const STATUS_RANK = { restricted: 3, uncertain: 2, loading: 1, clear: 0 }
+function worstStatus(statuses) {
+  return statuses.reduce(
+    (worst, s) => ((STATUS_RANK[s] || 0) > (STATUS_RANK[worst] || 0) ? s : worst),
+    'clear',
+  )
+}
+
+function initialsOf(name) {
+  const words = (name || '').trim().split(/\s+/).filter(Boolean)
+  const letters = words.slice(0, 2).map((w) => w.charAt(0).toUpperCase())
+  return letters.join('') || '?'
+}
 
 function IconEdit() {
   return (
@@ -59,8 +75,12 @@ export default function ContactCard({
   isVault = false,
 }) {
   const [copiedKey, setCopiedKey] = useState(null)
+  const [expanded, setExpanded] = useState(false)
   const statuses = contact.addresses.map((a) => getStatus(a.address, a.chainId))
-  const containsRestricted = statuses.includes('restricted')
+  const flag = worstStatus(statuses)
+  const primary = contact.addresses[0]
+  const netCount = contact.addresses.length
+  const detailsId = `ab-details-${contact.id}`
 
   function handleCopy(addr, key) {
     navigator.clipboard.writeText(addr).then(() => {
@@ -69,87 +89,111 @@ export default function ContactCard({
     })
   }
 
-  const initial = (contact.nickname || '?').trim().charAt(0).toUpperCase() || '?'
+  function copyButton(addr, key) {
+    const copied = copiedKey === key
+    return (
+      <button
+        type="button"
+        className={`ab-btn ab-btn-xs ab-copy-btn${copied ? ' ab-copy-btn--copied' : ''}`}
+        onClick={() => handleCopy(addr, key)}
+        aria-label={`Copy address ${addr}`}
+      >
+        {copied ? <IconCheck /> : <IconCopy />}
+        <span className="ab-sr-only">{copied ? 'Copied!' : 'Copy'}</span>
+      </button>
+    )
+  }
 
   return (
     <div className="ab-contact-card">
-      <div className="ab-contact-head">
-        <div className="ab-contact-id">
-          <span className="ab-contact-avatar" aria-hidden="true">
-            {initial}
+      <div className="ab-contact-main">
+        <span className="ab-contact-avatar" aria-hidden="true">
+          {initialsOf(contact.nickname)}
+        </span>
+        <div className="ab-contact-name">
+          <span className="ab-contact-nickname">{contact.nickname}</span>
+          {/* Spec 068 — a multisig vault is an ordinary address-book entry, badged by matching the
+              member's own vault references rather than by storing a type on the entry (the book is
+              a synced object whose loader rebuilds a fixed field list, so an extra key would be
+              dropped). Renaming it here renames it everywhere the vault appears. */}
+          {isVault && <span className="ab-contact-tag">Multisig</span>}
+        </div>
+        {/* Contact-level screening flag: worst status across the contact's
+            addresses (FR-012). RestrictionTag renders nothing when clear. */}
+        <div className="ab-contact-flag">
+          <RestrictionTag status={flag} />
+        </div>
+        <div className="ab-contact-line">
+          {primary && (
+            <>
+              <code className="ab-address-value" title={primary.address}>
+                {shorten(primary.address)}
+              </code>
+              {copyButton(primary.address, addressKey(primary.address, primary.chainId))}
+            </>
+          )}
+          <span className="ab-contact-netcount">
+            {netCount === 1 ? '1 network' : `${netCount} networks`}
           </span>
-          <div className="ab-contact-name">
-            <span className="ab-contact-nickname">{contact.nickname}</span>
-            {/* Spec 068 — a multisig vault is an ordinary address-book entry, badged by matching the
-                member's own vault references rather than by storing a type on the entry (the book is
-                a synced object whose loader rebuilds a fixed field list, so an extra key would be
-                dropped). Renaming it here renames it everywhere the vault appears. */}
-            {isVault && <span className="ab-contact-tag">Multisig</span>}
-            {containsRestricted && (
-              <span className="ab-contact-restricted-flag">
-                <RestrictionTag status="restricted" />
-              </span>
-            )}
-          </div>
         </div>
-        <div className="ab-contact-actions">
-          <button
-            type="button"
-            className="ab-btn ab-btn-sm"
-            onClick={() => onEdit?.(contact)}
-            aria-label={`Edit contact ${contact.nickname}`}
-          >
-            <IconEdit />
-            <span className="ab-btn-label">Edit</span>
-          </button>
-          <button
-            type="button"
-            className="ab-btn ab-btn-sm ab-btn-danger"
-            onClick={() => onDeleteContact?.(contact.id)}
-            aria-label={`Delete contact ${contact.nickname}`}
-          >
-            <IconTrash />
-            <span className="ab-btn-label">Delete</span>
-          </button>
-        </div>
+        <button
+          type="button"
+          className="ab-details-btn"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          aria-controls={detailsId}
+          aria-label={`${expanded ? 'Close' : 'Show'} details for ${contact.nickname}`}
+        >
+          {expanded ? 'Close' : 'Details'}
+        </button>
       </div>
 
-      <ul className="ab-address-list">
-        {contact.addresses.map((a, i) => {
-          const key = addressKey(a.address, a.chainId)
-          const copied = copiedKey === key
-          return (
-            <li key={key} className="ab-address-row">
-              <div className="ab-address-main">
-                <code className="ab-address-value" title={a.address}>
-                  {shorten(a.address)}
-                </code>
-                <button
-                  type="button"
-                  className={`ab-btn ab-btn-xs ab-copy-btn${copied ? ' ab-copy-btn--copied' : ''}`}
-                  onClick={() => handleCopy(a.address, key)}
-                  aria-label={`Copy address ${a.address}`}
-                >
-                  {copied ? <IconCheck /> : <IconCopy />}
-                  <span className="ab-btn-label">{copied ? 'Copied!' : 'Copy'}</span>
-                </button>
-              </div>
-              <div className="ab-address-tags">
-                <NetworkPill chainId={a.chainId} name={networkName(a.chainId)} />
-              </div>
-              {/* Screening status sits on its own line below the network pills so
-                  an Unscreened/Restricted state is never lost in the tag row
-                  (issue #1023). RestrictionTag renders nothing when clear. */}
-              {statuses[i] && statuses[i] !== 'clear' && (
-                <div className="ab-address-status">
-                  <RestrictionTag status={statuses[i]} />
-                </div>
-              )}
-              {a.notes && <p className="ab-address-notes">{a.notes}</p>}
-            </li>
-          )
-        })}
-      </ul>
+      {expanded && (
+        <div className="ab-contact-details" id={detailsId}>
+          <ul className="ab-address-list">
+            {contact.addresses.map((a, i) => {
+              const key = addressKey(a.address, a.chainId)
+              return (
+                <li key={key} className="ab-address-row">
+                  <div className="ab-address-netlabel">
+                    <span>{networkName(a.chainId)}</span>
+                    {statuses[i] && statuses[i] !== 'clear' && (
+                      <RestrictionTag status={statuses[i]} />
+                    )}
+                  </div>
+                  <div className="ab-address-main">
+                    <code className="ab-address-full" title={a.address}>
+                      {a.address}
+                    </code>
+                    {copyButton(a.address, `${key}:full`)}
+                  </div>
+                  {a.notes && <p className="ab-address-notes">{a.notes}</p>}
+                </li>
+              )
+            })}
+          </ul>
+          <div className="ab-contact-actions">
+            <button
+              type="button"
+              className="ab-btn ab-btn-sm"
+              onClick={() => onEdit?.(contact)}
+              aria-label={`Edit contact ${contact.nickname}`}
+            >
+              <IconEdit />
+              <span>Edit</span>
+            </button>
+            <button
+              type="button"
+              className="ab-btn ab-btn-sm ab-btn-danger"
+              onClick={() => onDeleteContact?.(contact.id)}
+              aria-label={`Delete contact ${contact.nickname}`}
+            >
+              <IconTrash />
+              <span>Delete</span>
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/account/ContactCard.jsx
+++ b/frontend/src/components/account/ContactCard.jsx
@@ -141,7 +141,9 @@ export default function ContactCard({
           className="ab-details-btn"
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
-          aria-controls={detailsId}
+          // The details region only exists in the DOM while expanded, so only
+          // reference it then (a dangling aria-controls id fails axe).
+          aria-controls={expanded ? detailsId : undefined}
           aria-label={`${expanded ? 'Close' : 'Show'} details for ${contact.nickname}`}
         >
           {expanded ? 'Close' : 'Details'}


### PR DESCRIPTION
Follow-up to #1106 for issue #1023: reworks the Address Book to match the approved **design 3a** (compact roster with expandable details) from the uploaded design doc.

## What changed

- **Collapsed roster card** — green-tint avatar with two-letter initials, nickname, Multisig pill, and a **contact-level screening flag** (worst status across the contact's addresses: Restricted > Unscreened). Below/beside it: the primary address in a mono chip with copy, a network count ("2 networks"), and a green **Details / Close** toggle (`aria-expanded`/`aria-controls`).
- **Expanded details** — per network: an uppercase network label with a per-address screening tag when not clear, the **full address** in a mono chip with its own copy action, and notes; then the Edit / Delete actions in a separated footer row. Per 3a, the roster no longer shows colored chain badges — `NetworkPill` remains for the `AddressBookPicker` dropdown.
- **Header / search** — Export/Import stay as quiet text buttons; the add button moves next to the search input (round green **+** on mobile, labelled pill ≥640px; accessible name "Add contact" unchanged).
- **Meta row** — "N saved addresses" on the left, amber "N needs review" on the right (contacts with unscreened/restricted addresses), hidden when empty.
- **Responsive** — single-column list; at ≥720px the collapsed card lays out as one roster line (avatar | name | address+count | flag | Details) with expanded details indented beneath the address column, mirroring 3a's desktop panel.

All existing functionality is preserved: add/edit/delete, search, copy, Export/Import, QR scan, screening (FR-010/FR-012), recovery notes, spec-068 Multisig badge.

## Verification

- `npx vitest run src/test/addressBook` — 14 files, 73 tests pass (includes axe accessibility test)
- `npx vitest run src/test/custody/CustodyAddressField.test.jsx src/test/home.axe.test.jsx src/test/PayPanel.test.jsx` — 30 tests pass
- eslint clean on changed files; `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yjGYfVRKCcg61op3ZiaG4

---
_Generated by [Claude Code](https://claude.ai/code/session_011yjGYfVRKCcg61op3ZiaG4)_